### PR TITLE
fix(#54): enforce LF for *.jl + harden migration-format scan against CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Line-ending policy for PormG.
+#
+# Julia source is LF by convention, and several tests read migration files as raw
+# bytes — e.g. the frozen v1 fixture's `# pormg-migration-format: N` header scan in
+# test/unit/test_migration_format_v1.jl, whose checksum is byte-pinned. Without this,
+# a Windows checkout with core.autocrlf=true rewrites LF -> CRLF in the working tree,
+# and the trailing CR breaks the `$`-anchored line scan (and would desync a byte-frozen
+# fixture). Pin LF so the working tree matches the index (already LF) on every platform.
+*.jl text eol=lf

--- a/docs/src/migrations/stability.md
+++ b/docs/src/migrations/stability.md
@@ -31,8 +31,9 @@ constant `PormG.Migrations.MIGRATION_FORMAT_VERSION` (currently `1`):
   It is a **comment, not a `const`**, deliberately: migration files are re-`include`d across runs,
   and a constant would emit `Warning: redefining constant` and conflict once files of different
   format versions coexist. The header is read by line-scan with the regex
-  `^# pormg-migration-format: (\d+)$` **before** the module is ever executed — so a future engine
-  detects the format and decides how to parse a file *before* trusting it.
+  `^# pormg-migration-format: (\d+)\r?$` **before** the module is ever executed — so a future engine
+  detects the format and decides how to parse a file *before* trusting it. The optional `\r?` keeps
+  the scan line-ending agnostic (a file checked out with CRLF on Windows still matches).
 
 - **In the database** — the `pormg_migrations.format_version` column records the format of each
   applied record. This column is the **authoritative** version source (the runtime history table is

--- a/test/integration/test_row_mutation.jl
+++ b/test/integration/test_row_mutation.jl
@@ -181,4 +181,4 @@ end
     # save() must detect pk_field === nothing and throw ArgumentError
     # instead of building a filter on the literal string "nothing".
     @test_throws ArgumentError row.save()
-end
+end

--- a/test/unit/test_migration_format_v1.jl
+++ b/test/unit/test_migration_format_v1.jl
@@ -57,8 +57,10 @@ const _MANUAL_DIGEST    = "ee7ee5c8ede0b94b23ff384d1f9b2e2f9ac9d87c3be23647d032a
         text = read(fixture_file, String)
 
         # 1. The on-disk format marker is present and parses to version 1 (read by line-scan, exactly
-        #    as a future engine would detect the format before executing the file).
-        m = match(r"(?m)^# pormg-migration-format: (\d+)$", text)
+        #    as a future engine would detect the format before executing the file). The optional `\r?`
+        #    keeps the scan line-ending agnostic: a committed migration may be checked out with CRLF on
+        #    Windows (core.autocrlf), and the trailing CR would otherwise defeat the `$` anchor.
+        m = match(r"(?m)^# pormg-migration-format: (\d+)\r?$", text)
         @test m !== nothing
         @test parse(Int, m.captures[1]) == 1
 
@@ -87,7 +89,7 @@ const _MANUAL_DIGEST    = "ee7ee5c8ede0b94b23ff384d1f9b2e2f9ac9d87c3be23647d032a
 
             # Header present, parses to the current format version.
             @test occursin("# pormg-migration-format: $(Migrations.MIGRATION_FORMAT_VERSION)", text)
-            m = match(r"(?m)^# pormg-migration-format: (\d+)$", text)
+            m = match(r"(?m)^# pormg-migration-format: (\d+)\r?$", text)
             @test m !== nothing
             @test parse(Int, m.captures[1]) == Migrations.MIGRATION_FORMAT_VERSION
 


### PR DESCRIPTION
Closes #54.

## What this does

Pins `*.jl` to LF and hardens the migration-format scan against CRLF, so Windows checkouts
(`core.autocrlf=true`) stop smudging LF→CRLF in the working tree — the churn that produced phantom
full-file diffs and broke the byte-level `# pormg-migration-format: N` header scan.

## Scope correction

The issue assumed a repo-wide normalization. On inspection (authoritative byte-counting, not the
unreliable Windows `grep`), **HEAD is already LF for 122 of 123 tracked `.jl` files** — only
`test/integration/test_row_mutation.jl` was actually committed with CRLF. So the change is small:

- **`.gitattributes`** (new): `*.jl text eol=lf` — the structural fix that stops the smudge going
  forward.
- **`test/integration/test_row_mutation.jl`**: normalize CRLF → LF (the one committed-CRLF file).
- **`test/unit/test_migration_format_v1.jl`**: make the format-header scan CRLF-tolerant —
  `^# pormg-migration-format: (\d+)\r?$` — so detection survives a stray CR even if a file is
  checked out CRLF somewhere (e.g. a downstream app's migration).
- **`docs/src/migrations/stability.md`**: document the CRLF tolerance.

The 368-line diff on `test_row_mutation.jl` is the EOL flip of that one file (content unchanged).

## Verification

`test/unit/test_migration_format_v1.jl` — **32/32 pass** against the LF fixture, confirming the
`\r?`-tolerant scan and the byte-pinned checksum both hold after normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
