### PR TITLE
fix(sqlite): avoid INSERT...RETURNING hang in create()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -202,6 +202,13 @@ Issues identified during the code review of recent main changes
     )
 
 
+- [/] **SQLite `INSERT ... RETURNING *` hang + worker/pool stability** (`src/querybuilder/execution.jl`, `src/ConnectionPool.jl`)
+  Surfaced running the SQLite integration suite (`PORMG_DB=db_sl julia -t 1 --project=. test/integration/runtests.jl`) on Windows + SQLite.jl 3.51.
+  - [x] **`create()` RETURNING hang** — `INSERT ... RETURNING *` spun indefinitely inside libsqlite3 for tables whose AUTOINCREMENT primary key migrations left in a non-first column position (e.g. `django_contract_scratch`, pk `id` at column 3). The old broad `catch` masked it by re-running a plain INSERT, which then tripped a spurious UNIQUE violation because the first INSERT had already written the row. **Fixed** (branch `fix/sqlite-insert-returning-hang`): plain INSERT + `SELECT * WHERE rowid = last_insert_rowid()` read-back on the same connection (pinned via `run_in_transaction`); broad catch removed; the returned Dict still carries all columns (matches the Postgres `RETURNING *` contract, incl. unset nullables).
+  - [ ] **Native segfault in the SQLite async worker** — intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64` during F1 fixture seeding (`test_database_setup.jl`); nondeterministic (GC-timed, did not recur on re-run). Suspect: the single global `Threads.@spawn` worker + GC finalizers racing on `SQLite.Stmt`/`SQLite.DB` objects.
+  - [ ] **SQLite connection-pool timeout in transactions** — "Timeout after 30s waiting for available SQLite connection" in `test_transactions.jl`; the pool grows past size 3 then exhausts after `run_in_transaction` exits. Runtime worker/pool accounting issue, not the query builder.
+  - **Note**: PostgreSQL (`db_2`) is the validated integration path (1349/1350 pass; the 1 error is a network connection-pool timeout to the remote host, not a code bug). Treat the two open items as a SQLite worker/pool-stability effort (async-worker/pool redesign or a SQLite.jl bump), not a quick patch.
+
 ## 🔗 Custom Join (`cjoin`) Gaps
 
 Features needed to express complex join patterns (e.g., self-joins with multi-OR ON clauses, field-to-field comparisons, SQL functions in ON) without falling back to raw SQL.

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -464,19 +464,33 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     pk_exist && _update_sequence(model, connection, pk_field, settings)
     return Tables.rowtable(result) |> Base.first |> x -> Dict(Symbol(k) => v for (k, v) in pairs(x))
   elseif connection isa PormGSQLite
-    # SQLite: use fetch() to properly acquire/release from pool
-    # Use RETURNING * if supported (SQLite 3.35+)
-    try
-      result = fetch(settings, sql * " RETURNING *;", parameters)
-      pk_exist && _update_sequence(model, connection, pk_field, settings)
-      return Tables.rowtable(result) |> Base.first |> x -> Dict(Symbol(k) => v for (k, v) in pairs(x))
-    catch e
-      # Fallback for older SQLite versions
+    # SQLite: deliberately avoid `INSERT ... RETURNING *`. RETURNING can hang
+    # indefinitely inside SQLite/libsqlite3 for some table shapes (observed: an
+    # AUTOINCREMENT primary key that migrations left in a non-first column
+    # position). The previous broad `catch` masked that hang/error by re-running a
+    # plain INSERT, which then tripped a spurious UNIQUE violation because the
+    # first INSERT had already written the row. Instead: run a plain INSERT, then
+    # read the full inserted row back with a SELECT on the SAME connection
+    # (last_insert_rowid() is per-connection session state). Reading the whole row
+    # keeps the returned Dict consistent with the Postgres `RETURNING *` path —
+    # all columns present, including nullable ones the caller did not set.
+    do_insert = () -> begin
       fetch(settings, sql, parameters)
-      pk_exist && _update_sequence(model, connection, pk_field, settings)
-      # Return the input data as a fallback (will lack auto-generated fields)
-      return Dict(Symbol(k) => v for (k, v) in pairs(real_obj.insert))
+      rows = fetch(settings,
+        "SELECT * FROM $(safe_table_name) WHERE rowid = last_insert_rowid();") |> Tables.rowtable
+      isempty(rows) ?
+        Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(real_obj.insert)) :
+        Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(rows[1]))
     end
+
+    # INSERT and the row read-back must run on one connection (last_insert_rowid()
+    # is per-connection). Reuse the active transaction if there is one; otherwise
+    # pin a connection for the pair.
+    result_dict = transaction_connection_for(settings) !== nothing ?
+      do_insert() : run_in_transaction(do_insert, settings)
+
+    pk_exist && _update_sequence(model, connection, pk_field, settings)
+    return result_dict
   else
     throw("Unsupported connection type")
   end


### PR DESCRIPTION
## Problem
`INSERT ... RETURNING *` on SQLite hangs indefinitely inside libsqlite3 for tables whose AUTOINCREMENT primary key migrations left in a non-first column position (e.g. `django_contract_scratch`, pk `id` at column 3). The old broad `catch` masked it by re-running a plain INSERT, which then tripped a spurious `UNIQUE constraint failed` because the first INSERT had already written the row.

Root-caused by reproducing the spin in isolation (raw SQLite.jl, no PormG): a plain `INSERT ... RETURNING *` on the affected table CPU-spins, while the same statement on a simple table — and a plain INSERT — both work.

## Fix
`src/querybuilder/execution.jl` (SQLite branch of `insert`):
- Replace `INSERT ... RETURNING *` with a plain `INSERT` + `SELECT * WHERE rowid = last_insert_rowid()` on the same connection (pinned via `run_in_transaction`, or the active transaction connection when already inside one).
- Reading the full row keeps the returned `Dict` consistent with Postgres `RETURNING *` — all columns present, including unset nullables.
- Remove the error-masking `catch` that caused the double-insert.

## Verification
- `create()` returns correctly (id, timestamps, all columns); id persists; sequence intact (verified on `db_sl`).
- Returned dict now includes nullable columns the caller didn't set (e.g. `payload => missing`), fixing the `JSONField Updates` regression.
- PostgreSQL path unchanged.

## Open follow-ups (tracked in TODO.md, not in this PR)
Two separate, pre-existing SQLite-on-Windows worker/pool issues, only reachable now that the hang is fixed:
- Intermittent native segfault in `sqlite3_bind_int64` on the async worker during fixture seeding.
- Connection-pool timeout in the Transactions testset.

PostgreSQL (`db_2`) remains the validated integration path (1349/1350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)