### PR TITLE
feat(#50): make db_column authoritative for generated DDL and queries

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,70 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `db_column` is now **authoritative** — map a field to a differently-named column
+
+- **PormG ref**: issue #50 (make `db_column` authoritative); [src/Models.jl](src/Models.jl) (`field_db_column` / `fk_target_column`), [src/Dialect.jl](src/Dialect.jl), [src/querybuilder/](src/querybuilder/), [src/migrations/planner.jl](src/migrations/planner.jl)
+- **Recorded**: 2026-06-27
+- **Severity**: **non-breaking — opt-in.** The default is unchanged (column == field name), so existing models and schemas keep working with **no edits**. This entry exists so apps can *adopt* the new capability; the rollout table is "no action required" unless you want it.
+
+### What changed
+
+`db_column` used to be accepted on `CharField` but **silently ignored** (and `ForeignKey`/
+`OneToOneField` didn't accept it at all). Now `db_column` is **authoritative** across the whole stack
+— DDL (`create_table`/`add_field`/`alter_field`), queries (`filter`/`values`/`order_by`/`update`/
+`create`, and `bulk_insert`/`bulk_update`/`bulk_copy`), FK constraints, and the migration diff — on
+**every field type except `ManyToManyField`**.
+
+The field name stays the identity you declare and query by; only the **physical column** changes, and
+all results stay **keyed by the field name**. This complements case preservation (#57): use the
+declared name (lowercase house style) as your code-facing identity and `db_column` to point it at a
+legacy column whose physical name you don't control.
+
+### How to adopt (optional)
+
+```julia
+# A field whose physical column differs from the code-facing name:
+Product = Models.Model("product",
+    id   = Models.IDField(),
+    sku  = Models.CharField(db_column="product_sku"),   # field `sku` → column "product_sku"
+)
+M.Product.objects.filter("sku" => "ABC").values("sku")  # query by the field name `sku`
+row.sku                                                  # results stay keyed by `sku`
+
+# ForeignKey: db_column renames the LOCAL fk column.
+Entry = Models.Model("entry",
+    id     = Models.IDField(),
+    driver = Models.ForeignKey(Product, db_column="driver_fk"),  # local column "driver_fk"
+)
+```
+
+Notes / limits:
+
+- On an FK, `db_column` renames the **local** column. The **referenced** parent column follows
+  `pk_field`; when the parent's pk field *itself* uses `db_column`, declare the FK target as a model
+  **instance** (`ForeignKey(Parent, pk_field="code")`, not the string `"Parent"`) so the generated
+  FK constraint resolves the parent's `db_column`.
+- `ManyToManyField` through-table columns are **not** configurable via `db_column`.
+
+### Verify
+
+After adding `db_column`, run `makemigrations` / `dry_run`: a fresh model creates the column under the
+`db_column` name, and re-running reports **no changes** (the diff is keyed by physical column, so
+there is no churn).
+
+### Per-app rollout
+
+Non-breaking — no edits required. Mark an app ✅ only if/when it intentionally adopts `db_column`.
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | — | non-breaking; adopt only if mapping a renamed column |
+| app-2 | — | non-breaking; adopt only if mapping a renamed column |
+| app-3 | — | non-breaking; adopt only if mapping a renamed column |
+| app-4 | — | non-breaking; adopt only if mapping a renamed column |
+
+---
+
 ## Field names — declared **case is preserved** and lookups are **case-sensitive**
 
 - **PormG ref**: issue #57 (preserve declared field-name case) + #58 (lowercase house-style convention); [src/Models.jl](src/Models.jl) (`format_fild_name` / `format_model_name`), [src/querybuilder/deletion.jl](src/querybuilder/deletion.jl), [src/querybuilder/types.jl](src/querybuilder/types.jl)

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -21,12 +21,14 @@ This comprehensive guide covers all field types available in PormG, inspired by 
 - **Be descriptive and clear**: `User_profile`, `Product_category`, `Order_history`
 
 ### Database Column Mapping
-- **Column names follow the field name verbatim, with case preserved**: a field declared `firstName`
-  becomes the column `"firstName"`; declare `first_name` to get `first_name`.
+- **By default, column names follow the field name verbatim, with case preserved**: a field declared
+  `firstName` becomes the column `"firstName"`; declare `first_name` to get `first_name`.
 - **The house style is lowercase snake_case** — prefer it for new schemas; reserve mixed-case
   declarations for faithfully mapping existing columns you don't control.
-- The schema generator does not currently rename columns via `db_column` — see
-  [Schema Conventions](schema_conventions.md).
+- **`db_column` maps a field to a differently-named column** and is authoritative across DDL,
+  queries, and migrations (#50) — e.g. `sku = CharField(db_column="product_sku")` keeps the field
+  `sku` but targets the column `"product_sku"`. Supported on all field types except `ManyToManyField`;
+  see [Schema Conventions](schema_conventions.md).
 
 ### Examples of Good Naming
 
@@ -1000,7 +1002,7 @@ All field types support these common parameters:
 
 ### Database Options
 - `db_index::Bool = false`: Create database index for faster queries
-- `db_column::Union{String, Nothing} = nothing`: Accepted but **not currently honored** by schema generation — the column name is the field name (see [Schema Conventions](schema_conventions.md))
+- `db_column::Union{String, Nothing} = nothing`: Maps this field to a differently-named physical column; **authoritative** across DDL, queries, and migrations (#50). Defaults to the field name (see [Schema Conventions](schema_conventions.md))
 - `db_constraint::Bool = true`: Create database constraints (for relationships)
 
 ### Example with All Common Options

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -90,10 +90,32 @@ Two consequences worth noting:
 - The FK field name is also the **join/lookup prefix**: `Result.objects.filter("driverid__surname"
   => "Senna")`. There is no separate "related object vs. raw id" split like Django's
   `obj.author` / `obj.author_id` — the one field name serves both, by design.
-- A column always equals its field name in generated DDL. Some field types accept a `db_column`
-  parameter, but the schema generator does **not currently honor it** — `field_to_column` renders
-  the field-name key regardless. Making `db_column` authoritative for generated DDL would be a safe,
-  non-breaking future change; until then, name the field as you want the column.
+- By default a column equals its field name. To map a field to a **differently-named** column, set
+  `db_column` — it is **authoritative** (#50) across generated DDL, queries (SELECT/WHERE/ORDER BY/
+  INSERT/UPDATE, and the bulk APIs), and the migration diff. The field name stays the identity you
+  declare and query by; only the physical column changes, and results stay keyed by the field name:
+
+  ```julia
+  sku = Models.CharField(db_column="product_sku")   # field `sku` → column "product_sku"
+  ```
+
+  This is non-breaking: the default (column == field name) is unchanged, so existing schemas are
+  unaffected. On a `ForeignKey`/`OneToOneField`, `db_column` renames the **local** FK column; the
+  **referenced** parent column follows `pk_field`, resolved through the parent field's own
+  `db_column` when the FK target is a resolved model.
+
+  !!! note "Limitations when db_column is on a *key* field"
+      `db_column` on a primary key works for ordinary CRUD (create/get/update, bulk, sequence
+      sync). A few join/reference paths that derive a column from a *parent key field* do not yet
+      resolve that parent's `db_column` and fall back to the field name — tracked in
+      [#62](https://github.com/PingoLee/PormG.jl/issues/62):
+
+      - An FK whose target is given as a **string** (`ForeignKey("Driver", pk_field="code")`) when
+        the referenced parent field itself uses `db_column` — declare the target as a model
+        **instance** (`ForeignKey(Driver, pk_field="code")`) so the FK constraint/join resolve it.
+      - A **ManyToMany** or **CTE** join whose participating model's *primary key* uses `db_column`.
+
+      ManyToMany through-table columns are not configurable via `db_column`.
 
 !!! note "Imported models differ"
     The Django importer appends `_id` to a `ForeignKey`/`OneToOneField` field and points it at the
@@ -163,7 +185,8 @@ CREATE TABLE result (
 | Table name | `model.name` lowercased, verbatim — no pluralization |
 | `django_prefix` | optional Django-interop prefix; shapes generated `name`/accessors, not the physical-table rule |
 | Primary key | explicit `IDField` on native models; no implicit `id` (importer auto-adds `id`) |
-| FK column | declared field name, verbatim (case preserved) — no `_id` suffix (importer adds `_id`) |
+| FK column | declared field name, verbatim (case preserved), or `db_column` when set — no `_id` suffix (importer adds `_id`) |
+| `db_column` | authoritative: maps a field to a differently-named column (default: column == field name) |
 | Default `on_delete` | `NO ACTION` |
 | Timestamps | opt-in `auto_now` / `auto_now_add`; no implicit `created`/`modified` |
 | Quoting | double quotes both backends; table names lowercased, column names case-preserved |

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -7,7 +7,7 @@ import PormG: backend_sqlite_version  # SQLite library-version probe (driver bod
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse
 import PormG: get_constraints_pk, get_constraints_unique, get_constraints_check
-import PormG.Models: Migration, get_model_pk_field, format_model_name
+import PormG.Models: Migration, get_model_pk_field, format_model_name, field_db_column, fk_target_column
 
 import PormG: @pormg_debug
 
@@ -585,6 +585,8 @@ _requires_non_negative_check(field::PormGField)::Bool = field isa Union{sPositiv
 _non_negative_check_clause(col_name)::String = "CHECK (\"$(col_name)\" >= 0)"
 
 function field_to_column(col_name::String, field::PormGField, conn::PormGPostgres; temporary_default::Any=nothing)::String
+  # Resolve the physical column name (db_column when set, else the field name) — #50.
+  col_name = field_db_column(field, col_name)
   # Determine the base SQL type
   base_type = _get_column_type(field, conn)
 
@@ -628,6 +630,8 @@ function field_to_column(col_name::String, field::PormGField, conn::PormGPostgre
 end
 
 function field_to_column(col_name::String, field::PormGField, conn::PormGSQLite; temporary_default::Any=nothing)::String
+  # Resolve the physical column name (db_column when set, else the field name) — #50.
+  col_name = field_db_column(field, col_name)
   # Determine the base SQL type
   base_type = _get_column_type(field, conn)
 
@@ -721,8 +725,10 @@ function create_table(conn::PormGSQLite, model::PormGModel)
   for (field_name, field) in model.fields
     if field isa sForeignKey && field.db_constraint
       on_delete_str = _foreign_key_on_delete_sql(field.on_delete)
-      target_pk = isnothing(field.pk_field) ? "id" : field.pk_field
-      push!(columns, "FOREIGN KEY (\"$field_name\") REFERENCES \"$(field.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
+      # Local FK column and referenced parent column both honor db_column (#50).
+      local_col = field_db_column(field, string(field_name))
+      target_pk = fk_target_column(field)
+      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(field.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 
@@ -754,6 +760,10 @@ end
 # end
 
 function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, field_name::Union{Symbol,String}, new_field::PormGField, old_field::Union{Nothing,PormGField}, colect_not_equal::Vector{Symbol})::String # TODO add old_field
+  # Resolve to the physical column (db_column when set) so every ALTER targets the real
+  # column even when called with the field-name key (e.g. the temporary-default cleanup in
+  # _add_new_field). Idempotent when callers already pass the physical column (#50).
+  field_name = field_db_column(new_field, string(field_name))
   sql_statements = []
 
   # Non-negative CHECK constraint diffing on a type transition (Django-style).
@@ -929,12 +939,13 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
     push!(columns_defs, field_to_column(f_name |> string, f, conn))
   end
 
-  # Add foreign key constraints
+  # Add foreign key constraints (local + referenced columns honor db_column — #50)
   for (f_name, f) in model.fields
     if f isa sForeignKey && f.db_constraint
       on_delete_str = _foreign_key_on_delete_sql(f.on_delete)
-      target_pk = isnothing(f.pk_field) ? "id" : f.pk_field
-      push!(columns_defs, "FOREIGN KEY (\"$f_name\") REFERENCES \"$(f.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
+      local_col = field_db_column(f, string(f_name))
+      target_pk = fk_target_column(f)
+      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(f.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 
@@ -950,7 +961,9 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
   # constraint failure when the INSERT tries to populate the new table from the
   # old one — the new table's CREATE has the column as NOT NULL but the INSERT
   # simply doesn't mention it.
-  model_cols = [string(k) for k in keys(model.fields)]
+  # Physical column names (db_column when set) — both old and new tables use these,
+  # so the column-aligned copy stays correct for db_column-mapped fields (#50).
+  model_cols = [field_db_column(f, string(k)) for (k, f) in model.fields]
   cols_joined = join(["\"$c\"" for c in model_cols], ", ")
 
   insert_sql = """INSERT INTO "$new_table_name" ($cols_joined) SELECT $cols_joined FROM "$table_name";"""

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -406,6 +406,54 @@ function format_model_name(name::PormGModel)::String
   return name.name |> format_model_name
 end
 
+# Physical SQL column for a field given its declared identity `name` (#50). Returns
+# `db_column` when the field carries a non-empty one, else the field name. The
+# default (column == field name) keeps every existing schema unchanged; only fields
+# that explicitly set `db_column` map to a differently-named column. `hasproperty`
+# keeps this safe for any field type — including synthetic/introspected fields that
+# do not carry a `db_column` member.
+function field_db_column(field::PormGField, name::AbstractString)::String
+  if hasproperty(field, :db_column)
+    dbc = getproperty(field, :db_column)
+    dbc isa AbstractString && !isempty(dbc) && return String(dbc)
+  end
+  return String(name)
+end
+field_db_column(field::PormGField, name::Symbol)::String = field_db_column(field, String(name))
+
+# Referenced (parent) physical column for a ForeignKey (#50). `pk_field` names a
+# field on the target model; resolve it to that field's `db_column` when the target
+# model is in scope (the normal query/migration path, where `to` is a resolved
+# PormGModel). The verbatim fallback is CORRECT for introspected models: their `to`
+# is a String and their `pk_field` is already the physical column, with no
+# `db_column` on the reconstructed field.
+function fk_target_column(field::PormGField)::String
+  pk = field.pk_field === nothing ? "id" : String(field.pk_field)
+  tgt = field.to
+  (tgt isa PormGModel && haskey(tgt.fields, pk)) && return field_db_column(tgt.fields[pk], pk)
+  return pk
+end
+
+# Resolve a field-name string to its physical column within `model` (db_column when
+# the named field carries one), verbatim when the name is not a field of `model`. For
+# call sites that hold only a model + a field-name string — e.g. reverse-relation join
+# keys assembled from `related_objects` tuples (#50). A strict no-op without db_column.
+function model_column(model::PormGModel, name::AbstractString)::String
+  haskey(model.fields, name) ? field_db_column(model.fields[name], name) : String(name)
+end
+
+# True when any field of `model` declares a non-empty db_column (#50). Lets write paths
+# skip the physical-column → field-name result remap on the common path (no db_column).
+function model_has_db_column(model::PormGModel)::Bool
+  for (_, f) in model.fields
+    if hasproperty(f, :db_column)
+      dbc = getproperty(f, :db_column)
+      dbc isa AbstractString && !isempty(dbc) && return true
+    end
+  end
+  return false
+end
+
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Model Constructors
 #═══════════════════════════════════════════════════════════════════════════════
@@ -985,9 +1033,11 @@ function _compare_field_foreign_key(new_field::PormGField, old_field::PormGField
   old_to = old_field.to isa PormGModel ? old_field.to.name : old_field.to
   normalized_new_to = isnothing(new_to) ? nothing : format_model_name(string(new_to))
   normalized_old_to = isnothing(old_to) ? nothing : format_model_name(string(old_to))
-  normalized_new_pk = isnothing(new_field.pk_field) ? nothing : format_fild_name(string(new_field.pk_field))
-  normalized_old_pk = isnothing(old_field.pk_field) ? nothing : format_fild_name(string(old_field.pk_field))
-  if normalized_new_to == normalized_old_to && normalized_new_pk == normalized_old_pk
+  # Compare the referenced column by its RESOLVED physical name (fk_target_column), so a
+  # field-name pk_field on the code side matches the introspected physical column when the
+  # parent's pk field is renamed via db_column (#50). With no db_column this equals the
+  # field name, so behavior is unchanged for existing schemas.
+  if normalized_new_to == normalized_old_to && fk_target_column(new_field) == fk_target_column(old_field)
     return true
   end
   return false

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -92,10 +92,12 @@ function _add_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite
        return nothing
     end
     constraint_name = "$(name)_fk" |> lowercase
-    resolved_pk = isnothing(new_field.pk_field) ? "id" : string(new_field.pk_field)
+    # Local FK column and referenced parent column both honor db_column (#50).
+    resolved_pk = Models.fk_target_column(new_field)
+    local_col = Models.field_db_column(new_field, string(field_name))
     on_delete_sql = hasfield(typeof(new_field), :on_delete) ? Dialect._foreign_key_on_delete_sql(new_field.on_delete) : nothing
-    _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name", 
-    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$field_name\"",  "\"$(new_field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+    _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
+    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(new_field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
   end
   return nothing
 end
@@ -108,21 +110,24 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
   if hasfield(field |> typeof, :to) && field.db_constraint
     if conn isa PormGPostgres
       constraint_name = name * "_fk" |> lowercase
-      resolved_pk = isnothing(field.pk_field) ? "id" : string(field.pk_field)
+      # Local FK column and referenced parent column both honor db_column (#50).
+      resolved_pk = Models.fk_target_column(field)
+      local_col = Models.field_db_column(field, string(field_name))
       on_delete_sql = hasfield(typeof(field), :on_delete) ? Dialect._foreign_key_on_delete_sql(field.on_delete) : nothing
-      _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name", 
-      Dialect.add_foreign_key(conn, model.name, "\"$constraint_name\"", "\"$field_name\"",  "\"$(field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+      _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
+      Dialect.add_foreign_key(conn, model.name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
     # For SQLite, FKs are added in CREATE TABLE, so if we are adding a field to an existing table, 
     # we might need recreation if it's a FK.
     end
   end
 
-  # If the new field is also indexed
-  if !field.primary_key && field.db_index 
+  # If the new field is also indexed (index targets the physical column, db_column #50)
+  if !field.primary_key && field.db_index
     index_name = name * "_idx" |> lowercase
-    _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name", 
-    Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$field_name\""]))
-  end  
+    index_col = Models.field_db_column(field, string(field_name))
+    _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name",
+    Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$index_col\""]))
+  end
   nothing
 end
 
@@ -188,8 +193,12 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
     model_fields_map = Dict(String(strip(key, '"')) => String(key) for key in keys(model.fields))
     stripped_model_fields = Set(keys(model_fields_map))
 
-    # Do the same for current_schema model fields
-    current_fields_map = Dict(String(strip(key, '"')) => String(key) for key in keys(current_schema[model_name][:model].fields))
+    # Do the same for current_schema model fields, but key by the PHYSICAL column name
+    # (db_column when set, else the field name) so the code side aligns with the
+    # column-keyed introspected DB side — otherwise a field whose db_column differs from
+    # its name would churn as a spurious DROP + ADD (#50). The value stays the real
+    # field-name key for accessing model.fields.
+    current_fields_map = Dict(Models.field_db_column(field, String(strip(String(key), '"'))) => String(key) for (key, field) in current_schema[model_name][:model].fields)
     stripped_current_fields = Set(keys(current_fields_map))
 
     # check the field are not in current_schema (deletion)
@@ -228,7 +237,14 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
             old_var = getfield(old_field, attr)
             if new_var != old_var                  
               attr == :to && Models._compare_field_foreign_key(field, old_field) && continue
-              attr in [:blank, :on_delete, :related_name, :verbose_name, :editable, :how, :formater] && continue 
+              # pk_field is compared by RESOLVED referenced column: a field-name pk_field on
+              # the code side matches the introspected physical column when the parent pk is
+              # renamed via db_column (#50). No-op when the referenced column isn't renamed.
+              attr == :pk_field && Models.fk_target_column(field) == Models.fk_target_column(old_field) && continue
+              # :db_column never alters the live schema by itself — the column identity is
+              # already proven equal by the matched (column-keyed) field, and the introspected
+              # side carries db_column=nothing (#50).
+              attr in [:blank, :on_delete, :related_name, :verbose_name, :editable, :how, :formater, :db_column] && continue
               push!(colect_not_equal, attr)
             end
           end
@@ -302,8 +318,10 @@ function _resolve_table_fields(
     field_name_sym = colect_addition[1]
     field_name = field_name_sym |> string       
     colect_numbered, list_to_question = _colect_numbered_fields(colect_deletion)
-    if colect_deletion |> isempty 
-      _add_new_field(conn, migration_plan, model_name, current_model, field_name, temporary_default_value = _get_temporary_default_value(current_model.fields[current_fields_map[field_name]], settings))
+    if colect_deletion |> isempty
+      # `field_name` here is the physical column; pass the real field key so _add_new_field's
+      # model.fields lookup resolves (the DDL re-derives the db_column from the field) (#50).
+      _add_new_field(conn, migration_plan, model_name, current_model, current_fields_map[field_name], temporary_default_value = _get_temporary_default_value(current_model.fields[current_fields_map[field_name]], settings))
     else       
       response = "no"
       if interactive
@@ -313,7 +331,8 @@ function _resolve_table_fields(
       end
       
       if response in ["no", "n"]
-        _add_new_field(conn, migration_plan, model_name, current_model, field_name, temporary_default_value = _get_temporary_default_value(current_model.fields[current_fields_map[field_name]], settings))
+        # `field_name` is the physical column; pass the real field key (see above) (#50).
+        _add_new_field(conn, migration_plan, model_name, current_model, current_fields_map[field_name], temporary_default_value = _get_temporary_default_value(current_model.fields[current_fields_map[field_name]], settings))
       else
         old_field_sym::Union{Symbol,Nothing} = nothing
         try

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -7,6 +7,7 @@ struct sIDField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -76,7 +77,7 @@ Order = Models.Model(
 function IDField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :primary_key, :auto_increment, :unique, :blank, :null, :db_index, :default, :editable, :generated, :generated_always
+      :verbose_name, :primary_key, :auto_increment, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :generated, :generated_always
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -92,6 +93,7 @@ function IDField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, true)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   generated = get(kwargs, :generated, true)
@@ -106,6 +108,7 @@ function IDField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(generated isa Bool) && throw(ArgumentError("The 'generated' must be a Boolean"))
   !(generated_always isa Bool) && throw(ArgumentError("The 'generated_always' must be a Boolean"))
@@ -113,7 +116,7 @@ function IDField(; kwargs...)
   default = validate_default(default, Union{Int64, Nothing}, "IDField", format2int64)
   # Return the field instance
   return sIDField(
-    verbose_name, primary_key, auto_increment, unique, blank, null, db_index, default, editable, "BIGINT", format_number_sql, generated, generated_always
+    verbose_name, primary_key, auto_increment, unique, blank, null, db_index, db_column, default, editable, "BIGINT", format_number_sql, generated, generated_always
   )
 end
 
@@ -124,6 +127,7 @@ mutable struct sForeignKey <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   to::Union{String, PormGModel, Nothing}
@@ -168,6 +172,7 @@ The `ForeignKey` field represents a relationship where many records in the curre
 - `how::Union{String, Nothing} = nothing`: Join type for queries ("INNER JOIN", "LEFT JOIN", etc.)
 - `related_name::Union{String, Nothing} = nothing`: Name for the reverse relation
 - `db_constraint::Bool = true`: Whether to create a database foreign key constraint
+- `db_column::Union{String, Nothing} = nothing`: Map the local FK column to a differently-named physical column (#50). The *referenced* parent column follows `pk_field` (resolved through the parent field's own `db_column` when the target is a resolved model). Defaults to the field name
 
 # Database Mapping
 - **PostgreSQL Type**: BIGINT with foreign key constraint
@@ -245,7 +250,7 @@ Message = Models.Model(
 function ForeignKey(to::Union{String, PormGModel}; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :default, :editable, :pk_field, :on_delete, :on_update, :deferrable, :initially_deferred, :how, :related_name, :db_constraint
+      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :pk_field, :on_delete, :on_update, :deferrable, :initially_deferred, :how, :related_name, :db_constraint
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -260,6 +265,7 @@ function ForeignKey(to::Union{String, PormGModel}; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, true)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   pk_field = get(kwargs, :pk_field, nothing)
@@ -283,6 +289,7 @@ function ForeignKey(to::Union{String, PormGModel}; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(deferrable isa Bool) && throw(ArgumentError("The 'deferrable' must be a Boolean"))
   !(initially_deferred isa Bool) && throw(ArgumentError("The 'initially_deferred' must be a Boolean"))
@@ -310,6 +317,7 @@ function ForeignKey(to::Union{String, PormGModel}; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     to,
@@ -435,6 +443,7 @@ mutable struct sOneToOneField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   to::Union{String, PormGModel, Nothing}
@@ -479,6 +488,7 @@ The `OneToOneField` represents a strict one-to-one relationship where each recor
 - `how::Union{String, Nothing} = nothing`: Join type for queries ("INNER JOIN", "LEFT JOIN", etc.)
 - `related_name::Union{String, Nothing} = nothing`: Name for the reverse relation
 - `db_constraint::Bool = true`: Whether to create a database foreign key constraint
+- `db_column::Union{String, Nothing} = nothing`: Map the local column to a differently-named physical column (#50); defaults to the field name
 
 # Database Mapping
 - **PostgreSQL Type**: BIGINT with unique foreign key constraint
@@ -577,7 +587,7 @@ However, OneToOneField is more explicit about the intended relationship type and
 function OneToOneField(to::Union{String, PormGModel}; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :default, :editable, :pk_field, :on_delete, :on_update, :deferrable, :initially_deferred, :how, :related_name, :db_constraint
+      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :pk_field, :on_delete, :on_update, :deferrable, :initially_deferred, :how, :related_name, :db_constraint
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -592,6 +602,7 @@ function OneToOneField(to::Union{String, PormGModel}; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, true)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   pk_field = get(kwargs, :pk_field, nothing)
@@ -615,6 +626,7 @@ function OneToOneField(to::Union{String, PormGModel}; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(deferrable isa Bool) && throw(ArgumentError("The 'deferrable' must be a Boolean"))
   !(initially_deferred isa Bool) && throw(ArgumentError("The 'initially_deferred' must be a Boolean"))
@@ -634,6 +646,9 @@ function OneToOneField(to::Union{String, PormGModel}; kwargs...)
 
   # Resolve db_index based on db_constraint
   db_index = db_index || !db_constraint
+  # Normalize pk_field (strip one leading underscore for reserved-word escaping), matching
+  # ForeignKey — so a referenced parent field resolves to its stored (stripped) key (#50).
+  pk_field = format_fild_name(pk_field)
 
   return sOneToOneField(
     unique,
@@ -642,6 +657,7 @@ function OneToOneField(to::Union{String, PormGModel}; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     to,
@@ -666,6 +682,7 @@ mutable struct sAutoField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -725,7 +742,7 @@ The `AutoField` is designed for auto-incrementing integer primary keys and autom
 function AutoField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :primary_key, :auto_increment, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :primary_key, :auto_increment, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -741,6 +758,7 @@ function AutoField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -753,12 +771,13 @@ function AutoField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Validate default
   default = validate_default(default, Union{Int64, Nothing}, "AutoField", format2int64)
   # Return the field instance
 
-  return sAutoField(verbose_name, primary_key, auto_increment, unique, blank, null, db_index, default, editable, "INTEGER", format_number_sql)
+  return sAutoField(verbose_name, primary_key, auto_increment, unique, blank, null, db_index, db_column, default, editable, "INTEGER", format_number_sql)
 end
 
 mutable struct sCharField <: PormGField
@@ -831,7 +850,7 @@ The `CharField` is the most commonly used field for storing textual data with a 
 - `blank::Bool = false`: Whether the field can be left blank in forms
 - `null::Bool = false`: Whether the database column can store NULL values
 - `db_index::Bool = false`: Whether to create a database index on this field
-- `db_column::Union{String, Nothing} = nothing`: Accepted but not currently honored by schema generation; the generated column is the field name
+- `db_column::Union{String, Nothing} = nothing`: Map this field to a differently-named physical column (Django `db_column`). Authoritative across DDL, queries, and migrations (#50); defaults to the field name
 - `default::Union{String, Nothing} = nothing`: Default value for the field
 - `choices::Union{NTuple{N, Tuple{AbstractString, AbstractString}}, Nothing} = nothing`: Restricted set of valid values
 - `editable::Bool = true`: Whether the field should be editable in forms
@@ -1032,6 +1051,7 @@ mutable struct sIntegerField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -1102,7 +1122,7 @@ Review = Models.Model(
 function IntegerField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1116,12 +1136,13 @@ function IntegerField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
   !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
-  
+
   # Validate default using validate_default
   default = validate_default(default, Union{Int64, Nothing}, "IntegerField", format2int64)
   
@@ -1130,8 +1151,9 @@ function IntegerField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Booleadn"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
-  
+
   return sIntegerField(
     verbose_name,
     false, # primary_key
@@ -1139,6 +1161,7 @@ function IntegerField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "INTEGER",
@@ -1153,6 +1176,7 @@ mutable struct sPositiveSmallIntegerField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -1204,7 +1228,7 @@ Standing = Models.Model(
 function PositiveSmallIntegerField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1218,6 +1242,7 @@ function PositiveSmallIntegerField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -1235,6 +1260,7 @@ function PositiveSmallIntegerField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
 
   return sPositiveSmallIntegerField(
@@ -1244,6 +1270,7 @@ function PositiveSmallIntegerField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "SMALLINT",
@@ -1258,6 +1285,7 @@ mutable struct sPositiveIntegerField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -1309,7 +1337,7 @@ Lap_times = Models.Model(
 function PositiveIntegerField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1323,6 +1351,7 @@ function PositiveIntegerField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -1340,6 +1369,7 @@ function PositiveIntegerField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
 
   return sPositiveIntegerField(
@@ -1349,6 +1379,7 @@ function PositiveIntegerField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "INTEGER UNSIGNED",
@@ -1363,6 +1394,7 @@ mutable struct sBigIntegerField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
@@ -1442,7 +1474,7 @@ SocialMedia = Models.Model(
 function BigIntegerField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1456,12 +1488,13 @@ function BigIntegerField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
   !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
-  
+
   # Validate default using validate_default
   default = validate_default(default, Union{Int64, Nothing}, "BigIntegerField", format2int64)
   
@@ -1470,8 +1503,9 @@ function BigIntegerField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
-  
+
   return sBigIntegerField(
     verbose_name,
     false, # primary_key
@@ -1479,6 +1513,7 @@ function BigIntegerField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "BIGINT",
@@ -1493,6 +1528,7 @@ mutable struct sBooleanField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Bool, Nothing}
   editable::Bool
   type::String
@@ -1539,7 +1575,7 @@ The field handles various input formats:
 function BooleanField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1553,6 +1589,7 @@ function BooleanField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -1565,6 +1602,7 @@ function BooleanField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sBooleanField(
@@ -1574,6 +1612,7 @@ function BooleanField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "BOOLEAN",
@@ -1588,6 +1627,7 @@ mutable struct sDateField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Date, Nothing}
   editable::Bool
   auto_now::Bool
@@ -1677,7 +1717,7 @@ The field accepts various input formats:
 function DateField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable, :auto_now, :auto_now_add
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :auto_now, :auto_now_add
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1691,10 +1731,11 @@ function DateField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   auto_now = get(kwargs, :auto_now, false)
-  auto_now_add = get(kwargs, :auto_now_add, false)  
+  auto_now_add = get(kwargs, :auto_now_add, false)
 
   # Validate verbose_name
   !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
@@ -1705,6 +1746,7 @@ function DateField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(auto_now isa Bool) && throw(ArgumentError("The 'auto_now' must be a Boolean"))
   !(auto_now_add isa Bool) && throw(ArgumentError("The 'auto_now_add' must be a Boolean"))
@@ -1716,6 +1758,7 @@ function DateField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     auto_now,
@@ -1732,6 +1775,7 @@ mutable struct sDateTimeField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{ZonedDateTime, DateTime, Nothing}
   editable::Bool
   auto_now::Bool
@@ -1784,7 +1828,7 @@ deadline = DateTimeField(null=true, blank=true)```
 function DateTimeField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable, :auto_now, :auto_now_add, :type
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :auto_now, :auto_now_add, :type
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1798,6 +1842,7 @@ function DateTimeField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   auto_now = get(kwargs, :auto_now, false)
@@ -1834,6 +1879,7 @@ function DateTimeField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(auto_now isa Bool) && throw(ArgumentError("The 'auto_now' must be a Boolean"))
   !(auto_now_add isa Bool) && throw(ArgumentError("The 'auto_now_add' must be a Boolean"))
@@ -1849,6 +1895,7 @@ function DateTimeField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     auto_now,
@@ -1865,6 +1912,7 @@ mutable struct sDecimalField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Float64, Nothing}
   editable::Bool
   max_digits::Int
@@ -1920,7 +1968,7 @@ discount = DecimalField(
 function DecimalField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable, :max_digits, :decimal_places, :primary_key
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :max_digits, :decimal_places, :primary_key
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -1934,6 +1982,7 @@ function DecimalField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   max_digits = get(kwargs, :max_digits, 10)
@@ -1963,8 +2012,9 @@ function DecimalField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
-  
+
   return sDecimalField(
     verbose_name,
     false, # primary_key
@@ -1972,6 +2022,7 @@ function DecimalField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     max_digits,
@@ -1988,6 +2039,7 @@ mutable struct sEmailField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2032,7 +2084,7 @@ primary_email = EmailField(
 function EmailField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2046,6 +2098,7 @@ function EmailField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -2058,6 +2111,7 @@ function EmailField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sEmailField(
@@ -2067,6 +2121,7 @@ function EmailField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "VARCHAR",
@@ -2087,6 +2142,7 @@ mutable struct sPasswordField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2200,7 +2256,7 @@ Users can continue to log in without any password reset.
 function PasswordField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :blank, :null, :editable, :max_length, :auto_hash
+      :verbose_name, :blank, :null, :editable, :max_length, :auto_hash, :db_column
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2215,6 +2271,7 @@ function PasswordField(; kwargs...)
   editable = get(kwargs, :editable, true)
   max_length = get(kwargs, :max_length, 128)
   auto_hash = get(kwargs, :auto_hash, true)
+  db_column = get(kwargs, :db_column, nothing)
 
   # Validate verbose_name
   !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
@@ -2225,6 +2282,7 @@ function PasswordField(; kwargs...)
   !(max_length isa Int) && throw(ArgumentError("The 'max_length' must be an Integer"))
   max_length < 64 && throw(ArgumentError("The 'max_length' must be at least 64 to store password hashes"))
   !(auto_hash isa Bool) && throw(ArgumentError("The 'auto_hash' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   
   # Return the field instance
   return sPasswordField(
@@ -2234,13 +2292,14 @@ function PasswordField(; kwargs...)
     blank,
     null,
     false, # db_index - never index passwords
+    db_column,
     nothing, # default - no default password
     editable,
     "VARCHAR",
     format_text_sql,
     max_length,
     auto_hash
-  )  
+  )
 end
 
 mutable struct sFloatField <: PormGField
@@ -2250,6 +2309,7 @@ mutable struct sFloatField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Float64, String, Int64, Nothing}
   editable::Bool
   type::String
@@ -2285,7 +2345,7 @@ weight = FloatField(null=true)
 function FloatField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable, :primary_key
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :primary_key
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2299,6 +2359,7 @@ function FloatField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   primary_key = get(kwargs, :primary_key, false)
@@ -2319,8 +2380,9 @@ function FloatField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
-  
+
   return sFloatField(
     verbose_name,
     false, # primary_key
@@ -2328,6 +2390,7 @@ function FloatField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "FLOAT",
@@ -2342,6 +2405,7 @@ mutable struct sImageField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2386,7 +2450,7 @@ banner = ImageField(
 function ImageField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2400,6 +2464,7 @@ function ImageField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -2412,6 +2477,7 @@ function ImageField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sImageField(
@@ -2421,6 +2487,7 @@ function ImageField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "BLOB",
@@ -2436,7 +2503,7 @@ Accepted kwargs: `verbose_name`, `unique`, `blank`, `null`, `db_index`, `default
 """
 function FileField(; kwargs...)
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable,
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable,
       :upload_to, :max_length
   ])
   for (k, v) in kwargs
@@ -2449,6 +2516,7 @@ function FileField(; kwargs...)
   blank        = get(kwargs, :blank, false)
   null         = get(kwargs, :null, false)
   db_index     = get(kwargs, :db_index, false)
+  db_column    = get(kwargs, :db_column, nothing)
   default      = get(kwargs, :default, nothing)
   editable     = get(kwargs, :editable, true)
 
@@ -2458,6 +2526,7 @@ function FileField(; kwargs...)
   !(blank    isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null     isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
 
   return sImageField(
@@ -2467,6 +2536,7 @@ function FileField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "BLOB",
@@ -2481,6 +2551,7 @@ mutable struct sTextField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2525,7 +2596,7 @@ template = TextField(
 ```
 """
 function TextField(; kwargs...)
-  accepted = Set([:verbose_name, :unique, :blank, :null, :db_index, :default, :editable])
+  accepted = Set([:verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable])
   for (k, v) in kwargs
       if !(k in accepted)
           @warn "Unexpected parameter for TextField. It will be ignored." field="TextField" param=k value=v
@@ -2536,6 +2607,7 @@ function TextField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -2548,6 +2620,7 @@ function TextField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sTextField(
@@ -2557,6 +2630,7 @@ function TextField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "TEXT",
@@ -2571,6 +2645,7 @@ mutable struct sTimeField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{Time, Nothing}
   editable::Bool
   type::String
@@ -2580,7 +2655,7 @@ end
 function TimeField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2594,6 +2669,7 @@ function TimeField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -2606,6 +2682,7 @@ function TimeField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sTimeField(
@@ -2615,6 +2692,7 @@ function TimeField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "TIME",
@@ -2629,6 +2707,7 @@ mutable struct sBinaryField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2639,7 +2718,7 @@ end
 function BinaryField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable, :max_length
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :max_length
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2653,6 +2732,7 @@ function BinaryField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
   max_length = get(kwargs, :max_length, nothing)
@@ -2678,6 +2758,7 @@ function BinaryField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sBinaryField(
@@ -2687,6 +2768,7 @@ function BinaryField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "BLOB",
@@ -2702,6 +2784,7 @@ mutable struct sDurationField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2711,7 +2794,7 @@ end
 function DurationField(; kwargs...)
   # List of accepted parameters
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   # Check for unexpected parameters
   for (k, v) in kwargs
@@ -2725,6 +2808,7 @@ function DurationField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, false)
 
@@ -2737,6 +2821,7 @@ function DurationField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   # Return the field instance
   return sDurationField(
@@ -2746,6 +2831,7 @@ function DurationField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "INTERVAL",
@@ -2764,6 +2850,7 @@ mutable struct sUUIDField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2807,7 +2894,7 @@ Session = Models.Model(
 """
 function UUIDField(; kwargs...)
   accepted = Set([
-      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :default, :editable, :auto_add
+      :verbose_name, :primary_key, :unique, :blank, :null, :db_index, :db_column, :default, :editable, :auto_add
   ])
   for (k, v) in kwargs
       if !(k in accepted)
@@ -2820,6 +2907,7 @@ function UUIDField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
   auto_add = get(kwargs, :auto_add, false)
@@ -2830,6 +2918,7 @@ function UUIDField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
   !(auto_add isa Bool) && throw(ArgumentError("The 'auto_add' must be a Boolean"))
 
@@ -2848,6 +2937,7 @@ function UUIDField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "UUID",
@@ -2868,6 +2958,7 @@ mutable struct sURLField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -2907,7 +2998,7 @@ Circuit = Models.Model(
 """
 function URLField(; kwargs...)
   accepted = Set([
-      :verbose_name, :max_length, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :max_length, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   for (k, v) in kwargs
       if !(k in accepted)
@@ -2920,6 +3011,7 @@ function URLField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
@@ -2931,6 +3023,7 @@ function URLField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
 
   default = validate_default(default, Union{String, Nothing}, "URLField", x -> string(x))
@@ -2943,6 +3036,7 @@ function URLField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "VARCHAR",
@@ -2962,6 +3056,7 @@ mutable struct sSlugField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -3002,7 +3097,7 @@ Race = Models.Model(
 """
 function SlugField(; kwargs...)
   accepted = Set([
-      :verbose_name, :max_length, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :max_length, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   for (k, v) in kwargs
       if !(k in accepted)
@@ -3015,6 +3110,7 @@ function SlugField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, true)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
@@ -3027,6 +3123,7 @@ function SlugField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
 
   default = validate_default(default, Union{String, Nothing}, "SlugField", x -> string(x))
@@ -3039,6 +3136,7 @@ function SlugField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "VARCHAR",
@@ -3057,6 +3155,7 @@ mutable struct sJSONField <: PormGField
   blank::Bool
   null::Bool
   db_index::Bool
+  db_column::Union{String, Nothing}
   default::Union{String, Nothing}
   editable::Bool
   type::String
@@ -3101,7 +3200,7 @@ Race = Models.Model(
 """
 function JSONField(; kwargs...)
   accepted = Set([
-      :verbose_name, :unique, :blank, :null, :db_index, :default, :editable
+      :verbose_name, :unique, :blank, :null, :db_index, :db_column, :default, :editable
   ])
   for (k, v) in kwargs
       if !(k in accepted)
@@ -3113,6 +3212,7 @@ function JSONField(; kwargs...)
   blank = get(kwargs, :blank, false)
   null = get(kwargs, :null, false)
   db_index = get(kwargs, :db_index, false)
+  db_column = get(kwargs, :db_column, nothing)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
@@ -3121,6 +3221,7 @@ function JSONField(; kwargs...)
   !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
   !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
   !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
   !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
 
   # Validate JSON format for string defaults (validate_default won't invoke the
@@ -3138,6 +3239,7 @@ function JSONField(; kwargs...)
     blank,
     null,
     db_index,
+    db_column,
     default,
     editable,
     "JSONB",

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -426,8 +426,10 @@ function _solve_field(field::String, model::PormGModel, instruct::SQLInstruction
   end
   # (instruct.django !== nothing && hasfield(model.fields[field] |> typeof, :to)) && (field = string(field, "_id"))
 
-  # Quote the field name to prevent SQL injection
-  return quote_identifier(field, instruct.connection)
+  # Resolve to the physical column (db_column when set, else the field name) and quote
+  # it to prevent SQL injection (#50). SELECT auto-aliases back to the field name, so
+  # rows stay keyed by the declared field name even when the column differs.
+  return quote_identifier(Models.field_db_column(model.fields[field], field), instruct.connection)
 end
 _solve_field(field::String, _module::Module, model_name::Symbol, instruct::SQLInstruction) = _solve_field(field, getfield(_module, model_name), instruct)
 _solve_field(field::String, _module::Module, model_name::String, instruct::SQLInstruction) = _solve_field(field, _module, Symbol(model_name), instruct)

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -247,8 +247,9 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     end
     # @pormg_debug
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
-    row_join["key_b"] = first_field.pk_field::String
-    row_join["key_a"] = first_column
+    # Local FK column and referenced parent column both honor db_column (#50).
+    row_join["key_b"] = Models.fk_target_column(first_field)
+    row_join["key_a"] = Models.field_db_column(first_field, first_column)
   elseif haskey(instruct.object.model.related_objects, vector[1])
     related_object = instruct.object.model.related_objects[vector[1]]
     if related_object isa Models.ManyToManyRelation
@@ -279,8 +280,10 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     end
 
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
-    row_join["key_a"] = instruct.object.model.related_objects[vector[1]][2] |> String
-    row_join["key_b"] = instruct.object.model.related_objects[vector[1]][1] |> String
+    # Reverse join: key_a is the parent's referenced column, key_b the child's FK
+    # column; both honor db_column (resolved in their own model, no-op without it) (#50).
+    row_join["key_a"] = Models.model_column(instruct.object.model, instruct.object.model.related_objects[vector[1]][2] |> String)
+    row_join["key_b"] = Models.model_column(reverse_model, instruct.object.model.related_objects[vector[1]][1] |> String)
     foreign_table_name = s_model |> string
     @pormg_debug false
     end
@@ -346,8 +349,9 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
         size(vector, 1) == 2 && (last_field = getfield(foreing_table_module, foreign_table_name |> Symbol).fields[vector[2]])
       end
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias) # TODO chage by row_join and test the speed
-      row_join["key_b"] = new_object.fields[first_column].pk_field::String
-      row_join["key_a"] = first_column    
+      # Local FK column and referenced parent column both honor db_column (#50).
+      row_join["key_b"] = Models.fk_target_column(first_field)
+      row_join["key_a"] = Models.field_db_column(first_field, first_column)
     elseif haskey(new_object.related_objects, vector[1])
       related_object = new_object.related_objects[vector[1]]
       if related_object isa Models.ManyToManyRelation
@@ -377,8 +381,10 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       end
 
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
-      row_join["key_a"] = new_object.related_objects[vector[1]][2] |> String
-      row_join["key_b"] = new_object.related_objects[vector[1]][1] |> String
+      # Reverse join: key_a is the parent's referenced column, key_b the child's FK
+      # column; both honor db_column (resolved in their own model, no-op without it) (#50).
+      row_join["key_a"] = Models.model_column(new_object, new_object.related_objects[vector[1]][2] |> String)
+      row_join["key_b"] = Models.model_column(reverse_model, new_object.related_objects[vector[1]][1] |> String)
       foreign_table_name = s_model |> string
       vector = vector[2:end]
       _reverse_advanced = true

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -445,7 +445,9 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
   # @info keys[1][:objct] |> query
   for key in keys
     pk_field = key[:key]
-    push!(_where, """"$(pk_field)" IN ($(query(key[:objct], parameters=parameters)))""")
+    # Outer WHERE targets the physical column (db_column when set); the subquery already
+    # projects/aliases the key, so only this identifier needs resolving (#50).
+    push!(_where, """"$(Models.model_column(model, pk_field))" IN ($(query(key[:objct], parameters=parameters)))""")
   end
   sql::String = ""
   if size(keys, 1) == 1
@@ -468,7 +470,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     deleted_counter[model.name] = show_query === :execute ? (_query |> do_count) : 0
     _query.values(pk_field) # Ensure the query is built
     @pormg_debug false
-    sql = "DELETE FROM $(model.name |> lowercase) WHERE \"$(pk_field)\" IN ($(query(_query, parameters=parameters)))"
+    sql = "DELETE FROM $(model.name |> lowercase) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   end
 
   sql == "" && throw("Error in delete, the SQL query is empty, this should not happen")
@@ -489,7 +491,8 @@ function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::Porm
   _query = keys[:objct]
   parameters = get_parameter(connection)
   value_sql = value === nothing ? "NULL" : model.fields[field].formater(value)
-  sql = "UPDATE $(model.name |> lowercase) SET \"$(field)\" = $(value_sql) WHERE \"$(pk_field)\" IN ($(query(_query, parameters=parameters)))"
+  # SET column and outer WHERE key both target the physical column (db_column) — #50.
+  sql = "UPDATE $(model.name |> lowercase) SET \"$(Models.model_column(model, field))\" = $(value_sql) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   if show_query !== :execute
     return _show_query_result(show_query, sql, connection, model, :update, parameters=parameters)
   end

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -381,6 +381,17 @@ function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAli
   end
 end
 
+# Build a Dict{Symbol,Any} from a result row, mapping physical column names back to the
+# declared field names so callers always see field-name keys even when a field maps to a
+# differently-named column via db_column (#50). No-op shape on the common path.
+function _row_to_field_keyed_dict(row, model::PormGModel)::Dict{Symbol,Any}
+  if !Models.model_has_db_column(model)
+    return Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(row))
+  end
+  rev = Dict{String,Symbol}(Models.field_db_column(f, string(k)) => Symbol(k) for (k, f) in model.fields)
+  return Dict{Symbol,Any}(get(rev, string(k), Symbol(k)) => v for (k, v) in pairs(row))
+end
+
 function insert(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = nothing, connection::Union{Nothing, PormGPostgres, PormGSQLite} = nothing, show_query::Symbol = :execute)
 real_obj = objct isa SQLObjectHandler ? objct.object : objct
   model = real_obj.model
@@ -446,8 +457,8 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     # check if the field is a primary key
     model.fields[field].primary_key && (pk_exist = true; push!(pk_field, field))
 
-     # Add safely quoted field name to columns list
-    push!(quoted_field_columns, quote_identifier(field, connection))
+     # Add safely quoted physical column (db_column when set) to columns list (#50)
+    push!(quoted_field_columns, quote_identifier(Models.field_db_column(model.fields[field], field), connection))
 
     # Format and add value to parameters
     push!(param_values, add_parameter!(parameters, real_obj.insert[field] |> model.fields[field].formater))
@@ -475,7 +486,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
   if connection isa PormGPostgres
     result = fetch(settings, sql * " RETURNING *;", parameters)
     pk_exist && _update_sequence(model, connection, pk_field, settings)
-    return Tables.rowtable(result) |> Base.first |> x -> Dict(Symbol(k) => v for (k, v) in pairs(x))
+    return _row_to_field_keyed_dict(Tables.rowtable(result) |> Base.first, model)
   elseif connection isa PormGSQLite
     # SQLite: deliberately avoid `INSERT ... RETURNING *`. RETURNING can hang
     # indefinitely inside SQLite/libsqlite3 for some table shapes (observed: an
@@ -493,7 +504,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
         "SELECT * FROM $(safe_table_name) WHERE rowid = last_insert_rowid();") |> Tables.rowtable
       isempty(rows) ?
         Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(real_obj.insert)) :
-        Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(rows[1]))
+        _row_to_field_keyed_dict(rows[1], model)
     end
 
     # INSERT and the row read-back must run on one connection (last_insert_rowid()
@@ -531,7 +542,9 @@ function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field
   !(settings.change_db || settings.django_prefix !== nothing) && return nothing
 
   for field in pk_field
-    sequence_name = _get_owned_sequence_name(connection, model, field; ignore_tx=ignore_tx)
+    # Resolve the PK field to its physical column (db_column when set) — #50.
+    col = Models.model_column(model, field)
+    sequence_name = _get_owned_sequence_name(connection, model, col; ignore_tx=ignore_tx)
 
     if isnothing(sequence_name)
       # Fallback for Django-managed tables where sequence ownership is not set:
@@ -546,7 +559,7 @@ function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field
       sequence_name = seqs_df[1, :sequencename]
     end
 
-    safe_field_name = quote_identifier(field, connection)
+    safe_field_name = quote_identifier(col, connection)
     safe_table_name = safe_table_identifier(string(model.name), connection)
     fetch(
       connection,
@@ -587,7 +600,7 @@ end
 # end
 function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::SQLConn)
   for field in pk_field
-    safe_field_name = quote_identifier(field, connection)
+    safe_field_name = quote_identifier(Models.model_column(model, field), connection)  # db_column (#50)
     safe_table_name = safe_table_identifier(string(model.name), connection)
     safe_table_literal = replace(string(model.name |> lowercase), "'" => "''")
     max_id_query = "SELECT MAX($(safe_field_name)) as m FROM $(safe_table_name);"
@@ -783,7 +796,7 @@ function _build_update_target_pk_subquery(instruction::SQLInstruction)::Union{St
 
   safe_table_name = safe_table_identifier(instruction.object.model.name, instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
-  quoted_pk = quote_identifier(String(pk_field_sym), instruction.connection)
+  quoted_pk = quote_identifier(Models.model_column(instruction.object.model, String(pk_field_sym)), instruction.connection)  # db_column (#50)
 
   io = IOBuffer()
   print(io, "SELECT DISTINCT ", safe_alias, ".", quoted_pk)
@@ -892,7 +905,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
     validate_field_data(model, field, objct.insert[field], "update"; allow_primary_key = false)
     Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add!, remove!, clear!, or set! methods"))
     
-    quoted_field = quote_identifier(field, connection)
+    quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)  # db_column (#50)
 
     if isa(objct.insert[field], SQLTypeF) || isa(objct.insert[field], SQLTypeFunction)
       f_value = _set_update_query(objct.insert[field], instruction)
@@ -920,7 +933,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
       pk_subquery = (!set_uses_join_aliases && isempty(real_obj.ctes)) ? _build_update_target_pk_subquery(instruction) : nothing
 
       if pk_subquery !== nothing && pk_field_sym !== nothing
-        quoted_pk = quote_identifier(String(pk_field_sym), connection)
+        quoted_pk = quote_identifier(Models.model_column(model, String(pk_field_sym)), connection)  # db_column (#50)
         sql = """
         UPDATE $(safe_table_name) AS $(safe_alias)
         SET $(set_clause)

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -233,7 +233,7 @@ function _allocate_pg_ids(model::PormGModel, connection::PormGPostgres, pk_field
   parameters = get_parameter(connection)
   set_context!(parameters, :select)
   table_placeholder = add_parameter!(parameters, safe_table)
-  field_placeholder = add_parameter!(parameters, pk_field)
+  field_placeholder = add_parameter!(parameters, Models.model_column(model, pk_field))  # db_column (#50)
   count_placeholder = add_parameter!(parameters, n)
   sql = """
   SELECT nextval(pg_get_serial_sequence($(table_placeholder), $(field_placeholder))) AS reserved_id
@@ -256,7 +256,7 @@ function _allocate_sqlite_ids(model::PormGModel, connection::PormGSQLite, pk_fie
   safe_table = string(model.name |> lowercase)
   safe_table_name = safe_table_identifier(safe_table, connection)
   safe_table_literal = replace(safe_table, "'" => "''")
-  safe_field = quote_identifier(pk_field, connection)
+  safe_field = quote_identifier(Models.model_column(model, pk_field), connection)  # db_column (#50)
   sql = """
   SELECT MAX(candidate) AS max_id
   FROM (
@@ -809,10 +809,11 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   _columns = _normalize_bulk_columns(columns)
   mapping, fields_df, pk_exist, pk_field = _prepare_bulk_df!(df, model, _columns, :copy, settings)
 
-  # Security: Quote table name and field names
+  # Security: Quote table name and physical column names (db_column when set, #50).
+  # The CSV is positional (HEADER FALSE), so the data order still matches.
   safe_table_name = safe_table_identifier(string(model.name), connection)
-  quoted_fields = [quote_identifier(field, connection) for field in fields_df]
-  
+  quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields_df]
+
   # Construct the COPY command (using CSV format for safety)
   sql = "COPY $(safe_table_name) ($(join(quoted_fields, ", "))) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
   
@@ -894,10 +895,11 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
   pk_exist::Bool, pk_field::Vector{String}, settings::SQLConn, 
   django_prefix::Bool, show_query::Symbol, parameters:: AbstractPormGParam)
 
-  # Security: Quote table name and field names
+  # Security: Quote table name and physical column names (db_column when set, #50).
+  # VALUES rows are positional and built in `fields` order, so they still align.
   safe_table_name = safe_table_identifier(string(model.name), connection)
-  quoted_fields = [quote_identifier(field, connection) for field in fields]
-  
+  quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields]
+
   # Construct the bulk insert SQL.
   sql = """
   INSERT INTO $(safe_table_name) ($(join(quoted_fields, ", ")))
@@ -1051,7 +1053,9 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
   for field in fields_df
     if !(field in deny_fields)
       # @pormg_debug
-      quoted_field = quote_identifier(field, connection)
+      # SET target uses the physical column (db_column); the source.* reference and the
+      # VALUES/CTE source column list stay the field name (#50).
+      quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)
       quoted_source_field = quote_identifier(field, connection)
       field_type = model.fields[field].type |> lowercase
       if connection isa PormGPostgres
@@ -1142,7 +1146,9 @@ function _bulk_update(model::PormGModel,
   # Security: Build safe WHERE conditions with quoted identifiers
   safe_where_conditions::Vector{String} = []
   for filter in dinanic_filters
-    quoted_tb_field = quote_identifier(filter, connection)
+    # WHERE target (Tb.) uses the physical column (db_column); the source.* reference
+    # and the source column list stay the field name (#50).
+    quoted_tb_field = quote_identifier(Models.field_db_column(model.fields[filter], filter), connection)
     quoted_source_field = quote_identifier(filter, connection)
     field_type = model.fields[filter].type |> lowercase
     if connection isa PormGPostgres

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -328,4 +328,42 @@ Case_preserve_child_scratch = Models.Model("case_preserve_child_scratch",
   lapTime = Models.IntegerField(null=true),
 )
 
+# db_column (#50) fixtures — the FIELD name differs from the physical COLUMN name.
+# `sku` → column "product_sku"; the FK `parent` → column "parent_fk". Proves PormG
+# creates/queries the db_column physical names while results stay keyed by field name.
+Db_column_scratch = Models.Model("db_column_scratch",
+  id = Models.IDField(),
+  sku = Models.CharField(db_column="product_sku"),
+  name = Models.CharField(null=true),
+)
+
+Db_column_child_scratch = Models.Model("db_column_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_scratch, db_column="parent_fk", on_delete="CASCADE", related_name="children", null=true),
+  note = Models.CharField(null=true),
+)
+
+# db_column on a PRIMARY KEY (#50): field `code` → physical column "pk_code". Exercises
+# sequence sync / id allocation against the db_column column on insert.
+Db_column_pk_scratch = Models.Model("db_column_pk_scratch",
+  code = Models.IDField(db_column="pk_code"),
+  label = Models.CharField(null=true),
+)
+
+# SET_NULL child over a db_column FK (#50): deleting the parent must NULL "parent_fk"
+# (exercises the cascade SET_NULL UPDATE on the physical column).
+Db_column_setnull_child_scratch = Models.Model("db_column_setnull_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_scratch, db_column="parent_fk", on_delete="SET_NULL", related_name="snchildren", null=true),
+  note = Models.CharField(null=true),
+)
+
+# FK over a RENAMED parent PK (#50): references Db_column_pk_scratch.code (physical column
+# "pk_code") via pk_field; the FK constraint AND joins must resolve the parent's db_column.
+Db_column_pk_child_scratch = Models.Model("db_column_pk_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_pk_scratch, pk_field="code", db_column="parent_code_fk", on_delete="CASCADE", related_name="pkchildren", null=true),
+  tag = Models.CharField(null=true),
+)
+
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -328,4 +328,42 @@ Case_preserve_child_scratch = Models.Model("case_preserve_child_scratch",
   lapTime = Models.IntegerField(null=true),
 )
 
+# db_column (#50) fixtures — the FIELD name differs from the physical COLUMN name.
+# `sku` → column "product_sku"; the FK `parent` → column "parent_fk". Proves PormG
+# creates/queries the db_column physical names while results stay keyed by field name.
+Db_column_scratch = Models.Model("db_column_scratch",
+  id = Models.IDField(),
+  sku = Models.CharField(db_column="product_sku"),
+  name = Models.CharField(null=true),
+)
+
+Db_column_child_scratch = Models.Model("db_column_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_scratch, db_column="parent_fk", on_delete="CASCADE", related_name="children", null=true),
+  note = Models.CharField(null=true),
+)
+
+# db_column on a PRIMARY KEY (#50): field `code` → physical column "pk_code". Exercises
+# sequence sync / id allocation against the db_column column on insert.
+Db_column_pk_scratch = Models.Model("db_column_pk_scratch",
+  code = Models.IDField(db_column="pk_code"),
+  label = Models.CharField(null=true),
+)
+
+# SET_NULL child over a db_column FK (#50): deleting the parent must NULL "parent_fk"
+# (exercises the cascade SET_NULL UPDATE on the physical column).
+Db_column_setnull_child_scratch = Models.Model("db_column_setnull_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_scratch, db_column="parent_fk", on_delete="SET_NULL", related_name="snchildren", null=true),
+  note = Models.CharField(null=true),
+)
+
+# FK over a RENAMED parent PK (#50): references Db_column_pk_scratch.code (physical column
+# "pk_code") via pk_field; the FK constraint AND joins must resolve the parent's db_column.
+Db_column_pk_child_scratch = Models.Model("db_column_pk_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_column_pk_scratch, pk_field="code", db_column="parent_code_fk", on_delete="CASCADE", related_name="pkchildren", null=true),
+  tag = Models.CharField(null=true),
+)
+
 end

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -30,6 +30,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "PormGRow and get()"           begin include("test_row_and_get.jl")        end
     @testset "PormGRow Mutation"            begin include("test_row_mutation.jl")       end
     @testset "Field-name Case Preservation" begin include("test_field_name_case_db.jl") end
+    @testset "db_column Authoritative"       begin include("test_db_column_db.jl")       end
     @testset "Field Expressions"            begin include("test_field_expressions.jl")  end
     @testset "Updates"                      begin include("test_updates.jl")            end
     @testset "Deletes"                      begin include("test_deletes.jl")            end

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -1,0 +1,229 @@
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+# column_names() lives in the migration setup helpers.
+if !isdefined(Main, :column_names)
+    include("common_migration_setup.jl")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_column (#50) — end-to-end against a live database.
+#
+# The Db_column_scratch / Db_column_child_scratch fixtures declare fields whose
+# names differ from their physical columns (sku → "product_sku", FK parent →
+# "parent_fk"). This file proves PormG CREATES those db_column physical columns on
+# the real backend and that create/get/update/values, FK joins, reverse traversal,
+# and the bulk APIs all target the db_column — while every result the user sees
+# stays keyed by the FIELD name (the headline #50 contract), verified beyond the
+# unit layer where everything renders before any DB round-trip.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "db_column: physical columns use the db_column name" begin
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+
+    cols = column_names(pool, "db_column_scratch")
+    @test "product_sku" in cols        # the db_column physical name exists
+    @test !("sku" in cols)             # the field name is NOT a column
+
+    ccols = column_names(pool, "db_column_child_scratch")
+    @test "parent_fk" in ccols         # FK local column uses db_column
+    @test !("parent" in ccols)
+
+    pkcols = column_names(pool, "db_column_pk_scratch")
+    @test "pk_code" in pkcols          # a PRIMARY KEY can use db_column
+    @test !("code" in pkcols)
+end
+
+# A primary key declared with db_column must round-trip: the INSERT/RETURNING remap keys
+# the result by the field name, and the post-insert sequence-sync / id-allocation must
+# target the PHYSICAL column (regression for the four key-field fixes in #50).
+@testset "db_column: primary key with db_column round-trips (sequence sync)" begin
+    M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    try
+        # Explicit PK value → triggers _update_sequence on the db_column PK column.
+        created = M.Db_column_pk_scratch.objects.create("code" => 100, "label" => "first")
+        @test created[:code] == 100            # returned keyed by the FIELD name
+        @test !haskey(created, :pk_code)
+
+        row = M.Db_column_pk_scratch.objects.filter("code" => 100).values("code", "label").first()
+        @test row.code == 100
+        @test row.label == "first"
+
+        M.Db_column_pk_scratch.objects.filter("code" => 100).update("label" => "second")
+        @test M.Db_column_pk_scratch.objects.filter("code" => 100).values("label").first().label == "second"
+
+        # Bulk insert with explicit PKs → sequence sync + id handling on the db_column column.
+        bulk_insert(M.Db_column_pk_scratch.objects, DataFrame(code=[200, 201], label=["b1", "b2"]))
+        @test M.Db_column_pk_scratch.objects.count() == 3
+
+        # A subsequent AUTO-PK create must not collide — proves the sequence was advanced
+        # past 201 against the physical "pk_code" column (the bug would have errored earlier).
+        auto = M.Db_column_pk_scratch.objects.create("label" => "auto")
+        @test auto[:code] > 201
+    finally
+        M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# allocate_primary_keys pre-reserves ids for a db_column PK — exercises _allocate_pg_ids /
+# _allocate_sqlite_ids against the physical column, then proves the reserved ids insert.
+@testset "db_column: allocate_primary_keys on a db_column PK" begin
+    M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    try
+        allocated = allocate_primary_keys(M.Db_column_pk_scratch.objects, DataFrame(label=["x", "y", "z"]))
+        @test "code" in DataFrames.names(allocated)         # filled under the FIELD name
+        @test length(unique(allocated[!, "code"])) == 3     # three distinct ids
+        @test all(allocated[!, "code"] .> 0)
+
+        # The reserved ids must insert cleanly into the db_column PK column.
+        bulk_insert(M.Db_column_pk_scratch.objects, allocated)
+        @test M.Db_column_pk_scratch.objects.count() == 3
+    finally
+        M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+@testset "db_column: create / get / update / values keyed by field name" begin
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        # create() returns a dict keyed by the FIELD name, not the physical column —
+        # this exercises the INSERT/RETURNING column → field-name remap.
+        created = M.Db_column_scratch.objects.create("sku" => "ABC", "name" => "Widget")
+        @test created[:sku] == "ABC"
+        @test !haskey(created, :product_sku)
+
+        # filter/values resolve `sku` to "product_sku" in SQL but key the row by `sku`.
+        row = M.Db_column_scratch.objects.filter("sku" => "ABC").values("sku", "name").first()
+        @test row.sku == "ABC"
+        @test row.name == "Widget"
+        @test_throws Exception row.product_sku   # the physical column name is not a field
+
+        # update targets the db_column in the SET clause.
+        M.Db_column_scratch.objects.filter("sku" => "ABC").update("name" => "Gadget")
+        row2 = M.Db_column_scratch.objects.filter("sku" => "ABC").values("name").first()
+        @test row2.name == "Gadget"
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+@testset "db_column: FK forward join and reverse traversal via the db_column column" begin
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        parent = M.Db_column_scratch.objects.create("sku" => "P1", "name" => "Parent")
+        M.Db_column_child_scratch.objects.create("parent" => parent[:id], "note" => "child-note")
+
+        # Forward join child → parent across the db_column FK ("parent_fk" = "id"),
+        # projecting a parent field (itself a db_column field) under an alias.
+        fwd = M.Db_column_child_scratch.objects.
+            filter("parent__sku" => "P1").values("note", "psku" => "parent__sku").first()
+        @test fwd.note == "child-note"
+        @test fwd.psku == "P1"
+
+        # Reverse traversal parent → children, filtering on a child column.
+        rev = M.Db_column_scratch.objects.
+            filter("children__note" => "child-note").values("sku").first()
+        @test rev.sku == "P1"
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# Live join over an FK whose REFERENCED parent PK is itself renamed via db_column: the
+# ON clause must resolve the parent's db_column (child."parent_code_fk" = parent."pk_code").
+# Covers fk_target_column's resolved branch end-to-end (beyond the unit/render + Phase 15 DDL).
+@testset "db_column: FK join over a renamed parent PK" begin
+    M.Db_column_pk_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    try
+        M.Db_column_pk_scratch.objects.create("code" => 500, "label" => "RP")
+        M.Db_column_pk_child_scratch.objects.create("parent" => 500, "tag" => "rp-child")
+
+        # Forward join child → parent on the renamed parent PK, projecting a parent field.
+        fwd = M.Db_column_pk_child_scratch.objects.
+            filter("parent__label" => "RP").values("tag", "plabel" => "parent__label").first()
+        @test fwd.tag == "rp-child"
+        @test fwd.plabel == "RP"
+
+        # Reverse traversal parent → children.
+        rev = M.Db_column_pk_scratch.objects.
+            filter("pkchildren__tag" => "rp-child").values("label").first()
+        @test rev.label == "RP"
+    finally
+        M.Db_column_pk_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+@testset "db_column: bulk_insert / bulk_update target the db_column" begin
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        df = DataFrame(sku=["B1", "B2"], name=["n1", "n2"])
+        bulk_insert(M.Db_column_scratch.objects, df)
+        @test M.Db_column_scratch.objects.count() == 2
+
+        # bulk_update: match on the db_column field, set another — SET targets the
+        # db_column ("product_sku") while the source columns stay field-named.
+        upd = DataFrame(sku=["B1"], name=["updated"])
+        bulk_update(M.Db_column_scratch.objects, upd, columns=["name"], match_on=["sku"])
+        r = M.Db_column_scratch.objects.filter("sku" => "B1").values("name").first()
+        @test r.name == "updated"
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# Deleting a parent must cascade across db_column FK columns: a CASCADE child is removed
+# and a SET_NULL child has its db_column FK column nulled (covers the deletion.jl key-field
+# fixes — the cascade collection filters by "parent_fk" and the SET_NULL UPDATE targets it).
+@testset "db_column: cascade delete + SET_NULL over a db_column FK" begin
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_setnull_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        parent = M.Db_column_scratch.objects.create("sku" => "CASC", "name" => "Parent")
+        cascade_child = M.Db_column_child_scratch.objects.create("parent" => parent[:id], "note" => "cascade")
+        setnull_child = M.Db_column_setnull_child_scratch.objects.create("parent" => parent[:id], "note" => "setnull")
+
+        # Delete the parent → PormG cascades over the db_column FK columns.
+        M.Db_column_scratch.objects.filter("sku" => "CASC").delete()
+
+        # CASCADE child is gone.
+        @test M.Db_column_child_scratch.objects.filter("id" => cascade_child[:id]).count() == 0
+        # SET_NULL child survives with its db_column FK column nulled.
+        survivor = M.Db_column_setnull_child_scratch.objects.filter("id" => setnull_child[:id]).values("note", "parent").first()
+        @test survivor.note == "setnull"
+        @test survivor.parent === nothing || ismissing(survivor.parent)   # SQL NULL → missing/nothing
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_setnull_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# bulk_copy is PostgreSQL-only (SQLite falls back to bulk_insert elsewhere).
+@testset "db_column: bulk_copy targets the db_column (PostgreSQL)" begin
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+    if pool isa PormG.PormGPostgres
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+        try
+            df = DataFrame(sku=["C1", "C2"], name=["cn1", "cn2"])
+            bulk_copy(M.Db_column_scratch.objects, df)
+            @test M.Db_column_scratch.objects.count() == 2
+            r = M.Db_column_scratch.objects.filter("sku" => "C1").values("name").first()
+            @test r.name == "cn1"
+        finally
+            M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+            M.Db_column_scratch.objects.delete(allow_delete_all=true)
+        end
+    else
+        @test true  # SQLite: bulk_copy unsupported; covered by bulk_insert above.
+    end
+end

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -968,6 +968,105 @@ end
     @test !isfile(pending)
   end
 
+  # ── Phase 15: db_column drives the physical column + no churn (#50) ─
+  # A field's db_column drives the PHYSICAL column name; the field name never
+  # becomes a column. Proves create_table + ADD COLUMN target the db_column, and
+  # that re-running makemigrations detects no churn (introspection reads the
+  # db_column physical name and the diff is keyed by column, not field name).
+  @testset "Phase 15: db_column Columns + No Churn (#50)" begin
+    write_edge_models("""
+    DbColTable = Models.Model(
+        id = Models.IDField(),
+        sku = Models.CharField(db_column="product_sku"),
+        name = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # (a) The physical column carries the db_column name; the field name is NOT a column.
+    cols = column_names(pool, "dbcoltable")
+    @test "product_sku" in cols
+    @test !("sku" in cols)
+    @test "name" in cols
+
+    # (b) No churn: re-running with the SAME models writes no pending plan.
+    pending = joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl")
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+
+    # (c) ADD path: a new db_column field → ADD COLUMN targets the db_column name.
+    write_edge_models("""
+    DbColTable = Models.Model(
+        id = Models.IDField(),
+        sku = Models.CharField(db_column="product_sku"),
+        name = Models.CharField(null=true),
+        qty = Models.IntegerField(db_column="quantity_col", null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    result = Migrations.dry_run(pool, edge_settings)
+    @test any(s -> occursin("quantity_col", lowercase(s)), result.statements)   # ADD COLUMN → db_column
+    @test !any(s -> occursin("add column \"qty\"", lowercase(s)), result.statements)  # not the field name
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+    cols2 = column_names(pool, "dbcoltable")
+    @test "quantity_col" in cols2
+    @test !("qty" in cols2)
+
+    # (d) No churn after the ADD.
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+
+    # (d2) ADD a NOT NULL DateTimeField with db_column — exercises the temporary-default
+    # path (ADD COLUMN "stamp_ts" ... DEFAULT <now>, then DROP DEFAULT). The DROP DEFAULT
+    # must target the db_column; on PostgreSQL the field-name form errored before the fix.
+    write_edge_models("""
+    DbColTable = Models.Model(
+        id = Models.IDField(),
+        sku = Models.CharField(db_column="product_sku"),
+        name = Models.CharField(null=true),
+        qty = Models.IntegerField(db_column="quantity_col", null=true),
+        stamp = Models.DateTimeField(db_column="stamp_ts")
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)  # must not error on the DROP DEFAULT
+    stamp_cols = column_names(pool, "dbcoltable")
+    @test "stamp_ts" in stamp_cols
+    @test !("stamp" in stamp_cols)
+
+    # (e) FK honors db_column on BOTH the local column and the referenced parent
+    # column (the parent's pk field is itself renamed via db_column). The FK target
+    # is a model instance, so fk_target_column resolves the parent's db_column —
+    # migrate() succeeding proves the FK REFERENCES targets the real column.
+    # The parent's PRIMARY KEY field is itself renamed via db_column (IDField is
+    # inherently unique — satisfies PostgreSQL's FK-target requirement — and round-trips
+    # cleanly through introspection, unlike a UNIQUE non-PK column).
+    write_edge_models("""
+    DbColParent = Models.Model("dbcolparent",
+        code = Models.IDField(db_column="parent_code"),
+        label = Models.CharField(null=true)
+    )
+    DbColChild = Models.Model("dbcolchild",
+        id = Models.IDField(),
+        parent = Models.ForeignKey(DbColParent, pk_field="code", db_column="parent_fk", null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+    @test "parent_code" in column_names(pool, "dbcolparent")   # parent pk physical column
+    ccols = column_names(pool, "dbcolchild")
+    @test "parent_fk" in ccols                                 # local FK column = db_column
+    @test !("parent" in ccols)                                 # field name is NOT a column
+
+    # (f) No churn for the FK models either.
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+  end
+
   # ── Cleanup ─────────────────────────────────────────────────────────
   PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
   delete!(PormG.config, joinpath(@__DIR__, edge_db_name))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ end
     @testset "Dedicated Inspection API" include("unit/test_inspect_query.jl")
     @testset "Reserved-word / Underscore Field Names" include("unit/test_reserved_word_fields.jl")
     @testset "Field-name Case Preservation (#57)" include("unit/test_field_name_case.jl")
+    @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")

--- a/test/unit/test_db_column.jl
+++ b/test/unit/test_db_column.jl
@@ -1,0 +1,257 @@
+"""
+Unit coverage for the `db_column` field option (#50).
+
+`db_column` makes the generated SQL column name differ from the declared field name,
+Django-style: `sku = CharField(db_column="product_sku")` keeps field identity `sku` but
+renders the physical column `"product_sku"` in DDL, SELECT/WHERE/ORDER BY, INSERT/UPDATE,
+and FK constraints — while query results stay keyed by the field name (`sku`). The default
+(column == field name) is unchanged, so existing schemas are unaffected (non-breaking).
+
+All assertions render via mock PostgreSQL/SQLite connections (no live database required).
+"""
+
+using Test
+using PormG
+using DataFrames
+using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, OneToOneField,
+                    field_db_column, fk_target_column, model_column, model_has_db_column,
+                    are_model_fields_equal
+using PormG.QueryBuilder: inspect_query, Count
+
+# Dedicated mock connections — uniquely named so they never clash with other unit files'
+# mock structs when runtests.jl includes them into the same module.
+struct MockPostgresDbColumn <: PormG.PormGPostgres end
+struct MockSQLiteDbColumn <: PormG.PormGSQLite end
+PormG.config["default"] = PormG.Configuration.Settings(
+  connections = MockPostgresDbColumn(),
+  change_data = true,
+)
+
+# Scalar db_column fixture: field `sku` maps to physical column `product_sku`.
+Product = Model("product_scratch",
+  id   = IDField(),
+  sku  = CharField(db_column="product_sku"),
+  name = CharField(),
+)
+Product.connect_key = "default"
+
+# Parent whose REFERENCED field carries a db_column — exercises fk_target_column. The FK
+# target is passed as a model instance so `.to` is resolved (mirrors a post-set_models graph).
+DriverRef = Model("driverref_scratch",
+  id   = IDField(),
+  code = CharField(db_column="driver_code", unique=true),
+)
+DriverRef.connect_key = "default"
+
+# Child FK: local column renamed (`drv`) AND referencing a renamed parent column (`code`).
+Entry = Model("entry_scratch",
+  id     = IDField(),
+  driver = ForeignKey(DriverRef, pk_field="code", db_column="drv"),
+)
+Entry.connect_key = "default"
+
+@testset "db_column authoritative (#50)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # field_db_column: db_column when set & non-empty, else the field name. This is the
+  # single helper every field→column conversion flows through.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "field_db_column helper" begin
+    @test field_db_column(CharField(db_column="product_sku"), "sku") == "product_sku"
+    @test field_db_column(CharField(), "sku")                        == "sku"   # unset → field name
+    @test field_db_column(CharField(db_column=""), "sku")            == "sku"   # empty treated as unset
+    @test field_db_column(IntegerField(db_column="qty_col"), "qty")  == "qty_col"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # fk_target_column: resolve the FK's referenced parent column to that field's
+  # db_column when the target model is in scope; verbatim fallback otherwise.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "fk_target_column helper" begin
+    @test fk_target_column(ForeignKey(DriverRef, pk_field="code")) == "driver_code"  # resolved
+    @test fk_target_column(ForeignKey("UnresolvedTarget", pk_field="code")) == "code" # String .to → verbatim
+    @test fk_target_column(ForeignKey(DriverRef)) == "id"                             # no pk_field → id
+
+    # Underscore-escaped reserved-word pk_field resolves to the parent's stored (stripped)
+    # key — ForeignKey AND OneToOneField both normalize pk_field via format_fild_name.
+    ParentEnd = Model("parent_end_scratch", id=IDField(), _end=CharField(db_column="end_col"))
+    @test ForeignKey(ParentEnd, pk_field="_end").pk_field == "end"
+    @test OneToOneField(ParentEnd, pk_field="_end").pk_field == "end"
+    @test fk_target_column(ForeignKey(ParentEnd, pk_field="_end")) == "end_col"
+    @test fk_target_column(OneToOneField(ParentEnd, pk_field="_end")) == "end_col"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # model_column (guarded name→column) and model_has_db_column (fast-path gate).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "model_column / model_has_db_column helpers" begin
+    @test model_column(Product, "sku")  == "product_sku"
+    @test model_column(Product, "name") == "name"
+    @test model_column(Product, "not_a_field") == "not_a_field"   # verbatim fallback
+    @test model_has_db_column(Product)
+    @test !model_has_db_column(Model("nocol_scratch", id=IDField(), name=CharField()))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # DDL: column names use db_column; a field WITHOUT db_column keeps the field name
+  # (non-breaking default); the table name is unchanged.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "create_table renders db_column (PG + SQLite)" begin
+    for conn in (MockPostgresDbColumn(), MockSQLiteDbColumn())
+      ddl = PormG.Dialect.create_table(conn, Product)
+      @test occursin("\"product_sku\"", ddl)   # db_column column present
+      @test !occursin("\"sku\"", ddl)           # field name does NOT leak as a column
+      @test occursin("\"name\"", ddl)           # non-db_column field unchanged
+      @test occursin("product_scratch", ddl)    # table name unchanged
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # SQLite FK constraint: local FK column = db_column ("drv"); referenced parent
+  # column = the parent field's db_column ("driver_code"), via fk_target_column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "SQLite create_table FK constraint honors db_column both sides" begin
+    ddl = PormG.Dialect.create_table(MockSQLiteDbColumn(), Entry)
+    @test occursin("FOREIGN KEY (\"drv\")", ddl)         # local FK column = db_column
+    @test occursin("(\"driver_code\")", ddl)             # referenced parent column resolved
+    @test occursin("\"driverref_scratch\"", ddl)         # referenced table name
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # add_field (ALTER TABLE ADD COLUMN) renders the db_column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "add_field renders db_column" begin
+    sql = PormG.Dialect.add_field(MockPostgresDbColumn(), "product_scratch", "sku", Product.fields["sku"])
+    @test occursin("\"product_sku\"", sql)
+    @test !occursin("\"sku\"", sql)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Reads: WHERE/SELECT/ORDER BY target the db_column; SELECT auto-aliases the
+  # projection back to the field name so rows stay keyed by `sku`.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "reads render db_column, alias back to field name" begin
+    q = Product.objects
+    q.filter("sku" => "ABC")
+    q.values("sku", "name")
+    insp = inspect_query(q)
+    @test occursin("\"product_sku\" = \$1", insp[:sql_text])              # WHERE → db_column
+    @test occursin("\"Tb\".\"product_sku\" as \"sku\"", insp[:sql_text])  # SELECT → "col as field"
+    @test insp[:parameters] == ["ABC"]
+
+    oq = Product.objects
+    oq.order_by("sku")
+    @test occursin("\"product_sku\"", inspect_query(oq)[:sql_text])       # ORDER BY → db_column
+
+    aq = Product.objects
+    aq.values("n" => Count("sku"))
+    @test occursin("\"product_sku\"", inspect_query(aq)[:sql_text])       # aggregate over db_column
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Filter OPERATORS (not just `=`) on a db_column field resolve to the db_column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "filter operators resolve db_column" begin
+    qin = Product.objects; qin.filter("sku__@in" => ["A", "B"])
+    @test occursin("\"product_sku\"", inspect_query(qin)[:sql_text])      # IN (...)
+
+    qlike = Product.objects; qlike.filter("sku__@contains" => "x")
+    @test occursin("\"product_sku\"", inspect_query(qlike)[:sql_text])    # LIKE
+
+    qgt = Product.objects; qgt.filter("sku__@gt" => "M")
+    @test occursin("\"product_sku\"", inspect_query(qgt)[:sql_text])      # > comparison
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Writes: INSERT column list and UPDATE SET clause target the db_column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "INSERT and UPDATE render db_column" begin
+    ins = Product.objects.create("sku" => "ABC", "name" => "n", show_query=:sql)
+    @test occursin("INSERT INTO", uppercase(ins))
+    @test occursin("\"product_sku\"", ins)
+    @test !occursin("\"sku\"", ins)
+
+    upd = Product.objects.filter("id" => 1).update("sku" => "NEW", show_query=:sql)
+    @test occursin("UPDATE", uppercase(upd))
+    @test occursin("\"product_sku\"", upd)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Bulk: bulk_insert + bulk_copy column lists use db_column. bulk_update applies the
+  # SPLIT rule — the SET target uses db_column, but the source.* reference and the
+  # VALUES/CTE source column list stay the FIELD name (they name the internal source).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "bulk paths honor db_column with source/target split" begin
+    df = DataFrame(sku=["A", "B"], name=["n1", "n2"])
+
+    bi = PormG.bulk_insert(Product.objects, df, show_query=:sql)
+    bi_sql = bi isa AbstractString ? bi : join(string.(bi), "\n")
+    @test occursin("\"product_sku\"", bi_sql)
+
+    bc = PormG.bulk_copy(Product.objects, df, show_query=:sql)
+    bc_sql = bc isa AbstractString ? bc : join(string.(bc), "\n")
+    @test occursin("\"product_sku\"", bc_sql)             # COPY targets the db_column
+
+    # bulk_update: SET "product_sku" = source."sku"; source column list is ("sku").
+    up_df = DataFrame(id=[1], sku=["X"])
+    bu = PormG.bulk_update(Product.objects, up_df, columns=["sku"], match_on=["id"], show_query=:sql)
+    bu_sql = bu isa AbstractString ? bu : join(string.(bu), "\n")
+    @test occursin("\"product_sku\" = source.\"sku\"", bu_sql)  # target db_column, source field name
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Comparison: adding a db_column IS a real model change (code-vs-code), so the diff
+  # engine must report it — even though it produces no spurious migration churn
+  # against an already-matching DB (that no-churn path is an integration test).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "are_model_fields_equal treats db_column as a real change" begin
+    same  = Model("product_scratch", id=IDField(), sku=CharField(db_column="product_sku"), name=CharField())
+    plain = Model("product_scratch", id=IDField(), sku=CharField(),                         name=CharField())
+    @test are_model_fields_equal(Product, same)    # identical db_column → equal
+    @test !are_model_fields_equal(Product, plain)  # db_column added/removed → not equal
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Serialization (migration snapshots): the field serializer emits db_column for a
+  # scalar, a ForeignKey, and a OneToOneField, and omits it when unset.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "Model_to_str serializes db_column" begin
+    g = PormG.Models._model_to_str_general("sku", CharField(db_column="product_sku"), :CharField, String[], "")
+    @test occursin("db_column=\"product_sku\"", g)
+
+    fk = PormG.Models._model_to_str_foreign_key("driver", ForeignKey("Driver", db_column="drv"), :ForeignKey, String[], "")
+    @test occursin("db_column=\"drv\"", fk)
+
+    o2o = PormG.Models._model_to_str_foreign_key("prof", OneToOneField("Driver", db_column="prof_col"), :OneToOneField, String[], "")
+    @test occursin("db_column=\"prof_col\"", o2o)
+
+    plain = PormG.Models._model_to_str_general("sku", CharField(), :CharField, String[], "")
+    @test !occursin("db_column", plain)   # omitted when unset
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #57 × #50: a mixed-case field NAME with a snake_case db_column. Case is preserved
+  # for the field identity and the SELECT alias; the physical column is the db_column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "mixed-case field name with snake_case db_column (#57 × #50)" begin
+    Legacy = Model("legacy_case_scratch",
+      id       = IDField(),
+      driverId = CharField(db_column="driver_id"),
+    )
+    Legacy.connect_key = "default"
+
+    @test field_db_column(Legacy.fields["driverId"], "driverId") == "driver_id"
+
+    ddl = PormG.Dialect.create_table(MockPostgresDbColumn(), Legacy)
+    @test occursin("\"driver_id\"", ddl)
+    @test !occursin("\"driverId\"", ddl)   # the mixed-case field name is not a column
+
+    q = Legacy.objects
+    q.filter("driverId" => "senna")
+    q.values("driverId")
+    insp = inspect_query(q)
+    @test occursin("\"driver_id\" = \$1", insp[:sql_text])            # WHERE → db_column
+    @test occursin("\"driver_id\" as \"driverId\"", insp[:sql_text])  # alias back to the mixed-case field
+  end
+
+end


### PR DESCRIPTION
## Summary

Makes `db_column` **authoritative** (Django semantics): a model field can map to a
differently-named physical column across the whole stack — DDL, queries
(SELECT/WHERE/ORDER BY/INSERT/UPDATE and the bulk APIs), FK constraints/joins, and the
migration diff — on **every field type except `ManyToManyField`**.

**Non-breaking:** the default stays *column == field name*, so existing models and schemas
are unaffected. Results returned to the user always stay keyed by the **field name**.

```julia
sku = Models.CharField(db_column="product_sku")   # field `sku` → column "product_sku"
M.Product.objects.filter("sku" => "ABC").values("sku")   # query by `sku`; row keyed by `sku`
```

Closes #50.

## What changed

- **Models:** `field_db_column` / `fk_target_column` / `model_column` / `model_has_db_column` helpers.
- **Fields:** `db_column` added to all field structs (except `ManyToManyField`) + constructors; also normalize `OneToOneField.pk_field` like `ForeignKey` (pre-existing inconsistency).
- **DDL:** `field_to_column`, FK constraints (local + referenced), SQLite table-recreation data-copy.
- **QueryBuilder:** `_solve_field`; forward/reverse joins; INSERT (+ result remap back to field-name keys); UPDATE SET + pk-subquery; bulk insert/update/copy; sequence sync; id allocation; DELETE / cascade-UPDATE WHERE.
- **Migrations:** column-keyed diff (no churn), `:db_column`/`:pk_field` skips, FK/index resolution.
- **Docs:** `schema_conventions.md`, `fields.md`, FK/O2O docstrings, `UPGRADING.md` (opt-in entry).

## Tests

New unit (`test/unit/test_db_column.jl`) + integration (`test/integration/test_db_column_db.jl`) suites, plus migration **Phase 15** (no-churn, ADD path, renamed-parent-PK FK). Coverage includes: helpers, DDL (both backends), reads (filter/values/order/aggregate/operators), writes (insert + return-remap, update, bulk insert/update/copy), **PK with db_column** (sequence sync, `allocate_primary_keys`), **cascade delete + SET_NULL**, **mixed-case × db_column** (#57 × #50), and a **live forward/reverse join over a renamed parent PK**.

| Suite | Result |
|------|--------|
| Unit | 1990 / 1990 |
| Integration SQLite (`db_sl`) | 1456 / 1456 |
| Integration PostgreSQL (`db_2`) | 1492 / 1492 |
| Docs build | clean |

Two code-review passes (multi-agent) were run; all findings were fixed or assessed as non-issues.

## Deferred (documented limitations → #62)

When the **referenced parent PK itself uses `db_column`**, two paths fall back to the field name: an FK declared with a **string** target, and **M2M / CTE** join keys. These are documented in `schema_conventions.md` and tracked in #62. The common cases (model-instance FK targets, parent `id` PKs) are fully resolved and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
