### PR TITLE
SQLite async-worker segfault fix, TTY-aware error messages, and TODO→issues migration

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -44,6 +44,7 @@ rows = M.Result.objects
 | `src/migrations/`, `src/Migrations.jl`, migration CI | `.github/skills/pormg-migrations-development/SKILL.md` |
 | Consuming PormG in a downstream app — setup, queries, examples (no internals) | `.github/skills/pormg-usage/SKILL.md` |
 | Pre-push / pre-PR review | `.github/skills/pormg-changed-code-review/SKILL.md` |
+| Managing the backlog — creating/updating GitHub issues, migrating or syncing the `TODO.md` index | `.github/skills/pormg-issue-management/SKILL.md` |
 
 Cross-cutting changes: public-API skill + the most specific subsystem skill. Reviews: review skill only — **except doc-content reviews** ("review the doc/examples in …"), which read the review skill **and** the public-API skill, so the live-database example-verification recipe applies.
 

--- a/.github/skills/pormg-issue-management/SKILL.md
+++ b/.github/skills/pormg-issue-management/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: pormg-issue-management
+description: Manage the PormG backlog with the gh CLI — create/update/close GitHub issues, bulk-migrate TODO.md items to issues, and keep TODO.md as a linked index. Covers the label taxonomy, the draft-before-create safety flow, and cross-reference discipline.
+---
+
+# PormG Issue Management
+
+## Purpose
+
+Use this skill for any work on the project backlog: creating or editing GitHub issues,
+migrating `TODO.md` items into issues, syncing the `TODO.md` index after issues change, or
+curating labels. It encodes the conventions settled when the backlog was first migrated so the
+tracker stays consistent.
+
+This is a process skill, not a code skill — it does not touch `src/`.
+
+## Use This Skill For
+
+- Creating one or many GitHub issues (especially bulk migration from `TODO.md`)
+- Editing, closing, commenting on, or relabeling existing issues
+- Keeping `TODO.md` in sync with the issue tracker
+- Adding or adjusting labels
+
+## The TODO.md ↔ Issues model
+
+- **GitHub Issues are the source of truth.** `TODO.md` is a *curated linked index of OPEN work
+  only*: one line per open item, grouped by the historical sections, each linking to its `#issue`.
+- **When an item is solved, remove its line from `TODO.md`** — do not keep a completed list. The full
+  history (discussion, linked commits/PRs, close reason, timestamps) already lives in GitHub's closed
+  issues: `gh issue list --state closed`. A parallel archive in `TODO.md` only duplicates that and
+  drifts. (Work completed *before* the issue tracker existed lives in git history, not GitHub issues.)
+- **Do not delete `TODO.md`.** `.github/instructions/general.instructions.md` references it for the
+  `⚠️ do BEFORE the first General-registry publish` release-gating tag. That exact phrase and the
+  pre-publish items must remain visible in the index (linking to their issues) so the reference
+  resolves.
+- Edit **issues** for status/discussion; touch `TODO.md` only when an item is opened or closed.
+
+## Tooling
+
+- Use the **`gh` CLI** (authenticated as the maintainer). Confirm with `gh auth status` and
+  `gh repo view --json nameWithOwner,hasIssuesEnabled` before acting. Repo: `PingoLee/PormG.jl`
+  (public — see safety note below).
+- Common ops: `gh issue create`, `gh issue edit`, `gh issue close`, `gh issue comment`,
+  `gh issue list --state open --label <l>`, `gh issue view <n> --json title,labels,body`.
+- Always pass rich markdown bodies via `--body-file <path>`, never inline `--body "…"` — heredocs
+  and shell escaping mangle backticks, `$`, and code fences. Write the body to a file first.
+
+## Label taxonomy
+
+Reuse the GitHub defaults that fit (`enhancement`, `bug`, `documentation`); create the project
+ones idempotently with `gh label create <name> --color <hex> --description "…" --force`.
+
+| Kind | Labels |
+|------|--------|
+| Type | `enhancement`, `bug`, `documentation`, `tech-debt` |
+| Subsystem | `postgres`, `sqlite`, `migrations`, `cjoin`, `performance`, `infrastructure` |
+| Release gating | `pre-publish` (must be settled before the first General-registry publish) |
+
+## Safety: issues are public and outward-facing
+
+Creating issues publishes content on a public repo and notifies watchers — it is noisy to undo.
+**For any bulk creation (more than a couple of issues), draft first and get explicit confirmation
+before hitting the API.** A single targeted issue the user asked for can be created directly.
+
+## Bulk migration / creation workflow
+
+1. **Draft, then confirm.** Write every proposed issue (title, labels, full body) to a review file
+   and show the user the plan (a title/label table is enough). Create nothing public until they
+   approve. Surface grouping decisions (e.g. merging related sub-items into one issue) so they can
+   adjust.
+2. **One issue per top-level item.** Nested sub-items become a markdown task list (`- [ ]`) in the
+   body; preserve the original context (the "why now", blockers, file references).
+3. **Verify the parse before the API.** If you split a source file (e.g. `TODO.md`) into per-issue
+   bodies programmatically, print the parsed title/labels/first-body-line for every issue and eyeball
+   it before any `gh` call — a malformed public issue is the cost of a parse bug.
+4. **Labels first, then issues.** Create/refresh labels (idempotent `--force`), then loop:
+   `gh issue create --title "<t>" --label "<comma,separated>" --body-file <f>`.
+5. **Capture the real numbers.** You do not know an issue's number until it is created — record each
+   returned URL/number into a map.
+6. **Fix cross-references.** Never hardcode draft/sequence numbers in bodies. After creation, rewrite
+   any `#N` sibling references to the **real** issue numbers (`gh issue edit <n> --body-file …`),
+   otherwise `#11` etc. silently links to an unrelated old issue or PR.
+7. **Verify after.** Check the open count, label assignment, and spot-check that a rich body (task
+   lists, blockquotes, code fences) rendered: `gh issue view <n> --json body -q '.body'`.
+8. **Update the index.** Rewrite `TODO.md` to link each item to its issue, keep the section grouping
+   and the `⚠️` gating note, and move shipped work to the Completed archive.
+
+## Closing a resolved issue
+
+Closing the issue and syncing the index are **one operation**, not two — never close an issue
+without updating `TODO.md` in the same pass.
+
+1. **Link the fix.** Prefer letting GitHub auto-close: put `Closes #N` (or `Fixes #N`) in the PR
+   description or the commit message that lands the work, so the issue closes on merge *with a
+   back-reference to the commit*. For a direct close, use
+   `gh issue close <n> --comment "Fixed in <commit/PR>: <one-line summary>"` — always say what fixed
+   it, never close silently.
+2. **Partial progress ≠ closed.** If only some task-list items are done, do **not** close. Check the
+   finished boxes (`- [ ]` → `- [x]`) in the body via `gh issue edit <n> --body-file …` and comment
+   on what landed. Close only when every box is done — or split the remainder into a new issue and
+   close the original with a pointer to it.
+3. **Remove it from `TODO.md`.** Delete the item's line from its section in the same pass — do not
+   archive it in `TODO.md`; its history is the closed GitHub issue. If closing spawned a
+   residual/follow-up issue, make sure that new one is listed in the index. Keep the `⚠️` pre-publish
+   note even as its gated items close.
+4. **Verify.** Confirm the issue is closed (`gh issue view <n> --json state,closed`) and the index no
+   longer lists it.
+
+## Do Not
+
+- Bulk-create issues without showing a draft and getting confirmation first.
+- Close an issue that still has unfinished task-list items — check them off or split them out first.
+- Close an issue without a comment/PR/commit reference saying what resolved it.
+- Close or open an issue without syncing the `TODO.md` index in the same pass.
+- Delete `TODO.md` or drop the `⚠️ do BEFORE the first General-registry publish` tag from it.
+- Put draft/placeholder numbers in issue bodies and leave them — resolve to real `#numbers`.
+- Inline rich bodies on the command line — use `--body-file`.
+- Commit `TODO.md` (or any) changes unless the user asks; backlog edits follow the normal
+  commit-only-when-asked rule.

--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -96,12 +96,13 @@ When adding any new identifier-quoting path, go through `quote_identifier` — n
 
 Error messages may colorize the offending token with ANSI for the REPL, but they **must** degrade off-TTY. Construct `ArgumentError`s via `_argerr(msg)` (defined in `querybuilder/exceptions.jl`), or wrap a raw `throw`/`error` string with `_emsg(...)`:
 
-- `_emsg(msg)` keeps ANSI when `Base.have_color` is true and strips every `\e[..m` code otherwise (CI, file logs, structured logging) — the same flag Julia uses to colorize its own error displays.
+- `_emsg(msg; color = Base.have_color === true)` is the single shared helper, defined in `src/tools.jl` (the `PormG` namespace). It keeps ANSI when color is on and strips every `\e[..m` code otherwise (CI, file logs, structured logging) — `Base.have_color` is the same flag Julia uses to colorize its own error displays, so it honors `--color` and `NO_COLOR`. The `color` keyword exists for deterministic testing.
 - `_argerr(msg) = ArgumentError(_emsg(msg))` is the common case: a call site changes only `ArgumentError(` → `_argerr(` (paren structure unchanged).
 - Never write `throw(ArgumentError("...\e[31m..."))` directly — raw escape codes leak as noise into non-TTY sinks.
-- *Logging* macros (`@info` / `@warn` / `@error`) may keep raw ANSI, since they write to a TTY.
+- `_emsg(io, msg)` is the IO-aware overload for `show` / `print(io, …)` methods: it keys off the destination stream's `:color` IOContext property (`get(io, :color, false)`) rather than the global flag, so a non-color buffer (`sprint`, `repr`, a file) stays clean even on a color terminal.
+- *Logging* macros (`@info` / `@warn` / `@error`) and interactive `print`/`println` also route their colored messages through `_emsg(…)` — this keeps log files and captured output ANSI-free when redirected (Julia clears `Base.have_color` for non-TTY stdout). Don't add a new `@info("…\e[31m…")` without the `_emsg` wrapper.
 
-Scope: `_argerr`/`_emsg` are QueryBuilder-internal, so this contract applies to `src/querybuilder/`. If colored errors are ever needed in `Migrations`/`Models`, promote the helper to a shared module (e.g. `Utils.jl`) and import it — don't re-embed raw ANSI.
+Scope: `_emsg` is shared (`src/tools.jl`, `PormG` namespace, both string and `IO`-aware methods); `QueryBuilder`, `Models`, and `Migrations` all `import PormG: _emsg`. `_argerr` is the QueryBuilder-internal convenience wrapper. Any submodule that needs colored errors/logs should import `_emsg` from `PormG` rather than re-embedding raw ANSI. Regression coverage: `test/unit/test_error_message_ansi.jl`.
 
 ### Query generation
 
@@ -183,4 +184,4 @@ julia -t auto --project=. test/integration/test_cte.jl
 - Do not bypass public API regressions when the failure is visible to package users
 - Do not mix unrelated SQL formatting changes into a targeted regression fix
 - Do not revert to silent identifier stripping (e.g. `replace(id, r"[^a-zA-Z0-9_]" => "")`) — the contract is fail-closed: validate via `_validate_identifier`, then quote; never silently rewrite an identifier
-- Do not embed raw ANSI (`\e[...`) in a `throw`/`error` message — route through `_argerr`/`_emsg` so color degrades off-TTY (logging macros may keep ANSI)
+- Do not embed raw ANSI (`\e[...`) in a `throw`/`error`/`@info`/`@warn`/`@error`/`print` message — route through `_argerr`/`_emsg` (or `_emsg(io, …)` inside `show` methods) so color degrades off-TTY

--- a/TODO.md
+++ b/TODO.md
@@ -1,271 +1,67 @@
-# TODO List
+# TODO — issue index
 
-This document tracks missing features and planned improvements for PormG.jl, with a focus on reaching parity with Django-style ORM capabilities and leveraging PostgreSQL-specific power features.
+> **Open work now lives in [GitHub Issues](https://github.com/PingoLee/PormG.jl/issues).**
+> This file is a curated index of **open work only**, grouped by the historical TODO sections, so the
+> roadmap stays readable in-repo. Edit the **issues** for status/discussion; this file only needs
+> updating when an issue is opened or closed. When an issue closes, its line is **removed** here —
+> the history stays on the closed issue.
+
+Focus on parity with Django-style ORM capabilities and PostgreSQL power features.
 
 ## 🚀 High Priority: Core ORM Parity
 
-- [x] **Make bulk DataFrame→field matching case-sensitive (abandon case-insensitive matching)** — All three matching spots in `src/querybuilder/execution_bulk.jl` now match **exactly (case-sensitive)** and **fail loudly** when a name differs only in case, via shared helpers `_case_fold_candidates` + `_bulk_case_mismatch_msg` (the error names the candidate and suggests `rename!(df, lowercase.(names(df)))` or an explicit `"DF_COL" => "field"` mapping):
-  - `_prepare_bulk_df!` auto-detect (`columns=nothing`): a DataFrame column differing only in case from a model field raises instead of folding/overwriting.
-  - `_prepare_bulk_df!` explicit-`columns=` string fallback: a case-only mismatch raises; a truly-absent name still passes through as an auto-populated field.
-  - `_prepare_bulk_df!` explicit-`columns=` **Pair** (`"df_col" => "field"`): a missing source column now **throws** (previously `@error`-logged and bound a bad mapping that crashed downstream), with the same case hint when the near-miss differs only in case.
-  - `_resolve_match_column!` (`match_on=`): reordered to exact → reuse an explicit `columns=` mapping (`allow_reuse`) → case-mismatch error → not-found. An explicit `columns=` mapping still wins over a case error.
-  - **Migration applied**: the F1 test DB setup (`test_database_setup.jl`) and the docs F1 load examples (`docs/src/write/bulk.md`) now `rename!(df, lowercase.(names(df)))` for the camelCase `circuits`/`drivers`/`constructors` CSVs. Docs (`bulk.md`, `api.md`) updated to state case-sensitive matching plus the symmetric missing-`columns=`-column error.
-  - **Test coverage**: unit (`test/unit/test_bulk_update_column_scope.jl`) flips the old case-insensitive test and adds Site A/B/C, the explicit-Pair path, and allow_reuse-precedence cases. Integration tests that asserted the old fold were rewritten: in `test/integration/test_updates.jl`, one to the exact-column PK-fallback path, one into a case-sensitivity **migration** test (upper-case raises + DB untouched, then `rename!` succeeds), and the "Auto-lowercase mapping" Adaptor test flipped to assert auto-detect now rejects a case-only mismatch; in `test/integration/test_internals.jl`, the show_query bulk_insert load of `constructors.csv` now `rename!`s the camelCase headers. Verified against PostgreSQL (`db_2`): the F1 seed loads (91/91 "Inserts and Schema") and the migration + PK-fallback rewrites pass; the two follow-up fixes match the exact errors that same run surfaced (one reuses the seed's proven `rename!`, one asserts the observed case error). The only non-code failure was an environmental remote-DB connection timeout in the Phase-0 temp-DB migration test, unrelated to this change.
-
-- [/] **Advanced Query Expressions**
-  - [x] Support for **Subqueries** (using `OuterRef`). — Correlated `Exists(subquery)`, `OuterRef("field")`, and `__@in` subquery membership tests are fully implemented and tested. Gaps: no scalar subqueries, no UNION/set operations.
-  - [x] **Window Functions** (`OVER`, `RANK`, `ROW_NUMBER`). — Implemented inline `OVER` support with `WindowOver`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, and `NthValue`. Remaining gaps: aggregate-over-window helpers, named `WINDOW` clauses, and SQLite explicit frame support.
-  - [x] **Conditional Expressions** (`Case`, `When`). — Fully implemented. Works in `values()`, `filter()`, and `update()` SET clauses; nests correctly inside aggregates like `Sum(Case([...]))`.
-  - [/] **F-Expression** expansion.
-    - [x] Arithmetic (`+`, `-`, `*`, `/`) and comparison operators (`==`, `>`, `<=`, etc.) — fully implemented, including field-to-field arithmetic and chaining.
-    - [x] **Bitwise operations** (`&`, `|`, `⊻`/`xor`, `<<`, `>>`) — fully implemented and verified on SQLite & PostgreSQL.
-    - [x] **Date/Time extraction**: `Extract()`, `@date`, `@year`, `@month`, `@day`, `@quarter` lookups — implemented and dialect-aware.
-    - [/] **Date arithmetic with duration types**: Integer-offset `F("date") + 30` works. Explicit Julia duration types like `Day(30)` / `Interval()` are not recognized — arithmetic relies on bare integers interpreted as days by the dialect.
-    - [ ] **Extend test coverage** for date/time functions to ensure cross-database compatibility and correct SQL generation.
-
-
-- [x] **Refactor QueryBuilder Parameter Handling (Contextual Buckets Strategy)**
-  - **Context:** Currently, the query builder generates PostgreSQL parameters (`$1`, `$2`...) sequentially. MySQL/MariaDB and SQLite use positional parameters (`?`), which require a "Bucket" strategy because code execution order (e.g., Processing `WHERE` before `JOIN` to determine needs) doesn't match SQL string order.
-  - **Goal:** Implement this in [src/querybuilder/parameters.jl](src/querybuilder/parameters.jl) using Multiple Dispatch.
-  - **Implementation Details:**
-    1. **Abstract Base Type**: `AbstractPormGParam`.
-    2. **PostgreSQL**: `PormGPostgresParam <: AbstractPormGParam` (concrete `PgParameterizedQuery`; single vector/counter).
-    3. **Positional (SQLite)**: `PormGSQLiteParam <: AbstractPormGParam` (concrete `SQLiteParameterizedQuery`) with distinct buckets for `cte_params`, `select_params`, `update_params`, `join_params`, `where_params`, `having_params`. *(`update_params` added beyond the original plan for UPDATE `SET` clauses. MySQL/MariaDB would reuse this positional strategy when a backend is added.)*
-    4. **Context Control**: `set_context!(params, context::Symbol)` to direct parameters to the correct bucket.
-    5. **Finalization**: `get_final_parameters` returns `vcat` of buckets in standard SQL order.
-    - [x] **show_query**: Update to support new parameter structure and ensure correct SQL string generation for each dialect. Finishing the concept of Symbol-based `show_query` modes for flexible inspection.
-    - [x] **Testing & Alignment Verification**:
-      - [x] **Positional Cross-Check**: Create tests that count the number of `?` in each SQL block (SELECT, JOIN, WHERE) and compare them against the length of the corresponding parameter bucket.
-      - [x] **Execution Order Stress Test**: Specifically test queries where JOINs are calculated dynamically based on filters to ensure parameter positions don't drift.
-      - [x] **Subquery Isolation**: Verify that nested subqueries correctly restore the parent's `current_context` after execution.
-      - [x] **Unit Tests**: Storage-layer tests (buckets/ordering) live in `test/unit/test_parameters.jl`; the `inspect_query` + mocked-connection (`MockSQLite`) alignment tests live in `test/unit/test_alignment_sqlite.jl`. Both are wired into `test/runtests.jl` (388 assertions across the two files, green).
-
-- [ ] **Full Transaction Control**
-  - [ ] **Savepoints**: Support for nested transactions/atomic blocks.
-  - [ ] **Row-Level Locking**: `select_for_update()` with `SKIP LOCKED` and `OF` support.
-
-- [x] **Query Inspection & Developer Tooling**
-  - [x] **Intent Detection**: Improve the `:operation` heuristic in `inspect_query` to distinguish between `:select` and `:delete` without explicit overrides.
-  - [ ] **Finalize `show_query` with `:inspection` mode**: Ensure it returns a comprehensive metadata dictionary with consistent keys across all operations (select, insert, update, delete) for use in debugging and potential future tooling (e.g., query logging middleware).
-  - [ ] **Metadata Enrichment**: Include additional context in the inspection dict, such as estimated execution time (using EXPLAIN), potential indexes used, and warnings about missing indexes or inefficient queries.
-  - [ ] **SQL Formatting**: Add a `:pretty` mode to `show_query` to return formatted/indented SQL for better readability in logs.
-  - [ ] **Explain Support**: Add an `explain_query()` API to return the database's `EXPLAIN (ANALYZE, BUFFERS)` output directly as metadata.
-
+- [#25](https://github.com/PingoLee/PormG.jl/issues/25) — Advanced Query Expressions: F-expression date arithmetic (`Day(30)`/`Interval`) + cross-DB date/time test coverage
+- [#48](https://github.com/PingoLee/PormG.jl/issues/48) — Query inspection tooling: `:inspection` mode, metadata enrichment, SQL formatting, EXPLAIN
+- [#26](https://github.com/PingoLee/PormG.jl/issues/26) — Full Transaction Control: savepoints + row-level locking (`select_for_update`)
 
 ## 🐘 PostgreSQL Specific Enhancements
 
-- [ ] **JSONB Support**
-  - [x] Implement `JSONField`.
-  - [ ] Support for JSON lookups (`data__key`, `data__0__key`).
-  - [ ] JSON containment and overlap operators (`@>`, `?`, `?|`, `?&`).
-
-- [ ] **Specialized Data Types**
-  - [x] `UUIDField` (using native `uuid` type).
-  - [ ] `ArrayField` (PostgreSQL native arrays).
-  - [x] `IntervalField` (PostgreSQL `interval`). — implemented as `DurationField` (renders to `INTERVAL`).
-  - [ ] `INET`/`CIDR` Fields for network addresses.
-
-- [ ] **Advanced Indexing**
-  - [ ] Support for `GIN`, `GIST`, and `BRIN` indexes in migrations.
-  - [ ] Functional indexes (indexing the result of a function).
-  - [ ] Partial indexes (indexing a subset of rows via `WHERE`).
-
-- [ ] **Performance Bulk Operations**
-  - [x] **COPY command**: Implement high-speed bulk inserts using PostgreSQL's `COPY` protocol.
-  - [x] **Dataframes Type Normalization**: Create integration tests for bulk operation type normalization in `execution_bulk.jl`.
-    - Validate edge cases for `bulk_insert`, `bulk_update`, and `bulk_copy`:
-      - Float to Integer coercion (e.g., `14.0` in `Vector{Float64}` to `Int64`).
-      - Mixed types in column (Strings that are numeric).
-      - Null/Missing handling in required vs optional fields.
-      - Foreign key violation reporting in bulk contexts.
-      - Duplicate key handling.
-  - [ ] **Upsert (`ON CONFLICT`)**: Support for `update_or_create` using `INSERT ... ON CONFLICT DO UPDATE`.
-
-- [ ] **Full-Text Search (FTS)**
-  - [ ] Integration with `tsvector` and `tsquery`.
-  - [ ] ORM lookups for `search`, `rank`, and `headline`.
+- [#27](https://github.com/PingoLee/PormG.jl/issues/27) — JSONB support: lookups + containment/overlap operators
+- [#28](https://github.com/PingoLee/PormG.jl/issues/28) — Specialized data types: `ArrayField` + `INET`/`CIDR`
+- [#29](https://github.com/PingoLee/PormG.jl/issues/29) — Advanced indexing: GIN/GiST/BRIN, functional, partial
+- [#30](https://github.com/PingoLee/PormG.jl/issues/30) — Bulk upsert: `update_or_create` via `ON CONFLICT`
+- [#31](https://github.com/PingoLee/PormG.jl/issues/31) — Full-Text Search (`tsvector`/`tsquery`)
 
 ## 🛠 Project Infrastructure & Quality
 
-> ⚠️ **Pre-publish window** — the items marked *do BEFORE the first General-registry publish* lock in contracts that are cheap to settle now (zero published users) but become breaking/irreversible afterward. Tier 1 (migration format, schema conventions) touches **user data / live databases** — a version bump cannot fix an already-migrated production DB. Tier 2 (loading contract, export surface) is code-fixable in a 0.x bump but breaks every user's `using` at once. The adapter decoupling and export curation are coupled — do them together.
->
-> **Sequence (do in this order):** (1) freeze the migration file + tracking-table contract → (2) freeze the generated DB schema conventions → (3) decouple SQL adapters into weakdeps + extensions → (4) curate the public export surface. Items 1–2 are **Tier 1** (irreversible user-data — settle first); items 3–4 are the coupled **Tier 2** pair shipped together, with adapter-decoupling first because export-curation depends on it (a core-exported `libpq_execute` cannot survive `LibPQ` moving to an extension). The two unmarked items below (PG migration fixture, PG pool exhaustion) are not publish-gating and follow afterward.
+> ⚠️ **do BEFORE the first General-registry publish** — the items below lock in contracts that are
+> cheap to settle now (zero published users) but become breaking/irreversible afterward.
+> **Sequence:** (1) freeze migration contract → (2) freeze schema conventions → (3) decouple
+> adapters → (4) curate exports. Items 1–2 are **Tier 1** (irreversible user-data — settle first);
+> 3–4 are the coupled **Tier 2** pair, adapter-decoupling first (export-curation depends on it).
 
-- [ ] **Freeze & document the migration file + tracking-table contract** ⚠️ *do BEFORE the first General-registry publish* — **Tier 1 (user data, irreversible)**
-  - **Why now**: Once a user generates migration files with 0.1.0, commits them, and applies them to a production DB (recorded in the migrations bookkeeping table), that history is frozen **on disk and in their database**. If a later release changes the migration file structure, the checksum/`compute_checksum` scheme, or the tracking-table schema, the existing applied history breaks — and no version pin can repair an already-migrated prod DB.
-  - **Goal (decide & lock, not necessarily rewrite)**: Pin and document, as a stability contract: (1) the on-disk migration file format/layout, (2) the checksum algorithm (`compute_checksum`), (3) the migrations tracking-table name + columns, (4) the recorded state representation. Add a documented format/version marker so future changes can be migrated forward instead of silently breaking.
-  - **Deliverable**: a "Migration format stability" section in the docs + a format-version field; a test that reads a committed 0.1.0-era migration fixture and asserts it still applies/validates.
-
-- [ ] **Freeze & document the generated DB schema conventions** ⚠️ *do BEFORE the first General-registry publish* — **Tier 1 (user data, irreversible)**
-  - **Why now**: The moment a user runs `migrate`, these naming choices are **physically in their database**. Changing them later means the ORM no longer matches the user's existing schema, with no version-pin escape.
-  - **Conventions to pin & document**: table pluralization (Inflector), FK column spelling (README/examples use `driverid`, not `driver_id` — confirm this is the intended, final convention), implicit PK / `id` field, auto timestamp/`created`/`modified` fields, default `on_delete`, identifier quoting/case rules.
-  - **Goal**: settle each convention now and document it as stable; where a convention is genuinely undecided, decide it before publish rather than after. (Django froze these on day one and never moved them.)
-
-- [ ] **Decouple SQL adapters into weakdeps + extensions** ⚠️ *do BEFORE the first General-registry publish* — **Tier 2 (loading contract); coupled with export curation — do BEFORE it**
-  - **Why now**: Moving `LibPQ`/`SQLite` from `[deps]` to `[weakdeps]` changes the user-facing loading contract (`using PormG` → `using PormG, LibPQ`). With zero published users the migration cost is zero; after the first release it becomes a breaking change forced on every adopter. The 0.1.0 publish window is the right (and cheapest) time.
-  - **Chosen model**: Weakdeps + extensions in this repo (single package). `LibPQ` and `SQLite` become `[weakdeps]`; driver code moves into `ext/PormGLibPQExt.jl` and `ext/PormGSQLiteExt.jl` (machinery already exists — see `PormGReviseExt`, `PormGTachikomaExt`). User opts in with `using PormG, LibPQ` / `using PormG, SQLite`. (Rejected: separate backend packages, asymmetric SQLite-bundled.)
-  - **Key insight — the real driver surface is small**: Of the ~27 files referencing `SQLite`, most are **SQL-string generation (dialect)** that never touch the driver package and can stay in core. The code that genuinely needs the driver package is concentrated in ~4 places: `src/ConnectionPool.jl`, `src/querybuilder/execution*.jl`, and the one version probe `SQLite.C.sqlite3_libversion_number()` in `src/Dialect.jl`. Split "dialect" (pure SQL, stays in core) from "driver" (open/execute/release, moves to extension).
-  - **Hard blocker to clear first — core structs name concrete driver types**: extensions can add methods to core generics but core cannot reference names defined in an extension. These must stop naming `LibPQ.Connection` / `SQLite.DB`:
-    - `PostgresConnectionPool.connections::Vector{Union{Nothing, LibPQ.Connection}}` ([ConnectionPool.jl:88-89](src/ConnectionPool.jl#L88-L89))
-    - `SQLiteConnectionPool.connections::Vector{Union{Nothing, SQLite.DB}}` ([ConnectionPool.jl:96-97](src/ConnectionPool.jl#L96-L97))
-    - Driver-typed method signatures: `release_connection`, `is_connection_alive`, `reconnect_db`, `libpq_execute`/`sqlite_execute`, `libpq_execute_async`/`sqlite_execute_async`, `_create_sqlite_connection`, `close_pool!` (all in `ConnectionPool.jl`).
-  - **Ordered plan**:
-    1. Define backend interface as empty generics in core: connection open, `execute`, `execute_async`, `release`, `is_alive`, `reconnect`, plus the SQLite version probe. Keep dispatch keyed on the existing `PormGPostgres`/`PormGSQLite` abstract types.
-    2. Erase concrete driver types from core: make the pool generic (`Pool{C}`) or store connections behind an abstract `AbstractDBConnection` wrapper so core never writes `SQLite.DB` / `LibPQ.Connection`.
-    3. Move all `LibPQ.*` / `SQLite.*` method bodies into `ext/PormGLibPQExt.jl` / `ext/PormGSQLiteExt.jl`; add the two `[extensions]` entries and move both packages to `[weakdeps]` in `Project.toml`.
-    4. Keep dialect/SQL-string code in core untouched (no driver dependency there).
-    5. Update docs + README install/quick-start to show `using PormG, LibPQ` (and SQLite equivalent); document the backend interface as the official path for a future 3rd backend (MySQL/DuckDB).
-    6. Add a CI job (or test) that loads PormG **without** each driver to prove core has no hard driver reference, and one per backend that loads the driver and runs the existing suite.
-
-- [ ] **Curate the public export surface** ⚠️ *do BEFORE the first General-registry publish* — **Tier 2 (breaks every user's `using` at once); coupled with adapter decoupling — do AFTER it**
-  - **Why now**: Un-exporting a name after publish breaks all `using PormG`-based user code. The current surface was never curated — decide the public/internal boundary before anyone depends on it.
-  - **Problems in the current surface**:
-    - **Collision-prone generic names** dumped into `Main`: `Sum, Avg, Count, Max, Min, F, Q, Value, Case, When, Rank, Extract, Lag, Lead, Round, Floor, Ceil, Sqrt, Exp, Ln, Mod, Abs, Length, Power, Replace, Trim, With, OP`. Consider namespacing (`PormG.Sum`) or a submodule (`using PormG.Functions`) instead of flooding the user namespace.
-    - **`fetch` is exported but does not extend `Base.fetch`** (only `first, get` are imported from Base at [src/QueryBuilder.jl:17](src/QueryBuilder.jl#L17)) — so `using PormG` shadows `Base.fetch` and forces qualification. Audit every export that collides with Base; either `import Base: x` to extend, or rename/un-export.
-    - **Driver internals are exported**: `libpq_execute`, `libpq_execute_async`, `is_connection_alive`, `reconnect_db`. This is incoherent with the adapter-decoupling item — a core-exported `libpq_execute` cannot survive `LibPQ` moving to an extension. **Curate exports and decouple adapters in the same pass.**
-    - **Duplicate exports** to clean up: `close_pool!`, `with_advisory_lock`, `with_savepoint`, `fetch_async`/`await_result`/`FetchTask` are each exported more than once.
-  - **Goal**: produce an explicit, documented list of public symbols; move everything else to internal (unexported). Add an Aqua/test check that the public export list matches the documented API.
-  - **Related**: settle the `list()` default return shape (`Vector{PormGRow}`) as a documented contract — see *Strongly Typed Model Returns* under Performance & Type Stability.
-
-- [ ] **Isolated PostgreSQL migration fixture (`db_test_migration_pg/`)**
-  - **Context**: The migration edge-case suite in `test/integration/test_migration_bootstrap.jl` (Phase C) needs a throwaway database. When `test/integration/db_test_migration_pg/connection.yml` is absent, it falls back to hydrating from the *selected* integration DB and runs `_reset_postgres!`, which **drops every table in `public`** ([test_migration_bootstrap.jl:180](test/integration/test_migration_bootstrap.jl#L180)). Running the Postgres edge-case suite against the shared `db_2` (`pormg_teste`) would therefore wipe it.
-  - **Goal**: Commit a `db_test_migration_pg/connection.yml` pointing at a dedicated, disposable PostgreSQL database (separate from `db_2`) so the full Postgres edge-case suite — including the `PositiveSmallIntegerField` CHECK lifecycle (Phase 8a2) — runs in isolation without risking the shared integration DB.
-  - **Status**: The CHECK lifecycle is already verified — through the real `makemigrations`/`migrate` engine on SQLite (Phase 8a2 passes), and via the live `get_constraints_check` / `alter_field` introspection paths on PostgreSQL. This item only tracks wiring the isolated fixture so Phase 8a2 also runs end-to-end on Postgres in CI.
-
-
-- [ ] **Investigate PG pool exhaustion under remote-latency integration runs**
-  - **Symptom**: Running `test/integration/runtests.jl` against the remote `db_2` (`pormg_teste` @ 187.121.224.221) logs `PG pool expanded beyond initial size (current_size=15, initial_size=3)` followed by repeated `No available PG connections, retrying (N/300)`.
-  - **Root cause (current understanding)**: The `dev` section of [test/integration/db_2/connection.yml](test/integration/db_2/connection.yml) sets no `pool_size`, so it defaults to **3** ([Configuration.jl:221](src/Configuration.jl#L221)); the hard expansion cap is `pool_size * 5` = **15** ([ConnectionPool.jl:244](src/ConnectionPool.jl#L244)). The async-first suite saturates the small pool against a high-latency remote DB and parks callers in the 100ms retry loop. All release paths (`await_result`/`run_in_transaction` `finally`, `fetch_async` error path) appear correct — this looks like sizing/contention, not a leak.
-  - **To verify**: Confirm whether the suite ever reaches `300/300` and throws (genuine starvation) vs. recovering after a few retries (transient backpressure). If it only recovers, the warnings are cosmetic; if it throws/hangs, sizing is mandatory.
-  - **Likely fix**: a larger initial pool so it never expands. ⚠️ **Not via `db_2/connection.yml`** — `*connection.yml` is git-ignored (`.gitignore:3`), so a `pool_size:` there only fixes the local machine and a fresh checkout reverts to default 3. A durable fix must be committed: set the test pool size in `test/integration/common_setup.jl` (after `Configuration.load`) or raise the in-code default, and/or root-cause the contention/leak. Consider lowering the `@warn`/retry noise or making expansion silent up to the cap.
-  - **Also audit**: whether any code path calls `fetch_async` without an `await_result` (would leak a connection), and whether `bulk_*`/`inspect_query`/COPY paths always release.
+- [#32](https://github.com/PingoLee/PormG.jl/issues/32) — ⚠️ **[Tier 1]** Freeze & document the migration file + tracking-table contract
+- [#33](https://github.com/PingoLee/PormG.jl/issues/33) — ⚠️ **[Tier 1]** Freeze & document the generated DB schema conventions
+- [#34](https://github.com/PingoLee/PormG.jl/issues/34) — ⚠️ **[Tier 2]** Decouple SQL adapters into weakdeps + extensions
+- [#35](https://github.com/PingoLee/PormG.jl/issues/35) — ⚠️ **[Tier 2]** Curate the public export surface
+- [#36](https://github.com/PingoLee/PormG.jl/issues/36) — Isolated PostgreSQL migration fixture (`db_test_migration_pg/`)
+- [#37](https://github.com/PingoLee/PormG.jl/issues/37) — Investigate PG pool exhaustion under remote-latency integration runs
 
 ## 🏗 Phase 2: Operational Maturity
 
-- [ ] **Advanced Migration Support**
-  - [ ] **Rename Operations**: Better detection and handling of renamed models/fields.
-  - [ ] **Non-Interactive Renames**: Allow explicit rename hints or declarative rename operations so CI does not depend on prompts.
-  - [ ] **Targeted Execution**: Support `migrate_to(version)` / `up(version)` instead of only applying the latest pending diff.
-  - [ ] **Rollback / Reversible Migrations**: Support `rollback()`, `down`, `last_down`, and rollback-to-version flows for operational recovery.
-  - [ ] **Deployment Safety**: Define startup-safe locking and clear failure semantics for multi-instance deploys.
-  - [ ] **Data Migration Support**: Support manual SQL or Julia functions in migrations for complex transformations (e.g., splitting columns).
-  - [ ] **Schema Object Coverage**: Add first-class migration support for views, triggers, composite constraints/indexes, and other non-table schema objects.
-
-- [ ] **SQLite Parity**: Carry over PostgreSQL improvements to the SQLite adapter where possible.
-- [ ] **Documentation Expansion**:
-  - [ ] Expand the Formula 1 dataset examples in the docs.
-  - [ ] Add a "PostgreSQL Power User" guide.
-
-- [ ] **Performance & Type Stability**
-  - **Context**: `list()` now returns `Vector{PormGRow}` by default, while `list(:dict)` preserves the dynamic dictionary path for integrations that require real `Dict` values. Fully concrete application structs would still be faster for high-throughput Nitro.jl applications.
-  - **Goal**: Allow queries to return concrete Julia `struct` types instead of dynamically typed Dictionaries.
-  - [ ] **Strongly Typed Model Returns (Nitro compatibility)**: Implement `list_as(query, MyModel)` or similar to map DB results directly to typed structs.
-  - [ ] **Fast JSON Serialization**: Optimize serialization path (e.g., via `JSON3.jl`) to leverage type-stable structs for lightning-fast JSON output.
-  - [ ] **Review `OperObject.values` Type Design**: Evaluate whether the large Union in `OperObject.values` should stay as-is, be grouped behind type aliases, or move to a parametric/tagged representation. Only pursue a runtime change if profiling shows it is a real bottleneck.
-  - [ ] **Allocation Reduction with IO Strategy**:
-    - **Context**: String concatenation (`*=` and interpolation) in the query builder triggers significant GC overhead.
-    - [ ] Expand the `IOBuffer` approach used in `query()` to `insert()`, `update()`, `delete()`, `do_count()`, and `do_exists()`.
-    - [ ] Refactor internal helper functions (`_query_select`, `build_cte_clause`, etc.) to optionally take an `IO` object.
-  - [ ] **Performance Benchmarking**: Establish a baseline for query generation and execution overhead.
-  - [ ] **Thread Safety**: Audit connection pool for concurrent `Async` safety.
+- [#38](https://github.com/PingoLee/PormG.jl/issues/38) — Advanced migration support (renames, targeted execution, rollback, deployment safety, data migrations, schema objects)
+- [#39](https://github.com/PingoLee/PormG.jl/issues/39) — SQLite parity with PostgreSQL features
+- [#40](https://github.com/PingoLee/PormG.jl/issues/40) — Documentation expansion (F1 examples, PostgreSQL power-user guide)
+- [#41](https://github.com/PingoLee/PormG.jl/issues/41) — Performance & type stability (typed returns, fast JSON, IO allocation, benchmarking, thread-safety audit)
 
 ## 🔍 Review possible issues
 
-Issues identified during the code review of recent main changes
-
-- [ ] **`Base.getproperty(q::ObjectHandler)` — accumulated issues** (`src/querybuilder/object_manager.jl`)
-  Several unrelated problems were noticed while working on the `list(format)` / `PormGRow` feature. None are blockers today but should be addressed before a public release.
-
-  - [ ] **`:inspect_query` alias** — `sym === :inspect_query || sym === :inspect` has the same problem as `:all` had for `:list`: two names for one terminal, only the shorter `:inspect` should survive. The alias won't forward new positional args if `:inspect` ever gains them.
-
-  - [ ] **`:count` and `:exists` silently ignore `show_query`** — both are bound as `return () -> do_count(q)` with no kwargs. There is no way to inspect the generated SQL. Should become `return (; show_query=:execute) -> do_count(q; show_query=show_query)` (and same for `:exists`).
-
-  - [ ] **`args...` is widespread and type-unstable** — `:with`, `:cjoin`, `:on`, `:create`, `:update` all use `(args...; kwargs...)`. The compiler cannot infer return types for these closures. For chainable methods this is tolerable (return type is always `ObjectHandler`), but for `:create` and `:update` the return type is unknown. Consider typed signatures where the argument shape is fixed.
-
-  - [ ] **Category 2/3 comment is mis-indented** — the `# === CATEGORY 2: Terminal methods ===` comment sits inside the `elseif sym === :copy` block due to indentation, making the structure misleading when reading the file. Cosmetic but confusing.
-
-- [ ] **Centralize ANSI color in error/log messages behind a TTY check**
-  - **Context**: Error and log strings hardcode raw ANSI escape codes (`\e[4m\e[31m…\e[0m`) to emphasize values — ~28 occurrences across 9 files (`src/querybuilder/execution_bulk.jl`, `execution.jl`, `deletion.jl`, `ctes.jl`, `many_to_many.jl`, `build_*.jl`, `migrations/planner.jl`). There is no TTY guard anywhere, so the codes are emitted unconditionally.
-  - **Problem**: The codes only render as color on a real terminal. In any non-TTY sink — log files, CI logs, the IDE output panel, `sprint(showerror, e)`, serialized error reports — they appear as literal garbage (`^[[4m^[[31mpoints^[[0m`). Thrown `ArgumentError`/`ErrorException` messages are the worst offenders, since `showerror` re-displays them in many non-TTY contexts (test-failure dumps, captured strings).
-  - **Goal**: Add one helper (e.g. `emph(x; color=:red, underline=true)`) that colors only when `get(stderr, :color, false)` is true and returns plain text otherwise; route all call sites through it. Honors Julia's `--color` flag and `NO_COLOR`.
-  - **Scope**: prioritize the exception call sites over `@warn`/`@error` logs. Add a regression test asserting no `\e[` leaks into a message when color is disabled.
-
-- [ ] **`deepcopy(ctes)` → `copy(ctes)` shared-state risk**
-  - **Location**: `src/querybuilder/types.jl`, `Base.deepcopy(::SQLObjectQuery)`.
-  - **Issue**: Two query objects created via `deepcopy(query)` now share CTE sub-query internal state (filters, values). Mutating a CTE after the copy affects both queries.
-  - **Fix**: Document the limitation, or implement a custom deep-copy that clones CTE dict values without traversing Module references.
-
-- [ ] **Think in this aproach** With new aproach:
-   # Main query joining CTE
-    q = M.Result.objects.with("r91" => races_91).filter(
-        "raceid" => F("r91__raceid"),
-        "positionorder" => 1
-    )
-
-
-- [/] **SQLite `INSERT ... RETURNING *` hang + worker/pool stability** (`src/querybuilder/execution.jl`, `src/ConnectionPool.jl`)
-  Surfaced running the SQLite integration suite (`PORMG_DB=db_sl julia -t 1 --project=. test/integration/runtests.jl`) on Windows + SQLite.jl 3.51.
-  - [x] **`create()` RETURNING hang** — `INSERT ... RETURNING *` spun indefinitely inside libsqlite3 for tables whose AUTOINCREMENT primary key migrations left in a non-first column position (e.g. `django_contract_scratch`, pk `id` at column 3). The old broad `catch` masked it by re-running a plain INSERT, which then tripped a spurious UNIQUE violation because the first INSERT had already written the row. **Fixed** (branch `fix/sqlite-insert-returning-hang`): plain INSERT + `SELECT * WHERE rowid = last_insert_rowid()` read-back on the same connection (pinned via `run_in_transaction`); broad catch removed; the returned Dict still carries all columns (matches the Postgres `RETURNING *` contract, incl. unset nullables).
-  - [ ] **Native segfault in the SQLite async worker** — intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64` during F1 fixture seeding (`test_database_setup.jl`); nondeterministic (GC-timed, did not recur on re-run). Suspect: the single global `Threads.@spawn` worker + GC finalizers racing on `SQLite.Stmt`/`SQLite.DB` objects.
-  - [x] **SQLite connection-pool timeout in transactions** — "Timeout after 30s waiting for available SQLite connection" in `test_transactions.jl`. **Root-caused & fixed 2026-06-24** (branch `feat/bulk-case-sensitive-matching`). It was **not** a pool leak or accounting bug (the pool returns to `in_use=0` after every other testset — verified by instrumenting `available[]` across the whole suite). It was a **writer-serialization deadlock**: the trigger is the *"Multithreaded inserts"* subtest (5 concurrent `create()` calls, no explicit tx). Each `create()` wraps its INSERT in `run_in_transaction` → `BEGIN IMMEDIATE`. SQLite allows one writer per file, and every statement funnels through the **single global async worker** ([ConnectionPool.jl](src/ConnectionPool.jl) `_ensure_sqlite_async_worker!`). A *losing* `BEGIN IMMEDIATE` blocks **inside libsqlite3** for `busy_timeout=30000ms` (a native call) — while it blocks, the worker can't run the *winning* tx's INSERT/COMMIT, so the winner never releases the lock → deadlock until 30s elapse. Under `-t 1` the native call also freezes every Julia task, so `acquire_connection`'s 30s timer expires → the timeout. This is why **a bigger pool never helped** (it's writer serialization, not slot contention) and why PostgreSQL is immune (real MVCC). **Fix:** a per-pool `write_lock` on `SQLiteConnectionPool` held for the whole `BEGIN..COMMIT/ROLLBACK` via `ConnectionPool.with_sqlite_write_lock` (no-op on PG), applied in `run_in_transaction` (covers `create`/`update`/`bulk_*`/`save`/m2m), in the `delete()` manual-transaction path ([deletion.jl](src/querybuilder/deletion.jl)), and in the SQLite migration lifecycle ([runner.jl](src/migrations/runner.jl) `_execute_migration_lifecycle`). Now only one `BEGIN IMMEDIATE` is ever outstanding across *every* SQLite write path; reads (WAL) are unaffected. **Verified:** full SQLite suite **1380/1380 pass** (was stopping dead at Transactions); `test_transactions.jl` 37/37 incl. a new regression testset *"Concurrent writers exceed pool size without deadlock"* (8 writers + a concurrent delete vs. default pool 3). No `pool_size` override needed — the committed default 3 works.
-  - **Note**: PostgreSQL (`db_2`) is the validated integration path (re-run 2026-06-23: **1355/1356 pass**; the lone error is `Migration Engine Edge Cases (PostgreSQL temp DB)`, whose `_reset_postgres!` needs fresh connections and errored during a transient remote-host TCP timeout — `Connection timed out (10060)` to `187.121.224.221` — a network/infra blip, not a code bug; the same run's bulk case-sensitivity testsets all passed: Inserts 91/91, Updates 201/201, Internals 63/63, Bulk copy 55/55). Treat the two open SQLite items as a worker/pool-stability effort (async-worker/pool redesign or a SQLite.jl bump), not a quick patch.
+- [#42](https://github.com/PingoLee/PormG.jl/issues/42) — `ObjectHandler` getproperty cleanup (`:inspect` alias, `:count`/`:exists` ignore `show_query`, `args...` type instability)
+- [#43](https://github.com/PingoLee/PormG.jl/issues/43) — `deepcopy(ctes)` → `copy(ctes)` shared-state risk
+- [#44](https://github.com/PingoLee/PormG.jl/issues/44) — CTE ergonomics: reference CTE fields via `F()` in the main query
 
 ## 🔗 Custom Join (`cjoin`) Gaps
 
-Features needed to express complex join patterns (e.g., self-joins with multi-OR ON clauses, field-to-field comparisons, SQL functions in ON) without falling back to raw SQL.
+- [#45](https://github.com/PingoLee/PormG.jl/issues/45) — `cjoin` gaps: arbitrary ON clauses, cross-table `F()` in ON, SQL functions in ON (`strftime`/`EXTRACT`)
 
-### Motivation: Target Raw SQL
-The following self-join query is currently impossible to represent natively in PormG due to the complex `OR` logic, cross-table comparisons, and string/date formatting functions directly in the `ON` clause:
+## 🐞 SQLite worker / pool stability
 
-```sql
-SELECT
-    b1."index" as id1,
-    b2."index" as id2,
-    b1.nome as nome1,
-    b2.nome as nome2,
-    b1.nome_mae as nm_m1,
-    b2.nome_mae as nm_m2,
-    b1.dn as dn1,
-    b2.dn as dn2
-FROM b1_proc as b1            
-INNER JOIN b2_proc as b2 ON b2.dn = b1.dn OR 
-    (b2.sxpn = b1.sxpn AND b2.sxun = b1.sxun AND b2.sxpnm = b1.sxpnm AND NOT b2.sxpnm IS NULL) OR
-    (b2.sxpn = b1.sxpn AND b2.sxsn = b1.sxsn AND b2.sexo = b1.sexo) OR
-    (b2.sxun = b1.sxun AND strftime('%Y', b2.dn) = strftime('%Y', b1.dn))
-WHERE
-    b1."index" >= $inicio AND b1."index" <= $fim AND
-    NOT b1."index" IS NULL AND NOT b2."index" IS NULL
-ORDER BY id1, id2
-```
+- [#47](https://github.com/PingoLee/PormG.jl/issues/47) — SQLite connection / file-handle release at teardown (`close_pool!` leased-close + non-idempotent `_close_db!`)
 
-- [ ] **Arbitrary ON clauses in `cjoin`**
-  - **Context**: `cjoin` always establishes a single equi-join anchor (`main.field = target.pk_field`) and appends user filters with AND. Queries where the entire ON clause is a custom disjunction (e.g., 4 independent OR branches comparing different column pairs) cannot be expressed.
-  - **Goal**: Allow `Qor()` / `Q()` / `F()` expressions to **fully replace** the default equi-join condition, not just append to it. Possibly via a `on_replace=true` flag or a new `cjoin` overload that accepts only filter expressions as the join condition.
-  - **Example that should work**:
-    ```julia
-    # Self-join b1_proc ↔ b2_proc with pure OR logic in ON
-    query = M.B1_proc.objects
-    query.cjoin("index" => "B2_proc",
-        on=[Qor(
-            F("b2.dn") == F("b1.dn"),
-            Q(F("b2.sxpn") == F("b1.sxpn"), F("b2.sxun") == F("b1.sxun"), ...),
-            ...
-        )],
-        join_type="INNER"
-    )
-    ```
+## 🔮 Future Considerations
 
-- [ ] **Cross-table F-expressions in ON clauses**
-  - **Context**: `F()` expressions currently work in `filter()` (WHERE) and `values()` (SELECT), but `cjoin` filters do not support `F()` for field-to-field comparisons across both sides of the join (e.g., `F("b2.sxpn") == F("b1.sxpn")`). The filter normalization in `_prefix_join_filter` only handles the joined model's fields.
-  - **Goal**: Support `F()` references that resolve to columns on **either** side of the join inside ON-clause predicates. Requires the SQL renderer to alias-qualify both left and right sides correctly.
-  - **Touches**: `src/querybuilder/ctes.jl` (`_prefix_join_filter`, `cjoin`), `src/querybuilder/build_joins.jl` (ON clause rendering), `src/Dialect.jl` (alias resolution).
+- [#46](https://github.com/PingoLee/PormG.jl/issues/46) — Parameterize LIMIT/OFFSET
 
-- [ ] **SQL functions in join conditions (e.g., `strftime`, `EXTRACT`)**
-  - **Context**: Date transforms like `__@year` exist for WHERE/SELECT, but they are not recognized inside ON clauses. Queries that join on `strftime('%Y', b2.dn) = strftime('%Y', b1.dn)` or `EXTRACT(YEAR FROM ...)` cannot be expressed in `cjoin` filters.
-  - **Goal**: Allow date transforms (`__@year`, `__@month`, etc.) and possibly arbitrary SQL functions to work inside `cjoin` filter expressions, generating the correct dialect-aware SQL in the ON clause.
-  - **Dialect note**: SQLite uses `strftime('%Y', col)`, PostgreSQL uses `EXTRACT(YEAR FROM col)` — the existing `__@year` transform already handles this divergence in WHERE; the same logic needs to be reachable from ON-clause rendering.
+---
 
-## Future Considerations
-- [ ] **Parameterize LIMIT/OFFSET (Future)**
-  - **Context**: Currently, `LIMIT` and `OFFSET` are rendered as literal integers in the SQL string. This is safe (Julia enforces `Int` types), but parameterizing them would enable prepared statement caching across different page sizes and improve consistency with the bucket strategy.
-  - **Task**: Add a `:limit` bucket to `PormGPositionalParam`, render `LIMIT ?` / `OFFSET ?`, and append values at the tail of `get_final_parameters` (after `:having`).
+*Completed work is not listed here — see [closed issues](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aissue+is%3Aclosed). (Work that predates the issue tracker lives in git history.)*

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -6,6 +6,7 @@ import PormG: @pormg_debug
 
 import SQLite
 import LibPQ
+import Tables
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, with_savepoint, with_savepoint
@@ -501,14 +502,51 @@ function libpq_execute(conn::LibPQ.Connection, sql::String, params::Vector{Any})
 end
 libpq_execute(conn::LibPQ.Connection, sql::String, params::PormGPostgresParam) = libpq_execute(conn, sql, params.parameters)
 
+# Prepare an UNREGISTERED statement, execute it, fully materialize the result rows into a
+# connection-independent rowtable, and finalize the statement deterministically.
+#
+# Why not `SQLite.DBInterface.execute(conn, sql, params)` directly: that path
+# (`execute(prepare(conn, sql), params)`) *registers* the `SQLite.Stmt` in the DB's
+# `WeakKeyDict` and returns a *lazy* cursor whose backing `sqlite3_stmt` is finalized only
+# when the GC later runs the `Stmt` finalizer — on an arbitrary thread, at an arbitrary
+# safepoint. Two consequences, both observed as instability on SQLite:
+#
+#   1. The lazy cursor outlived its pool lease: `await_result` releases the connection as
+#      soon as `fetch` returns, but callers materialized the rows (`Tables.rowtable`, etc.)
+#      afterwards — stepping a cursor on a connection that had already been handed back to
+#      the pool and possibly reused by another statement.
+#   2. Under bulk seeding, thousands of registered `Stmt`s accumulate, each with a pending
+#      `sqlite3_finalize` finalizer. Those fire while the single async worker is mid
+#      `bind`/`step` on the same connection. SQLite is built serialized (THREADSAFE=1) so a
+#      well-formed concurrent call is mutex-safe, but combined with the non-idempotent
+#      explicit-close paths this opened a use-after-free / double-free window that surfaced
+#      as an intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64`.
+#
+# Preparing with `register = false` keeps the statement out of the `WeakKeyDict` (so a DB
+# close never double-finalizes it), `Tables.rowtable` materializes every row while the
+# connection is still leased on the worker, and the explicit `close!` finalizes the
+# statement immediately instead of deferring to the GC. The returned rowtable is a plain
+# `Vector{<:NamedTuple}` that is safe to hand back across the response channel.
+function _sqlite_execute_materialized(conn::SQLite.DB, sql::String, params)
+  stmt = SQLite.Stmt(conn, sql; register = false)
+  try
+    cursor = params === nothing ?
+      SQLite.DBInterface.execute(stmt) :
+      SQLite.DBInterface.execute(stmt, params)
+    return Tables.rowtable(cursor)
+  finally
+    SQLite.DBInterface.close!(stmt)
+  end
+end
+
 function sqlite_execute(conn::SQLite.DB, sql::String, params::Nothing)
-  return _sqlite_with_retry(() -> SQLite.DBInterface.execute(conn, sql))
+  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, nothing))
 end
 function sqlite_execute(conn::SQLite.DB, sql::String, params::Vector{Any})
-  return _sqlite_with_retry(() -> SQLite.DBInterface.execute(conn, sql, params))
+  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, params))
 end
 function sqlite_execute(conn::SQLite.DB, sql::String, params::PormGSQLiteParam)
-  return _sqlite_with_retry(() -> SQLite.DBInterface.execute(conn, sql, params.parameters))
+  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, params.parameters))
 end
 
 mutable struct SQLiteAsyncWorkItem

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -22,6 +22,7 @@ import PormG.Configuration: get_settings
 using Logging
 
 import PormG: @pormg_debug
+import PormG: _emsg  # shared TTY-aware error/log-message strip helper (tools.jl)
 
 import PormG: Models, Migration, Dialect
 import PormG.Models: format_model_name

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -6,6 +6,7 @@ using UUIDs
 import JSON
 import PormG: PormGField, PormGModel, reserved_words, Migration
 import PormG: DATETIME_FORMAT
+import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG: SQLConn, config, Configuration
 import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING, PROTECT
 # import PormG: make_password, check_password, password_needs_upgrade, DEFAULT_PBKDF2_ITERATIONS
@@ -443,7 +444,7 @@ function Model(name::AbstractString, fields::Dict{Symbol, Any})
 end
 function Model(name::String)
   example_usage = "\e[32musers = Models.PormGModel(\"users\", name = Models.CharField(), age = Models.IntegerField())\e[0m"
-  throw(ArgumentError("You need to add fields to the model, example: $example_usage"))
+  throw(ArgumentError(_emsg("You need to add fields to the model, example: $example_usage")))
 end
 function Model(; fields...)
   return Model("", fields |> Tuple)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -9,6 +9,7 @@ import PormG: Dialect, Models
 import PormG: config
 import PormG: SQLType, SQLConn, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
 import PormG: PormGsuffix, PormGtransform, run_in_transaction
+import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,
 	get_sqlite_reserved_primary_key_max, register_sqlite_reserved_primary_key_max!,

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -77,7 +77,7 @@ function import_models_from_sqlite(db::String = "db";
 
   generate_models_from_db(file, Instructions, settings; path=model_path)
 
-  @info("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m")
+  @info(_emsg("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m"))
   @info("The models have been saved to '$(joinpath(model_path, file))'.")
 
   return nothing
@@ -148,7 +148,7 @@ function import_models_from_postgres(db::String;
   # Generate the models file
   generate_models_from_db(file, Instructions, settings, path=model_path)
   
-  @info("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m")
+  @info(_emsg("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m"))
   @info("The models have been saved to '$(joinpath(model_path, file))'.")
   
   return nothing
@@ -186,7 +186,7 @@ function import_models_from_postgres(;db::PormGPostgres = connection(),
   # Generate the models file
   generate_models_from_db(file, Instructions, settings, path=model_path)
   
-  @info("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m")
+  @info(_emsg("\e[32mSuccessfully imported $(length(models_array)) models from the database.\e[0m"))
   @info("The models have been saved to '$(joinpath(model_path, file))'.")
   
   return nothing

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -307,7 +307,7 @@ function _resolve_table_fields(
     else       
       response = "no"
       if interactive
-        print("Is the field \"\e[4m\e[31m$field_name\e[0m\" from table \"\e[4m\e[34m$model_name\e[0m\" the same as one of the following fields: \e[4m\e[33m$list_to_question\e[0m? If yes, please enter the corresponding number; otherwise, type 'no':")
+        print(_emsg("Is the field \"\e[4m\e[31m$field_name\e[0m\" from table \"\e[4m\e[34m$model_name\e[0m\" the same as one of the following fields: \e[4m\e[33m$list_to_question\e[0m? If yes, please enter the corresponding number; otherwise, type 'no':"))
         response = readline()
         response = strip(lowercase(response))
       end
@@ -512,7 +512,7 @@ migration_plan = get_migration_plan(models_array, current_models, connection, se
 
 # store migration_plan as pending_migrations.jl file
 if migration_plan |> isempty
-  @info("\e[32mYour database schema is already up-to-date. No migrations are pending.\e[0m")    
+  @info(_emsg("\e[32mYour database schema is already up-to-date. No migrations are pending.\e[0m"))    
 else     
   path = joinpath(settings.db_def_folder, "migrations")
   if !ispath(path)
@@ -520,7 +520,7 @@ else
   end
   generate_migration_plan("pending_migrations.jl", migration_plan, path)
   @warn("The migration plan has been saved to '$(settings.db_def_folder)/migrations/pending_migrations.jl'. Review the plan before applying the migrations.")
-  @info("\e[32mMigration plan generated successfully. Run 'PormG.Migrations.migrate($( settings.db_def_folder == "db" ? "" : string("\"", settings.db_def_folder, "\"")))' to apply the migrations.\e[0m")
+  @info(_emsg("\e[32mMigration plan generated successfully. Run 'PormG.Migrations.migrate($( settings.db_def_folder == "db" ? "" : string("\"", settings.db_def_folder, "\"")))' to apply the migrations.\e[0m"))
 end
 
 end
@@ -548,7 +548,7 @@ function makemigrations(connection::PormGSQLite, settings::SQLConn; path::String
 
   # store migration_plan as pending_migrations.jl file
   if migration_plan |> isempty
-    @info("\e[32mYour database schema is already up-to-date. No migrations are pending.\e[0m")    
+    @info(_emsg("\e[32mYour database schema is already up-to-date. No migrations are pending.\e[0m"))    
   else     
     path = joinpath(settings.db_def_folder, "migrations")
     if !ispath(path)
@@ -556,7 +556,7 @@ function makemigrations(connection::PormGSQLite, settings::SQLConn; path::String
     end
     generate_migration_plan("pending_migrations.jl", migration_plan, path)
     @warn("The migration plan has been saved to '$(settings.db_def_folder)/migrations/pending_migrations.jl'. Review the plan before applying the migrations.")
-    @info("\e[32mMigration plan generated successfully. Run 'PormG.Migrations.migrate($( settings.db_def_folder == "db" ? "" : string("\"", settings.db_def_folder, "\"")))' to apply the migrations.\e[0m")
+    @info(_emsg("\e[32mMigration plan generated successfully. Run 'PormG.Migrations.migrate($( settings.db_def_folder == "db" ? "" : string("\"", settings.db_def_folder, "\"")))' to apply the migrations.\e[0m"))
   end
 end
 

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -246,14 +246,14 @@ function Base.show(io::IO, s::MigrationStatus)
   println(io, "  History table: ", s.has_history_table ? "✓ exists" : "✗ not initialized (run init_migrations)")
   println(io, "  Applied: ", length(s.applied), " migration(s)")
   if !isempty(s.failed)
-    println(io, "  \e[31mFailed: ", length(s.failed), " migration(s)\e[0m")
+    println(io, _emsg(io, "  \e[31mFailed: $(length(s.failed)) migration(s)\e[0m"))
     for m in s.failed
       println(io, "    - v", m[:version], " ", m[:name])
     end
   end
-  println(io, "  Pending file: ", s.pending ? "\e[33myes (review and run migrate)\e[0m" : "none")
+  println(io, "  Pending file: ", _emsg(io, s.pending ? "\e[33myes (review and run migrate)\e[0m" : "none"))
   if !isempty(s.drift_signals)
-    println(io, "  \e[33mDrift signals:\e[0m")
+    println(io, _emsg(io, "  \e[33mDrift signals:\e[0m"))
     for d in s.drift_signals
       println(io, "    ⚠ ", d)
     end
@@ -420,14 +420,14 @@ function Base.show(io::IO, r::DryRunResult)
   println(io, "  Checksum: ", r.checksum[1:min(16, length(r.checksum))], "...")
   println(io, "  Total statements: ", total_statements(r))
   if is_destructive(r)
-    println(io, "  \e[31m⚠ DESTRUCTIVE: ", length(r.destructive_statements), " destructive statement(s)\e[0m")
+    println(io, _emsg(io, "  \e[31m⚠ DESTRUCTIVE: $(length(r.destructive_statements)) destructive statement(s)\e[0m"))
     for s in r.destructive_statements
       # Show first 120 chars of each destructive statement
       display_s = length(s) > 120 ? s[1:120] * "..." : s
       println(io, "    → ", display_s)
     end
   else
-    println(io, "  \e[32m✓ Safe (no destructive operations)\e[0m")
+    println(io, _emsg(io, "  \e[32m✓ Safe (no destructive operations)\e[0m"))
   end
   println(io, "\n  SQL statements:")
   for (i, s) in enumerate(r.statements)
@@ -623,7 +623,7 @@ function migrate(connection::PormGPostgres, settings::SQLConn;
   ordered_statements, all_sql = _order_statements(migration_plan)
   
   if isempty(ordered_statements)
-    @info("\e[32mNo SQL statements to execute.\e[0m")
+    @info(_emsg("\e[32mNo SQL statements to execute.\e[0m"))
     return nothing
   end
   
@@ -639,8 +639,8 @@ function migrate(connection::PormGPostgres, settings::SQLConn;
   
   # Destructive guard
   if has_destructive && !destructive
-    @error("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
-           "Pass `destructive=true` to confirm.\e[0m")
+    @error(_emsg("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
+           "Pass `destructive=true` to confirm.\e[0m"))
     for s in destructive_stmts
       display_s = length(s) > 120 ? s[1:120] * "..." : s
       @error("  → $display_s")
@@ -651,10 +651,10 @@ function migrate(connection::PormGPostgres, settings::SQLConn;
   # Interactive confirmation
   if interactive
     if has_destructive
-      @info("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m")
+      @info(_emsg("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m"))
     end
-    @info("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m")
-    print("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m")
+    @info(_emsg("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m"))
+    print(_emsg("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m"))
     response = readline()
     response = strip(lowercase(response))
     if !(response in ["yes", "y"])
@@ -700,7 +700,7 @@ function migrate(connection::PormGSQLite, settings::SQLConn;
   ordered_statements, all_sql = _order_statements(migration_plan)
   
   if isempty(ordered_statements)
-    @info("\e[32mNo SQL statements to execute.\e[0m")
+    @info(_emsg("\e[32mNo SQL statements to execute.\e[0m"))
     return nothing
   end
   
@@ -716,8 +716,8 @@ function migrate(connection::PormGSQLite, settings::SQLConn;
   
   # Destructive guard
   if has_destructive && !destructive
-    @error("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
-           "Pass `destructive=true` to confirm.\e[0m")
+    @error(_emsg("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
+           "Pass `destructive=true` to confirm.\e[0m"))
     for s in destructive_stmts
       display_s = length(s) > 120 ? s[1:120] * "..." : s
       @error("  → $display_s")
@@ -728,10 +728,10 @@ function migrate(connection::PormGSQLite, settings::SQLConn;
   # Interactive confirmation
   if interactive
     if has_destructive
-      @info("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m")
+      @info(_emsg("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m"))
     end
-    @info("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m")
-    print("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m")
+    @info(_emsg("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m"))
+    print(_emsg("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m"))
     response = readline()
     response = strip(lowercase(response))
     if !(response in ["yes", "y"])
@@ -767,7 +767,7 @@ function _execute_migration_lifecycle(connection::PormGPostgres, settings::SQLCo
     
     # Commit
     with_transaction(connection, "COMMIT;", conn=conn, release_conn=true)
-    @info("\e[32mMigrations applied successfully. Version: $version\e[0m")
+    @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
   catch e
     # Rollback and record failure
     try
@@ -819,7 +819,7 @@ function _execute_migration_lifecycle(connection::PormGSQLite, settings::SQLConn
 
       # Commit
       with_transaction(connection, "COMMIT;", conn=conn, release_conn=true)
-      @info("\e[32mMigrations applied successfully. Version: $version\e[0m")
+      @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
     catch e
       try
         with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=true)
@@ -987,7 +987,7 @@ whether a pending file exists.
 function discard_pending_migration(settings::SQLConn; backup::Bool = true)
   pending_path = joinpath(settings.db_def_folder, "migrations", "pending_migrations.jl")
   if !isfile(pending_path)
-    @info("\e[32mNo pending migration to discard.\e[0m")
+    @info(_emsg("\e[32mNo pending migration to discard.\e[0m"))
     return nothing
   end
 
@@ -1011,8 +1011,8 @@ function discard_pending_migration(settings::SQLConn; backup::Bool = true)
     rm(pending_path)
   end
 
-  @info("\e[33mDiscarded pending migration ($(tables) table(s), $(statements) statement(s)).\e[0m" *
-        (backup ? " Backup saved to $(backup_path)." : ""))
+  @info(_emsg("\e[33mDiscarded pending migration ($(tables) table(s), $(statements) statement(s)).\e[0m" *
+        (backup ? " Backup saved to $(backup_path)." : "")))
   return (discarded = true, path = pending_path, backup = backup_path, tables = tables, statements = statements)
 end
 

--- a/src/querybuilder/exceptions.jl
+++ b/src/querybuilder/exceptions.jl
@@ -16,12 +16,9 @@ Base.showerror(io::IO, e::MultipleObjectsReturned) =
   print(io, "$(e.model_name).MultipleObjectsReturned: Expected 1 record, got $(e.count) for filters: $(e.filters)")
 
 # ── Error-message colorization (TTY-aware) ──────────────────────────────────
-# Many error messages embed ANSI SGR codes (`\e[31m…`) to highlight the offending
-# token in the REPL. Those codes are nice on a color terminal but leak as raw
-# `\e[..m` noise into non-TTY sinks (CI output, file logs, structured logging).
-# `_emsg` strips them whenever Julia is not in color mode — the same flag Julia
-# itself consults to colorize error displays — so messages render coloured in the
-# REPL and as plain text everywhere else. `_argerr` wraps the common case so a
-# call site only changes `ArgumentError(` → `_argerr(`.
-_emsg(msg::AbstractString) = Base.have_color === true ? String(msg) : replace(msg, r"\e\[[0-9;]*m" => "")
+# `_emsg` (the single shared definition in `tools.jl`, imported via QueryBuilder's
+# `import PormG: … _emsg`) strips ANSI escape codes whenever Julia is not in color
+# mode, so coloured error tokens render in the REPL and as plain text in every
+# non-TTY sink (CI output, file logs, `sprint(showerror, e)`). `_argerr` wraps the
+# common case so a call site only changes `ArgumentError(` → `_argerr(`.
 _argerr(msg::AbstractString) = ArgumentError(_emsg(msg))

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -307,9 +307,12 @@ function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlia
     $(instruction.agregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "") 
     """
   query_result = fetch(settings, resposta, instruction.parameters)
-  # SQLite returns a Query iterator that doesn't support [row, col] indexing;
-  # convert to a rowtable first, then extract the scalar count value.
-  if query_result isa AbstractMatrix || hasmethod(getindex, Tuple{typeof(query_result), Int, Int})
+  # PostgreSQL returns a LibPQ.Result that supports scalar [row, col] indexing.
+  # SQLite returns a materialized rowtable (Vector{<:NamedTuple}); a Vector *also* has a
+  # (Int, Int) getindex method (trailing-singleton dimension), so exclude vectors explicitly
+  # and take the Tables path, which extracts the scalar from the single COUNT row.
+  if !(query_result isa AbstractVector) &&
+     (query_result isa AbstractMatrix || hasmethod(getindex, Tuple{typeof(query_result), Int, Int}))
     return query_result[1, 1]
   else
     row = Tables.rowtable(query_result) |> Base.first

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -475,7 +475,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   
   # Final sanity check for fields_df existence in model
   for field in fields_df
-    in(field, fields) || throw(_emsg("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(model.name)\e[0m"))
+    in(field, fields) || throw(_argerr("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(model.name)\e[0m"))
   end
 
   # Return fields_df cleaned up (unique and existing in mapping)
@@ -518,7 +518,7 @@ function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
   kind::String="match_on", allow_reuse::Bool=true)
 
   field in model.field_names ||
-    throw(ArgumentError("bulk_update: $(kind) field \e[4m\e[31m$(field)\e[0m is not a field of model $(model.name)"))
+    throw(_argerr("bulk_update: $(kind) field \e[4m\e[31m$(field)\e[0m is not a field of model $(model.name)"))
 
   resolved = if df_col in names(df)
     df_col                                # exact (case-sensitive) match wins

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,13 +1,43 @@
 
 """
+    _emsg(msg; color = (Base.have_color === true))
+
+TTY-aware error-message colorizer. Many PormG error strings embed ANSI SGR codes
+(`\\e[31m…\\e[0m`) to highlight the offending token in the REPL. Those codes are
+helpful on a color terminal but leak as raw `\\e[..m` noise into non-TTY sinks
+(CI output, file logs, `sprint(showerror, e)`, structured logging).
+
+`_emsg` keeps the codes when `color` is true and strips every `\\e[..m` sequence
+otherwise. The default tracks `Base.have_color` — the same flag Julia consults to
+colorize its own error displays, so it honors the `--color` flag and `NO_COLOR`.
+The `color` keyword exists so tests can exercise both branches deterministically.
+
+This is the single shared definition; `QueryBuilder` (`_argerr`) and `Models` both
+import it rather than re-embedding the strip logic.
+"""
+_emsg(msg::AbstractString; color::Bool = (Base.have_color === true)) =
+  color ? String(msg) : replace(msg, r"\e\[[0-9;]*m" => "")
+
+"""
+    _emsg(io, msg)
+
+IO-aware variant of [`_emsg`](@ref) for use inside `show` / `print(io, …)` methods:
+it keeps ANSI only when the destination stream advertises color via its `:color`
+IOContext property. This is the correct signal for rendered output, because a
+non-color buffer (`sprint`, `repr`, a captured string, a file) must stay ANSI-free
+even when the process itself is attached to a color terminal.
+"""
+_emsg(io::IO, msg::AbstractString) = _emsg(msg; color = get(io, :color, false))
+
+"""
     setup(path::String = DB_PATH)
 
 Interactively setup the `connection.yml` file for PormG.
 This will prompt for database adapter, name, and connection details.
 """
 function setup(path::String = DB_PATH)
-    println("\e[34m--- PormG Database Setup ---\e[0m")
-    println("Setting up configuration in folder: \e[32m$path\e[0m")
+    println(_emsg("\e[34m--- PormG Database Setup ---\e[0m"))
+    println(_emsg("Setting up configuration in folder: \e[32m$path\e[0m"))
 
     read_input() = String(strip(readline()))
     
@@ -67,11 +97,11 @@ function setup(path::String = DB_PATH)
 
     Generator.create_models_jl(path, models_filename)
 
-    println("\e[32mConfiguration saved successfully to $(joinpath(path, "connection.yml"))\e[0m")
-    println("You can now load it using: \e[36mPormG.Configuration.load(\"$path\")\e[0m")
+    println(_emsg("\e[32mConfiguration saved successfully to $(joinpath(path, "connection.yml"))\e[0m"))
+    println(_emsg("You can now load it using: \e[36mPormG.Configuration.load(\"$path\")\e[0m"))
 
     println()
-    println("\e[34m--- AI Assistant Setup ---\e[0m")
+    println(_emsg("\e[34m--- AI Assistant Setup ---\e[0m"))
     println("PormG can install 'AI skills' (.cursor/skills) to help coding assistants")
     println("(Cursor and other agents) understand the PormG API in your project.")
     print("Do you want to install PormG AI skills? (Y/n) [Default Y]: ")
@@ -103,7 +133,7 @@ function install_ai_skills(target_dir::String = pwd())
 
         if isfile(skill_src)
             cp(skill_src, target_skill_file; force=true)
-            println("\e[32mPormG AI skill installed → $target_skill_file\e[0m")
+            println(_emsg("\e[32mPormG AI skill installed → $target_skill_file\e[0m"))
             println("Your coding assistant now understands PormG's query API, models, and migrations.")
         else
             @warn "Could not find PormG skill blueprint" expected_path=skill_src

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
     @testset "Schema Importers (key resolution)" include("unit/test_importers.jl")
     @testset "Discard Pending Migration" include("unit/test_discard_pending_migration.jl")
     @testset "Positive Integer Fields CHECK" include("unit/test_positive_small_integer_check.jl")
+    @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     # include("unit/test_migration_planner.jl")
 end
 

--- a/test/unit/test_error_message_ansi.jl
+++ b/test/unit/test_error_message_ansi.jl
@@ -1,0 +1,186 @@
+using Test
+using PormG
+using PormG.Models: Model, IDField, IntegerField
+using PormG.QueryBuilder: bulk_update
+import DataFrames
+
+# Helpers under test live in the package namespace / QueryBuilder submodule.
+const _emsg = PormG._emsg
+const _argerr = PormG.QueryBuilder._argerr
+
+# A representative message carrying the same ANSI vocabulary the real call sites
+# use: underline + foreground color around the offending token, reset at the end.
+const SAMPLE = "the field \e[4m\e[31mpoints\e[0m is not allowed"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: _emsg strips ANSI off-TTY, keeps it on-TTY
+# The shared `_emsg` helper must drop every `\e[..m` SGR sequence when color is
+# disabled (CI logs, file sinks, captured `showerror` strings) and leave the
+# message untouched when color is enabled (interactive REPL). The `color` keyword
+# pins both branches so the assertion does not depend on how Julia was launched.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_emsg color branches" begin
+    # Off-TTY: not a single escape byte may survive.
+    stripped = _emsg(SAMPLE; color=false)
+    @test !occursin("\e[", stripped)
+    @test stripped == "the field points is not allowed"   # text is otherwise intact
+
+    # On-TTY: the codes are preserved verbatim for the REPL.
+    colored = _emsg(SAMPLE; color=true)
+    @test colored == SAMPLE
+    @test occursin("\e[", colored)
+
+    # Plain messages (no ANSI) are returned unchanged in both modes.
+    @test _emsg("plain message"; color=false) == "plain message"
+    @test _emsg("plain message"; color=true) == "plain message"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: _argerr routes ArgumentError messages through _emsg
+# Every QueryBuilder call site builds ArgumentErrors via `_argerr`; this proves
+# the wiring (so a regression that bypasses `_emsg` is caught) without depending
+# on the ambient color mode — both sides resolve `Base.have_color` identically.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_argerr wiring" begin
+    err = _argerr(SAMPLE)
+    @test err isa ArgumentError
+    # _argerr must produce exactly what _emsg produces under the same color mode.
+    @test err.msg == _emsg(SAMPLE)
+end
+
+# Run `f()` with `Base.have_color` pinned to `flag`, restoring the prior value
+# afterwards. `_emsg`'s default color decision reads `Base.have_color`, so this
+# lets the end-to-end assertions below exercise both the strip and keep paths
+# deterministically regardless of how the test process was launched (in scripts
+# `Base.have_color` is often `nothing`, not a Bool).
+function _with_have_color(f, flag::Bool)
+    old = Base.have_color
+    try
+        Base.eval(Base, :(have_color = $flag))
+        f()
+    finally
+        Base.eval(Base, :(have_color = $old))
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: real thrown messages honor the color mode end-to-end
+# Guard against the exception sites that previously embedded raw escape codes
+# (here: Models.Model with no fields, which builds its message via `_emsg`). With
+# color forced off the rendered `showerror` text must be free of `\e[` noise; with
+# color forced on the codes must survive — proving the message is genuinely routed
+# through the TTY-aware helper rather than being plain text either way.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "no ANSI leak in real thrown messages" begin
+    raise_model = () -> try
+        PormG.Models.Model("drivers")   # no fields → example-usage ArgumentError
+        nothing
+    catch e
+        e
+    end
+
+    # Color OFF: thrown message and its showerror rendering are ANSI-free.
+    _with_have_color(false) do
+        err = raise_model()
+        @test err isa ArgumentError
+        @test !occursin("\e[", err.msg)
+        @test !occursin("\e[", sprint(showerror, err))
+    end
+
+    # Color ON: the same site keeps its escape codes for the REPL.
+    _with_have_color(true) do
+        err = raise_model()
+        @test err isa ArgumentError
+        @test occursin("\e[", err.msg)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: _emsg(io, msg) keys off the destination stream's color
+# The IO-aware overload used inside `show` / `print(io, …)` methods must decide on
+# the stream's `:color` IOContext property, NOT the global `Base.have_color`. This
+# is the bug class where a plain `IOBuffer` (from `sprint`/`repr`) must stay clean
+# even when the process is attached to a color terminal.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_emsg(io, msg) color context" begin
+    # A bare IOBuffer advertises no color → strip, regardless of Base.have_color.
+    _with_have_color(true) do
+        @test !occursin("\e[", _emsg(IOBuffer(), SAMPLE))
+    end
+    # An IOContext that opts into color → keep.
+    @test occursin("\e[", _emsg(IOContext(IOBuffer(), :color => true), SAMPLE))
+    # An IOContext that opts out → strip, even on a color terminal.
+    _with_have_color(true) do
+        @test !occursin("\e[", _emsg(IOContext(IOBuffer(), :color => false), SAMPLE))
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: show methods do not leak ANSI into non-color buffers
+# End-to-end guard for the migration `Base.show` sites (MigrationStatus) that emit
+# colored summary lines. `sprint`/`repr` build a non-color buffer, so the captured
+# string must be ANSI-free even when color is on; an explicit color IOContext must
+# preserve the codes for the REPL.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "no ANSI leak in show methods" begin
+    # A status with a failed migration, a pending file, and a drift signal — this
+    # exercises all three colored branches of `Base.show(::MigrationStatus)`.
+    status = PormG.Migrations.MigrationStatus(
+        NamedTuple[],                          # applied
+        [(version = "0001", name = "init")],   # failed   → red line
+        true,                                  # pending  → yellow line
+        true,                                  # has_history_table
+        ["schema drift detected"],             # drift_signals → yellow line
+    )
+
+    _with_have_color(true) do
+        # Captured via sprint (non-color buffer): must be clean despite color on.
+        @test !occursin("\e[", sprint(show, status))
+        # Explicit color context: codes are preserved.
+        @test occursin("\e[", sprint(io -> show(IOContext(io, :color => true), status)))
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error colorization: real bulk error paths route through _argerr end-to-end
+# The bulk validation sites in `execution_bulk.jl` build ANSI-highlighted messages
+# and were converted from raw `throw`/`throw(_emsg(...))` to `_argerr`. This drives
+# a genuine `bulk_update` failure (unknown `match_on` field) and asserts both the
+# behavior — an `ArgumentError`, never a bare `String` — and the off-TTY contract:
+# no `\e[` when color is off, codes preserved when on. No live DB is needed; a mock
+# Postgres scope plus `show_query=:dict` returns before any network call.
+# ─────────────────────────────────────────────────────────────────────────────
+struct _AnsiBulkMockPg <: PormG.PormGPostgres end
+PormG.config["ansi_bulk_default"] = PormG.Configuration.Settings(
+    connections = _AnsiBulkMockPg(),
+    change_data = true,
+)
+
+@testset "no ANSI leak in bulk error messages" begin
+    model = Model("ansi_bulk_metrics", id = IDField(), weight = IntegerField(null = true))
+    model.connect_key = "ansi_bulk_default"
+    df = DataFrames.DataFrame(id = [1], weight = [5])
+
+    # `match_on = ["not_a_field"]` fails the model-field check in execution_bulk.jl
+    # (`bulk_update: match_on field … is not a field of model`), a `_argerr` site.
+    raise_bulk = () -> try
+        bulk_update(model.objects, df;
+            columns = ["weight"], match_on = ["not_a_field"], show_query = :dict)
+        nothing
+    catch e
+        e
+    end
+
+    _with_have_color(false) do
+        err = raise_bulk()
+        @test err isa ArgumentError                       # not a raw String
+        @test !occursin("\e[", err.msg)
+        @test !occursin("\e[", sprint(showerror, err))
+    end
+
+    _with_have_color(true) do
+        err = raise_bulk()
+        @test err isa ArgumentError
+        @test occursin("\e[", err.msg)                    # highlighting kept on-TTY
+    end
+end


### PR DESCRIPTION
Bundles this session's work as three reviewable commits.

## Summary

- **`fix(sqlite)` — async-worker use-after-free segfault.** The worker ran queries via `SQLite.DBInterface.execute(conn, sql, params)`, which registered each `Stmt` in the DB's `WeakKeyDict` (GC-finalized at an arbitrary time/thread) and returned a *lazy* cursor materialized only after the connection was released. Under bulk seeding, pending `sqlite3_finalize` finalizers fired while the single `Threads.@spawn` worker was mid `bind`/`step` on a reused connection — an intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64`. SQLite_jll is built serialized (`threadsafe=1`), so this was a use-after-free, not a race. The worker now prepares an **unregistered** statement, **materializes the rowtable while the connection is still leased**, and **finalizes deterministically** (`_sqlite_execute_materialized`). SQLite `fetch` now returns a `Vector{<:NamedTuple}`; `do_count` gained an `AbstractVector` guard. PostgreSQL path unchanged.

- **`feat(errors)` — centralize TTY-aware ANSI stripping behind a shared `_emsg` helper.** `_emsg` moves to `src/tools.jl` (string + IO-aware overloads); every exception / `@info` / `@warn` / `@error` / interactive `print` site routes through it, so colored error tokens render in the REPL and degrade to plain text in non-TTY sinks. Also fixes a latent bug where a `bulk_update` field error threw a bare `String` instead of an `ArgumentError`.

- **`docs(backlog)` — migrate TODO to GitHub issues + add an issue-management skill.** `TODO.md` becomes a curated linked index of open work only (pre-publish gating note preserved); a new `pormg-issue-management` skill documents the `gh`-based create/edit/close lifecycle and the "close = remove from the index" convention.

## Verification

- SQLite integration suite: **1383/1383** (`-t 1`), exit 0.
- Unit suite: **1779/1779** (includes the new `test_error_message_ansi.jl` + load-order checks).
- Segfault repro path (F1 fixture seeding) clean under both `-t 1` and `-t 4` (heavier cross-thread GC).
- Code-reviewed (multi-angle): no correctness findings.

## Notes

- PostgreSQL integration suite was **not** re-run; the changed paths (`do_count` guard, `_emsg`) are backend-agnostic and provably PG-neutral.
- No issues are closed by this PR. The residual SQLite teardown-robustness item remains open and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
