### PR TITLE
refactor(#42)!: ObjectHandler accessor cleanup — drop :inspect_query alias, count/exists honor show_query

### DIFF
--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -199,7 +199,7 @@ meta = query.list(show_query=:dict)
 @time query.list(show_query=:none)
 
 # Dedicated inspection API with heuristic intent detection
-inspection = query.inspect_query()
+inspection = query.inspect()
 println(inspection[:sql])
 println(inspection[:operation])  # => :select
 ```
@@ -213,7 +213,7 @@ println(inspection[:operation])  # => :select
 | `:params` | Parameters array only. |
 | `:none` | `nothing` (zero-overhead benchmarking). |
 
-`show_query` is supported on terminal methods such as `list()`, `first()`, `get()`, `delete()`, `update()`, `bulk_insert()`, and `bulk_update()`.
+`show_query` is supported on terminal methods such as `list()`, `first()`, `get()`, `count()`, `exists()`, `delete()`, `update()`, `bulk_insert()`, and `bulk_update()`.
 
 ---
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -275,7 +275,7 @@ show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(q; show_query=mode)
 # Count or check if exists
 #
 
-function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing)::Integer
+function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
   # Resolve settings
   settings, connection, conn_key = get_settings(oq)
   
@@ -304,8 +304,13 @@ function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlia
     FROM $safe_table_name as $safe_alias
     $(join(instruction.join, "\n"))
     $(instruction._where |> length > 0 ? "WHERE" : "") $(join(instruction._where, " AND \n   "))
-    $(instruction.agregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "") 
+    $(instruction.agregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "")
     """
+  # Inspection short-circuit: return SQL/metadata without hitting the database.
+  if show_query !== :execute
+    return _show_query_result(show_query, resposta, instruction.connection, q.object.model.name, :select;
+                            parameters=instruction.parameters)
+  end
   query_result = fetch(settings, resposta, instruction.parameters)
   # PostgreSQL returns a LibPQ.Result that supports scalar [row, col] indexing.
   # SQLite returns a materialized rowtable (Vector{<:NamedTuple}); a Vector *also* has a
@@ -320,7 +325,7 @@ function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlia
   end
 end
 
-function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing)
+function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
   try
     # Resolve settings
     settings, connection, conn_key = get_settings(oq)
@@ -355,7 +360,12 @@ function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAli
     $(instruction.agregate && !isempty(instruction.group) ? "GROUP BY $(join(instruction.group, ", "))" : "")
     $limit_clause
     $offset_clause
-    """    
+    """
+    # Inspection short-circuit: return SQL/metadata without hitting the database.
+    if show_query !== :execute
+      return _show_query_result(show_query, sql, instruction.connection, q.object.model.name, :select;
+                              parameters=instruction.parameters)
+    end
     @pormg_debug false
     result = fetch(settings, sql, instruction.parameters) |> Tables.rowtable
     @pormg_debug false

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -232,30 +232,32 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
   elseif sym === :copy
     return () -> deepcopy(q)
 
-
-    # === CATEGORY 2: Terminal methods (return result) ===
-    # End the chain. E.g.: query.create(...) returns a Dict.
+  # === CATEGORY 2: Terminal methods (return result) ===
+  # End the chain. E.g.: query.create(...) returns a Dict.
   elseif sym === :create
-    # Returns a function that forwards to up_create!
+    # `args...` is intentionally untyped: the execute path returns a Dict, while
+    # show_query=:sql/:dict/:params/:none return String/Dict/Vector/nothing. A typed
+    # signature would force the inspect contract to fork, so the return stays `Any`.
     return (args...; kwargs...) -> up_create!(q.object, args; kwargs...)
   elseif sym === :update
+    # Same dual execute/inspect return contract as :create — see the note above.
     return (args...; kwargs...) -> up_update!(q.object, args; kwargs...)
   elseif sym === :count
-    return () -> do_count(q)
+    return (; show_query=:execute) -> do_count(q; show_query=show_query)
   elseif sym === :exists
-    return () -> do_exists(q)
+    return (; show_query=:execute) -> do_exists(q; show_query=show_query)
   elseif sym === :first
     return (; kwargs...) -> first(q; kwargs...)
   elseif sym === :get
     return (args...; show_query=:execute) -> get(q, args...; show_query=show_query)
   elseif sym === :list
     return (format::Symbol=:row; show_query::Symbol=:execute) -> list(q, Val(format); show_query=show_query)
-  elseif sym === :inspect_query || sym === :inspect
+  elseif sym === :inspect
     return (; kwargs...) -> inspect_query(q; kwargs...)
   elseif sym === :delete
     return (; kwargs...) -> delete(q; kwargs...)
 
-    # === CATEGORY 3: Internal fields ===
+  # === CATEGORY 3: Internal fields ===
   else
     return getfield(q, sym)
   end

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -530,4 +530,64 @@ PormG.config["default"] = MockSettings
     @test_throws ArgumentError inspect_query(note_query)
   end
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # count() / exists() inspection (#42): both terminals must honor show_query so
+  # their generated SQL is inspectable without a live database. The short-circuit
+  # returns before fetch(), so MockPostgres is sufficient.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "count()/exists() honor show_query" begin
+    q = DriverModel.objects
+    q.filter("nationality" => "British")
+
+    # count(show_query=:sql) renders the COUNT SELECT without executing.
+    count_sql = q.count(show_query=:sql)
+    @test count_sql isa String
+    @test contains(count_sql, "COUNT")
+    @test occursin("drivers", lowercase(count_sql))
+
+    # count(show_query=:dict) exposes the full metadata dict with bound parameters.
+    count_meta = q.count(show_query=:dict)
+    @test count_meta isa Dict
+    @test count_meta[:operation] === :select
+    @test count_meta[:model] == "drivers"
+    @test contains(count_meta[:sql_text], "COUNT")
+    @test count_meta[:parameters] == ["British"]
+
+    # exists(show_query=:sql) renders the `SELECT 1 ... LIMIT 1` probe.
+    exists_sql = q.exists(show_query=:sql)
+    @test exists_sql isa String
+    @test contains(exists_sql, "SELECT 1")
+    @test contains(exists_sql, "LIMIT 1")
+
+    # exists(show_query=:dict) exposes the same metadata shape.
+    exists_meta = q.exists(show_query=:dict)
+    @test exists_meta isa Dict
+    @test exists_meta[:model] == "drivers"
+    @test contains(exists_meta[:sql_text], "SELECT 1")
+    @test exists_meta[:parameters] == ["British"]
+
+    # Default path (no show_query) is unchanged: count() still returns an Integer.
+    # (Skipped here — requires a live DB; covered in integration suites.)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Terminal-name cleanup (#42): `query.inspect()` is the only surviving inspection
+  # terminal. The `query.inspect_query()` alias was removed, so the accessor must
+  # fall through to getfield and error.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "inspect terminal: alias removed, :inspect survives" begin
+    q = DriverModel.objects
+    q.filter("nationality" => "Italian")
+
+    # `.inspect()` forwards to inspect_query and returns the same metadata.
+    via_terminal = q.inspect()
+    via_function = inspect_query(q)
+    @test via_terminal isa Dict
+    @test via_terminal[:sql_text] == via_function[:sql_text]
+    @test via_terminal[:parameters] == via_function[:parameters]
+
+    # The removed alias is no longer a property → getfield fallback throws.
+    @test_throws ErrorException q.inspect_query
+  end
+
 end


### PR DESCRIPTION
Closes #42 (tagged `pre-publish` + `breaking`).

Cleanup of the `ObjectHandler.getproperty` accessor surface, settled now because it locks public terminal names before the first General-registry publish.

## Changes

| Sub-task | Result |
|---|---|
| Remove `:inspect_query` alias | **Done** — `query.inspect()` is the sole inspection terminal. The free `inspect_query(q)` function is unchanged. |
| `:count`/`:exists` honor `show_query` | **Done** — `show_query` threaded into `do_count`/`do_exists`; both short-circuit to `_show_query_result` before any DB call, so `query.count(show_query=:sql)` / `:dict` (and `exists`) are inspectable without executing. |
| `:create`/`:update` typed signatures | **Considered — intentionally not typed.** The execute path returns `Dict`, but `show_query=:sql/:dict/:params/:none` return `String`/`Dict`/`Vector`/`nothing`; a typed signature would fork the inspect contract. Documented with a contract comment at the accessor. |
| Mis-indented CATEGORY 2/3 comment | **Done** — re-aligned to the `elseif` level. |

## ⚠️ Breaking

`query.inspect_query()` (the terminal form) is removed. Use `query.inspect()`. The standalone `inspect_query(q)` / `PormG.QueryBuilder.inspect_query(q)` function is **not** affected. Only the in-repo doc example used the removed terminal form; it's updated.

## Docs & tests

- `docs/src/read/index.md`: `.inspect()` example + `count()`/`exists()` added to the `show_query`-supported terminal list.
- `test/unit/test_inspect_query.jl`: regression coverage for `count`/`exists` inspection modes and for the removed alias falling through to `getfield`.

## Verification

- Full unit suite green: **1905/1905**.
- SQLite integration (`test_internals.jl`) confirms the `count()`/`exists()` execute path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
