### PR TITLE
feat(#57)!: preserve declared field-name case (support mixed-case columns)

### DIFF
--- a/.github/skills/pormg-changed-code-review/SKILL.md
+++ b/.github/skills/pormg-changed-code-review/SKILL.md
@@ -116,7 +116,7 @@ In the final pass, review `docs`, `ext`, `.github`, `.cursor`, `db`, and any rem
 - workflow or CI changes that hide failures or leak secrets
 - generated files that drift from source-of-truth files
 - configuration changes that alter runtime or migration behavior without matching tests
-- **changed query examples in `docs/`, `README.MD`, or `src/*.md`** that were not verified against the live `db_sl` data — confirm the SQL shape, execute the example, and cross-check the value per the verification recipe in [`../pormg-public-api-development/SKILL.md`](../pormg-public-api-development/SKILL.md) ("Verifying doc examples against the live database"). Flag camelCase join paths (`driverId__surname`) — query paths must be lowercase or they throw at build time.
+- **changed query examples in `docs/`, `README.MD`, or `src/*.md`** that were not verified against the live `db_sl` data — confirm the SQL shape, execute the example, and cross-check the value per the verification recipe in [`../pormg-public-api-development/SKILL.md`](../pormg-public-api-development/SKILL.md) ("Verifying doc examples against the live database"). Flag query paths whose case doesn't match the declared field — lookups are case-sensitive (#57). The F1 models declare lowercase fields, so `driverId__surname` throws (the field is `driverid`); the path must match the declared case.
 
 ## Review Method
 

--- a/.github/skills/pormg-public-api-development/SKILL.md
+++ b/.github/skills/pormg-public-api-development/SKILL.md
@@ -151,7 +151,7 @@ raw = (M.Result.objects.filter("constructorid" => 131).values("points") |> DataF
 Rules and gotchas:
 
 - **Verify the value, not just execution.** For aggregates/computed columns, recompute the answer independently (raw row scan, plain `Sum`, etc.) and assert equality — a query that runs can still be wrong.
-- **Query field paths must be lowercase** (`constructorid__name`), even though models declare camelCase fields. CamelCase join paths throw at build time.
+- **Query a field by the exact case it was declared** — field lookups are case-sensitive (#57). The F1 models declare **lowercase** fields, so their paths are lowercase (`constructorid__name`); a camelCase path like `constructorId__name` throws *because the field is `constructorid`*, not because PormG folds case. (House style is lowercase snake_case; mixed-case is supported for legacy columns.)
 - **`@import_models` resolves its path relative to the script file's directory** — keep the script in `test/integration/` or pass an absolute path.
 - **Dialect placeholders differ:** db_sl (SQLite) renders `?`, db_2 (PostgreSQL) renders `$1`. Doc SQL blocks conventionally show the PostgreSQL form; note the SQLite difference when it matters.
 - `inspect_query(q)[:sql_text]` (or `show_query=:sql`) renders before any DB round-trip, so the SQL-shape check works even without a live connection.

--- a/.github/skills/pormg-usage/SKILL.md
+++ b/.github/skills/pormg-usage/SKILL.md
@@ -104,7 +104,7 @@ end
 - **Field names**: Lowercase, snake_case: `first_name`, `created_at`
 - **Never use `__`** in field or table names — reserved for ORM join traversal
 - Prefix reserved Julia keywords: `_id`, `_type`, `_end`
-- **In query operations, field paths are lowercase** (`constructorid__name`), even when the model declares camelCase fields — camelCase join paths throw at build time.
+- **Query fields in the case they were declared** — lookups are case-sensitive (#57). The F1 models declare **lowercase** fields, so their paths are lowercase (`constructorid__name`); a camelCase path throws because the field doesn't exist under that case. (House style is lowercase snake_case; mixed-case columns are supported when you declare them that way.)
 
 > Migrations, create/update/delete, bulk operations, and transactions live in [`writing.md`](writing.md).
 
@@ -156,7 +156,7 @@ df   = query |> DataFrame   # DataFrames.DataFrame
 ## 4. Joins and Lookups
 
 ### Relationship traversal
-Use `__` to traverse ForeignKey relationships (lowercase field paths):
+Use `__` to traverse ForeignKey relationships (query each segment in the case it was declared; the F1 models use lowercase):
 
 ```julia
 # Filter by joined field
@@ -417,7 +417,7 @@ Alias identifiers must start with a Unicode letter or underscore, followed by le
 | `query \|> list` (free function) | `query.list()` |
 | `delete(query)` (free function) | `query.delete()` |
 | `SELECT *` across joins | `.values("*", "joined__field")` explicitly |
-| camelCase join path in a query | lowercase path (`constructorid__name`) |
+| Wrong-case join path for a lowercase-declared field | match the declared case (`constructorid__name`) |
 | Loops for batch inserts | `bulk_insert()` or `bulk_copy()` (see `writing.md`) |
 | Python-style `annotate()` | `values("alias" => F("field") * 1.5)` |
 | `F("points") > 20` in filter | `"points__@gt" => 20` (suffix syntax) |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,107 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Field names — declared **case is preserved** and lookups are **case-sensitive**
+
+- **PormG ref**: issue #57 (preserve declared field-name case) + #58 (lowercase house-style convention); [src/Models.jl](src/Models.jl) (`format_fild_name` / `format_model_name`), [src/querybuilder/deletion.jl](src/querybuilder/deletion.jl), [src/querybuilder/types.jl](src/querybuilder/types.jl)
+- **Recorded**: 2026-06-27
+- **Severity**: **breaking** — has both a **code** dimension (query/row access is case-sensitive) and a **database** dimension (the declared field name *is* the physical column name, verbatim).
+
+### What changed
+
+PormG used to **force every field name to lowercase** at model registration: a field declared
+`driverId` was stored as `driverid`, its column was `driverid`, and queries had to be lowercase. The
+query-side lookup had already become **case-sensitive**, so the two halves disagreed and mixed-case
+columns were impossible to target.
+
+Now the **declared case is preserved end to end**:
+
+- `driverId = IDField()` → field identity `driverId` → column `"driverId"` → query `driverId__…`.
+- **Field lookups are case-sensitive** everywhere: `filter`, `values`, `order_by`, `update`, join
+  paths (`fk__field`), and `PormGRow` attribute/index access must use the **exact declared case**.
+- **Table/model names are unchanged** — still lowercased (frozen convention #33). Only *columns*
+  preserve case.
+- House style remains **lowercase snake_case** (#58); mixed/upper-case is now supported specifically
+  so you can map legacy/Django columns faithfully.
+
+This is what unblocks porting apps whose real DB columns are mixed-case (`driverId`, `foreName`, …).
+
+### How to find the calls to migrate
+
+The breakage depends on whether the app's models declared mixed-case fields against a database whose
+physical columns are **lowercase** (anything created by old PormG):
+
+1. **Build-time** — a query path whose case no longer matches the field:
+   ```text
+   The field driverid not found in Driver: driverId, foreName, …
+   ```
+2. **Execution-time (PostgreSQL)** — declared `driverId` but the physical column is `driverid`:
+   ```text
+   ERROR: column "driverId" does not exist
+   ```
+   (SQLite is case-insensitive on column names, so it may *silently* keep working — PostgreSQL will not.)
+3. **Row access** — `row.driverId` when the field is `driverid`:
+   ```text
+   Driver row has no field or accessor 'driverId'
+   ```
+4. **Migration churn** — `makemigrations` / `dry_run` proposes spurious rename/add/drop on columns
+   that differ only in case. That is the signal your declared case ≠ physical column case.
+
+Grep each app for its model declarations and for query field paths / `row.<Field>` accesses that use
+capital letters.
+
+### Migrate your app
+
+The rule: **the declared field-name case must exactly equal the physical column case**, and you must
+query in that same case. Choose per model:
+
+```julia
+# ✗ before — old PormG lowercased the declaration; you queried lowercase
+Driver = Models.Model("driver",
+    driverId = Models.IDField(),                 # was stored as "driverid"
+    foreName = Models.CharField(),
+)
+M.Driver.objects.filter("driverid__surname" => "Senna")   # lowercase "worked"
+row.driverid
+
+# ✓ after (a) — EXISTING DB with lowercase columns (the common case): declare lowercase
+Driver = Models.Model("driver",
+    driverid = Models.IDField(),                 # matches the physical "driverid"
+    forename = Models.CharField(),
+)
+M.Driver.objects.filter("driverid__surname" => "Senna")   # unchanged; stays green
+row.driverid
+
+# ✓ after (b) — targeting a legacy MIXED-CASE schema (now possible): declare the real case
+Driver = Models.Model("driver",
+    driverId = Models.IDField(),                 # column "driverId" (must exist that way)
+    foreName = Models.CharField(),
+)
+M.Driver.objects.filter("driverId__surname" => "Senna")   # query in the declared case
+row.driverId
+```
+
+Then update **all** field references to the chosen case: `filter`, `values`, `order_by`, `update`,
+join paths, `Q`/`Qor`/`F`/`OuterRef` field strings, and every `PormGRow` `.field` / `[:field]` access.
+
+**Verify (do not skip):** after editing, run `makemigrations` / `dry_run` and confirm it reports **no
+changes** for the affected tables. Any proposed rename/add/drop means a declared-case ↔ column-case
+mismatch still remains. Watch three spots when adopting **mixed-case** against an old lowercase DB —
+they assume declared case == physical column: PostgreSQL identity-**sequence** names
+(`<table>_<pk>_seq`), **many-to-many** auto through-columns (`<model>_<pk>`), and FK `pk_field`
+references. Keeping a model lowercase (path *a*) avoids all of these.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
 ## Export surface — SQL function constructors moved to `PormG.Functions`
 
 - **PormG ref**: issue #35 (Tier 2 pre-publish · curate the public export surface); [src/PormG.jl](src/PormG.jl) (`module Functions`), [docs/src/api.md](docs/src/api.md)

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -5,8 +5,13 @@ This comprehensive guide covers all field types available in PormG, inspired by 
 ## Naming Conventions and Considerations
 
 ### Field Naming Rules
-- **Use lowercase for all field names**: `username`, `email`, `created_at`
-- **Use snake_case for multi-word fields**: `first_name`, `last_name`, `birth_date`
+- **Recommended house style: lowercase snake_case** — `username`, `email`, `created_at`, `first_name`.
+  PormG's own models and examples follow this, and it is the convention to prefer for new schemas.
+- **Field-name case is preserved, not folded.** Whatever case you declare is the field's identity
+  *and* its database column. A field declared `driverId` registers as `driverId` and maps to the
+  column `"driverId"`. This is what lets PormG faithfully target mixed-case / uppercase columns in
+  existing (e.g. legacy Django) schemas. Field lookups are **case-sensitive** — query a field by the
+  exact case you declared it.
 - **Never use double underscores (`__`)** in field names or table names (reserved for internal use)
 - **Prefix reserved Julia keywords with underscore**: `_id`, `_type`, `_end`, `_function`
 
@@ -16,9 +21,12 @@ This comprehensive guide covers all field types available in PormG, inspired by 
 - **Be descriptive and clear**: `User_profile`, `Product_category`, `Order_history`
 
 ### Database Column Mapping
-- **Field names automatically become lowercase** in the database
-- **PormG handles the conversion**: `firstName` → `firstname` in database
-- **Column names follow the field name** (lowercased, otherwise verbatim); the schema generator does not currently rename columns via `db_column` — see [Schema Conventions](schema_conventions.md)
+- **Column names follow the field name verbatim, with case preserved**: a field declared `firstName`
+  becomes the column `"firstName"`; declare `first_name` to get `first_name`.
+- **The house style is lowercase snake_case** — prefer it for new schemas; reserve mixed-case
+  declarations for faithfully mapping existing columns you don't control.
+- The schema generator does not currently rename columns via `db_column` — see
+  [Schema Conventions](schema_conventions.md).
 
 ### Examples of Good Naming
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -118,7 +118,7 @@ dev:
 Create `db/models.jl` with your model definitions. 
 
 > [!NOTE]
-> PormG automatically formats field names to lowercase internally under the hood. While you can define fields with capital letters (e.g. `driverId`), they are stored lowercase (`driverid`) and **must** be queried in lowercase in all filter, values, and order_by operations. To avoid confusion, define your fields in lowercase snake_case directly.
+> PormG **preserves the case** you declare field names with: `driverId` stays `driverId` (column `"driverId"`), and field lookups are **case-sensitive** — query a field by the exact case you declared it. The recommended house style is **lowercase snake_case** (PormG's own models use it), so define new fields that way; reserve mixed-case declarations for faithfully mapping existing mixed-case/uppercase columns you don't control.
 
 ```julia
 module models
@@ -213,7 +213,8 @@ using PormG.Functions: Count
 # Simple filter and list
 drivers = M.Driver.objects.filter("nationality" => "Brazilian").order_by("surname").list()
 
-# Chainable methods with DataFrame output (always use lowercase field names in queries!)
+# Chainable methods with DataFrame output (query fields in the case they were declared;
+# the F1 models use lowercase, so the paths below are lowercase)
 df = M.Result.objects.filter(
         "driverid__nationality" => "Brazilian",
         "positionorder"         => 1

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -36,13 +36,13 @@ import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING
 
 
 Status = Models.Model(
-  statusId = Models.IDField(),
+  statusid = Models.IDField(),
   status = Models.CharField()
 )
 
 Circuit = Models.Model( # You can create a model like a Django model for each table so that you can define a huge number of tables at once in just one file. Please capitalize the names of models.
-  circuitId = Models.IDField(), # PormG automatically lowercases the name of the field, so you can use a capital letter in the name of the field. However, you must use lowercase in query operations.
-  circuitRef = Models.CharField(),
+  circuitid = Models.IDField(), # House style: declare field names in lowercase snake_case. PormG preserves the case you declare (so mixed-case/uppercase legacy columns are supported) and field lookups are case-sensitive — query fields in the same case you declared them.
+  circuitref = Models.CharField(),
   name = Models.CharField(),
   location = Models.CharField(),
   country = Models.CharField(),
@@ -53,10 +53,10 @@ Circuit = Models.Model( # You can create a model like a Django model for each ta
 )
 
 Race = Models.Model(
-  raceId = Models.IDField(),
+  raceid = Models.IDField(),
   year = Models.IntegerField(),
   round = Models.IntegerField(),
-  circuitId = Models.ForeignKey(Circuit, pk_field="circuitId", on_delete="CASCADE"),
+  circuitid = Models.ForeignKey(Circuit, pk_field="circuitid", on_delete="CASCADE"),
   name = Models.CharField(),
   date = Models.DateField(),
   time = Models.TimeField(null=true),
@@ -74,8 +74,8 @@ Race = Models.Model(
 )
 
 Driver = Models.Model(
-  driverId = Models.IDField(),
-  driverRef = Models.CharField(),
+  driverid = Models.IDField(),
+  driverref = Models.CharField(),
   number = Models.IntegerField(null=true),
   code = Models.CharField(),
   forename = Models.CharField(),
@@ -86,39 +86,39 @@ Driver = Models.Model(
 )
 
 Constructor = Models.Model(
-  constructorId = Models.IDField(),
-  constructorRef = Models.CharField(),
+  constructorid = Models.IDField(),
+  constructorref = Models.CharField(),
   name = Models.CharField(),
   nationality = Models.CharField(),
   url = Models.CharField()
 )
 
 Result = Models.Model(
-  resultId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  resultid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number = Models.IntegerField(null=true),
   grid = Models.IntegerField(),
   position = Models.IntegerField(null=true),
-  positionText = Models.CharField(),
-  positionOrder = Models.IntegerField(),
+  positiontext = Models.CharField(),
+  positionorder = Models.IntegerField(),
   points = Models.FloatField(),
   laps = Models.IntegerField(),
   time = Models.CharField(null=true),
   milliseconds = Models.IntegerField(null=true),
-  fastestLap = Models.IntegerField(null=true),
+  fastestlap = Models.IntegerField(null=true),
   rank = Models.IntegerField(null=true),
-  fastestLapTime = Models.DurationField(null=true),
-  fastestLapSpeed = Models.FloatField(null=true),
-  statusId = Models.ForeignKey(Status, pk_field="statusId", on_delete="CASCADE")
+  fastestlaptime = Models.DurationField(null=true),
+  fastestlapspeed = Models.FloatField(null=true),
+  statusid = Models.ForeignKey(Status, pk_field="statusid", on_delete="CASCADE")
 )
 
 Just_a_test_deletion = Models.Model(
   id = Models.IDField(),
   name = Models.CharField(),
-  test_result = Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion"),
-  test_result2 = Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion2")
+  test_result = Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion"),
+  test_result2 = Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion2")
 )
 
 end
@@ -193,7 +193,7 @@ PormG.@models_module my_models "db" begin
     import PormG.Models as M
 
     Driver = M.Model("drivers",
-        driverId = M.IDField(),
+        driverid = M.IDField(),
         forename = M.CharField()
     )
 end

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -70,8 +70,8 @@ The `IDField` renders as an auto-incrementing key per backend:
 
 ## Foreign-key columns
 
-A foreign-key column is the **declared field name, lowercased, verbatim** — PormG never appends
-`_id` or otherwise transforms it:
+A foreign-key column is the **declared field name, verbatim (case preserved)** — PormG never appends
+`_id`, lowercases, or otherwise transforms it:
 
 ```julia
 Result = Models.Model("result",
@@ -142,8 +142,10 @@ Driver = Models.Model("driver",
 ## Identifier quoting and case
 
 All table and column identifiers are emitted with **double quotes** (`"…"`) on **both** PostgreSQL
-and SQLite, and identifiers are **lowercased** before quoting. There are no backticks and no
-backend-specific quoting differences:
+and SQLite (no backticks, no backend-specific quoting). **Table names are lowercased** before
+quoting; **column names preserve the declared field-name case** (#57) — so a field declared
+`driverId` becomes `"driverId"`. Declaring lowercase snake_case (the house style) yields all-lowercase
+identifiers as below:
 
 ```sql
 CREATE TABLE result (
@@ -161,10 +163,10 @@ CREATE TABLE result (
 | Table name | `model.name` lowercased, verbatim — no pluralization |
 | `django_prefix` | optional Django-interop prefix; shapes generated `name`/accessors, not the physical-table rule |
 | Primary key | explicit `IDField` on native models; no implicit `id` (importer auto-adds `id`) |
-| FK column | declared field name, lowercased, verbatim — no `_id` suffix (importer adds `_id`) |
+| FK column | declared field name, verbatim (case preserved) — no `_id` suffix (importer adds `_id`) |
 | Default `on_delete` | `NO ACTION` |
 | Timestamps | opt-in `auto_now` / `auto_now_add`; no implicit `created`/`modified` |
-| Quoting | double quotes, lowercase identifiers, both backends |
+| Quoting | double quotes both backends; table names lowercased, column names case-preserved |
 
 The migration *format* that records these schemas (file layout, checksum, tracking table) is a
 separate frozen contract — see [Migration Format Stability](migrations/stability.md).

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -374,14 +374,18 @@ function ensure_model_initialized(model::PormGModel)
     return false
 end
 
+# Normalize a field name: strip ONE leading underscore (the escape hatch for SQL
+# reserved words / `id`, e.g. `_end` -> `end`) and validate. The declared case is
+# PRESERVED (#57): a field declared `driverId` keeps that case as its identity and
+# its column name, so PormG can faithfully target mixed-case/uppercase DB columns.
+# Table/model names still lowercase — see `format_model_name` below.
 function format_fild_name(name::String)::String
   isempty(name) && return name
-  name[1] == '_' && (name = name[2:end])   
+  name[1] == '_' && (name = name[2:end])
   isempty(name) && return name
-  name = lowercase(name)
   if occursin(r"__|@|^_", name)
     throw(ArgumentError("The field name $name contains __ or @ or starts with _; this is not allowed"))
-  end 
+  end
   return name
 end
 function format_fild_name(name::Nothing)::Nothing
@@ -389,8 +393,11 @@ function format_fild_name(name::Nothing)::Nothing
 end
 format_fild_name(name::Symbol)::String = name |> String |> format_fild_name
 
-function format_model_name(name::String)::String  
-  return format_fild_name(name)  
+# Table/model names are LOWERCASED (frozen schema convention, #33) — independent of
+# field-name case preservation (#57). Reuses `format_fild_name`'s leading-underscore
+# strip + validation, then lowercases the result.
+function format_model_name(name::String)::String
+  return lowercase(format_fild_name(name))
 end
 function format_model_name(name::Symbol)::String
   return name |> String |> format_model_name  

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -195,11 +195,13 @@ const DIRECT_DELETE_KEY_SENTINEL = "__pormg_direct_delete__"
 function resolve_delete_key(model::PormGModel; fallback::Union{Nothing,String}=nothing, allow_direct::Bool=false)
   pk_field = get_model_pk_field(model)
   if pk_field !== nothing
-    return string(pk_field) |> lowercase
+    # Preserve the declared case (#57): field_names and column names are case-sensitive,
+    # so the delete key must match the field's declared case verbatim.
+    return string(pk_field)
   end
 
   if fallback !== nothing
-    fallback = lowercase(fallback)
+    # Match the user-supplied fallback verbatim — field lookup is case-sensitive (#57).
     fallback in model.field_names || throw(ArgumentError("The fallback delete field $(fallback) was not found in $(model.name)"))
     return fallback
   end

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -694,7 +694,8 @@ mutable struct PormGRow
 end
 PormGRow(data::Dict{Symbol,<:Any}, model::PormGModel) = PormGRow(Dict{Symbol,Any}(data), model, Set{Symbol}())
 
-"""Normalize row-facing symbols to the lowercase storage keys used internally."""
+"""Normalize row-facing symbols to the declared-case storage keys used internally
+(strips a leading underscore per `format_fild_name`; case is preserved, #57)."""
 function _normalize_row_symbol(sym::Symbol)::Symbol
   parts = split(String(sym), "__")
   any(isempty, parts) && throw(ArgumentError("Invalid projected row field '$sym'. Empty '__' path segment."))

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -5,13 +5,13 @@ import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING
 
 
 Status = Models.Model(
-  statusId=Models.IDField(),
+  statusid=Models.IDField(),
   status=Models.CharField()
 )
 
 Circuit = Models.Model( # You can create a model like a Django model for each table so that you can define a huge number of tables at once in just one file. Please capitalize the names of models.
-  circuitId=Models.IDField(), # the PormG automatically do a lowercase for the name of the field, so you can use a capital letter in the name of the field, Hoewver you need to use a lowercase in the query operations.
-  circuitRef=Models.CharField(),
+  circuitid=Models.IDField(), # House style: declare field names in lowercase snake_case. PormG preserves the case you declare (so mixed-case/uppercase legacy columns are supported) and field lookups are case-sensitive — query fields in the same case you declared them.
+  circuitref=Models.CharField(),
   name=Models.CharField(),
   location=Models.CharField(),
   country=Models.CharField(),
@@ -22,10 +22,10 @@ Circuit = Models.Model( # You can create a model like a Django model for each ta
 )
 
 Race = Models.Model(
-  raceId=Models.IDField(),
+  raceid=Models.IDField(),
   year=Models.IntegerField(),
   round=Models.IntegerField(),
-  circuitId=Models.ForeignKey(Circuit, pk_field="circuitId", on_delete="CASCADE"),
+  circuitid=Models.ForeignKey(Circuit, pk_field="circuitid", on_delete="CASCADE"),
   name=Models.CharField(),
   date=Models.DateField(),
   time=Models.TimeField(null=true),
@@ -43,8 +43,8 @@ Race = Models.Model(
 )
 
 Driver = Models.Model(
-  driverId=Models.IDField(),
-  driverRef=Models.CharField(),
+  driverid=Models.IDField(),
+  driverref=Models.CharField(),
   number=Models.IntegerField(null=true),
   code=Models.CharField(),
   forename=Models.CharField(),
@@ -55,18 +55,18 @@ Driver = Models.Model(
 )
 
 Driver_standings = Models.Model(
-  driverStandingsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete=" RESTRICT"),
+  driverstandingsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete=" RESTRICT"),
   points = Models.FloatField(),  # F1 data has half-points (e.g. 1.5) from shared fastest-lap bonuses
   position = Models.IntegerField(),
-  positionText = Models.CharField(),
+  positiontext = Models.CharField(),
   wins = Models.IntegerField()
-) 
+)
 
 Lap_times = Models.Model(
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
   lap = Models.IntegerField(),
   position = Models.IntegerField(),
   time = Models.DurationField(),
@@ -74,8 +74,8 @@ Lap_times = Models.Model(
 )
 
 Pit_stops = Models.Model(
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
   stop = Models.IntegerField(),
   lap = Models.IntegerField(),
   time = Models.TimeField(),
@@ -84,36 +84,36 @@ Pit_stops = Models.Model(
 )
 
 Constructor = Models.Model(
-  constructorId=Models.IDField(),
-  constructorRef=Models.CharField(),
+  constructorid=Models.IDField(),
+  constructorref=Models.CharField(),
   name=Models.CharField(),
   nationality=Models.CharField(),
   url=Models.CharField()
 )
 
 Constructor_results = Models.Model(
-  constructorResultsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  constructorresultsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   points = Models.DecimalField(),
   status = Models.CharField()
 )
 
 Constructor_standings = Models.Model(
-  constructorStandingsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  constructorstandingsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   points = Models.DecimalField(),
   position = Models.IntegerField(),
-  positionText = Models.CharField(),
+  positiontext = Models.CharField(),
   wins = Models.IntegerField()
-) 
+)
 
 Qualifying = Models.Model(
-  qualifyingId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  qualifyingid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number = Models.IntegerField(null=true),
   position = Models.IntegerField(null=true),
   q1 = Models.DurationField(null=true),
@@ -122,52 +122,52 @@ Qualifying = Models.Model(
 )
 
 Sprint_results = Models.Model(
-  sprintId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  sprintid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number = Models.IntegerField(null=true),
   grid = Models.IntegerField(),
   position = Models.IntegerField(null=true),
-  positionText = Models.CharField(),
-  positionOrder = Models.IntegerField(),
+  positiontext = Models.CharField(),
+  positionorder = Models.IntegerField(),
   points = Models.FloatField(),
   laps = Models.IntegerField(),
   time = Models.CharField(null=true),
   milliseconds = Models.IntegerField(null=true),
-  fastestLap = Models.IntegerField(null=true),
-  fastestLapTime = Models.DurationField(null=true),
-  statusId = Models.ForeignKey(Status, pk_field="statusId", on_delete="CASCADE")
+  fastestlap = Models.IntegerField(null=true),
+  fastestlaptime = Models.DurationField(null=true),
+  statusid = Models.ForeignKey(Status, pk_field="statusid", on_delete="CASCADE")
 )
 
 Result = Models.Model(
-  resultId=Models.IDField(),
-  raceId=Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId=Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId=Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  resultid=Models.IDField(),
+  raceid=Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid=Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid=Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number=Models.IntegerField(null=true),
   grid=Models.IntegerField(),
   position=Models.IntegerField(null=true),
-  positionText=Models.CharField(),
-  positionOrder=Models.IntegerField(),
+  positiontext=Models.CharField(),
+  positionorder=Models.IntegerField(),
   points=Models.FloatField(),
   laps=Models.IntegerField(),
   time=Models.CharField(null=true),
   milliseconds=Models.IntegerField(null=true),
-  fastestLap=Models.IntegerField(null=true),
+  fastestlap=Models.IntegerField(null=true),
   rank=Models.IntegerField(null=true),
-  fastestLapTime=Models.DurationField(null=true),
-  fastestLapSpeed=Models.FloatField(null=true),
-  statusId=Models.ForeignKey(Status, pk_field="statusId", on_delete="CASCADE")
+  fastestlaptime=Models.DurationField(null=true),
+  fastestlapspeed=Models.FloatField(null=true),
+  statusid=Models.ForeignKey(Status, pk_field="statusid", on_delete="CASCADE")
 )
 
 Just_a_test_deletion = Models.Model(
   id=Models.IDField(),
   name=Models.CharField(),
-  test_result=Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion"),
-  test_result2=Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion2"),
-  test_result_set_null=Models.ForeignKey(Result, pk_field="resultId", on_delete="SET_NULL", null=true, related_name="test_deletion_set_null"),
-  test_result_set_default=Models.ForeignKey(Result, pk_field="resultId", on_delete="SET_DEFAULT", default=1, null=true, related_name="test_deletion_set_default")
+  test_result=Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion"),
+  test_result2=Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion2"),
+  test_result_set_null=Models.ForeignKey(Result, pk_field="resultid", on_delete="SET_NULL", null=true, related_name="test_deletion_set_null"),
+  test_result_set_default=Models.ForeignKey(Result, pk_field="resultid", on_delete="SET_DEFAULT", default=1, null=true, related_name="test_deletion_set_default")
 )
 
 Just_a_nested_roll_back = Models.Model(
@@ -241,7 +241,7 @@ M2m_sponsor_scratch = Models.Model("m2m_sponsor_scratch",
 
 M2m_driver_endorsement_scratch = Models.Model("m2m_driver_endorsement_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   sponsors = Models.ManyToManyField(M2m_sponsor_scratch, related_name="drivers")
 )
 
@@ -259,7 +259,7 @@ M2m_sponsor_with_country_scratch = Models.Model("m2m_sponsor_with_country_scratc
 
 M2m_driver_multi_hop_scratch = Models.Model("m2m_driver_multi_hop_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   sponsors = Models.ManyToManyField(M2m_sponsor_with_country_scratch, related_name="drivers")
 )
 
@@ -271,7 +271,7 @@ M2m_team_scratch = Models.Model("m2m_team_scratch",
 
 M2m_driver_explicit_scratch = Models.Model("m2m_driver_explicit_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   teams = Models.ManyToManyField(M2m_team_scratch, through="M2m_membership_scratch", related_name="drivers")
 )
 
@@ -290,7 +290,7 @@ M2m_team_plain_scratch = Models.Model("m2m_team_plain_scratch",
 
 M2m_driver_plain_scratch = Models.Model("m2m_driver_plain_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   teams = Models.ManyToManyField(M2m_team_plain_scratch, through="M2m_link_plain_scratch", related_name="drivers")
 )
 
@@ -308,8 +308,24 @@ M2m_brand_scratch = Models.Model("m2m_brand_scratch",
 
 M2m_driver_default_reverse_scratch = Models.Model("m2m_driver_default_reverse_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   partners = Models.ManyToManyField(M2m_brand_scratch),
+)
+
+# Case-preservation (#57) fixtures — DELIBERATELY mixed-case COLUMNS (driverRef,
+# foreName, parentRef, lapTime) to prove PormG creates and queries genuinely
+# mixed-case columns on a live DB. These are capability fixtures, NOT the house
+# style: declare lowercase snake_case in real models. Table names stay lowercase.
+Case_preserve_parent_scratch = Models.Model("case_preserve_parent_scratch",
+  id = Models.IDField(),
+  driverRef = Models.CharField(unique=true),
+  foreName = Models.CharField(null=true),
+)
+
+Case_preserve_child_scratch = Models.Model("case_preserve_child_scratch",
+  id = Models.IDField(),
+  parentRef = Models.ForeignKey(Case_preserve_parent_scratch, pk_field="id", on_delete="CASCADE", related_name="children"),
+  lapTime = Models.IntegerField(null=true),
 )
 
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -5,13 +5,13 @@ import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING
 
 
 Status = Models.Model(
-  statusId=Models.IDField(),
+  statusid=Models.IDField(),
   status=Models.CharField()
 )
 
 Circuit = Models.Model( # You can create a model like a Django model for each table so that you can define a huge number of tables at once in just one file. Please capitalize the names of models.
-  circuitId=Models.IDField(), # the PormG automatically do a lowercase for the name of the field, so you can use a capital letter in the name of the field, Hoewver you need to use a lowercase in the query operations.
-  circuitRef=Models.CharField(),
+  circuitid=Models.IDField(), # House style: declare field names in lowercase snake_case. PormG preserves the case you declare (so mixed-case/uppercase legacy columns are supported) and field lookups are case-sensitive — query fields in the same case you declared them.
+  circuitref=Models.CharField(),
   name=Models.CharField(),
   location=Models.CharField(),
   country=Models.CharField(),
@@ -22,10 +22,10 @@ Circuit = Models.Model( # You can create a model like a Django model for each ta
 )
 
 Race = Models.Model(
-  raceId=Models.IDField(),
+  raceid=Models.IDField(),
   year=Models.IntegerField(),
   round=Models.IntegerField(),
-  circuitId=Models.ForeignKey(Circuit, pk_field="circuitId", on_delete="CASCADE"),
+  circuitid=Models.ForeignKey(Circuit, pk_field="circuitid", on_delete="CASCADE"),
   name=Models.CharField(),
   date=Models.DateField(),
   time=Models.TimeField(null=true),
@@ -43,8 +43,8 @@ Race = Models.Model(
 )
 
 Driver = Models.Model(
-  driverId=Models.IDField(),
-  driverRef=Models.CharField(),
+  driverid=Models.IDField(),
+  driverref=Models.CharField(),
   number=Models.IntegerField(null=true),
   code=Models.CharField(),
   forename=Models.CharField(),
@@ -55,18 +55,18 @@ Driver = Models.Model(
 )
 
 Driver_standings = Models.Model(
-  driverStandingsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete=" RESTRICT"),
+  driverstandingsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete=" RESTRICT"),
   points = Models.FloatField(),  # F1 data has half-points (e.g. 1.5) from shared fastest-lap bonuses
   position = Models.IntegerField(),
-  positionText = Models.CharField(),
+  positiontext = Models.CharField(),
   wins = Models.IntegerField()
-) 
+)
 
 Lap_times = Models.Model(
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
   lap = Models.IntegerField(),
   position = Models.IntegerField(),
   time = Models.DurationField(),
@@ -74,8 +74,8 @@ Lap_times = Models.Model(
 )
 
 Pit_stops = Models.Model(
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
   stop = Models.IntegerField(),
   lap = Models.IntegerField(),
   time = Models.TimeField(),
@@ -84,36 +84,36 @@ Pit_stops = Models.Model(
 )
 
 Constructor = Models.Model(
-  constructorId=Models.IDField(),
-  constructorRef=Models.CharField(),
+  constructorid=Models.IDField(),
+  constructorref=Models.CharField(),
   name=Models.CharField(),
   nationality=Models.CharField(),
   url=Models.CharField()
 )
 
 Constructor_results = Models.Model(
-  constructorResultsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  constructorresultsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   points = Models.DecimalField(),
   status = Models.CharField()
 )
 
 Constructor_standings = Models.Model(
-  constructorStandingsId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  constructorstandingsid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   points = Models.DecimalField(),
   position = Models.IntegerField(),
-  positionText = Models.CharField(),
+  positiontext = Models.CharField(),
   wins = Models.IntegerField()
-) 
+)
 
 Qualifying = Models.Model(
-  qualifyingId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  qualifyingid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number = Models.IntegerField(null=true),
   position = Models.IntegerField(null=true),
   q1 = Models.DurationField(null=true),
@@ -122,52 +122,52 @@ Qualifying = Models.Model(
 )
 
 Sprint_results = Models.Model(
-  sprintId = Models.IDField(),
-  raceId = Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId = Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId = Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  sprintid = Models.IDField(),
+  raceid = Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid = Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number = Models.IntegerField(null=true),
   grid = Models.IntegerField(),
   position = Models.IntegerField(null=true),
-  positionText = Models.CharField(),
-  positionOrder = Models.IntegerField(),
+  positiontext = Models.CharField(),
+  positionorder = Models.IntegerField(),
   points = Models.FloatField(),
   laps = Models.IntegerField(),
   time = Models.CharField(null=true),
   milliseconds = Models.IntegerField(null=true),
-  fastestLap = Models.IntegerField(null=true),
-  fastestLapTime = Models.DurationField(null=true),
-  statusId = Models.ForeignKey(Status, pk_field="statusId", on_delete="CASCADE")
+  fastestlap = Models.IntegerField(null=true),
+  fastestlaptime = Models.DurationField(null=true),
+  statusid = Models.ForeignKey(Status, pk_field="statusid", on_delete="CASCADE")
 )
 
 Result = Models.Model(
-  resultId=Models.IDField(),
-  raceId=Models.ForeignKey(Race, pk_field="raceId", on_delete="CASCADE"),
-  driverId=Models.ForeignKey(Driver, pk_field="driverId", on_delete="RESTRICT"),
-  constructorId=Models.ForeignKey(Constructor, pk_field="constructorId", on_delete="RESTRICT"),
+  resultid=Models.IDField(),
+  raceid=Models.ForeignKey(Race, pk_field="raceid", on_delete="CASCADE"),
+  driverid=Models.ForeignKey(Driver, pk_field="driverid", on_delete="RESTRICT"),
+  constructorid=Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="RESTRICT"),
   number=Models.IntegerField(null=true),
   grid=Models.IntegerField(),
   position=Models.IntegerField(null=true),
-  positionText=Models.CharField(),
-  positionOrder=Models.IntegerField(),
+  positiontext=Models.CharField(),
+  positionorder=Models.IntegerField(),
   points=Models.FloatField(),
   laps=Models.IntegerField(),
   time=Models.CharField(null=true),
   milliseconds=Models.IntegerField(null=true),
-  fastestLap=Models.IntegerField(null=true),
+  fastestlap=Models.IntegerField(null=true),
   rank=Models.IntegerField(null=true),
-  fastestLapTime=Models.DurationField(null=true),
-  fastestLapSpeed=Models.FloatField(null=true),
-  statusId=Models.ForeignKey(Status, pk_field="statusId", on_delete="CASCADE")
+  fastestlaptime=Models.DurationField(null=true),
+  fastestlapspeed=Models.FloatField(null=true),
+  statusid=Models.ForeignKey(Status, pk_field="statusid", on_delete="CASCADE")
 )
 
 Just_a_test_deletion = Models.Model(
   id=Models.IDField(),
   name=Models.CharField(),
-  test_result=Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion"),
-  test_result2=Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion2"),
-  test_result_set_null=Models.ForeignKey(Result, pk_field="resultId", on_delete="SET_NULL", null=true, related_name="test_deletion_set_null"),
-  test_result_set_default=Models.ForeignKey(Result, pk_field="resultId", on_delete="SET_DEFAULT", default=1, null=true, related_name="test_deletion_set_default")
+  test_result=Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion"),
+  test_result2=Models.ForeignKey(Result, pk_field="resultid", on_delete="CASCADE", null=true, related_name="test_deletion2"),
+  test_result_set_null=Models.ForeignKey(Result, pk_field="resultid", on_delete="SET_NULL", null=true, related_name="test_deletion_set_null"),
+  test_result_set_default=Models.ForeignKey(Result, pk_field="resultid", on_delete="SET_DEFAULT", default=1, null=true, related_name="test_deletion_set_default")
 )
 
 Just_a_nested_roll_back = Models.Model(
@@ -241,7 +241,7 @@ M2m_sponsor_scratch = Models.Model("m2m_sponsor_scratch",
 
 M2m_driver_endorsement_scratch = Models.Model("m2m_driver_endorsement_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   sponsors = Models.ManyToManyField(M2m_sponsor_scratch, related_name="drivers")
 )
 
@@ -259,7 +259,7 @@ M2m_sponsor_with_country_scratch = Models.Model("m2m_sponsor_with_country_scratc
 
 M2m_driver_multi_hop_scratch = Models.Model("m2m_driver_multi_hop_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   sponsors = Models.ManyToManyField(M2m_sponsor_with_country_scratch, related_name="drivers")
 )
 
@@ -271,7 +271,7 @@ M2m_team_scratch = Models.Model("m2m_team_scratch",
 
 M2m_driver_explicit_scratch = Models.Model("m2m_driver_explicit_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   teams = Models.ManyToManyField(M2m_team_scratch, through="M2m_membership_scratch", related_name="drivers")
 )
 
@@ -290,7 +290,7 @@ M2m_team_plain_scratch = Models.Model("m2m_team_plain_scratch",
 
 M2m_driver_plain_scratch = Models.Model("m2m_driver_plain_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   teams = Models.ManyToManyField(M2m_team_plain_scratch, through="M2m_link_plain_scratch", related_name="drivers")
 )
 
@@ -308,8 +308,24 @@ M2m_brand_scratch = Models.Model("m2m_brand_scratch",
 
 M2m_driver_default_reverse_scratch = Models.Model("m2m_driver_default_reverse_scratch",
   id = Models.IDField(),
-  driverRef = Models.CharField(unique=true),
+  driverref = Models.CharField(unique=true),
   partners = Models.ManyToManyField(M2m_brand_scratch),
+)
+
+# Case-preservation (#57) fixtures — DELIBERATELY mixed-case COLUMNS (driverRef,
+# foreName, parentRef, lapTime) to prove PormG creates and queries genuinely
+# mixed-case columns on a live DB. These are capability fixtures, NOT the house
+# style: declare lowercase snake_case in real models. Table names stay lowercase.
+Case_preserve_parent_scratch = Models.Model("case_preserve_parent_scratch",
+  id = Models.IDField(),
+  driverRef = Models.CharField(unique=true),
+  foreName = Models.CharField(null=true),
+)
+
+Case_preserve_child_scratch = Models.Model("case_preserve_child_scratch",
+  id = Models.IDField(),
+  parentRef = Models.ForeignKey(Case_preserve_parent_scratch, pk_field="id", on_delete="CASCADE", related_name="children"),
+  lapTime = Models.IntegerField(null=true),
 )
 
 end

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -29,6 +29,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Selection and Filters"        begin include("test_selection.jl")          end # TODO: split this into multiple files (selection, filters, expressions)
     @testset "PormGRow and get()"           begin include("test_row_and_get.jl")        end
     @testset "PormGRow Mutation"            begin include("test_row_mutation.jl")       end
+    @testset "Field-name Case Preservation" begin include("test_field_name_case_db.jl") end
     @testset "Field Expressions"            begin include("test_field_expressions.jl")  end
     @testset "Updates"                      begin include("test_updates.jl")            end
     @testset "Deletes"                      begin include("test_deletes.jl")            end

--- a/test/integration/test_exists_correlated.jl
+++ b/test/integration/test_exists_correlated.jl
@@ -84,7 +84,7 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Correlated EXISTS with OuterRef("pk") auto-resolution
-# The F1 Result model has resultId as primary key.
+# The F1 Result model has resultid as primary key.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "Correlated EXISTS - OuterRef pk resolves to primary key" begin
     # Just_a_test_deletion.test_result is a FK back to Result.
@@ -105,7 +105,7 @@ end
      # FROM "result" as "Tb"
      # WHERE EXISTS (SELECT 1
      # FROM "just_a_test_deletion" as "R1"
-     # WHERE "R1"."test_result" = "Tb"."resultId"
+     # WHERE "R1"."test_result" = "Tb"."resultid"
      # LIMIT 1)
     count = q.count()
     total = M.Result.objects.count()

--- a/test/integration/test_field_name_case_db.jl
+++ b/test/integration/test_field_name_case_db.jl
@@ -1,0 +1,88 @@
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+# column_names()/table_exists() live in the migration setup helpers.
+if !isdefined(Main, :column_names)
+    include("common_migration_setup.jl")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case preservation (#57) — end-to-end against a live database.
+#
+# The Case_preserve_parent_scratch / _child_scratch fixtures declare camelCase
+# columns (driverRef, foreName, parentRef, lapTime). This file proves PormG
+# CREATES genuinely mixed-case columns on the real backend, and that
+# insert/select/update plus forward FK joins and reverse traversal all resolve
+# them case-sensitively — the headline #57 capability, verified beyond the unit
+# layer (where everything renders before any DB round-trip).
+#
+# Table/model names stay lowercase (frozen #33); only the columns are mixed-case.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "Case preservation: physical columns are mixed-case" begin
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+
+    parent_cols = column_names(pool, "case_preserve_parent_scratch")
+    @test "driverRef" in parent_cols
+    @test "foreName" in parent_cols
+    @test !("driverref" in parent_cols)   # the lowercased form must NOT exist
+
+    child_cols = column_names(pool, "case_preserve_child_scratch")
+    @test "parentRef" in child_cols
+    @test "lapTime" in child_cols
+end
+
+@testset "Case preservation: insert / select / update round-trip" begin
+    M.Case_preserve_child_scratch.objects.delete(allow_delete_all=true)
+    M.Case_preserve_parent_scratch.objects.delete(allow_delete_all=true)
+    try
+        parent = M.Case_preserve_parent_scratch.objects.create(
+            "driverRef" => "senna", "foreName" => "Ayrton")
+        M.Case_preserve_child_scratch.objects.create(
+            "parentRef" => parent[:id], "lapTime" => 90)
+
+        # Read back through mixed-case field paths (case-sensitive resolution).
+        row = M.Case_preserve_parent_scratch.objects.
+            filter("driverRef" => "senna").values("driverRef", "foreName").first()
+        @test row.driverRef == "senna"
+        @test row.foreName == "Ayrton"
+
+        # Update a mixed-case column.
+        M.Case_preserve_parent_scratch.objects.
+            filter("driverRef" => "senna").update("foreName" => "Ayrton Senna")
+        row2 = M.Case_preserve_parent_scratch.objects.
+            filter("driverRef" => "senna").values("foreName").first()
+        @test row2.foreName == "Ayrton Senna"
+    finally
+        M.Case_preserve_child_scratch.objects.delete(allow_delete_all=true)
+        M.Case_preserve_parent_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+@testset "Case preservation: forward FK join and reverse traversal" begin
+    M.Case_preserve_child_scratch.objects.delete(allow_delete_all=true)
+    M.Case_preserve_parent_scratch.objects.delete(allow_delete_all=true)
+    try
+        parent = M.Case_preserve_parent_scratch.objects.create(
+            "driverRef" => "prost", "foreName" => "Alain")
+        M.Case_preserve_child_scratch.objects.create(
+            "parentRef" => parent[:id], "lapTime" => 88)
+
+        # Forward join: child → parent across a mixed-case FK, projecting a
+        # mixed-case parent column under an explicit (lowercase) alias.
+        fwd = M.Case_preserve_child_scratch.objects.
+            filter("parentRef__driverRef" => "prost").
+            values("lapTime", "pforename" => "parentRef__foreName").first()
+        @test fwd.lapTime == 88
+        @test fwd.pforename == "Alain"
+
+        # Reverse traversal: parent → children via related_name, filtering on a
+        # mixed-case child column.
+        rev = M.Case_preserve_parent_scratch.objects.
+            filter("children__lapTime" => 88).values("driverRef").first()
+        @test rev.driverRef == "prost"
+    finally
+        M.Case_preserve_child_scratch.objects.delete(allow_delete_all=true)
+        M.Case_preserve_parent_scratch.objects.delete(allow_delete_all=true)
+    end
+end

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -9,7 +9,7 @@ Exercises ManyToManyField end-to-end against the selected integration database
   • ManyToManyManager `add!`, `remove!`, `clear!`, `set!` against the
     through table with parameterized SQL on both backends.
   • Forward-direction filter traversal (`endorsement.sponsors__name`).
-  • Reverse-direction filter traversal (`sponsor.drivers__driverRef`)
+  • Reverse-direction filter traversal (`sponsor.drivers__driverref`)
     using the `related_name="drivers"` declared on the field.
   • `manager.all()` returning a fluent query restricted to the related rows.
   • Empty/no-op mutators, `set!` rollback on FK failure, parent-delete cascade,

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -938,6 +938,36 @@ end
     @test pool_in_use(pool) == in_use_before
   end
 
+  # ── Phase 14: Mixed-case columns preserve case + no churn (#57) ────
+  # Declares a model with genuinely mixed-case COLUMNS, migrates it, then proves
+  # (a) create_table preserved the declared case on the real backend, and
+  # (b) a re-run detects NO changes — introspection reads the mixed-case columns
+  # and the diff compares case-correctly, so there is no spurious add/drop churn.
+  @testset "Phase 14: Mixed-case Columns + No Churn (#57)" begin
+    write_edge_models("""
+    MixedCaseTable = Models.Model(
+        id = Models.IDField(),
+        driverRef = Models.CharField(),
+        foreName = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # (a) The physical columns carry the declared case verbatim (table stays lowercase).
+    cols = column_names(pool, "mixedcasetable")
+    @test "driverRef" in cols
+    @test "foreName" in cols
+    @test !("driverref" in cols)   # no lowercased duplicate column
+
+    # (b) Re-running makemigrations with the SAME models writes NO pending plan:
+    #     introspection + diff agree on the mixed-case columns ⇒ zero churn.
+    pending = joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl")
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+  end
+
   # ── Cleanup ─────────────────────────────────────────────────────────
   PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
   delete!(PormG.config, joinpath(@__DIR__, edge_db_name))

--- a/test/integration/test_row_and_get.jl
+++ b/test/integration/test_row_and_get.jl
@@ -17,10 +17,14 @@ import TimeZones: ZonedDateTime
     @test length(rows) == 1
 
     row = rows[1]
-    @test row.driverId == row.driverid
-    @test row.driverId == row[:driverId]
-    @test row.driverId == row["driverId"]
-    @test haskey(row, :driverId)
+    # Field access is case-sensitive (#57): the field is declared `driverid`, so the
+    # lowercase name resolves and the camelCase form misses (no silent normalization).
+    @test row.driverid == row[:driverid]
+    @test row.driverid == row["driverid"]
+    @test haskey(row, :driverid)
+    @test !haskey(row, :driverId)
+    @test_throws ArgumentError row.driverId   # getproperty validates → ArgumentError
+    @test_throws KeyError row[:driverId]      # raw getindex → KeyError
     @test get(row, "missingField", :fallback) === :fallback
 
     dict_rows = M.Driver.objects.filter("driverref" => "hamilton").list(:dict)
@@ -63,10 +67,12 @@ end
     @test nrow(df_direct) == 1
     @test df_from_rows[1, :driverid] == df_direct[1, :driverid]
 
-    # Tables.getcolumn symbol normalization test (BUG-10 regression)
+    # Tables.getcolumn is case-sensitive (#57): the exact declared symbol resolves; a
+    # wrong-case symbol misses (the old case-insensitive normalization is incompatible
+    # with case preservation and was removed).
     row_item = row_result[1]
-    @test Tables.getcolumn(row_item, :driverId) == row_item.driverid
     @test Tables.getcolumn(row_item, :driverid) == row_item.driverid
+    @test_throws KeyError Tables.getcolumn(row_item, :driverId)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/integration/test_row_mutation.jl
+++ b/test/integration/test_row_mutation.jl
@@ -4,7 +4,7 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PormGRow mutation: assignment validation and dirty tracking
-# Verifies write-side field-name normalization, unknown-field rejection,
+# Verifies case-sensitive field-name resolution, unknown-field rejection,
 # projected-FK validation, and primary-key mutation protection.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "PormGRow assignment validation" begin
@@ -17,20 +17,25 @@ end
 
     original_position_text = row.positiontext
 
-    row.positionText = "Phase 2 pending"
+    # Assignment is case-sensitive (#57): write via the declared lowercase field name.
+    row.positiontext = "Phase 2 pending"
     @test row.positiontext == "Phase 2 pending"
-    @test row[:positionText] == "Phase 2 pending"
+    @test row[:positiontext] == "Phase 2 pending"
     @test :positiontext in row._dirty
 
     row.positiontext = original_position_text
-    @test row.positionText == original_position_text
+    @test row.positiontext == original_position_text
     @test :positiontext in row._dirty
+
+    # Wrong-case assignment misses the lowercase-declared field (no silent normalization).
+    @test_throws ArgumentError (row.positionText = "x")
 
     @test_throws ArgumentError (row.unknownField = 1)
     @test_throws ArgumentError (row.badFk__name = "x")
 
+    # Primary-key mutation is rejected (driverid is Driver's PK).
     driver = M.Driver.objects.get("driverref" => "hamilton")
-    @test_throws ArgumentError (driver.driverId = driver.driverid + 1)
+    @test_throws ArgumentError (driver.driverid = driver.driverid + 1)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
     @testset "Window Function SQL Generation" include("unit/test_window_functions.jl")
     @testset "Dedicated Inspection API" include("unit/test_inspect_query.jl")
     @testset "Reserved-word / Underscore Field Names" include("unit/test_reserved_word_fields.jl")
+    @testset "Field-name Case Preservation (#57)" include("unit/test_field_name_case.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")

--- a/test/unit/test_field_name_case.jl
+++ b/test/unit/test_field_name_case.jl
@@ -1,0 +1,140 @@
+"""
+Unit coverage for declared field-name CASE PRESERVATION (#57).
+
+PormG preserves the case you declare a field with: `driverId = IDField()` registers the
+field as `driverId` (not `driverid`), its column renders `"driverId"`, queries resolve it
+case-sensitively, and the migration diff compares case-correctly. This is what lets PormG
+faithfully target mixed-case / uppercase DB columns (e.g. legacy Django schemas).
+
+Table/model names stay LOWERCASE (frozen schema convention, #33) — only field/column
+names preserve case. The PormG-internal house style is lowercase snake_case (#58); this
+file deliberately uses a mixed-case mechanics model to exercise the preservation path.
+
+All assertions render via a mock PostgreSQL connection (no live database required).
+"""
+
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, ForeignKey, format_fild_name, are_model_fields_equal
+using PormG.QueryBuilder: inspect_query
+
+# Dedicated mock connection — uniquely named so it never clashes with other unit files'
+# mock structs when runtests.jl includes them into the same module.
+struct MockPostgresFieldCase <: PormG.PormGPostgres end
+PormG.config["default"] = PormG.Configuration.Settings(
+  connections = MockPostgresFieldCase(),
+  change_data = true,
+)
+
+# Mixed-case mechanics fixture: a legacy-style model whose columns are camelCase.
+LegacyEntryCase = Model("legacy_entry_case_scratch",
+  driverId = IDField(),
+  foreName = CharField(),
+  raceId   = ForeignKey("LegacyRaceCase", pk_field="raceId", on_delete="CASCADE", null=true),
+)
+LegacyEntryCase.connect_key = "default"
+
+@testset "Field-name case preservation (#57)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # format_fild_name: strips ONE leading underscore but PRESERVES case. This is the
+  # single function every field name flows through at registration.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "format_fild_name preserves declared case" begin
+    @test format_fild_name("driverId")  == "driverId"
+    @test format_fild_name("foreName")  == "foreName"
+    @test format_fild_name("_DriverId") == "DriverId"   # strip one underscore, keep case
+    @test format_fild_name("driverid")  == "driverid"   # lowercase passes through unchanged
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Field identity is the declared case; the lowercased form is NOT registered.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "field identity preserves case" begin
+    @test "driverId" in LegacyEntryCase.field_names
+    @test "foreName" in LegacyEntryCase.field_names
+    @test "raceId"   in LegacyEntryCase.field_names
+    @test !("driverid" in LegacyEntryCase.field_names)
+    @test !("forename" in LegacyEntryCase.field_names)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Queries render the declared-case column verbatim-quoted in WHERE/SELECT; the
+  # lowercase path is rejected (case-sensitive lookup) at build time.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "query renders preserved case; lowercase path throws" begin
+    q = LegacyEntryCase.objects
+    q.filter("foreName" => "Ayrton")
+    q.values("driverId", "foreName")
+    insp = inspect_query(q)
+    @test occursin("\"Tb\".\"foreName\" = \$1", insp[:sql_text])
+    @test occursin("\"Tb\".\"driverId\"", insp[:sql_text])
+    @test insp[:parameters] == ["Ayrton"]
+
+    bad = LegacyEntryCase.objects
+    bad.filter("forename" => "Ayrton")          # wrong case
+    # Broad matcher is intentional: the concrete type depends on the clause — a wrong-case
+    # filter key fails a `model.fields[...]` lookup (KeyError), while values()/order_by()
+    # reach `_solve_field` (ArgumentError). The contract under test is "rejected at build", not
+    # a specific exception type. Do not narrow this without checking the actual clause's path.
+    @test_throws Exception inspect_query(bad)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # UPDATE SET-clause and ORDER BY flow through the same _solve_field path as
+  # filter/values, so they too render the declared-case column verbatim-quoted.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "update SET and order_by render preserved case" begin
+    upd = LegacyEntryCase.objects.filter("driverId" => 1).update("foreName" => "Ayrton", show_query=:sql)
+    @test upd isa String
+    @test occursin("UPDATE", uppercase(upd))
+    @test occursin("\"foreName\"", upd)
+
+    oq = LegacyEntryCase.objects
+    oq.order_by("foreName")
+    osql = inspect_query(oq)[:sql_text]
+    @test occursin("order by", lowercase(osql))
+    @test occursin("\"foreName\"", osql)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # DDL: column names preserve case (quoted); the table name is lowercased.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "create_table preserves column case, lowercases table" begin
+    ddl = PormG.Dialect.create_table(MockPostgresFieldCase(), LegacyEntryCase)
+    @test occursin("\"driverId\"", ddl)
+    @test occursin("\"foreName\"", ddl)
+    @test occursin("\"raceId\"", ddl)
+    @test occursin("legacy_entry_case_scratch", ddl)   # table name lowercased
+    @test !occursin("\"driverid\"", ddl)               # no lowercased columns leak in
+    @test !occursin("\"forename\"", ddl)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Delete-key resolution returns the declared-case primary key (no lowercasing) so
+  # the DELETE WHERE clause targets the real column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "resolve_delete_key preserves case" begin
+    @test PormG.QueryBuilder.resolve_delete_key(LegacyEntryCase) == "driverId"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Migration diff is case-sensitive: an identical-case model diffs clean (no churn),
+  # while a lowercase variant is seen as a different schema (proving case matters).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "migration diff is case-sensitive (no spurious churn)" begin
+    same = Model("legacy_entry_case_scratch",
+      driverId = IDField(),
+      foreName = CharField(),
+      raceId   = ForeignKey("LegacyRaceCase", pk_field="raceId", on_delete="CASCADE", null=true),
+    )
+    lowered = Model("legacy_entry_case_scratch",
+      driverid = IDField(),
+      forename = CharField(),
+      raceid   = ForeignKey("LegacyRaceCase", pk_field="raceid", on_delete="CASCADE", null=true),
+    )
+    @test are_model_fields_equal(LegacyEntryCase, same)      # identical case → no diff
+    @test !are_model_fields_equal(LegacyEntryCase, lowered)  # case differs → not equal
+  end
+
+end

--- a/test/unit/test_reserved_word_fields.jl
+++ b/test/unit/test_reserved_word_fields.jl
@@ -4,8 +4,8 @@ Unit coverage for reserved-word / leading-underscore field names.
 PormG lets a model expose a SQL column whose name collides with a Julia reserved word
 (e.g. `end`, `function`) — or simply with `id` — by declaring the field with a single
 leading underscore (`_end`, `_function`, `_id`). `format_fild_name` strips that one
-leading underscore (then lowercases), so the field is referenced everywhere — model
-definition, `filter`, `values` — by its *stripped* name; the underscored form never
+leading underscore (case is preserved — see #57), so the field is referenced everywhere —
+model definition, `filter`, `values` — by its *stripped* name; the underscored form never
 reaches SQL.
 
 Downstream consumers depend on this contract: LinkSUS declares `_id` on every model and
@@ -43,7 +43,7 @@ PormG.config["default"] = PormG.Configuration.Settings(
 @testset "Reserved-word / underscore field names" begin
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # format_fild_name: normalization — strips ONE leading underscore then lowercases.
+  # format_fild_name: normalization — strips ONE leading underscore, PRESERVES case.
   # `_id`/`_end`/`_function` resolve to the bare SQL identifiers `id`/`end`/`function`.
   # This is the single function every column name and query key flows through.
   # ─────────────────────────────────────────────────────────────────────────────
@@ -55,6 +55,9 @@ PormG.config["default"] = PormG.Configuration.Settings(
     # Already-bare names pass through unchanged (idempotent on a stripped name).
     @test format_fild_name("nome")      == "nome"
     @test format_fild_name("id")        == "id"
+    # Case is PRESERVED, not folded (#57): declare `driverId`, keep `driverId`.
+    @test format_fild_name("driverId")  == "driverId"
+    @test format_fild_name("_DriverId") == "DriverId"
     # Only ONE leading underscore is stripped; a residual leading `_` is rejected so a
     # double leading underscore can never be mistaken for a stripped name.
     @test_throws ArgumentError format_fild_name("__id")


### PR DESCRIPTION
## Summary

Makes model **field names case-preserving** instead of force-lowercased, and settles the **lowercase snake_case house style**. A field declared `driverId` now registers as `driverId`, maps to column `"driverId"`, and is queried **case-sensitively** — so PormG can faithfully target mixed-case / uppercase DB columns (e.g. legacy Django schemas), the motivating use case. **Table/model names stay lowercased** (frozen schema convention #33).

Pre-publish, single maintainer, ~4 internal apps — a deliberate breaking change settled before the first General-registry publish.

## What changed

**Core (`src/`)**
- `Models.format_fild_name` no longer lowercases (preserves declared case; still strips one leading `_` and validates).
- `Models.format_model_name` decoupled → lowercases independently, so **tables stay lowercase**.
- `resolve_delete_key` drops its two `lowercase` calls (case-sensitive pk / fallback).
- `_normalize_row_symbol` is now self-consistent (comment updated).

**Fixtures & tests**
- F1 integration models (`db_sl` + `db_2`) declared **lowercase** to match their physical (lowercase) columns — zero query-path churn, suites stay green.
- Row-access tests rewritten to the case-sensitive contract.
- **New** `test/unit/test_field_name_case.jl` — preservation, identity, query/update/order_by/DDL/delete-key, diff no-churn (no DB).
- **New** `test/integration/test_field_name_case_db.jl` + migration-bootstrap **Phase 14** — live mixed-case columns, insert/select/update round-trip, forward join + reverse-FK traversal, and **no migration churn**.

**Docs & skills**
- Corrected the now-false "PormG auto-lowercases field names" guidance (`fields.md`, `index.md`, `models.md`, `schema_conventions.md`, 3 skills); documented lowercase snake_case as the recommended convention (#58).
- Added an `UPGRADING.md` rollout entry for consuming apps (case must match the physical column; per-app checklist).

## Test status
- Unit: **1934 / 1934** ✅
- SQLite integration: **1406 / 1406** ✅
- PostgreSQL integration: **1441 / 1441** ✅
- Docs build: clean ✅

## Notes
- Reviewed via `/code-review` (high) — caught and fixed a `db_2/models.jl` parse error and a too-narrow test assertion.
- `TODO.md` index update is deferred to post-merge per repo convention.

Closes #57, #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)