### PR TITLE
Tier 2 pre-publish: curate public export surface — PormG.Functions (#35)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -68,6 +68,7 @@ end
 
 ```julia
 using PormG, LibPQ, DataFrames          # LibPQ → PostgreSQL; use SQLite for the SQLite backend
+using PormG.Functions                   # SQL functions (Count, Sum, Max, …) — namespaced
 
 PormG.Configuration.load("db")          # loads db/settings.yml
 PormG.@import_models "db/models.jl" models

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -188,7 +188,8 @@ For the full list of operators and transforms, see [Filters and Aggregates](read
 `F()` enables database-side field references and arithmetic. Use it for field-to-field comparisons and computed expressions.
 
 ```julia
-using PormG: F, Sum, Count
+using PormG: F
+using PormG.Functions: Sum, Count
 
 # Field-to-field comparison
 M.Result.objects.filter(F("grid") == F("positionOrder"))
@@ -596,15 +597,16 @@ scope — the SQL function constructors are *not* among them (see
 
 ### SQL function library: `PormG.Functions`
 
-The aggregate, conditional, window, string and math constructors live in the
-`PormG.Functions` submodule instead of being exported into `Main` — their names
-(`Sum`, `Count`, `Max`, `Round`, `Replace`, `Length`, …) are generic enough to collide
-with `Base` and user code. Reach them any of these ways:
+The aggregate, conditional, window, string and math constructors live **only** in the
+`PormG.Functions` submodule — they are not exported into `Main`, and there is no
+`PormG.Sum` alias either. Their names (`Sum`, `Count`, `Max`, `Round`, `Replace`,
+`Length`, …) are generic enough to collide with `Base` and user code, so the library has
+exactly one home. Reach it either way:
 
 ```julia
 using PormG, PormG.Functions          # bring the whole library into scope
-using PormG: Sum, Count, Max          # opt in to specific ones (also works)
-M.Result.objects.values(              # or qualify without importing
+using PormG.Functions: Sum, Count     # …or just the ones you use
+M.Result.objects.values(              # …or qualify without importing
     "n" => PormG.Functions.Count("resultid"))
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -563,31 +563,71 @@ PormG's type hierarchy provides the foundation for the query builder and model s
 
 ## Exported Symbols
 
-The following symbols are exported by `PormG` and available after `using PormG`:
+This is the curated public surface. `using PormG` brings **only** the names below into
+scope — the SQL function constructors are *not* among them (see
+[SQL function library](#sql-function-library-pormgfunctions)).
 
 ### Query Builder
-`object`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `show_query`, `inspect_query`
+`object`, `get`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `show_query`, `inspect_query`
 
-### Aggregate Functions
-`Sum`, `Avg`, `Count`, `Max`, `Min`
-
-### SQL Functions
-`Case`, `Cast`, `Concat`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `Lower`, `Upper`, `Length`, `Abs`, `Round`, `NullIf`, `Replace`, `Trim`, `LTrim`, `RTrim`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`
+### Rows & exceptions
+`PormGRow`, `DoesNotExist`, `MultipleObjectsReturned`
 
 ### Bulk Operations
-`bulk_insert`, `bulk_update`, `bulk_copy`
+`bulk_insert`, `bulk_update`, `bulk_copy`, `allocate_primary_keys`
 
 ### Async API
 `fetch_async`, `await_result`, `FetchTask`
 
 ### Transactions
-`run_in_transaction`, `with_tx_context`, `in_transaction_context`
+`run_in_transaction`, `with_savepoint`, `with_tx_context`, `in_transaction_context`
 
 ### Locking
 `with_advisory_lock`
 
-### Utilities
-`setup`, `tui`, `@import_models`, `@models_module`
+### Utilities & lifecycle
+`setup`, `install_ai_skills`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
+
+!!! note "`fetch` extends `Base.fetch`"
+    The low-level `fetch(settings, sql; params=…)` escape hatch is a method of
+    `Base.fetch`, so it is always in scope (no import, no qualification) and does not
+    shadow Base. Prefer the fluent terminals (`list()`, `DataFrame`, `count()`) for
+    application code.
+
+### SQL function library: `PormG.Functions`
+
+The aggregate, conditional, window, string and math constructors live in the
+`PormG.Functions` submodule instead of being exported into `Main` — their names
+(`Sum`, `Count`, `Max`, `Round`, `Replace`, `Length`, …) are generic enough to collide
+with `Base` and user code. Reach them any of these ways:
+
+```julia
+using PormG, PormG.Functions          # bring the whole library into scope
+using PormG: Sum, Count, Max          # opt in to specific ones (also works)
+M.Result.objects.values(              # or qualify without importing
+    "n" => PormG.Functions.Count("resultid"))
+```
+
+`bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef` stay at the top level — they are query
+primitives, not part of the function library.
+
+**Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min`
+**Conditional** — `Case`, `When`
+**Window** — `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`
+**String** — `Concat`, `Lower`, `Upper`, `Length`, `Replace`, `Trim`, `LTrim`, `RTrim`
+**Math** — `Abs`, `Round`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`
+**Type / value** — `Cast`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `NullIf`
+
+### Result-shape contract for `list()`
+
+The terminal `list()` methods return a documented, stable shape:
+
+| Call | Returns |
+|------|---------|
+| `query.list()` | `Vector{PormGRow}` |
+| `query.list(:dict)` | `Vector{Dict{Symbol, Any}}` |
+| `query.list(:json)` | JSON string |
+| `query |> DataFrame` | `DataFrame` (preferred for analytical queries) |
 
 ---
 
@@ -596,6 +636,6 @@ The following symbols are exported by `PormG` and available after `using PormG`:
 The following section contains auto-generated documentation from docstrings in the source code:
 
 ```@autodocs
-Modules = [PormG, PormG.QueryBuilder, PormG.Models]
+Modules = [PormG, PormG.Functions, PormG.QueryBuilder, PormG.Models]
 Order   = [:function, :type]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -207,7 +207,8 @@ bulk_insert(M.Driver.objects, bulk_data)
 ### 7. Query Your Data
 
 ```julia
-using PormG: Count, F
+using PormG: F
+using PormG.Functions: Count
 
 # Simple filter and list
 drivers = M.Driver.objects.filter("nationality" => "Brazilian").order_by("surname").list()

--- a/docs/src/read/field_expressions.md
+++ b/docs/src/read/field_expressions.md
@@ -25,7 +25,8 @@
 ## Core Syntax
 
 ```julia
-using PormG: F, Count, Sum
+using PormG: F
+using PormG.Functions: Count, Sum
 
 # Field reference
 F("grid")

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -379,7 +379,7 @@ PormG provides five aggregate functions: `Count`, `Sum`, `Avg`, `Max`, and `Min`
 When aggregate values appear in `values()`, PormG **automatically groups by the non-aggregated columns**.
 
 ```julia
-using PormG: Count, Sum, Max, Min
+using PormG.Functions: Count, Sum, Max, Min
 
 query = M.Result.objects
 query.values(

--- a/docs/src/read/functions_and_dates.md
+++ b/docs/src/read/functions_and_dates.md
@@ -134,7 +134,7 @@ PormG exports string manipulation functions that work in `values()`:
 | `Replace("field", old, new)` | Replace substring | `"fixed" => Replace("name", "-", " ")` |
 
 ```julia
-using PormG: Concat, Value, Lower, Upper, Length
+using PormG.Functions: Concat, Value, Lower, Upper, Length
 
 query = M.Driver.objects
 query.values(
@@ -202,7 +202,7 @@ df = query |> DataFrame
 | `Mod("field", n)` | Modulo (remainder) | `Mod("driverid", Value(3))` |
 
 ```julia
-using PormG: Power, Round, Value, Abs
+using PormG.Functions: Power, Round, Value, Abs
 
 query = M.Driver.objects
 query.values(
@@ -225,7 +225,7 @@ df = query |> DataFrame
 ### `Coalesce` — First Non-Null Value
 
 ```julia
-using PormG: Coalesce
+using PormG.Functions: Coalesce
 
 query = M.Driver.objects
 query.values(
@@ -236,7 +236,7 @@ query.values(
 ### `NullIf` — Return NULL If Equal
 
 ```julia
-using PormG: NullIf
+using PormG.Functions: NullIf
 
 # Return NULL if code is an empty string
 query = M.Driver.objects
@@ -248,7 +248,7 @@ query.values(
 ### `Greatest` / `Least` — Max/Min of Values
 
 ```julia
-using PormG: Greatest, Least, Value
+using PormG.Functions: Greatest, Least, Value
 
 query = M.Result.objects
 query.values(
@@ -260,7 +260,7 @@ query.values(
 ### `Cast` — Type Conversion
 
 ```julia
-using PormG: Cast
+using PormG.Functions: Cast
 
 query = M.Result.objects
 query.values(
@@ -271,7 +271,7 @@ query.values(
 ### `Extract` — Extract Date/Time Part
 
 ```julia
-using PormG: Extract
+using PormG.Functions: Extract
 
 query = M.Race.objects
 query.values(
@@ -283,7 +283,7 @@ query.values(
 ### `To_char` — Format as String
 
 ```julia
-using PormG: To_char
+using PormG.Functions: To_char
 
 query = M.Race.objects
 query.values(
@@ -310,7 +310,7 @@ For a simple yes/no expression, pass `otherwise` directly to `When`. PormG wraps
 `CASE … END` automatically — no `Case` wrapper needed:
 
 ```julia
-using PormG: When
+using PormG.Functions: When
 
 # Did the driver win at least one race in their standing?
 query = M.Driver_standings.objects
@@ -362,7 +362,7 @@ For multiple conditions, wrap a vector of `When` fragments in `Case`. The `defau
 provides the `ELSE` branch:
 
 ```julia
-using PormG: Case, When
+using PormG.Functions: Case, When
 
 query = M.Driver.objects
 query.values(
@@ -398,7 +398,8 @@ Output:
 For more complex conditions, combine `Case`/`When` with `Q()` for boolean logic and `F()` for field references:
 
 ```julia
-using PormG: Case, When, Sum, Q, F, Value
+using PormG: Q, F
+using PormG.Functions: Case, When, Sum, Value
 
 query = M.Result.objects
 query.filter("driverid__forename" => "Mika")
@@ -463,7 +464,7 @@ dynamic thresholds. For example, the F1 points system awarded points to the top 
 from 2010 onwards, but only the top 8 before that:
 
 ```julia
-using PormG: Case, When
+using PormG.Functions: Case, When
 
 # Keep only results where the driver finished inside the points-scoring positions,
 # applying the correct threshold for each era.
@@ -519,7 +520,7 @@ All rows are from 1950 (classic era), so the CASE evaluates to `ELSE 8` — only
 Functions can be nested and combined with aggregates:
 
 ```julia
-using PormG: Count, Concat, Value, Upper
+using PormG.Functions: Count, Concat, Value, Upper
 
 # Count races per nationality, with formatted output
 query = M.Driver.objects

--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -55,7 +55,7 @@ query.filter("statusId__@in" => good_sub)
 You can use a SQL function alias as the single column. PormG counts a `"alias" => Function(...)` pair as one column, so the validator accepts it:
 
 ```julia
-using PormG: Max
+using PormG.Functions: Max
 
 # Subquery that returns the single highest driver id
 top_id_sub = M.Driver.objects.values("top_id" => Max("driverid"))
@@ -120,7 +120,7 @@ CTEs (SQL `WITH` clauses) are useful when a query becomes easier to reason about
 Define a subquery, give it a name, and join it to the main query via `join_field`:
 
 ```julia
-using PormG: Count
+using PormG.Functions: Count
 
 # Define the CTE: count results per driver (where status = 1)
 driver_stats = M.Result.objects
@@ -146,7 +146,7 @@ The `.with()` method:
 ## CTE with Multiple Aggregated Fields
 
 ```julia
-using PormG: Count, Sum
+using PormG.Functions: Count, Sum
 
 # CTE with multiple aggregates
 stats = M.Result.objects
@@ -208,7 +208,7 @@ Each `.with()` call adds another `WITH` clause and `JOIN` to the final SQL.
 By default, CTEs use `LEFT JOIN`. Use `join_type="INNER"` to filter out non-matching rows:
 
 ```julia
-using PormG: Sum
+using PormG.Functions: Sum
 
 high_scorers = M.Result.objects
 high_scorers.filter("points__@gte" => 10)
@@ -242,7 +242,7 @@ The SQL builder can also render `"RIGHT"` and `"FULL"` join keywords, but these 
 The `join_field` can contain a multi-level path with `__`. PormG builds the intermediate joins needed to connect the main query to the CTE:
 
 ```julia
-using PormG: Count
+using PormG.Functions: Count
 
 # CTE: count drivers per nationality
 nat_stats = M.Driver.objects

--- a/docs/src/read/window_functions.md
+++ b/docs/src/read/window_functions.md
@@ -23,7 +23,7 @@ The goal: for every 1991 race, assign each driver a rank based on their points �
 
 ```julia
 using PormG
-using PormG: WindowOver, Rank
+using PormG.Functions: WindowOver, Rank
 
 query = M.Driver_standings.objects
 query.filter(
@@ -116,7 +116,7 @@ ORDER BY "raceid" ASC,
 Rank drivers within their constructor by race points. `constructorid` lives in the `result` table (not `driver_standings`), so this example uses `M.Result.objects`. Each constructor is an independent group; the ranking never crosses constructor boundaries.
 
 ```julia
-using PormG: Rank, WindowOver
+using PormG.Functions: Rank, WindowOver
 
 # Each constructor is a separate window — ranks restart per constructor
 spec = WindowOver(partition_by=["constructorid"], order_by=["-points"])
@@ -162,7 +162,7 @@ Three things to notice:
 When there is no `partition_by`, all rows form a single group. `Lag` reaches back one row within that group — here, the previous lap for the same driver.
 
 ```julia
-using PormG: Lag, WindowOver
+using PormG.Functions: Lag, WindowOver
 
 # All laps in one window, ordered by lap number
 spec = WindowOver(order_by=["lap"])
@@ -218,7 +218,7 @@ The `?` for the `LAG` offset is the default `1` — one row back. There is no `P
 No `partition_by`. The window covers the **entire result set** as one group. `FirstValue` ordered by `positionorder` always picks the race winner's points and repeats it on every output row — no self-join needed.
 
 ```julia
-using PormG: FirstValue, WindowOver
+using PormG.Functions: FirstValue, WindowOver
 
 query = M.Result.objects
 query.filter("raceid" => 306, "positionorder__@lte" => 8)
@@ -305,7 +305,7 @@ Explicit frames are needed when the SQL default frame is wrong for your use case
 SQL's default frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` — it includes only rows up to and including the current one. For `LastValue`, that means "the last row I can see is the current row," so it silently returns the current row's own value instead of the partition's actual last row.
 
 ```julia
-using PormG: LastValue, WindowOver
+using PormG.Functions: LastValue, WindowOver
 
 # Default frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
 # LastValue sees only up to the current row → returns each row's own points
@@ -412,7 +412,7 @@ These functions assign a rank or row number to each row. They take no column arg
 | `RowNumber(over=...)` | `ROW_NUMBER() OVER (...)` | Unique sequential number per row |
 
 ```julia
-using PormG: Rank, DenseRank, RowNumber, WindowOver
+using PormG.Functions: Rank, DenseRank, RowNumber, WindowOver
 
 # Race 306 has two tie groups: Piquet/Patrese (6.0) and Suzuki/Alesi (1.0)
 spec = WindowOver(partition_by=["raceid"], order_by=["-points"])
@@ -486,7 +486,7 @@ ORDER BY "rank" ASC
 `Lag` reads from a previous row; `Lead` reads from a following row. Both accept a column reference, an optional `offset` (default `1`), and an optional `default` value returned when no such row exists.
 
 ```julia
-using PormG: Lag, Lead, WindowOver
+using PormG.Functions: Lag, Lead, WindowOver
 
 query = M.Lap_times.objects
 query.filter("raceid" => 841, "driverid" => 1)
@@ -547,7 +547,7 @@ ORDER BY "lap" ASC
 These functions return the value of a column at a specific position within the window frame.
 
 ```julia
-using PormG: FirstValue, LastValue, NthValue, WindowOver
+using PormG.Functions: FirstValue, LastValue, NthValue, WindowOver
 
 spec = WindowOver(partition_by=["raceid"], order_by=["positionorder"])
 
@@ -618,7 +618,7 @@ WHERE "Tb"."raceid" = $1
 Window function results support the same arithmetic operators as `F()` expressions:
 
 ```julia
-using PormG: RowNumber, Lag, WindowOver
+using PormG.Functions: RowNumber, Lag, WindowOver
 
 spec = WindowOver(order_by=["lap"])
 
@@ -678,7 +678,7 @@ Supported operators: `+`, `-`, `*`, `/`
 Window functions and aggregate functions can coexist in the same `values()` call. PormG correctly includes plain fields in `GROUP BY` while keeping window function aliases out of it.
 
 ```julia
-using PormG: Count, Rank, WindowOver
+using PormG.Functions: Count, Rank, WindowOver
 
 # Per constructor: total results count + within-constructor ranking by points
 query = M.Result.objects.filter("driverid__@in" => [846, 817], "points__@gt" => 0).values(

--- a/in_migration.md
+++ b/in_migration.md
@@ -19,50 +19,75 @@ Tracks **breaking / behavior changes in PormG** that require source-code changes
 | ⏳ | pending — not yet migrated |
 | — | n/a — app does not use the affected API |
 
+## Applying these in a consuming app
+
+This file is the **source of truth, kept in the PormG repo**. To fix a dependent app after a
+PormG bump, point an agent (or yourself) at this file — read it from the dev'd source
+(e.g. `~/.julia/dev/PormG/in_migration.md`) or from GitHub — and work the entries
+**newest first**:
+
+1. **Scope to this app.** In each entry's rollout table, skip rows already marked ✅ or —.
+   Work only the ⏳ rows for this app.
+2. **Find the call sites.** Run the entry's *"How to find the calls to migrate"* grep/error
+   inside the app.
+3. **Apply the `before → after`.** Edit each call site to the ✓ form shown in the entry.
+4. **Verify.** Run the app's own test/integration suite against the upgraded PormG. An entry
+   is done for this app only when its code is updated **and** its tests pass.
+5. **Record it.** Flip this app's cell in that entry's rollout table to ✅ (or — if the app
+   never used the affected API), and commit the table update back to PormG so the next app
+   sees accurate state.
+
+> **Tip — make it discoverable.** Add one line to each app's `AGENTS.md`/`CLAUDE.md`:
+> *"Before bumping the PormG dependency, apply any ⏳ rows in `PormG/in_migration.md` for this app."*
+> Then an agent working in that repo will pick up the rollout automatically.
+
 ---
 
 ## Export surface — SQL function constructors moved to `PormG.Functions`
 
 - **PormG ref**: issue #35 (Tier 2 pre-publish · curate the public export surface); [src/PormG.jl](src/PormG.jl) (`module Functions`), [docs/src/api.md](docs/src/api.md)
 - **Recorded**: 2026-06-25
-- **Severity**: **breaking** — only for code that relied on **bare `using PormG`** putting the function names into scope. Explicit imports are unaffected.
+- **Severity**: **breaking** — the function constructors now have a single home (`PormG.Functions`). Any code that reached them through `PormG` — whether by the bare-`using PormG` flood **or** by `using PormG: Sum` — must import them from `PormG.Functions`.
 
 ### What changed
 
-`using PormG` no longer exports the ~42 SQL function constructors (`Sum`, `Avg`, `Count`, `Max`, `Min`, `Case`, `When`, `Cast`, `Concat`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `Lower`, `Upper`, `Length`, `Abs`, `Round`, `NullIf`, `Replace`, `Trim`, `LTrim`, `RTrim`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`, `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`). They now live in the `PormG.Functions` submodule. The curated top-level surface dropped from 73 names to 31 (query primitives, bulk ops, transactions, async, lifecycle).
+`using PormG` no longer exports the ~42 SQL function constructors (`Sum`, `Avg`, `Count`, `Max`, `Min`, `Case`, `When`, `Cast`, `Concat`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `Lower`, `Upper`, `Length`, `Abs`, `Round`, `NullIf`, `Replace`, `Trim`, `LTrim`, `RTrim`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`, `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`). They live **only** in the `PormG.Functions` submodule — there is no `PormG.Sum` alias. The curated top-level surface dropped from 73 names to 31 (query primitives, bulk ops, transactions, async, lifecycle).
 
 `F`, `Q`, `Qor`, `Exists`, `OuterRef`, `object`, `get`, `show_query`, `inspect_query`, the `bulk_*` ops and the transaction/async API **stay at the top level**. `fetch` now extends `Base.fetch` (no longer a shadow) and needs no import.
 
-**What still works unchanged** (no migration needed): `using PormG: Sum, Count` (explicit opt-in) and `PormG.Sum` (qualified) — the names remain accessible, just not auto-exported.
-
 ### How to find the calls to migrate
 
-Only a `using PormG` followed by an **unqualified** function constructor breaks:
+Two patterns break:
 
-```text
-ERROR: UndefVarError: `Sum` not defined
-```
+1. **bare `using PormG`** then an unqualified `Sum(`/`Count(`/`Max(`/… — fails with:
+   ```text
+   ERROR: UndefVarError: `Sum` not defined
+   ```
+2. **`using PormG: Sum, Count, …`** (explicit opt-in of a function name) — now warns at load
+   (`Imported binding PormG.Sum was undeclared`) and leaves the name undefined.
 
-Grep the app for bare `using PormG` whose module then calls `Sum(`/`Count(`/`Max(`/… without a `using PormG: …` or `PormG.Functions` import.
+Grep the app for `using PormG` (bare or `using PormG: …` that lists any function name) and for unqualified function-constructor calls.
 
 ### Migrate your app
 
-Pick one (all equivalent):
+Bring the library in from `PormG.Functions` (pick one):
 
 ```julia
-# ✗ before — relied on bare `using PormG` exporting Sum/Count
-using PormG
+# ✗ before — reached Sum/Count through PormG (flood or `using PormG: Sum, Count`)
+using PormG                      # …or: using PormG: Sum, Count
 M.Result.objects.values("pts" => Sum("points"), "n" => Count("resultid"))
 
-# ✓ after — opt in to the whole function library
+# ✓ after — whole function library
 using PormG, PormG.Functions
 
-# ✓ after — opt in to specific names (also works, smallest diff)
-using PormG: Sum, Count
+# ✓ after — just the ones you use
+using PormG.Functions: Sum, Count
 
 # ✓ after — or qualify at the call site, no import
 M.Result.objects.values("pts" => PormG.Functions.Sum("points"))
 ```
+
+Query primitives are unaffected: `using PormG: Q, Qor, F, Exists, OuterRef` still works (they remain top-level).
 
 ### Per-app rollout
 

--- a/in_migration.md
+++ b/in_migration.md
@@ -21,6 +21,60 @@ Tracks **breaking / behavior changes in PormG** that require source-code changes
 
 ---
 
+## Export surface — SQL function constructors moved to `PormG.Functions`
+
+- **PormG ref**: issue #35 (Tier 2 pre-publish · curate the public export surface); [src/PormG.jl](src/PormG.jl) (`module Functions`), [docs/src/api.md](docs/src/api.md)
+- **Recorded**: 2026-06-25
+- **Severity**: **breaking** — only for code that relied on **bare `using PormG`** putting the function names into scope. Explicit imports are unaffected.
+
+### What changed
+
+`using PormG` no longer exports the ~42 SQL function constructors (`Sum`, `Avg`, `Count`, `Max`, `Min`, `Case`, `When`, `Cast`, `Concat`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `Lower`, `Upper`, `Length`, `Abs`, `Round`, `NullIf`, `Replace`, `Trim`, `LTrim`, `RTrim`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`, `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`). They now live in the `PormG.Functions` submodule. The curated top-level surface dropped from 73 names to 31 (query primitives, bulk ops, transactions, async, lifecycle).
+
+`F`, `Q`, `Qor`, `Exists`, `OuterRef`, `object`, `get`, `show_query`, `inspect_query`, the `bulk_*` ops and the transaction/async API **stay at the top level**. `fetch` now extends `Base.fetch` (no longer a shadow) and needs no import.
+
+**What still works unchanged** (no migration needed): `using PormG: Sum, Count` (explicit opt-in) and `PormG.Sum` (qualified) — the names remain accessible, just not auto-exported.
+
+### How to find the calls to migrate
+
+Only a `using PormG` followed by an **unqualified** function constructor breaks:
+
+```text
+ERROR: UndefVarError: `Sum` not defined
+```
+
+Grep the app for bare `using PormG` whose module then calls `Sum(`/`Count(`/`Max(`/… without a `using PormG: …` or `PormG.Functions` import.
+
+### Migrate your app
+
+Pick one (all equivalent):
+
+```julia
+# ✗ before — relied on bare `using PormG` exporting Sum/Count
+using PormG
+M.Result.objects.values("pts" => Sum("points"), "n" => Count("resultid"))
+
+# ✓ after — opt in to the whole function library
+using PormG, PormG.Functions
+
+# ✓ after — opt in to specific names (also works, smallest diff)
+using PormG: Sum, Count
+
+# ✓ after — or qualify at the call site, no import
+M.Result.objects.values("pts" => PormG.Functions.Sum("points"))
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
 ## Driver loading — `LibPQ`/`SQLite` are now weak dependencies (load the driver yourself)
 
 - **PormG ref**: issue #34 (Tier 2 pre-publish · decouple SQL adapters); [src/Backend.jl](src/Backend.jl), [ext/PormGLibPQExt.jl](ext/PormGLibPQExt.jl), [ext/PormGSQLiteExt.jl](ext/PormGSQLiteExt.jl), [Project.toml](Project.toml)

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -1,6 +1,10 @@
 module ConnectionPool
 
 import Logging
+# Extend Base.fetch rather than define a fresh `fetch` — a shadowing `fetch` forces every
+# caller to qualify it and conflicts with Base.fetch on `using` (#35). PormG owns the
+# first-argument types (PormGPostgres/PormGSQLite/SQLConn), so this is not type piracy.
+import Base: fetch
 import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel
 import PormG: @pormg_debug
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
@@ -9,7 +13,11 @@ import PormG: backend_connect, backend_renew_connection, backend_is_alive, backe
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, with_savepoint
-export acquire_connection, release_connection, close_pool!
+export acquire_connection, release_connection
+# NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
+# `close_pool!` (it dispatches on a pool OR a db-name String and delegates the pool case to
+# this module's `close_pool!`). Exporting it from both modules made `PormG.close_pool!`
+# ambiguous and therefore undefined (#35). Callers in this package use `CP.close_pool!`.
 
 # Import transaction context helpers from Configuration
 import PormG.Configuration: get_tx_connection, get_tx_pool, with_tx_context, transaction_connection_for, get_settings, ensure_before_connect!, connection_key_for_pool

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -110,7 +110,10 @@ include("AdvisoryLock.jl")
 using .AdvisoryLock
 
 include("QueryBuilder.jl")
-import .QueryBuilder: object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Sum, Avg, Count, Max, Min, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys, Case, When, Cast, Concat, Extract, To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
+# Query primitives only. The SQL function constructors are NOT imported into PormG — they
+# live solely in `PormG.Functions` (below). There is intentionally no `PormG.Sum`: the
+# function library has exactly one home, reached via `using PormG.Functions` / `PormG.Functions.X`.
+import .QueryBuilder: object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 
 """
     PormG.Functions

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -112,7 +112,37 @@ using .AdvisoryLock
 include("QueryBuilder.jl")
 import .QueryBuilder: object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Sum, Avg, Count, Max, Min, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys, Case, When, Cast, Concat, Extract, To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
 
-export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Sum, Avg, Count, Max, Min, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys, Case, When, Cast, Concat, Extract, To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
+"""
+    PormG.Functions
+
+The SQL function library — aggregate (`Sum`, `Avg`, `Count`, `Max`, `Min`), conditional
+(`Case`, `When`), window (`WindowOver`, `Rank`, `Lag`, …), string (`Lower`, `Replace`,
+`Trim`, …) and math (`Round`, `Floor`, `Power`, …) constructors.
+
+These are **not** exported into `Main` by `using PormG`: the names are generic enough to
+collide with `Base` and user code (`Sum`, `Count`, `Max`, `Replace`, `Round`, `Length`…).
+Opt in explicitly:
+
+```julia
+using PormG, PormG.Functions          # brings Sum, Count, … into scope
+# or qualify without importing:
+M.Result.objects.values("n" => PormG.Functions.Count("resultid"))
+```
+"""
+module Functions
+  import ..QueryBuilder: Sum, Avg, Count, Max, Min, Case, When, Cast, Concat, Extract,
+    To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
+    Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver,
+    WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
+  export Sum, Avg, Count, Max, Min, Case, When, Cast, Concat, Extract,
+    To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
+    Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver,
+    WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
+end
+
+# Curated top-level surface: query primitives only. The SQL function constructors above
+# live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
+export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, with_savepoint  # Async-first API
 export with_tx_context, in_transaction_context  # Transaction context helpers

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -93,8 +93,8 @@ import Logging
 
           # Selection and Aggregation
           q.values("forename", "surname")
-          q.values("forename", "count" => Count("driverId"))
-          q.values("points_sum" => Sum("points"))
+          q.values("forename", "count" => Functions.Count("driverId"))
+          q.values("points_sum" => Functions.Sum("points"))
 
           # Ordering and pagination
           q.order_by("-points")

--- a/test/integration/common_setup.jl
+++ b/test/integration/common_setup.jl
@@ -4,6 +4,11 @@ ENV["PORMG_ENV"] = "dev"
 
 using Revise
 using PormG
+# SQL function library (Sum, Count, Lower, Greatest, Floor, Extract, Abs, Concat, …) is
+# namespaced under PormG.Functions since #35 (no longer flooded into Main by `using PormG`).
+# Bring the whole library into scope so the integration tests can use the bare constructors —
+# this models the documented `using PormG, PormG.Functions` pattern (docs/src/api.md).
+using PormG.Functions
 # Activate the LibPQ/SQLite weakdep extensions (#34) before any DB work — without these
 # every backend operation raises the "load the driver" error. Robust across env types;
 # see test/load_drivers.jl.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ end
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
+    @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")
     # include("unit/test_migration_planner.jl")
 end
 

--- a/test/unit/test_complex_queries.jl
+++ b/test/unit/test_complex_queries.jl
@@ -467,7 +467,7 @@ ResultCamelDjangoModel._module = Main
 
   # ===== Section: Concat variadic vs vector form =====
   @testset "Concat variadic and vector forms produce identical SQL" begin
-    using PormG: Concat, Value
+    using PormG.Functions: Concat, Value
 
     # Variadic form: Concat("forename", Value(" "), "surname")
     q_var = DriverModel.objects
@@ -490,7 +490,7 @@ ResultCamelDjangoModel._module = Main
 
   # ===== Section: Case/When expression as filter RHS =====
   @testset "Case/When as filter RHS value" begin
-    using PormG: Case, When
+    using PormG.Functions: Case, When
 
     # Filter: year >= threshold where threshold comes from a Case expression
     q = RaceModel.objects

--- a/test/unit/test_execution_show.jl
+++ b/test/unit/test_execution_show.jl
@@ -108,7 +108,7 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "IN subqueries accept single SQL-function projections" begin
   # A single aliased SQL-function projection counts as one column — must pass validation.
-  subquery = TestDriver.objects.values("max_id" => PormG.Max("id"))
+  subquery = TestDriver.objects.values("max_id" => PormG.Functions.Max("id"))
   query = TestDriver.objects.filter("id__@in" => subquery)
 
   result = query.list(show_query=:dict)
@@ -126,7 +126,7 @@ end
 # two such pairs must trigger the same ArgumentError as two plain strings.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "IN subqueries reject two SQL-function projections" begin
-  subquery = TestDriver.objects.values("max_id" => PormG.Max("id"), "min_id" => PormG.Min("id"))
+  subquery = TestDriver.objects.values("max_id" => PormG.Functions.Max("id"), "min_id" => PormG.Functions.Min("id"))
   query = TestDriver.objects.filter("id__@in" => subquery)
 
   err = try

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -73,11 +73,17 @@ const EXPECTED_FUNCTIONS = Set([
         @test PormG.Functions.Sum === PormG.QueryBuilder.Sum
     end
 
-    # Explicit opt-in still works (the pattern the read/* docs use): `using PormG: Sum`.
-    @testset "Explicit opt-in import still resolves" begin
-        @test isdefined(PormG, :Sum)    # accessible as PormG.Sum (unexported)
-        @test isdefined(PormG, :Count)
-        @test PormG.Sum === PormG.QueryBuilder.Sum
+    # Clean break (#35): the function constructors have exactly ONE home — PormG.Functions.
+    # They are deliberately NOT accessible as `PormG.Sum`, so `using PormG: Sum` fails by
+    # design. Pre-publish, we want one obvious namespace rather than a redundant alias.
+    @testset "Function names live ONLY in PormG.Functions (no PormG.Sum alias)" begin
+        @test !isdefined(PormG, :Sum)
+        @test !isdefined(PormG, :Count)
+        @test !isdefined(PormG, :Round)
+        @test !isdefined(PormG, :Replace)
+        # The single home still resolves to the QueryBuilder source of truth:
+        @test isdefined(PormG.Functions, :Sum)
+        @test PormG.Functions.Sum === PormG.QueryBuilder.Sum
     end
 
     # `fetch` extends Base.fetch instead of shadowing it (no forced qualification).

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -1,0 +1,97 @@
+# ==============================================================================
+# UNIT TESTS: Public export surface (pre-publish · issue #35)
+#
+# Pin the *curated* public API so the surface can't silently regrow. `using PormG`
+# must bring exactly the documented top-level names — and NONE of the SQL function
+# constructors, which live in `PormG.Functions` to avoid flooding `Main` and colliding
+# with `Base`. The documented list lives in docs/src/api.md ("Exported Symbols"); this
+# test is the machine-checked counterpart. Adding/removing a public name is a deliberate
+# contract change that must update BOTH this set and api.md.
+#
+# Runs WITHOUT a live database — it only inspects module namespaces.
+# ==============================================================================
+
+using Test
+using PormG
+
+# The frozen top-level surface of `using PormG` (must match docs/src/api.md exactly).
+const EXPECTED_TOPLEVEL = Set([
+    # Query builder
+    :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :show_query, :inspect_query,
+    # Rows & exceptions
+    :PormGRow, :DoesNotExist, :MultipleObjectsReturned,
+    # Bulk operations
+    :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
+    # Async API
+    :fetch_async, :await_result, :FetchTask,
+    # Transactions
+    :run_in_transaction, :with_savepoint, :with_tx_context, :in_transaction_context,
+    # Locking
+    :with_advisory_lock,
+    # Utilities & lifecycle
+    :setup, :install_ai_skills, :tui, :register_ignore_tables!,
+    Symbol("@import_models"), Symbol("@models_module"), Symbol("@pormg_debug"),
+])
+
+# The SQL function library, namespaced under PormG.Functions (NOT exported by PormG).
+const EXPECTED_FUNCTIONS = Set([
+    :Sum, :Avg, :Count, :Max, :Min,
+    :Case, :When,
+    :WindowOver, :WindowSpec, :Rank, :DenseRank, :RowNumber, :Lag, :Lead, :FirstValue, :LastValue, :NthValue,
+    :Concat, :Lower, :Upper, :Length, :Replace, :Trim, :LTrim, :RTrim,
+    :Abs, :Round, :Floor, :Ceil, :Sqrt, :Exp, :Ln, :Power, :Mod,
+    :Cast, :Extract, :To_char, :Value, :Coalesce, :Greatest, :Least, :NullIf,
+])
+
+@testset "Public export surface (#35)" begin
+
+    # `names(PormG)` includes the module's own name; drop it, then compare exactly. An
+    # exact-set comparison catches BOTH accidental additions (re-flooding) and removals.
+    @testset "Top-level surface is exactly the documented set" begin
+        actual = Set(filter(n -> n !== :PormG, names(PormG)))
+        # Show the precise drift if this fails, so the fix is obvious.
+        @test setdiff(actual, EXPECTED_TOPLEVEL) == Set{Symbol}()   # nothing unexpected leaked in
+        @test setdiff(EXPECTED_TOPLEVEL, actual) == Set{Symbol}()   # nothing documented went missing
+        @test actual == EXPECTED_TOPLEVEL
+    end
+
+    # The SQL function constructors must NOT be exported at the top level (the whole point
+    # of #35 — these generic names flooded Main and collided with Base).
+    @testset "SQL function names are not top-level exports" begin
+        toplevel = Set(names(PormG))
+        for f in EXPECTED_FUNCTIONS
+            @test !(f in toplevel)
+        end
+    end
+
+    # …but they ARE exported by PormG.Functions, and resolve to the same QueryBuilder bindings.
+    @testset "PormG.Functions exports the function library" begin
+        fns = Set(filter(n -> n !== :Functions, names(PormG.Functions)))
+        @test fns == EXPECTED_FUNCTIONS
+        # Same binding as the source of truth (no divergent copy).
+        @test PormG.Functions.Count === PormG.QueryBuilder.Count
+        @test PormG.Functions.Sum === PormG.QueryBuilder.Sum
+    end
+
+    # Explicit opt-in still works (the pattern the read/* docs use): `using PormG: Sum`.
+    @testset "Explicit opt-in import still resolves" begin
+        @test isdefined(PormG, :Sum)    # accessible as PormG.Sum (unexported)
+        @test isdefined(PormG, :Count)
+        @test PormG.Sum === PormG.QueryBuilder.Sum
+    end
+
+    # `fetch` extends Base.fetch instead of shadowing it (no forced qualification).
+    @testset "fetch extends Base.fetch (no shadow)" begin
+        @test PormG.ConnectionPool.fetch === Base.fetch
+    end
+
+    # `close_pool!` was exported by BOTH Configuration and ConnectionPool as *different*
+    # functions, which made `PormG.close_pool!` ambiguous (undefined). The dedup leaves
+    # Configuration's full-featured version (pool OR db-name String) as the single one.
+    @testset "close_pool! is no longer a duplicate export" begin
+        @test isdefined(PormG, :close_pool!)
+        @test PormG.close_pool! === PormG.Configuration.close_pool!
+        # Still accepts a db-name String (the convenience the public version adds).
+        @test hasmethod(PormG.close_pool!, Tuple{String})
+    end
+end


### PR DESCRIPTION
Closes #35.

Second of two sequential Tier 2 pre-publish PRs. **Stacked on #52** (`pre-publish/tier2-decouple-drivers`) — review/merge #52 first; this PR's base will retarget to `main` automatically once #52 lands.

## What changes

Curate the export surface so `using PormG` stops flooding `Main` with ~42 generic SQL function names and the public contract is documented and enforced.

- **`PormG.Functions` submodule** — the SQL function constructors (`Sum`, `Count`, `Max`, `Case`, `When`, window funcs, …) now live **only** there. Opt in with `using PormG.Functions` or qualify `PormG.Functions.Sum`.
- **Clean break (no alias):** since PormG is pre-publish (single maintainer, ~4 internal apps, no external users), the names are removed from the top level entirely — there is no `PormG.Sum` alias and `using PormG: Sum` no longer resolves. One canonical home instead of two.
- **`fetch`** now `import Base: fetch` and extends it (PormG owns the first-arg type → not piracy) instead of shadowing `Base.fetch`.
- Curated top-level surface dropped from ~73 to 31 names; driver internals un-exported; duplicate exports resolved.
- **Documented public-symbol contract** in `docs/src/api.md` (incl. the `list()` return shape: `Vector{PormGRow}`, `list(:dict)` → `Vector{Dict{Symbol,Any}}`), guarded by a `test/unit/test_public_exports.jl` assertion + Aqua.
- Docs and `in_migration.md` updated; every doc example uses `using PormG.Functions`.

## Verification

- Unit suite **1886/1886** (incl. the new export-surface + no-alias assertions); PostgreSQL **1423/1423**; SQLite **1388/1388**.
- `docs/make.jl` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)