### PR TITLE
Tier 2 pre-publish: decouple LibPQ/SQLite into weakdep extensions (#34)

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -56,7 +56,8 @@ The subsystem map below is also the review **architecture checkpoint**: when a n
 |------|------|
 | `src/PormG.jl` | Package root (config, models, QueryBuilder, dialects, migrations) |
 | `src/Configuration.jl`, `src/constants.jl` | Config, `DB_PATH`, `PORMG_ENV`, transactions |
-| `src/ConnectionPool.jl` | `fetch`, pool lock, transaction context |
+| `src/ConnectionPool.jl` | `fetch`, pool lock, transaction context (driver-agnostic; untyped connection storage) |
+| `src/Backend.jl`, `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl` | Backend interface: `backend_*` generics + friendly fallbacks; driver bodies live in the weakdep extensions (`LibPQ`/`SQLite`). Core never names a concrete driver type |
 | `src/Models.jl`, `src/models/` | Models and fields |
 | `src/QueryBuilder.jl`, `src/querybuilder/` | Query builder (incl. `many_to_many.jl`) |
 | `src/Dialect.jl` | Backend SQL rendering |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,5 +35,41 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
 
       # julia-runtest runs test/runtests.jl via Pkg.test().
-      # Unit tests have no external database dependency.
+      # Unit tests have no external database dependency. The test target pulls in
+      # LibPQ + SQLite (Project.toml `[extras]`/`[targets]`) so the weakdep driver
+      # extensions load and the SQLite-backed unit tests run.
       - uses: julia-actions/julia-runtest@v1
+
+  # Prove the loading contract: `using PormG` works with NO SQL driver present, and a
+  # backend operation raises the friendly "load the driver" error instead of a missing
+  # method / hard reference. This is the guarantee that LibPQ/SQLite are truly weakdeps.
+  load-without-drivers:
+    name: Load without drivers — Julia ${{ matrix.julia-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.12', '1']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: using PormG with no driver loaded
+        run: |
+          julia --project=. -e '
+            using PormG
+            # No `using LibPQ` / `using SQLite`: the backend generics must fall back.
+            pool = PormG.ConnectionPool.PostgresConnectionPool("dummy"; pool_size=1)
+            threw = false
+            try
+              PormG.backend_connect(pool)
+            catch e
+              threw = true
+              @assert occursin("requires LibPQ", sprint(showerror, e)) "unexpected error: $(sprint(showerror, e))"
+            end
+            @assert threw "backend_connect should error when LibPQ is not loaded"
+            println("OK: PormG loads without drivers and fails friendly on backend use")
+          '

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ Decimals = "abce61dc-4473-55a0-ba07-351d65e31d42"
 Inflector = "6d011eab-0732-4556-8808-e463c76bf3b6"
 Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Millboard = "39ec1447-df44-5f4c-beaa-866f30b4d3b2"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -20,18 +19,21 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
+LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tachikoma = "468859d6-42d8-48b7-8ad9-1d312e0e3b0a"
 
 [extensions]
+PormGLibPQExt = "LibPQ"
 PormGReviseExt = "Revise"
+PormGSQLiteExt = "SQLite"
 PormGTachikomaExt = "Tachikoma"
 
 [compat]
@@ -74,11 +76,13 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
+LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 ProfileView = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SnoopCompile = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "Infiltrator", "SafeTestsets", "Test"]
+test = ["Aqua", "BenchmarkTools", "Infiltrator", "LibPQ", "SQLite", "SafeTestsets", "Test"]

--- a/README.MD
+++ b/README.MD
@@ -23,6 +23,17 @@ using Pkg
 Pkg.add("PormG")
 ```
 
+PormG does **not** pull in a SQL driver automatically — `LibPQ` (PostgreSQL) and `SQLite` are
+weak dependencies. Install and load the one your app uses:
+
+```julia
+Pkg.add("LibPQ")     # PostgreSQL
+Pkg.add("SQLite")    # SQLite
+```
+
+A bare `using PormG` loads the ORM but no backend; the first query then raises a clear error
+telling you to `using LibPQ` (or `using SQLite`).
+
 ---
 
 ## Quick Start
@@ -56,7 +67,7 @@ end
 ### Load configuration and models
 
 ```julia
-using PormG, DataFrames
+using PormG, LibPQ, DataFrames          # LibPQ → PostgreSQL; use SQLite for the SQLite backend
 
 PormG.Configuration.load("db")          # loads db/settings.yml
 PormG.@import_models "db/models.jl" models

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -15,7 +15,7 @@ PormG is designed for Julia's asynchronous task scheduling. This section covers 
 Use advisory locks to ensure long-running tasks (migrations, seeds, imports) do not run in parallel across processes.
 
 ```julia
-using PormG
+using PormG, LibPQ   # advisory locks are PostgreSQL-only
 
 # Wrap multiple operations in an advisory lock
 PormG.run_in_transaction("db") do

--- a/docs/src/configuration/setup.md
+++ b/docs/src/configuration/setup.md
@@ -29,7 +29,7 @@ PormG.setup("db_bs")
 If you already have a `connection.yml`, you can load it directly:
 
 ```julia
-using PormG
+using PormG, LibPQ   # load SQLite instead for a SQLite app
 
 # Load the configuration folder (e.g., "db")
 # This MUST happen BEFORE importing models!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,6 +39,25 @@ Pkg.develop(url="https://github.com/PingoLee/PormG.jl")
 > [!NOTE]
 > Since this is a development package, features may change and stability is not guaranteed. Please report any issues on the [GitHub repository](https://github.com/PingoLee/PormG.jl).
 
+### Install a database driver
+
+PormG does **not** pull in a SQL driver automatically — `LibPQ` (PostgreSQL) and `SQLite` are
+weak dependencies, so each app installs and loads the one it uses as a direct dependency:
+
+```julia
+using Pkg
+Pkg.add("LibPQ")     # PostgreSQL backend
+Pkg.add("SQLite")    # SQLite backend
+```
+
+Load the driver alongside PormG (`using PormG, LibPQ` or `using PormG, SQLite`). A bare
+`using PormG` loads the ORM but no backend, so the first query raises a clear error telling you
+which driver to load:
+
+```text
+PormG: the PostgreSQL backend requires LibPQ. Run `using LibPQ` (or `using PormG, LibPQ`) so the PostgreSQL extension loads.
+```
+
 ---
 
 ## Quick Start
@@ -149,7 +168,7 @@ end
 ### 4. Load Configuration and Import Models
 
 ```julia
-using PormG, DataFrames
+using PormG, LibPQ, DataFrames   # LibPQ → PostgreSQL; use SQLite instead if your adapter is SQLite
 
 # Load configuration — must happen BEFORE importing models
 PormG.Configuration.load("db")

--- a/docs/src/migrations/advanced.md
+++ b/docs/src/migrations/advanced.md
@@ -41,7 +41,7 @@ PormG.Migrations.remove_migration_record("db", "20260310120000")
 For complex logic that requires Julia-side data processing, use `run_in_transaction` to ensure atomicity:
 
 ```julia
-using PormG
+using PormG, LibPQ   # load SQLite instead for a SQLite app
 
 PormG.run_in_transaction("db") do
     # Fetch data

--- a/docs/src/read/custom_joins.md
+++ b/docs/src/read/custom_joins.md
@@ -30,7 +30,7 @@ The `.cjoin()` method allows you to add custom conditions to JOIN clauses at que
 The `.cjoin()` method is built into the query builder handler, meaning no special function imports are required once you have loaded PormG:
 
 ```julia
-using PormG
+using PormG, LibPQ   # load SQLite instead for a SQLite app
 # Q, Qor, and F are automatically exported by PormG
 ```
 

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -138,7 +138,7 @@ By default, `bulk_insert()` chunks data and processes each chunk in its own tran
 To ensure all-or-nothing semantics (all rows inserted or none), wrap `bulk_insert()` in `run_in_transaction()`:
 
 ```julia
-using PormG
+using PormG, LibPQ   # "db_2" is a PostgreSQL connection
 
 # All inserts succeed together, or all fail together
 PormG.run_in_transaction("db_2") do

--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -21,7 +21,7 @@ Because every operation runs through the async core, even synchronous-looking co
 The simplest pattern: pass your `"db_2"` database key to `run_in_transaction`, then execute your query block inside the callback.
 
 ```julia
-using PormG
+using PormG, LibPQ   # "db_2" is a PostgreSQL connection
 using DataFrames
 
 # Load configuration

--- a/ext/PormGLibPQExt.jl
+++ b/ext/PormGLibPQExt.jl
@@ -1,0 +1,101 @@
+# ==============================================================================
+# PormGLibPQExt — PostgreSQL backend for PormG
+#
+# Loaded automatically when the user runs `using LibPQ`. Implements the backend
+# generics declared in `src/Backend.jl` for PostgreSQL pools. Core never names
+# `LibPQ.Connection`; every LibPQ-typed body lives here, including the low-level
+# COPY drain (`LibPQ.libpq_c.*`).
+# ==============================================================================
+
+module PormGLibPQExt
+
+using PormG
+import PormG: PormGPostgres, PormGPostgresParam
+import LibPQ
+
+# ── Backend interface methods ────────────────────────────────────────────────
+
+PormG.backend_connect(pool::PormGPostgres; read_only::Bool = false) =
+  LibPQ.Connection(pool.connection_string)
+
+function PormG.backend_renew_connection(pool::PormGPostgres, conn::LibPQ.Connection; read_only::Bool = false)
+  # Reset the existing handle in place; if that fails, open a fresh connection.
+  # NOTE: the connection-reset API is `reset!` (with a bang) — plain `LibPQ.reset`
+  # only resolves to Base.reset methods (none accept a Connection), so the pre-#34
+  # `LibPQ.reset(conn)` always MethodError'd and silently fell through to recreate.
+  try
+    LibPQ.reset!(conn)
+    return conn
+  catch e
+    @debug "PG connection reset failed; opening a new connection" exception=e
+    return LibPQ.Connection(pool.connection_string)
+  end
+end
+
+function PormG.backend_is_alive(pool::PormGPostgres, conn::LibPQ.Connection)
+  try
+    return LibPQ.status(conn) == LibPQ.libpq_c.CONNECTION_OK
+  catch
+    return false
+  end
+end
+
+function PormG.backend_execute(pool::PormGPostgres, conn::LibPQ.Connection, sql::String, params)
+  resolved = params isa PormGPostgresParam ? params.parameters : params
+  return resolved === nothing ? LibPQ.execute(conn, sql) : LibPQ.execute(conn, sql, resolved)
+end
+
+function PormG.backend_execute_async(pool::PormGPostgres, conn::LibPQ.Connection, sql::String, params)
+  resolved = params isa PormGPostgresParam ? params.parameters : params
+  return resolved === nothing ? LibPQ.async_execute(conn, sql) : LibPQ.async_execute(conn, sql, resolved)
+end
+
+function PormG.backend_is_connection_error(pool::PormGPostgres, e)
+  msg = lowercase(string(e))
+  return (e isa LibPQ.Errors.UnknownError && string(e) == "LibPQ.Errors.UnknownError(\"\")") ||
+         occursin("server closed the connection", msg) ||
+         occursin("connection not open", msg)
+end
+
+PormG.backend_num_affected_rows(pool::PormGPostgres, result) = LibPQ.num_affected_rows(result)
+PormG.backend_num_rows(pool::PormGPostgres, result) = LibPQ.num_rows(result)
+
+function _drain_postgres_connection!(conn::LibPQ.Connection)
+  LibPQ.lock(conn) do
+    while true
+      # COPY can leave a trailing PGresult pending on the connection even after
+      # the main Result is closed. Drain it before the connection returns to the pool.
+      LibPQ.libpq_c.PQconsumeInput(conn.conn) == 1 || throw(LibPQ.Errors.PQConnectionError(conn))
+
+      if LibPQ.libpq_c.PQisBusy(conn.conn) == 1
+        yield()
+        continue
+      end
+
+      result_ptr = LibPQ.libpq_c.PQgetResult(conn.conn)
+      result_ptr == C_NULL && return nothing
+      LibPQ.libpq_c.PQclear(result_ptr)
+    end
+  end
+end
+
+# PostgreSQL COPY FROM STDIN. `LibPQ.CopyIn` owns the connection until the stream is
+# fully consumed; the caller in core holds the pool lease for the whole call.
+function PormG.backend_copy_in!(pool::PormGPostgres, conn::LibPQ.Connection, sql::String, data_itr)
+  try
+    res = LibPQ.execute(conn, LibPQ.CopyIn(sql, data_itr))
+    try
+      close(res)
+    finally
+      _drain_postgres_connection!(conn)
+    end
+  catch e
+    try
+      _drain_postgres_connection!(conn)
+    catch
+    end
+    rethrow(e)
+  end
+end
+
+end # module PormGLibPQExt

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -1,0 +1,132 @@
+# ==============================================================================
+# PormGSQLiteExt — SQLite backend for PormG
+#
+# Loaded automatically when the user runs `using SQLite`. Implements the backend
+# generics declared in `src/Backend.jl` for SQLite pools. Core never names
+# `SQLite.DB`; every SQLite-typed body lives here.
+# ==============================================================================
+
+module PormGSQLiteExt
+
+using PormG
+import PormG: PormGSQLite, PormGSQLiteParam
+import SQLite
+import Tables
+
+# Busy/locked retry policy (was in src/ConnectionPool.jl before SQLite became a weakdep).
+const _SQLITE_LOCK_RETRY_MAX_ATTEMPTS = 20
+const _SQLITE_LOCK_RETRY_BASE_DELAY = 0.005
+const _SQLITE_LOCK_RETRY_MAX_DELAY = 0.25
+
+function _is_sqlite_locked_error(e)::Bool
+  msg = lowercase(string(e))
+  return occursin("database is locked", msg) || occursin("database table is locked", msg)
+end
+
+function _sqlite_with_retry(op::Function)
+  attempt = 1
+  while true
+    try
+      return op()
+    catch e
+      if !_is_sqlite_locked_error(e) || attempt >= _SQLITE_LOCK_RETRY_MAX_ATTEMPTS
+        rethrow(e)
+      end
+
+      sleep_seconds = min(_SQLITE_LOCK_RETRY_BASE_DELAY * (1.4^(attempt - 1)), _SQLITE_LOCK_RETRY_MAX_DELAY)
+      sleep(sleep_seconds)
+      attempt += 1
+    end
+  end
+end
+
+function _create_sqlite_connection(connection_string::String; read_only::Bool = false)
+  new_conn = SQLite.DB(connection_string)
+  SQLite.execute(new_conn, "PRAGMA journal_mode = WAL;")
+  SQLite.execute(new_conn, "PRAGMA synchronous = NORMAL;")
+  SQLite.execute(new_conn, "PRAGMA busy_timeout = 30000;")
+  SQLite.execute(new_conn, "PRAGMA case_sensitive_like = ON;")
+  if read_only
+    SQLite.execute(new_conn, "PRAGMA query_only = ON;")
+  end
+  return new_conn
+end
+
+# Prepare an UNREGISTERED statement, execute it, fully materialize the result rows into a
+# connection-independent rowtable, and finalize the statement deterministically.
+#
+# Why not `SQLite.DBInterface.execute(conn, sql, params)` directly: that path
+# (`execute(prepare(conn, sql), params)`) *registers* the `SQLite.Stmt` in the DB's
+# `WeakKeyDict` and returns a *lazy* cursor whose backing `sqlite3_stmt` is finalized only
+# when the GC later runs the `Stmt` finalizer — on an arbitrary thread, at an arbitrary
+# safepoint. Two consequences, both observed as instability on SQLite:
+#
+#   1. The lazy cursor outlived its pool lease: `await_result` releases the connection as
+#      soon as `fetch` returns, but callers materialized the rows (`Tables.rowtable`, etc.)
+#      afterwards — stepping a cursor on a connection that had already been handed back to
+#      the pool and possibly reused by another statement.
+#   2. Under bulk seeding, thousands of registered `Stmt`s accumulate, each with a pending
+#      `sqlite3_finalize` finalizer. Those fire while the single async worker is mid
+#      `bind`/`step` on the same connection. SQLite is built serialized (THREADSAFE=1) so a
+#      well-formed concurrent call is mutex-safe, but combined with the non-idempotent
+#      explicit-close paths this opened a use-after-free / double-free window that surfaced
+#      as an intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64`.
+#
+# Preparing with `register = false` keeps the statement out of the `WeakKeyDict` (so a DB
+# close never double-finalizes it), `Tables.rowtable` materializes every row while the
+# connection is still leased on the worker, and the explicit `close!` finalizes the
+# statement immediately instead of deferring to the GC. The returned rowtable is a plain
+# `Vector{<:NamedTuple}` that is safe to hand back across the response channel.
+function _sqlite_execute_materialized(conn::SQLite.DB, sql::String, params)
+  stmt = SQLite.Stmt(conn, sql; register = false)
+  try
+    cursor = params === nothing ?
+      SQLite.DBInterface.execute(stmt) :
+      SQLite.DBInterface.execute(stmt, params)
+    return Tables.rowtable(cursor)
+  finally
+    SQLite.DBInterface.close!(stmt)
+  end
+end
+
+# ── Backend interface methods ────────────────────────────────────────────────
+
+PormG.backend_connect(pool::PormGSQLite; read_only::Bool = false) =
+  _create_sqlite_connection(pool.connection_string; read_only = read_only)
+
+PormG.backend_renew_connection(pool::PormGSQLite, conn::SQLite.DB; read_only::Bool = false) =
+  _create_sqlite_connection(pool.connection_string; read_only = read_only)
+
+function PormG.backend_is_alive(pool::PormGSQLite, conn::SQLite.DB)
+  try
+    # Simple query to check if the database is accessible
+    SQLite.execute(conn, "SELECT 1")
+    return true
+  catch
+    return false
+  end
+end
+
+# Synchronous execute — funnelled through the single global SQLite worker in core.
+function PormG.backend_execute(pool::PormGSQLite, conn::SQLite.DB, sql::String, params)
+  resolved = params isa PormGSQLiteParam ? params.parameters : params
+  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, resolved))
+end
+
+function PormG.backend_is_connection_error(pool::PormGSQLite, e)
+  msg = lowercase(string(e))
+  return occursin("database is closed", msg) ||
+         occursin("database connection is closed", msg) ||
+         occursin("disk i/o error", msg)
+end
+
+# Window-function support probe used by src/Dialect.jl.
+PormG.backend_sqlite_version(pool::PormGSQLite) = Int(SQLite.C.sqlite3_libversion_number())
+
+# ── Precompile hints (moved here from src/precompile.jl with SQLite) ─────────
+if ccall(:jl_generating_output, Cint, ()) == 1
+  Base.precompile(Tuple{typeof(SQLite.bind!), SQLite.Stmt, Int64, Float64})
+  Base.precompile(Tuple{typeof(SQLite.bind!), SQLite.Stmt, Int64, Int64})
+end
+
+end # module PormGSQLiteExt

--- a/in_migration.md
+++ b/in_migration.md
@@ -21,6 +21,60 @@ Tracks **breaking / behavior changes in PormG** that require source-code changes
 
 ---
 
+## Driver loading — `LibPQ`/`SQLite` are now weak dependencies (load the driver yourself)
+
+- **PormG ref**: issue #34 (Tier 2 pre-publish · decouple SQL adapters); [src/Backend.jl](src/Backend.jl), [ext/PormGLibPQExt.jl](ext/PormGLibPQExt.jl), [ext/PormGSQLiteExt.jl](ext/PormGSQLiteExt.jl), [Project.toml](Project.toml)
+- **Recorded**: 2026-06-25
+- **Severity**: **breaking** — `using PormG` no longer loads any SQL driver. The first database operation raises a clear error until the driver is loaded.
+
+### What changed
+
+`LibPQ` and `SQLite` moved from `[deps]` to `[weakdeps]` and their driver code now lives in package extensions (`ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl`). Core no longer references any concrete driver type; it dispatches through the `backend_*` generics in `src/Backend.jl`, whose methods are supplied by the extension that loads when you run `using LibPQ` / `using SQLite`.
+
+Consequence: **each app must load the driver(s) it uses**, and **declare them as direct dependencies** (they no longer arrive transitively through PormG).
+
+### How to find the calls to migrate
+
+The app starts fine but the first query/connection throws:
+
+```text
+PormG: the PostgreSQL backend requires LibPQ. Run `using LibPQ` (or `using PormG, LibPQ`) so the PostgreSQL extension loads.
+```
+
+(or the `SQLite` variant). Grep the app's startup for `using PormG`.
+
+### Migrate your app
+
+1. Add the driver to your app's `Project.toml` (`] add LibPQ` and/or `] add SQLite`).
+2. Load it alongside PormG:
+
+```julia
+# ✗ before — driver came in transitively
+using PormG
+
+# ✓ after — PostgreSQL app
+using PormG, LibPQ
+
+# ✓ after — SQLite app
+using PormG, SQLite
+
+# ✓ after — app that talks to both backends
+using PormG, LibPQ, SQLite
+```
+
+Also note: a handful of driver internals are **no longer exported** — `libpq_execute`, `libpq_execute_async`, `is_connection_alive`, `reconnect_db`, `is_connection_error`. They became internal `backend_*` generics inside the extensions. Apps that reached for them (rare) should use the public API (`PormG.fetch`, `run_in_transaction`, …) instead.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
 ## `bulk_update` — `match_on=` replaces dynamic match keys in `filters=`
 
 - **PormG ref**: "Bulk Operation API Refactoring" in [TODO.md](TODO.md#L7); implemented in [src/querybuilder/execution_bulk.jl](src/querybuilder/execution_bulk.jl)

--- a/src/AdvisoryLock.jl
+++ b/src/AdvisoryLock.jl
@@ -1,12 +1,11 @@
 module AdvisoryLock
 
 using Logging
-import LibPQ
 
 import PormG
-import PormG: SQLConn, PormGPostgres, PormGSQLite
+import PormG: SQLConn, PormGPostgres, PormGSQLite, backend_execute_async
 import PormG.Configuration: get_settings
-import PormG.ConnectionPool: acquire_connection, release_connection, reconnect_db, is_connection_error
+import PormG.ConnectionPool: acquire_connection, release_connection
 
 import PormG: @pormg_debug
 export with_advisory_lock
@@ -21,13 +20,15 @@ const UNLOCK_SQL = "SELECT pg_advisory_unlock($(ADVISORY_KEY_EXPR)) AS ok"
 """
 Execute a lock/unlock query on a held connection and return boolean result.
 """
-function _exec_lock_query(conn::LibPQ.Connection, sql::String, key::AbstractString)::Bool
-  # async_execute yields to the scheduler, allowing other Tasks to run
-  async_res = LibPQ.async_execute(conn, sql, Any[key])
-  
-  # FIX: fetch() waits for the task to complete and returns the LibPQ.Result
+function _exec_lock_query(pool::PormGPostgres, conn, sql::String, key::AbstractString)::Bool
+  # backend_execute_async yields to the scheduler, allowing other Tasks to run.
+  # It runs on the held connection without releasing it back to the pool, so the
+  # session-level lock stays bound to this connection.
+  async_res = backend_execute_async(pool, conn, sql, Any[key])
+
+  # fetch() waits for the task to complete and returns the driver result
   res = fetch(async_res)
-  
+
   rows = collect(res)
   return !isempty(rows) && rows[1][1] == true
 end
@@ -75,23 +76,22 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
     # Attempt to acquire lock
     if !wait
       # Non-blocking: single try
-      got_lock = _exec_lock_query(conn, TRY_SQL, key)
+      got_lock = _exec_lock_query(pool, conn, TRY_SQL, key)
     elseif strategy == :block
       # Server-side blocking with timeout
       try
-        prev = LibPQ.execute(conn, "SHOW statement_timeout")
+        prev = fetch(backend_execute_async(pool, conn, "SHOW statement_timeout", nothing))
         rows = collect(prev)
         !isempty(rows) && (old_timeout = rows[1][1])
       catch
         old_timeout = nothing
       end
-      
-      # FIX: use fetch() instead of collect() for commands without returned rows
-      async_res = LibPQ.async_execute(conn, "SET statement_timeout = $(timeout_ms)")
-      fetch(async_res) 
+
+      # use fetch() for commands without returned rows
+      fetch(backend_execute_async(pool, conn, "SET statement_timeout = $(timeout_ms)", nothing))
       
       try
-        got_lock = _exec_lock_query(conn, BLOCK_SQL, key)
+        got_lock = _exec_lock_query(pool, conn, BLOCK_SQL, key)
       catch e
         msg = lowercase(string(e))
         if occursin("canceling statement due to statement timeout", msg)
@@ -105,7 +105,7 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
       # Client-side polling with retry
       deadline = time() * 1_000 + timeout_ms
       while true
-        got_lock = _exec_lock_query(conn, TRY_SQL, key)
+        got_lock = _exec_lock_query(pool, conn, TRY_SQL, key)
         got_lock && break
         (time() * 1_000) >= deadline && break
         sleep(interval_ms / 1_000)
@@ -123,7 +123,7 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
     # Release lock if acquired (on same connection)
     if got_lock
       try
-        _exec_lock_query(conn, UNLOCK_SQL, key)
+        _exec_lock_query(pool, conn, UNLOCK_SQL, key)
       catch e
         @warn "Failed to release advisory lock; connection may have been dropped" key=key exception=(e, catch_backtrace())
       end
@@ -132,13 +132,13 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
     # Restore statement_timeout if we changed it
     if old_timeout !== nothing
       try
-        # wait() é suficiente para AsyncResult quando não precisamos do output
-        wait(LibPQ.async_execute(conn, "SET statement_timeout = '$(old_timeout)'"))
+        # wait() is enough for the async result when we don't need the output
+        wait(backend_execute_async(pool, conn, "SET statement_timeout = '$(old_timeout)'", nothing))
       catch
       end
     elseif strategy == :block
       try
-        wait(LibPQ.async_execute(conn, "SET statement_timeout TO DEFAULT"))
+        wait(backend_execute_async(pool, conn, "SET statement_timeout TO DEFAULT", nothing))
       catch
       end
     end

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -1,0 +1,49 @@
+# ==============================================================================
+# Backend interface — the seam between core and the SQL-driver extensions.
+#
+# `LibPQ` and `SQLite` are weak dependencies (see Project.toml `[weakdeps]`). Core
+# must never name a concrete driver type (`LibPQ.Connection`, `SQLite.DB`), so every
+# operation that touches the driver goes through one of the generic functions below.
+# The driver bodies live in `ext/PormGLibPQExt.jl` / `ext/PormGSQLiteExt.jl` and are
+# loaded only when the user runs `using LibPQ` / `using SQLite`.
+#
+# Dispatch is keyed on the pool MARKER type (`PormGPostgres` / `PormGSQLite`), which
+# is defined in core. A concrete pool (`PostgresConnectionPool <: PormGPostgres <:
+# SQLConn`) selects the extension method when the driver is loaded; otherwise the
+# varargs fallback fires with a friendly "load the driver" error.
+#
+# Type discipline: core stores connections untyped (`Any`); each extension method
+# pins the concrete driver type in its own signature (e.g.
+# `backend_execute(::PormGSQLite, ::SQLite.DB, sql, params)`), so the body
+# re-specializes fully. The only untyped step is the single dispatch at the call
+# boundary, once per DB round-trip — negligible against I/O.
+# ==============================================================================
+
+const _PG_DRIVER_HINT = "PormG: the PostgreSQL backend requires LibPQ. Run `using LibPQ` " *
+                        "(or `using PormG, LibPQ`) so the PostgreSQL extension loads."
+const _SQLITE_DRIVER_HINT = "PormG: the SQLite backend requires SQLite. Run `using SQLite` " *
+                            "(or `using PormG, SQLite`) so the SQLite extension loads."
+
+# Backend generics. Real methods are added by the driver extensions; the fallbacks
+# below fire when the matching driver has not been loaded.
+#
+#   backend_connect(pool; read_only=false)            -> open a physical connection
+#   backend_renew_connection(pool, conn; read_only)   -> reset or recreate a dead connection
+#   backend_is_alive(pool, conn)                       -> Bool liveness probe
+#   backend_execute(pool, conn, sql, params)           -> SYNC execute (SQLite worker; PG parity)
+#   backend_execute_async(pool, conn, sql, params)     -> async handle (PG: LibPQ.AsyncResult)
+#   backend_is_connection_error(pool, e)               -> Bool: is `e` a dropped-connection error
+#   backend_num_affected_rows(pool, result)            -> Int matched-row count (PG)
+#   backend_num_rows(pool, result)                     -> Int row count (PG)
+#   backend_copy_in!(pool, conn, sql, data_itr)        -> PostgreSQL COPY FROM STDIN
+#   backend_sqlite_version(pool)                        -> Int SQLite library version number
+for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
+           :backend_execute, :backend_execute_async, :backend_is_connection_error,
+           :backend_num_affected_rows, :backend_num_rows, :backend_copy_in!,
+           :backend_sqlite_version)
+  @eval begin
+    function $fn end
+    $fn(pool::PormGPostgres, args...; kwargs...) = error(_PG_DRIVER_HINT)
+    $fn(pool::PormGSQLite, args...; kwargs...) = error(_SQLITE_DRIVER_HINT)
+  end
+end

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -5,9 +5,9 @@ import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, config, P
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE
 import PormG: Generator
 import PormG: @pormg_debug
+# Backend generics — driver bodies live in the weakdep extensions (no direct LibPQ/SQLite here).
+import PormG: backend_num_rows, backend_is_alive
 
-import SQLite
-import LibPQ
 using Base.ScopedValues: ScopedValue, with
 
 export env, Settings, connection, close_pool!, get_settings
@@ -80,7 +80,7 @@ Used to ensure that nested fetch() calls within a transaction
 use the same database connection.
 """
 mutable struct TransactionContext
-  conn::Union{Nothing, LibPQ.Connection, SQLite.DB}
+  conn::Any  # driver connection handle (untyped: core never names LibPQ.Connection / SQLite.DB)
   pool::Union{Nothing, PormGPostgres, PormGSQLite}
   depth::Int  # Track nested transaction contexts
   sqlite_reserved_primary_keys::Dict{Tuple{String, String}, Int64}
@@ -92,7 +92,7 @@ end
 const _tx_context = ScopedValue(TransactionContext())
 
 """
-    get_tx_connection() -> Union{Nothing, LibPQ.Connection}
+    get_tx_connection() -> Union{Nothing, <driver connection>}
 
 Get the current transaction connection if we're inside a transaction context.
 Returns `nothing` if not in a transaction.
@@ -121,7 +121,7 @@ function in_transaction_context()
   return _tx_context[].depth > 0
 end
 
-function with_tx_context(f::Function, pool::Union{PormGPostgres, PormGSQLite}, conn::Union{LibPQ.Connection, SQLite.DB})
+function with_tx_context(f::Function, pool::Union{PormGPostgres, PormGSQLite}, conn)
   old_ctx = _tx_context[]
   new_ctx = TransactionContext()
   new_ctx.conn = conn
@@ -348,7 +348,7 @@ function _check_configured_extensions!(settings::SQLConn)::Nothing
     if extension == "unaccent"
       # Literal name only — never interpolate the raw YAML value into SQL.
       installed = try
-        LibPQ.num_rows(CP.fetch(settings, "SELECT 1 FROM pg_extension WHERE extname = 'unaccent';")) > 0
+        backend_num_rows(settings.connections, CP.fetch(settings, "SELECT 1 FROM pg_extension WHERE extname = 'unaccent';")) > 0
       catch e
         @warn "Could not verify PostgreSQL extension state" extension=extension db_def_folder=settings.db_def_folder exception=e
         continue
@@ -669,7 +669,7 @@ function ping(path_or_key::String)::Bool
     else
       conn = CP.acquire_connection(pool; timeout_seconds=5, max_retries=1)
     end
-    return CP.is_connection_alive(conn)
+    return backend_is_alive(pool, conn)
   catch e
     @warn "Database ping failed" key=key db_def_folder=settings.db_def_folder adapter=get(settings.db_config_settings, "adapter", nothing) exception=(e, catch_backtrace())
     return false

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -3,24 +3,18 @@ module ConnectionPool
 import Logging
 import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel
 import PormG: @pormg_debug
-
-import SQLite
-import LibPQ
-import Tables
+# Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
+import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
+              backend_execute_async, backend_is_connection_error, backend_copy_in!
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
-export with_transaction, with_transaction_async, run_in_transaction, with_savepoint, with_savepoint
+export with_transaction, with_transaction_async, run_in_transaction, with_savepoint
 export acquire_connection, release_connection, close_pool!
-export is_connection_alive, reconnect_db, is_connection_error
-export libpq_execute, libpq_execute_async
 
 # Import transaction context helpers from Configuration
 import PormG.Configuration: get_tx_connection, get_tx_pool, with_tx_context, transaction_connection_for, get_settings, ensure_before_connect!, connection_key_for_pool
 
 const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
-const _SQLITE_LOCK_RETRY_MAX_ATTEMPTS = 20
-const _SQLITE_LOCK_RETRY_BASE_DELAY = 0.005
-const _SQLITE_LOCK_RETRY_MAX_DELAY = 0.25
 
 # Sentinel returned by the locked acquire block when a new physical connection
 # must be opened. The before_connect hook then runs OUTSIDE the lock and the
@@ -44,28 +38,6 @@ function redact_secret(conn_str::String)::String
   return replace(conn_str, _REDACT_CONNECTION_STRING_RE => s"\1=****")
 end
 
-function _is_sqlite_locked_error(e)::Bool
-  msg = lowercase(string(e))
-  return occursin("database is locked", msg) || occursin("database table is locked", msg)
-end
-
-function _sqlite_with_retry(op::Function)
-  attempt = 1
-  while true
-    try
-      return op()
-    catch e
-      if !_is_sqlite_locked_error(e) || attempt >= _SQLITE_LOCK_RETRY_MAX_ATTEMPTS
-        rethrow(e)
-      end
-
-      sleep_seconds = min(_SQLITE_LOCK_RETRY_BASE_DELAY * (1.4^(attempt - 1)), _SQLITE_LOCK_RETRY_MAX_DELAY)
-      sleep(sleep_seconds)
-      attempt += 1
-    end
-  end
-end
-
 function _unwrap_async_exception(exception)
   current = exception
   while true
@@ -85,17 +57,21 @@ end
 #
 # Connection Pool Implementation
 #
+# Connections are stored untyped (`Vector{Any}`): core never names a concrete driver
+# type (`LibPQ.Connection` / `SQLite.DB`). The slots hold `nothing` or a live driver
+# handle produced by `backend_connect`; all driver work dispatches through the backend
+# generics keyed on the pool marker type.
 
 mutable struct PostgresConnectionPool <: PormGPostgres
-  connections::Vector{Union{Nothing, LibPQ.Connection}}
+  connections::Vector{Any}
   available::Vector{Bool}
   connection_string::String
   pool_size::Int
-  lock::ReentrantLock  # For thread safety  
+  lock::ReentrantLock  # For thread safety
 end
 
 mutable struct SQLiteConnectionPool <: PormGSQLite
-  connections::Vector{Union{Nothing, SQLite.DB}}
+  connections::Vector{Any}
   available::Vector{Bool}
   connection_string::String
   pool_size::Int
@@ -113,14 +89,14 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
 end
 
 function PostgresConnectionPool(connection_string::String; pool_size::Int = 3)
-  connections = Vector{Union{Nothing, LibPQ.Connection}}(nothing, pool_size)
-  available = fill(true, pool_size) 
+  connections = Vector{Any}(nothing, pool_size)
+  available = fill(true, pool_size)
   lock = ReentrantLock()
   PostgresConnectionPool(connections, available, connection_string, pool_size, lock)
 end
 
 function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false)
-  connections = Vector{Union{Nothing, SQLite.DB}}(nothing, pool_size)
+  connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
   effective_split = split_read_write && pool_size > 1
@@ -128,18 +104,6 @@ function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, spl
     @warn "SQLite split read/write mode requires pool_size > 1; falling back to shared pool" pool_size=pool_size
   end
   SQLiteConnectionPool(connections, available, connection_string, pool_size, effective_split, 1, 0, lock, ReentrantLock())
-end
-
-function _create_sqlite_connection(connection_string::String; read_only::Bool = false)
-  new_conn = SQLite.DB(connection_string)
-  SQLite.execute(new_conn, "PRAGMA journal_mode = WAL;")
-  SQLite.execute(new_conn, "PRAGMA synchronous = NORMAL;")
-  SQLite.execute(new_conn, "PRAGMA busy_timeout = 30000;")
-  SQLite.execute(new_conn, "PRAGMA case_sensitive_like = ON;")
-  if read_only
-    SQLite.execute(new_conn, "PRAGMA query_only = ON;")
-  end
-  return new_conn
 end
 
 function _sqlite_is_read_query(sql::String)::Bool
@@ -225,7 +189,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
       for i in 1:length(pool.connections)
         if pool.available[i]
           # Check if existing connection is still alive
-          if pool.connections[i] !== nothing && is_connection_alive(pool.connections[i])
+          if pool.connections[i] !== nothing && backend_is_alive(pool, pool.connections[i])
             pool.available[i] = false
             return pool.connections[i]
           end
@@ -235,7 +199,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
           before_connect_done || return _BEFORE_CONNECT_PENDING
 
           try
-            new_conn = LibPQ.Connection(pool.connection_string)
+            new_conn = backend_connect(pool)
             pool.connections[i] = new_conn
             pool.available[i] = false
             return new_conn
@@ -252,7 +216,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
       if length(pool.connections) < (pool.pool_size * 5)
         before_connect_done || return _BEFORE_CONNECT_PENDING
         try
-          new_conn = LibPQ.Connection(pool.connection_string)
+          new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
           @warn "PG pool expanded beyond initial size" current_size=length(pool.connections) initial_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
@@ -283,7 +247,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
     @info "No available PG connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
     sleep(0.1)  # Wait 100ms before retrying
   end
-  
+
   # If we've exhausted all retries
   if retry_count >= max_retries
     @error "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
@@ -302,7 +266,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
   before_connect_done = false
 
   mode in (:any, :read, :write) || throw(ArgumentError("Invalid SQLite acquire mode: $(mode). Expected :any, :read or :write."))
-  
+
   while retry_count < max_retries && (time() - start_time) < timeout_seconds
     connection = Base.lock(pool.lock) do
       slot_order = _sqlite_candidate_slots!(pool, mode)
@@ -311,7 +275,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
       for i in slot_order
         if pool.available[i]
           # Check if existing connection is still alive
-          if pool.connections[i] !== nothing && is_connection_alive(pool.connections[i])
+          if pool.connections[i] !== nothing && backend_is_alive(pool, pool.connections[i])
             pool.available[i] = false
             return pool.connections[i]
           end
@@ -321,7 +285,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
 
           try
             is_reader_slot = pool.split_read_write && i != pool.writer_slot
-            new_conn = _create_sqlite_connection(pool.connection_string; read_only = is_reader_slot)
+            new_conn = backend_connect(pool; read_only = is_reader_slot)
             pool.connections[i] = new_conn
             pool.available[i] = false
             return new_conn
@@ -332,13 +296,13 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
           end
         end
       end
-      
+
       # Expand pool logic
       can_expand = !pool.split_read_write && length(pool.connections) < (pool.pool_size * 5)
       if can_expand
         before_connect_done || return _BEFORE_CONNECT_PENDING
         try
-          new_conn = _create_sqlite_connection(pool.connection_string)
+          new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
           @warn "SQLite pool expanded beyond initial size" current_size=length(pool.connections) initial_size=pool.pool_size connection_string=pool.connection_string
@@ -347,7 +311,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
           @error "Failed to expand SQLite pool: $e"
         end
       end
-      
+
       return nothing
     end
 
@@ -360,21 +324,21 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
     if connection !== nothing
       return connection
     end
-    
+
     retry_count += 1
     @info "No available SQLite connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
     sleep(0.1)
   end
-  
-  error_msg = retry_count >= max_retries ? 
+
+  error_msg = retry_count >= max_retries ?
     "No available SQLite connections in the pool after $max_retries attempts" :
     "Timeout after $(timeout_seconds) seconds waiting for available SQLite connection"
-    
+
   @error error_msg pool_size=pool.pool_size connection_string=pool.connection_string
   throw(error_msg)
 end
 
-function release_connection(pool::PormGPostgres, conn::LibPQ.Connection)
+function release_connection(pool::PormGPostgres, conn)
   released = Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       if pool.connections[i] === conn
@@ -388,7 +352,7 @@ function release_connection(pool::PormGPostgres, conn::LibPQ.Connection)
   return false
 end
 
-function release_connection(pool::PormGSQLite, conn::SQLite.DB)
+function release_connection(pool::PormGSQLite, conn)
   released = Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       if pool.connections[i] === conn
@@ -402,45 +366,22 @@ function release_connection(pool::PormGSQLite, conn::SQLite.DB)
   return false
 end
 
-function is_connection_alive(conn::LibPQ.Connection)
-  @pormg_debug false
-  try
-    return LibPQ.status(conn) == LibPQ.libpq_c.CONNECTION_OK
-  catch
-    return false
-  end
-end
-
-function is_connection_alive(conn::SQLite.DB)
-  try
-    # Simple query to check if the database is accessible
-    SQLite.execute(conn, "SELECT 1")
-    return true
-  catch
-    return false
-  end
-end
-
-function reconnect_db(pool::PormGPostgres, conn::LibPQ.Connection)
+function reconnect_db(pool::PormGPostgres, conn)
   _run_before_connect!(pool)
 
   reconnect = Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       if pool.connections[i] === conn
-        try
-          # Try to reset the connection
-          reset = LibPQ.reset(conn)
-          return reset
+        new_conn = try
+          # Reset in place, or recreate if the reset fails (handled in the extension).
+          backend_renew_connection(pool, conn)
         catch e
-          @error "Failed to reset PG connection $i: $e"
+          @error "Failed to renew PG connection $i: $e"
+          nothing
         end
-        # If reset fails, create a new connection.
-        try
-          new_conn = LibPQ.Connection(pool.connection_string)
+        if new_conn !== nothing
           pool.connections[i] = new_conn
-          return pool.connections[i]
-        catch e
-          @error "Failed to recreate PG connection $i: $e"
+          return new_conn
         end
       end
     end
@@ -450,20 +391,23 @@ function reconnect_db(pool::PormGPostgres, conn::LibPQ.Connection)
   return nothing
 end
 
-function reconnect_db(pool::PormGSQLite, conn::SQLite.DB)
+function reconnect_db(pool::PormGSQLite, conn)
   _run_before_connect!(pool)
 
   reconnect = Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       if pool.connections[i] === conn
-        try
-          # For SQLite, we just create a new DB handle
-          is_reader_slot = pool.split_read_write && i != pool.writer_slot
-          new_conn = _create_sqlite_connection(pool.connection_string; read_only = is_reader_slot)
-          pool.connections[i] = new_conn
-          return pool.connections[i]
+        is_reader_slot = pool.split_read_write && i != pool.writer_slot
+        new_conn = try
+          # SQLite has no in-place reset; the extension opens a fresh DB handle.
+          backend_renew_connection(pool, conn; read_only = is_reader_slot)
         catch e
           @error "Failed to recreate SQLite connection $i: $e"
+          nothing
+        end
+        if new_conn !== nothing
+          pool.connections[i] = new_conn
+          return new_conn
         end
       end
     end
@@ -474,83 +418,15 @@ function reconnect_db(pool::PormGSQLite, conn::SQLite.DB)
 end
 
 #
-# Connection Execution Functions
+# Connection Execution
 #
-
-function is_connection_error(e, connection::PormGPostgres)
-    msg = lowercase(string(e))
-    return (e isa LibPQ.Errors.UnknownError && string(e) == "LibPQ.Errors.UnknownError(\"\")") ||
-           occursin("server closed the connection", msg) ||
-           occursin("connection not open", msg)
-end
-
-function is_connection_error(e, connection::PormGSQLite)
-    msg = lowercase(string(e))
-    return occursin("database is closed", msg) || 
-           occursin("database connection is closed", msg) ||
-           occursin("disk i/o error", msg)
-end
-
-#
-# Synchronous execution (legacy)
-#
-function libpq_execute(conn::LibPQ.Connection, sql::String, params::Nothing)
-  return LibPQ.execute(conn, sql)  
-end
-function libpq_execute(conn::LibPQ.Connection, sql::String, params::Vector{Any})
-  return LibPQ.execute(conn, sql, params) 
-end
-libpq_execute(conn::LibPQ.Connection, sql::String, params::PormGPostgresParam) = libpq_execute(conn, sql, params.parameters)
-
-# Prepare an UNREGISTERED statement, execute it, fully materialize the result rows into a
-# connection-independent rowtable, and finalize the statement deterministically.
-#
-# Why not `SQLite.DBInterface.execute(conn, sql, params)` directly: that path
-# (`execute(prepare(conn, sql), params)`) *registers* the `SQLite.Stmt` in the DB's
-# `WeakKeyDict` and returns a *lazy* cursor whose backing `sqlite3_stmt` is finalized only
-# when the GC later runs the `Stmt` finalizer — on an arbitrary thread, at an arbitrary
-# safepoint. Two consequences, both observed as instability on SQLite:
-#
-#   1. The lazy cursor outlived its pool lease: `await_result` releases the connection as
-#      soon as `fetch` returns, but callers materialized the rows (`Tables.rowtable`, etc.)
-#      afterwards — stepping a cursor on a connection that had already been handed back to
-#      the pool and possibly reused by another statement.
-#   2. Under bulk seeding, thousands of registered `Stmt`s accumulate, each with a pending
-#      `sqlite3_finalize` finalizer. Those fire while the single async worker is mid
-#      `bind`/`step` on the same connection. SQLite is built serialized (THREADSAFE=1) so a
-#      well-formed concurrent call is mutex-safe, but combined with the non-idempotent
-#      explicit-close paths this opened a use-after-free / double-free window that surfaced
-#      as an intermittent `EXCEPTION_ACCESS_VIOLATION` in `sqlite3_bind_int64`.
-#
-# Preparing with `register = false` keeps the statement out of the `WeakKeyDict` (so a DB
-# close never double-finalizes it), `Tables.rowtable` materializes every row while the
-# connection is still leased on the worker, and the explicit `close!` finalizes the
-# statement immediately instead of deferring to the GC. The returned rowtable is a plain
-# `Vector{<:NamedTuple}` that is safe to hand back across the response channel.
-function _sqlite_execute_materialized(conn::SQLite.DB, sql::String, params)
-  stmt = SQLite.Stmt(conn, sql; register = false)
-  try
-    cursor = params === nothing ?
-      SQLite.DBInterface.execute(stmt) :
-      SQLite.DBInterface.execute(stmt, params)
-    return Tables.rowtable(cursor)
-  finally
-    SQLite.DBInterface.close!(stmt)
-  end
-end
-
-function sqlite_execute(conn::SQLite.DB, sql::String, params::Nothing)
-  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, nothing))
-end
-function sqlite_execute(conn::SQLite.DB, sql::String, params::Vector{Any})
-  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, params))
-end
-function sqlite_execute(conn::SQLite.DB, sql::String, params::PormGSQLiteParam)
-  return _sqlite_with_retry(() -> _sqlite_execute_materialized(conn, sql, params.parameters))
-end
+# The actual driver execute paths live in the extensions as methods of
+# `backend_execute` (sync) and `backend_execute_async` (async). The SQLite async
+# worker below stays in core but dispatches each statement through `backend_execute`.
 
 mutable struct SQLiteAsyncWorkItem
-  conn::SQLite.DB
+  pool::PormGSQLite
+  conn::Any
   sql::String
   params::Any
   response::Channel{Any}
@@ -581,7 +457,8 @@ function _ensure_sqlite_async_worker!()
       while true
         item = take!(_sqlite_async_work_queue)
         try
-          result = sqlite_execute(item.conn, item.sql, item.params)
+          # Dispatches into the SQLite extension's backend_execute (materialized + retry).
+          result = backend_execute(item.pool, item.conn, item.sql, item.params)
           put!(item.response, SQLiteAsyncResponse(true, result))
         catch e
           put!(item.response, SQLiteAsyncResponse(false, e))
@@ -593,28 +470,18 @@ function _ensure_sqlite_async_worker!()
   end
 end
 
-#
-# Async execution (yields to Julia scheduler)
-#
-function libpq_execute_async(conn::LibPQ.Connection, sql::String, params::Nothing)
-  return LibPQ.async_execute(conn, sql)
-end
-function libpq_execute_async(conn::LibPQ.Connection, sql::String, params::Vector{Any})
-  return LibPQ.async_execute(conn, sql, params)
-end
-libpq_execute_async(conn::LibPQ.Connection, sql::String, params::PormGPostgresParam) = libpq_execute_async(conn, sql, params.parameters)
-
 """
-    sqlite_execute_async(conn::SQLite.DB, sql::String, params)
+    sqlite_execute_async(pool::PormGSQLite, conn, sql::String, params)
 
-Internal helper to execute a SQLite query on a separate thread using `Threads.@spawn`.
-This allows the main event loop to remain responsive while waiting for the database.
+Internal helper that funnels a SQLite query through the single global worker so all
+statements run serialized on one thread, then returns a `Task` the caller awaits. This
+keeps the main event loop responsive while waiting for the database.
 """
-function sqlite_execute_async(conn::SQLite.DB, sql::String, params)
+function sqlite_execute_async(pool::PormGSQLite, conn, sql::String, params)
   _ensure_sqlite_async_worker!()
 
   response = Channel{Any}(1)
-  work_item = SQLiteAsyncWorkItem(conn, sql, params, response)
+  work_item = SQLiteAsyncWorkItem(pool, conn, sql, params, response)
 
   return @async begin
     put!(_sqlite_async_work_queue, work_item)
@@ -634,32 +501,32 @@ A wrapper around an async database query result that manages connection lifecycl
 Use `await_result(task)` to get the result and properly release the connection.
 
 # Fields
-- `async_result::Union{LibPQ.AsyncResult, Task}`: The underlying async result (LibPQ.AsyncResult for PG, Task for SQLite)
+- `async_result`: The underlying async handle (a `LibPQ.AsyncResult` for PG, a `Task` for SQLite)
 - `pool::Union{PormGPostgres, PormGSQLite}`: The connection pool to release the connection to
-- `conn::Union{LibPQ.Connection, SQLite.DB}`: The connection being used for this query
+- `conn`: The driver connection being used for this query
 - `completed::Bool`: Whether the async result has been awaited
 - `result_cache::Union{Nothing, Any}`: Cached result for multiple `await_result` calls
 - `in_transaction::Bool`: Whether this task is part of a transaction (don't release connection)
 """
 mutable struct FetchTask
-  async_result::Union{LibPQ.AsyncResult, Task}  # Accept both AsyncResult and Task
+  async_result::Any  # LibPQ.AsyncResult (PG) or Task (SQLite)
   pool::Union{PormGPostgres, PormGSQLite}
-  conn::Union{LibPQ.Connection, SQLite.DB}
+  conn::Any
   completed::Bool
   result_cache::Union{Nothing, Any}
   in_transaction::Bool  # Whether this task is part of a transaction context
-  
+
   # Constructor for transaction-aware fetch
-  FetchTask(async_result::Union{LibPQ.AsyncResult, Task}, pool::Union{PormGPostgres, PormGSQLite}, conn::Union{LibPQ.Connection, SQLite.DB}, in_transaction::Bool) = 
+  FetchTask(async_result, pool::Union{PormGPostgres, PormGSQLite}, conn, in_transaction::Bool) =
     new(async_result, pool, conn, false, nothing, in_transaction)
-  
+
   # Legacy constructor (defaults to not in transaction)
-  FetchTask(async_result::Union{LibPQ.AsyncResult, Task}, pool::Union{PormGPostgres, PormGSQLite}, conn::Union{LibPQ.Connection, SQLite.DB}) = 
+  FetchTask(async_result, pool::Union{PormGPostgres, PormGSQLite}, conn) =
     new(async_result, pool, conn, false, nothing, false)
 end
 
 """
-    await_result(ft::FetchTask) -> LibPQ.Result
+    await_result(ft::FetchTask) -> result
 
 Await the completion of an async fetch task and return the result.
 Automatically releases the connection back to the pool.
@@ -672,7 +539,7 @@ function await_result(ft::FetchTask)
     # Already completed, just return the cached result
     return ft.result_cache
   end
-  
+
   try
     # Await the async result (works for both LibPQ.AsyncResult and Task)
     result = Base.fetch(ft.async_result)
@@ -712,23 +579,23 @@ users = await_result(task1)
 orders = await_result(task2)
 ```
 """
-function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String; 
-  conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, 
+function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
+  conn = nothing,
   params::Union{Nothing, AbstractPormGParam} = nothing,
   ignore_tx::Bool = false)
-  
+
   # Check for transaction context first
   tx_conn = ignore_tx ? nothing : get_tx_connection()
   use_tx_context = conn === nothing && tx_conn !== nothing
-  
+
   if use_tx_context
     # Use transaction context connection - don't acquire a new one
     conn = tx_conn
     try
       task = if connection isa PormGPostgres
-        libpq_execute_async(conn, sql, params)
+        backend_execute_async(connection, conn, sql, params)
       else
-        sqlite_execute_async(conn, sql, params)
+        sqlite_execute_async(connection, conn, sql, params)
       end
       # Return a special FetchTask that won't release the connection
       return FetchTask(task, connection, conn, true)  # true = in_transaction
@@ -748,9 +615,9 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
     try
       task = if connection isa PormGPostgres
-        libpq_execute_async(conn, sql, params)
+        backend_execute_async(connection, conn, sql, params)
       else
-        sqlite_execute_async(conn, sql, params)
+        sqlite_execute_async(connection, conn, sql, params)
       end
       return FetchTask(task, connection, conn, false)  # false = not in transaction
     catch e
@@ -760,9 +627,9 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
   end
 end
-fetch_async(settings::SQLConn, sql::String; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch_async(settings::SQLConn, sql::String, params::AbstractPormGParam; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, ignore_tx::Bool = false) = fetch_async(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::SQLConn, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
     fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String; params=nothing, ignore_tx=false) -> Tables.rowtable
@@ -770,20 +637,20 @@ fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::Ab
 Execute a database query synchronously (blocking).
 Internally uses async execution but immediately awaits the result.
 """
-function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String; 
-  conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, 
+function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
+  conn = nothing,
   params::Union{Nothing, AbstractPormGParam} = nothing,
   ignore_tx::Bool = false)
   @pormg_debug false
-  
+
   # Use async-first approach: start async query then await
   fetch_task = fetch_async(connection, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-  
+
   try
     return await_result(fetch_task)
-  catch e    
+  catch e
     root = _unwrap_async_exception(e)
-    if is_connection_error(root, connection)
+    if backend_is_connection_error(connection, root)
       @warn "Lost connection to database. Attempting to reconnect..."
       # Get a fresh connection and retry
       new_conn = reconnect_db(connection, fetch_task.conn)
@@ -795,76 +662,30 @@ function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     throw(root)
   end
 end
-fetch(settings::SQLConn, sql::String; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch(settings::SQLConn, sql::String, params::AbstractPormGParam; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, ignore_tx::Bool = false) = fetch(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-
-function _drain_postgres_connection!(conn::LibPQ.Connection)
-  LibPQ.lock(conn) do
-    while true
-      # COPY can leave a trailing PGresult pending on the connection even after
-      # the main Result is closed. Drain it before the connection returns to the pool.
-      LibPQ.libpq_c.PQconsumeInput(conn.conn) == 1 || error(LOGGER, LibPQ.Errors.PQConnectionError(conn))
-
-      if LibPQ.libpq_c.PQisBusy(conn.conn) == 1
-        yield()
-        continue
-      end
-
-      result_ptr = LibPQ.libpq_c.PQgetResult(conn.conn)
-      result_ptr == C_NULL && return nothing
-      LibPQ.libpq_c.PQclear(result_ptr)
-    end
-  end
-end
+fetch(settings::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::SQLConn, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
     fetch_copy(connection::PormGPostgres, sql::String, data_itr)
 
 Execute a PostgreSQL `COPY FROM STDIN` operation using an iterable of data chunks.
-Uses `LibPQ.execute` with `LibPQ.CopyIn` for high-performance data transfer.
+The driver-specific streaming (`LibPQ.CopyIn` + result drain) lives in the PostgreSQL
+extension as `backend_copy_in!`.
 """
 function fetch_copy(connection::PormGPostgres, sql::String, data_itr)
   # Check for transaction context
   tx_conn = get_tx_connection()
-  use_tx_context = tx_conn !== nothing
-  
-  if use_tx_context
-    # Reuse the transaction connection — COPY is part of the open transaction
-    try
-      res = LibPQ.execute(tx_conn, LibPQ.CopyIn(sql, data_itr))
-      try
-        close(res)
-      finally
-        _drain_postgres_connection!(tx_conn)
-      end
-    catch e
-      try
-        _drain_postgres_connection!(tx_conn)
-      catch
-      end
-      rethrow(e)
-    end
+
+  if tx_conn !== nothing
+    # Reuse the transaction connection — COPY is part of the open transaction.
+    backend_copy_in!(connection, tx_conn, sql, data_itr)
   else
-    # Acquire a pool connection for the duration of the COPY stream.
-    # LibPQ.CopyIn owns the connection until the stream is fully consumed,
-    # so we must not release it until execute() returns.
+    # Acquire a pool connection for the duration of the COPY stream. CopyIn owns the
+    # connection until the stream is fully consumed, so we hold it until done.
     conn = acquire_connection(connection)
     try
-      try
-        res = LibPQ.execute(conn, LibPQ.CopyIn(sql, data_itr))
-        try
-          close(res)
-        finally
-          _drain_postgres_connection!(conn)
-        end
-      catch e
-        try
-          _drain_postgres_connection!(conn)
-        catch
-        end
-        rethrow(e)
-      end
+      backend_copy_in!(connection, conn, sql, data_itr)
     finally
       release_connection(connection, conn)
     end
@@ -873,17 +694,17 @@ end
 fetch_copy(settings::SQLConn, sql::String, data_itr) = fetch_copy(settings.connections, sql, data_itr)
 
 """
-    with_transaction_async(pool::PormGPostgres, sql::String; ...) -> (FetchTask, LibPQ.Connection)
+    with_transaction_async(pool::PormGPostgres, sql::String; ...) -> (task, conn)
 
-Start an async transaction query. Returns the FetchTask and connection.
+Start an async transaction query. Returns the async handle and connection.
 The connection is NOT released - caller must manage it for transaction continuation.
 
 For transactions, you typically want to keep the connection for multiple queries.
 """
-function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::String; 
-  conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, 
+function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
+  conn = nothing,
   params::Union{Nothing, AbstractPormGParam} = nothing)
-  
+
   if conn === nothing
     if pool isa PormGSQLite
       conn = acquire_connection(pool; mode=:write)
@@ -893,9 +714,9 @@ function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::St
   end
   try
     task = if pool isa PormGPostgres
-      libpq_execute_async(conn, sql, params)
+      backend_execute_async(pool, conn, sql, params)
     else
-      sqlite_execute_async(conn, sql, params)
+      sqlite_execute_async(pool, conn, sql, params)
     end
     # Don't wrap in FetchTask since we don't want auto-release
     return task, conn
@@ -905,11 +726,11 @@ function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::St
   end
 end
 
-function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String; 
-  conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, 
-  release_conn::Bool = false, 
+function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
+  conn = nothing,
+  release_conn::Bool = false,
   params::Union{Nothing, AbstractPormGParam} = nothing)
-  
+
   conn_acquired = false
   if conn === nothing
     if pool isa PormGSQLite
@@ -923,9 +744,9 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
   try
     # Use async execution but await immediately
     task = if pool isa PormGPostgres
-      libpq_execute_async(conn, sql, params)
+      backend_execute_async(pool, conn, sql, params)
     else
-      sqlite_execute_async(conn, sql, params)
+      sqlite_execute_async(pool, conn, sql, params)
     end
     result = Base.fetch(task)
     return result, conn
@@ -944,8 +765,8 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
   end
 end
-with_transaction(pool::SQLConn, sql::AbstractString; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, release_conn::Bool = false, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction(pool.connections, sql; conn=conn, release_conn=release_conn, params=params)
-with_transaction_async(pool::SQLConn, sql::String; conn::Union{Nothing, LibPQ.Connection, SQLite.DB} = nothing, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction_async(pool.connections, sql; conn=conn, params=params)
+with_transaction(pool::SQLConn, sql::AbstractString; conn = nothing, release_conn::Bool = false, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction(pool.connections, sql; conn=conn, release_conn=release_conn, params=params)
+with_transaction_async(pool::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction_async(pool.connections, sql; conn=conn, params=params)
 
 """
     with_savepoint(f::Function, settings::SQLConn, name::String) -> result
@@ -1072,30 +893,30 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
   try
     # Begin transaction
     if pool isa PormGPostgres
-        task = libpq_execute_async(conn, "BEGIN;", nothing)
+        task = backend_execute_async(pool, conn, "BEGIN;", nothing)
         Base.fetch(task)
     else
-        # Use BEGIN IMMEDIATE for SQLite to prevent deadlocks and ensure 
+        # Use BEGIN IMMEDIATE for SQLite to prevent deadlocks and ensure
         # write lock is acquired early for multi-threaded scenarios.
-      task = sqlite_execute_async(conn, "BEGIN IMMEDIATE TRANSACTION;", nothing)
+      task = sqlite_execute_async(pool, conn, "BEGIN IMMEDIATE TRANSACTION;", nothing)
       Base.fetch(task)
     end
     tx_started = true
-    
+
     # Execute the function within transaction context
     result = with_tx_context(pool, conn) do
       f()
     end
-    
+
     # Commit on success
     if pool isa PormGPostgres
-        task = libpq_execute_async(conn, "COMMIT;", nothing)
+        task = backend_execute_async(pool, conn, "COMMIT;", nothing)
         Base.fetch(task)
     else
-      task = sqlite_execute_async(conn, "COMMIT;", nothing)
+      task = sqlite_execute_async(pool, conn, "COMMIT;", nothing)
       Base.fetch(task)
     end
-    
+
     return result
   catch e
     root = _unwrap_async_exception(e)
@@ -1103,10 +924,10 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
     if tx_started
       try
         if pool isa PormGPostgres
-            task = libpq_execute_async(conn, "ROLLBACK;", nothing)
+            task = backend_execute_async(pool, conn, "ROLLBACK;", nothing)
             Base.fetch(task)
         else
-          task = sqlite_execute_async(conn, "ROLLBACK;", nothing)
+          task = sqlite_execute_async(pool, conn, "ROLLBACK;", nothing)
           Base.fetch(task)
         end
       catch rollback_error

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -1,9 +1,9 @@
 module Dialect
 using Dates, TimeZones
-using SQLite
 using DataFrames
-using LibPQ
+import Tables
 import PormG: SQLConn, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeOper, SQLObject, AbstractModel, PormGModel, PormGField, PormGPostgres, PormGSQLite, PormGAbstractType
+import PormG: backend_sqlite_version  # SQLite library-version probe (driver body in the weakdep extension)
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse
 import PormG: get_constraints_pk, get_constraints_unique, get_constraints_check
@@ -123,10 +123,12 @@ end
 const SQLITE_WINDOW_MIN_VERSION = 3025000
 
 function _assert_sqlite_window_support(conn::PormGSQLite)
-  version_number = SQLite.C.sqlite3_libversion_number()
+  version_number = backend_sqlite_version(conn)
   if version_number < SQLITE_WINDOW_MIN_VERSION
-    version_text = unsafe_string(SQLite.C.sqlite3_libversion())
-    throw(ArgumentError("SQLite window functions require SQLite >= 3.25.0; current SQLite library is $version_text."))
+    # Reconstruct M.mm.pp from the packed version integer (e.g. 3039000 -> "3.39.0").
+    major, rem = divrem(version_number, 1_000_000)
+    minor, patch = divrem(rem, 1_000)
+    throw(ArgumentError("SQLite window functions require SQLite >= 3.25.0; current SQLite library is $major.$minor.$patch."))
   end
   return nothing
 end
@@ -1045,7 +1047,7 @@ function get_objects_to_delete(connection::PormGPostgres, model::PormGModel, ins
   """
   # Execute the query to get IDs of objects to delete
   @pormg_debug false
-  result = LibPQ.execute(connection, sql_to_delete)
+  result = fetch(connection, sql_to_delete)
   return Tables.rowtable(result)
 end
 

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -2,7 +2,6 @@ module Generator
 
 import PormG
 import PormG: MODEL_PATH, SQLConn, DB_PATH
-using SQLite, LibPQ
 import OrderedCollections: OrderedDict
 
 """
@@ -132,7 +131,7 @@ function generate_migration_plan(file::String, migration_plan::OrderedDict{Symbo
       # Stamp the frozen on-disk format version (issue #32) as an inert comment header rather than a
       # `const`: generated files are re-included across runs, and a const would warn on redefinition
       # and conflict once files of different format versions coexist. The header is read by line-scan
-      # (`^# pormg-migration-format: (\\d+)$`) *before* the module is executed — see docs:
+      # (`^# pormg-migration-format: (\\d+)\\r?$`, CRLF-tolerant) *before* the module is executed — see docs:
       # Migrations → Format Stability. The authoritative record is the pormg_migrations.format_version
       # column; this comment is the on-disk annotation.
       fmt_version = PormG.Migrations.MIGRATION_FORMAT_VERSION

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -11,8 +11,6 @@ using DataFrames
 using CSV
 using Dates
 using JSON
-using SQLite
-using LibPQ
 import OrderedCollections: OrderedDict
 import Random: randstring
 import SHA

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -31,8 +31,10 @@ export @pormg_debug
 
 import DataFrames, OrderedCollections, Dates, Logging, Millboard, YAML
 
-using SQLite
-using LibPQ
+# NOTE: LibPQ and SQLite are weak dependencies (Project.toml `[weakdeps]`). Core never
+# names a concrete driver type; all driver work goes through the backend generics in
+# `Backend.jl`, whose methods live in `ext/PormGLibPQExt.jl` / `ext/PormGSQLiteExt.jl`
+# and load on `using LibPQ` / `using SQLite`.
 
 abstract type PormGAbstractType end
 abstract type SQLConn <: PormGAbstractType end
@@ -71,6 +73,10 @@ if !haskey(ENV, "PORMG_ENV")
 end
 
 include("constants.jl")
+
+# Backend interface (empty generics + friendly fallbacks); driver bodies live in the
+# weakdep extensions. Must precede Configuration/ConnectionPool, which call the generics.
+include("Backend.jl")
 
 # upper functions
 function get_constraints_pk end

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -2,13 +2,13 @@ module QueryBuilder
 
 import DataFrames, Tables, JSON, CSV
 using Dates, TimeZones, Intervals, Decimals, UUIDs
-using SQLite, LibPQ
 
 import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField
 import PormG: Dialect, Models
 import PormG: config
 import PormG: SQLType, SQLConn, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
 import PormG: PormGsuffix, PormGtransform, run_in_transaction
+import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -218,8 +218,8 @@ end
 Insert a migration record into the history table within an existing transaction connection.
 """
 function _record_migration(pool::PormGPostgres, version::String, name::String, checksum::String, 
-                           sql_content::String, status::String, is_destr::Bool; 
-                           conn::Union{Nothing, LibPQ.Connection} = nothing)
+                           sql_content::String, status::String, is_destr::Bool;
+                           conn = nothing)
   sql = """INSERT INTO pormg_migrations ("version", "name", "checksum", "sql_content", "status", "is_destructive", "format_version")
            VALUES ('$(replace(version, "'" => "''"))', '$(replace(name, "'" => "''"))', '$(replace(checksum, "'" => "''"))',
            '$(replace(sql_content, "'" => "''"))', '$(replace(status, "'" => "''"))', $(is_destr), $(MIGRATION_FORMAT_VERSION));"""
@@ -232,8 +232,8 @@ function _record_migration(pool::PormGPostgres, version::String, name::String, c
 end
 
 function _record_migration(pool::PormGSQLite, version::String, name::String, checksum::String, 
-                           sql_content::String, status::String, is_destr::Bool; 
-                           conn::Union{Nothing, SQLite.DB} = nothing)
+                           sql_content::String, status::String, is_destr::Bool;
+                           conn = nothing)
   is_destr_val = is_destr ? 1 : 0
   sql = """INSERT INTO pormg_migrations ("version", "name", "checksum", "sql_content", "status", "is_destructive", "format_version")
            VALUES ('$(replace(version, "'" => "''"))', '$(replace(name, "'" => "''"))', '$(replace(checksum, "'" => "''"))',

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -5,7 +5,7 @@ import Logging
   # Mock settings to allow Model and QueryBuilder compilation Without actual DB connection
   # We use a dummy PostgresConnectionPool as it's a common target
   mock_pool = ConnectionPool.PostgresConnectionPool(
-    Union{Nothing, LibPQ.Connection}[],
+    Any[],
     Bool[],
     "dummy_connection_string",
     0,
@@ -196,7 +196,5 @@ if ccall(:jl_generating_output, Cint, ()) == 1
   Base.precompile(Tuple{typeof(merge!), Dict{Symbol, Any}, Dict{Symbol, Int64}})                                   # 0.03 s
   Base.precompile(Tuple{typeof(merge!), Dict{Symbol, Any}, Dict{Symbol, Union{Missing, Int64}}})                   # 0.03 s
 
-  # SQLite parameter binding ---------------------------------------------------
-  Base.precompile(Tuple{typeof(SQLite.bind!), SQLite.Stmt, Int64, Float64})      # 0.025 s
-  Base.precompile(Tuple{typeof(SQLite.bind!), SQLite.Stmt, Int64, Int64})        # 0.024 s
+  # SQLite parameter binding precompiles moved to ext/PormGSQLiteExt.jl (SQLite is a weakdep).
 end

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -114,7 +114,7 @@ function delete(objct::SQLObjectHandler;
 
   # Definition of run_deletions (backend agnostic)
   results = []
-  run_deletions = function(conn::Union{Nothing, LibPQ.Connection, SQLite.DB})
+  run_deletions = function(conn)
     # Process fast deletes first (objects that can be deleted directly)
     for (model, keys) in collector.fast_deletes
       res = delete_objects(connection, model, keys, show_query, deleted_counter, conn)
@@ -420,7 +420,7 @@ function collect_fast_deletes!(collector::DeletionCollector)
 end
 
 function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::PormGModel, keys::Vector{Dict{Symbol, Union{String, SQLObjectHandler}}},
-   show_query::Symbol, deleted_counter::Dict{String, Integer}, conn::Union{Nothing, LibPQ.Connection, SQLite.DB})
+   show_query::Symbol, deleted_counter::Dict{String, Integer}, conn)
   @pormg_debug false
   if size(keys, 1) == 1 && keys[1][:key] == DIRECT_DELETE_KEY_SENTINEL
     objct = keys[1][:objct]
@@ -479,7 +479,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
   return deleted_counter  # Return count of deleted objects
 end
 
-function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::PormGModel, field::String, value::Any, keys::Dict{Symbol, Union{String, SQLObjectHandler}}, show_query::Symbol, conn::Union{Nothing, LibPQ.Connection, SQLite.DB})
+function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::PormGModel, field::String, value::Any, keys::Dict{Symbol, Union{String, SQLObjectHandler}}, show_query::Symbol, conn)
   # Update field values using query object like CASCADE
   @pormg_debug false
   pk_field = keys[:key]

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -958,9 +958,10 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   # Execute with parameters and return affected row count (Django matched-rows semantics).
   try
     if connection isa PormGPostgres
-      # LibPQ.Result exposes num_affected_rows which counts matched rows.
+      # The driver result exposes a matched-row count; backend_num_affected_rows
+      # delegates to LibPQ.num_affected_rows in the PostgreSQL extension.
       result = fetch(settings, sql, parameters)
-      return LibPQ.num_affected_rows(result)
+      return backend_num_affected_rows(connection, result)
     elseif connection isa PormGSQLite
       # SQLite changes() must run on the same connection as the UPDATE.
       # If we are already inside a transaction context, fetch() reuses the

--- a/test/integration/common_setup.jl
+++ b/test/integration/common_setup.jl
@@ -4,6 +4,10 @@ ENV["PORMG_ENV"] = "dev"
 
 using Revise
 using PormG
+# Activate the LibPQ/SQLite weakdep extensions (#34) before any DB work — without these
+# every backend operation raises the "load the driver" error. Robust across env types;
+# see test/load_drivers.jl.
+include(joinpath(@__DIR__, "..", "load_drivers.jl"))
 using DataFrames
 using CSV
 using Test#, SafeTestsets

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -182,10 +182,10 @@ end
 # index_names, all_table_names).
 # ==============================================================================
 
-# Conditional imports: SQLite.jl is only needed for the SQLite adapter path
-if adapter_name == "SQLite"
-  using SQLite
-end
+# SQLite.jl is a weak dependency since #34 and cannot be `using`-ed directly under
+# `--project=.`. It is loaded and bound in Main by test/load_drivers.jl (included from
+# common_setup.jl), so the qualified `SQLite.*` calls in the column-introspection helpers
+# resolve to that binding for the SQLite adapter path.
 
 # Determine the temp DB folder based on the adapter
 edge_db_name = adapter_name == "SQLite" ? "db_test_migration" : "db_test_migration_pg"

--- a/test/load_drivers.jl
+++ b/test/load_drivers.jl
@@ -1,0 +1,29 @@
+# ==============================================================================
+# Activate the SQL-driver extensions for the test session.
+#
+# Since #34, LibPQ and SQLite are WEAK dependencies of PormG (Project.toml `[weakdeps]`).
+# Loading them activates ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl, which supply the
+# `backend_*` methods PormG dispatches to. Without them every DB operation raises the
+# friendly "run `using LibPQ` / `using SQLite`" error.
+#
+# Tests run in two kinds of environment, so we load defensively:
+#   • Pkg.test() / CI: the drivers are direct deps of the temp test env (`[extras]` +
+#     `[targets].test`), so a plain `using` works.
+#   • julia --project=. test/…: the package env lists them only as weakdeps, which cannot
+#     be `using`-ed — but they ARE in the manifest, so `Base.require` by UUID loads them
+#     and triggers the extension. (`Base.require` also works in the Pkg.test env.)
+# ==============================================================================
+
+for (name, uuid) in (("LibPQ",  "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"),
+                      ("SQLite", "0aa819cd-b072-5ff4-a722-6bc24af294d9"))
+    sym = Symbol(name)
+    try
+        # Direct dep of the active env (Pkg.test): `using` both loads it and binds the name.
+        @eval using $sym
+    catch
+        # Weakdep under `--project=.`: load from the manifest and bind the name in Main so
+        # that qualified references in tests (e.g. `SQLite.tables(conn)`) resolve.
+        m = Base.require(Base.PkgId(Base.UUID(uuid), name))
+        @eval Main const $sym = $m
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using Test
 using PormG
+# Activate the LibPQ/SQLite weakdep extensions (the unit suite runs against SQLite
+# `:memory:`). See test/load_drivers.jl for why this is robust across env types.
+include(joinpath(@__DIR__, "load_drivers.jl"))
 
 const HAS_AQUA = let available = false
     try


### PR DESCRIPTION
Closes #34.

First of two sequential Tier 2 pre-publish PRs (this one, then export-surface curation #35 stacked on top).

## What changes

`LibPQ` and `SQLite` move from hard `[deps]` to `[weakdeps]` + package extensions. The core no longer references any concrete driver type — it dispatches through `backend_*` generics whose methods are supplied by the extension that loads when you run `using LibPQ` / `using SQLite`.

- **New core file `src/Backend.jl`** — empty `backend_*` generics keyed on the pool marker types (`PormGPostgres`/`PormGSQLite`), plus friendly `::SQLConn` fallbacks that fire lazily on the first DB op when no driver is loaded.
- **New extensions** `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl` — the driver bodies (connect, execute sync/async, reconnect, COPY drain, version probe, retry helpers).
- **Untyped connection storage** (`Vector{Any}`) in the pools; each extension method pins the concrete driver type in its own signature, so execution re-specializes fully after a single dynamic dispatch per round-trip.
- `Project.toml`: `LibPQ`/`SQLite` → `[weakdeps]` + `[extensions]`; added to `[extras]` and `[targets].test`.
- CI: new `load-without-drivers` job proves the package loads with **zero** hard driver reference.

### Breaking — new loading contract

`using PormG` alone now loads the ORM but **no** backend. Apps must add the driver as a direct dependency and load it:

```julia
using PormG, LibPQ    # PostgreSQL
using PormG, SQLite   # SQLite
```

A bare `using PormG` raises a clear, actionable error on the first query telling you which driver to load. The user-facing docs (installation, Quick Start, and every DB-op example) are updated to match, and `in_migration.md` records the per-app rollout.

## Verification

- `julia --project=. -e 'using PormG'` loads with no driver; backend ops raise the friendly error.
- Unit suite (Pkg.test + Aqua) green; PostgreSQL and SQLite integration suites green.
- `docs/make.jl` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)