### PR TITLE
feat(#62): resolve string FK targets so db_column on a referenced parent key is honored

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,10 +83,11 @@ Entry = Models.Model("entry",
 Notes / limits:
 
 - On an FK, `db_column` renames the **local** column. The **referenced** parent column follows
-  `pk_field`; when the parent's pk field *itself* uses `db_column`, declare the FK target as a model
-  **instance** (`ForeignKey(Parent, pk_field="code")`, not the string `"Parent"`) so the generated
-  FK constraint resolves the parent's `db_column`.
-- `ManyToManyField` through-table columns are **not** configurable via `db_column`.
+  `pk_field` and is resolved through the parent field's own `db_column` — for **both** model-instance
+  and string targets (`ForeignKey(Parent, pk_field="code")` or `ForeignKey("Parent", pk_field="code")`),
+  and whether or not `pk_field` is spelled out (#62).
+- `ManyToManyField` through-table columns are **not** configurable via `db_column`. A `db_column` on a
+  model's primary key is also **not** yet honored by ManyToMany/CTE join keys (#64).
 
 ### Verify
 

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -102,18 +102,17 @@ Two consequences worth noting:
   This is non-breaking: the default (column == field name) is unchanged, so existing schemas are
   unaffected. On a `ForeignKey`/`OneToOneField`, `db_column` renames the **local** FK column; the
   **referenced** parent column follows `pk_field`, resolved through the parent field's own
-  `db_column` when the FK target is a resolved model.
+  `db_column`. This works for both model-instance and **string** targets
+  (`ForeignKey(Driver, pk_field="code")` or `ForeignKey("Driver", pk_field="code")`), and whether or
+  not `pk_field` is spelled out — string targets are resolved to the model object once, up front
+  ([#62](https://github.com/PingoLee/PormG.jl/issues/62)).
 
-  !!! note "Limitations when db_column is on a *key* field"
-      `db_column` on a primary key works for ordinary CRUD (create/get/update, bulk, sequence
-      sync). A few join/reference paths that derive a column from a *parent key field* do not yet
-      resolve that parent's `db_column` and fall back to the field name — tracked in
-      [#62](https://github.com/PingoLee/PormG.jl/issues/62):
-
-      - An FK whose target is given as a **string** (`ForeignKey("Driver", pk_field="code")`) when
-        the referenced parent field itself uses `db_column` — declare the target as a model
-        **instance** (`ForeignKey(Driver, pk_field="code")`) so the FK constraint/join resolve it.
-      - A **ManyToMany** or **CTE** join whose participating model's *primary key* uses `db_column`.
+  !!! note "Limitation: db_column on a ManyToMany/CTE key field"
+      `db_column` on a primary key works for ordinary CRUD (create/get/update, bulk, sequence sync)
+      **and** for FK constraints and joins (model-instance or string targets, including a renamed
+      parent PK). One path does not yet resolve a parent key's `db_column` and falls back to the
+      field name — tracked in [#64](https://github.com/PingoLee/PormG.jl/issues/64): a **ManyToMany**
+      or **CTE** join whose participating model's *primary key* uses `db_column`.
 
       ManyToMany through-table columns are not configurable via `db_column`.
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -195,13 +195,12 @@ function set_models(_module::Module, path::String)::Nothing
     # println(model.name)
     for (field_name, field) in pairs(model.fields)
       if field isa sForeignKey || field isa sOneToOneField
-        field_to::Union{PormGModel, Nothing} = nothing
-        try
-          field_to = field.to isa PormGModel ? field.to : getfield(_module, field.to |> Symbol)
-        catch
-          throw(ArgumentError("The model $(field.to) in the field $field_name in the model $(model.name) is not defined"))
-        end
-        # println("field_to_", field_to.name)
+        field_to::Union{PormGModel, Nothing} = _resolve_target_model(field.to, _module)
+        field_to === nothing && throw(ArgumentError("The model $(field.to) in the field $field_name in the model $(model.name) is not defined"))
+        # #62: persist the resolved target so `fk_target_column` honors a referenced
+        # parent's db_column for string-declared FKs too. Idempotent on reload (a model
+        # `.to` resolves to itself); the rest of this loop keeps using the local `field_to`.
+        field.to = field_to
         if field.pk_field === nothing
           pk_sym = get_model_pk_field(field_to)
           if pk_sym !== nothing
@@ -434,6 +433,23 @@ function fk_target_column(field::PormGField)::String
   return pk
 end
 
+# Resolve a string FK/O2O target to its model object within `mod` (#62). Returns the
+# resolved `PormGModel`, a model passed through untouched, or `nothing` when the name is
+# not a model binding (caller picks strictness). `fk_target_column` can only honor a
+# referenced parent's `db_column` once `field.to` is a resolved model, so both model-load
+# lifecycles (runtime `set_models`, the migration prelude) write the resolution back via
+# this helper. The catch is narrowed to `UndefVarError` (the "not defined" case) so a
+# genuine bug surfaces instead of being swallowed.
+function _resolve_target_model(to, mod::Module)::Union{PormGModel, Nothing}
+  to isa PormGModel && return to
+  m = try
+    getfield(mod, Symbol(to))
+  catch e
+    e isa UndefVarError ? nothing : rethrow()
+  end
+  return m isa PormGModel ? m : nothing
+end
+
 # Resolve a field-name string to its physical column within `model` (db_column when
 # the named field carries one), verbatim when the name is not a field of `model`. For
 # call sites that hold only a model + a field-name string — e.g. reverse-relation join
@@ -605,12 +621,17 @@ function _model_to_str_general(field_name, field, struct_name, sets, fields)
   return fields
 end
 function _model_to_str_foreign_key(field_name, field, struct_name, sets, fields)
-  to::String = "" 
+  to::String = ""
   for sfield in fieldnames(typeof(field))
-    sfield == :to && (to = getfield(field, sfield); continue)    
+    # #62: `.to` may now be a resolved PormGModel (set_models / migration prelude write
+    # back the model). Emit its generated variable name — `uppercasefirst(model.name)`,
+    # matching `Model_to_str` above — so a model-`.to` serializes identically to the
+    # string a user would have declared. (The only live caller, the import flow, always
+    # has a string `.to`; this branch is defensive, locked by a round-trip test.)
+    sfield == :to && (v = getfield(field, sfield); to = v isa PormGModel ? uppercasefirst(v.name) : v; continue)
     if getfield(field, sfield) != getfield(ForeignKey(""), sfield)
       push!(sets, """$sfield=$(getfield(field, sfield) |> format_string)""")
-    end    
+    end
   end
   fields *= ",\n  $field_name = Models.$struct_name(\"$to\", $(join(sets, ", ")))"
   return fields

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -517,11 +517,8 @@ catch e
   end
 end
 
-# get module from the path
-temp_module = Module(:TemporaryModels)
-Base.include(temp_module, path)
-# current_models = get_all_models(Base.invokelatest(getfield, temp_module, :models))
-current_models = Base.invokelatest(get_all_models, Base.invokelatest(getfield, temp_module, :models)) # TODO : i need create abstrations to deal with change :models name
+# get module from the path (load + resolve FK targets + default pk_field — #62)
+current_models = _load_current_models(path)
 
 @pormg_debug false
 
@@ -558,10 +555,8 @@ function makemigrations(connection::PormGSQLite, settings::SQLConn; path::String
     return
   end
 
-  # get module from the path
-  temp_module = Module(:TemporaryModels)
-  Base.include(temp_module, path)
-  current_models = Base.invokelatest(get_all_models, Base.invokelatest(getfield, temp_module, :models))
+  # get module from the path (load + resolve FK targets + default pk_field — #62)
+  current_models = _load_current_models(path)
 
   migration_plan = get_migration_plan(models_array, current_models, connection, settings, interactive=interactive)
 
@@ -601,4 +596,49 @@ for name in names(mod, all = true)
   end
 end
 return models
+end
+
+# #62: Shared makemigrations prelude — load the code models for a schema diff, then
+# resolve string FK/O2O targets to model objects and default `pk_field`. The planner
+# loads models into a throwaway module via `Base.include` and never runs `set_models`
+# (deliberately, to keep diffing free of `set_models`' global side effects), so the
+# resolution `set_models` does at runtime must be reproduced here — otherwise a
+# string-declared FK, or any FK with an omitted `pk_field`, would not honor a referenced
+# parent's `db_column` in the generated DDL. Both backends call this; see Follow-up
+# (#65) for collapsing the two load lifecycles into one.
+function _load_current_models(path::String)::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}
+  temp_module = Module(:TemporaryModels)
+  Base.include(temp_module, path)
+  models_module = Base.invokelatest(getfield, temp_module, :models)
+  current_models = Base.invokelatest(get_all_models, models_module)
+  Base.invokelatest(_resolve_fk_targets_and_pk!, current_models, models_module)
+  return current_models
+end
+
+# Resolve each code model's FK/O2O targets against `models_module` (write-back) and
+# default a missing `pk_field` to the parent's primary key. Best-effort: an unresolvable
+# string target is left as-is (e.g. a cross-module reference whose verbatim fallback is
+# already correct) with a `@debug`, never breaking the run. The runtime path's strict
+# throw lives in `set_models`, so typos surface loudly there first.
+function _resolve_fk_targets_and_pk!(current_models::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, models_module::Module)::Nothing
+  for (_, entry) in current_models
+    model = entry[:model]
+    model isa PormGModel || continue
+    for (field_name, field) in pairs(model.fields)
+      (field isa Models.sForeignKey || field isa Models.sOneToOneField) || continue
+      if !(field.to isa PormGModel)
+        resolved = Models._resolve_target_model(field.to, models_module)
+        if resolved === nothing
+          @debug "makemigrations: FK target $(field.to) of field $field_name in model $(model.name) is not a model binding in the models module; leaving as a string"
+          continue
+        end
+        field.to = resolved
+      end
+      if field.pk_field === nothing
+        pk_sym = Models.get_model_pk_field(field.to)
+        pk_sym !== nothing && (field.pk_field = string(pk_sym))
+      end
+    end
+  end
+  return nothing
 end

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -366,4 +366,13 @@ Db_column_pk_child_scratch = Models.Model("db_column_pk_child_scratch",
   tag = Models.CharField(null=true),
 )
 
+# #62: the SAME renamed-parent relationship, but the FK target is the model-name STRING
+# "Db_column_pk_scratch" (not the model instance). set_models must resolve it so the FK
+# constraint and join ON clause still target the parent's db_column ("pk_code").
+Db_column_pk_strchild_scratch = Models.Model("db_column_pk_strchild_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey("Db_column_pk_scratch", pk_field="code", db_column="parent_code_strfk", on_delete="CASCADE", related_name="pkstrchildren", null=true),
+  tag = Models.CharField(null=true),
+)
+
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -366,4 +366,13 @@ Db_column_pk_child_scratch = Models.Model("db_column_pk_child_scratch",
   tag = Models.CharField(null=true),
 )
 
+# #62: the SAME renamed-parent relationship, but the FK target is the model-name STRING
+# "Db_column_pk_scratch" (not the model instance). set_models must resolve it so the FK
+# constraint and join ON clause still target the parent's db_column ("pk_code").
+Db_column_pk_strchild_scratch = Models.Model("db_column_pk_strchild_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey("Db_column_pk_scratch", pk_field="code", db_column="parent_code_strfk", on_delete="CASCADE", related_name="pkstrchildren", null=true),
+  tag = Models.CharField(null=true),
+)
+
 end

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -159,6 +159,33 @@ end
     end
 end
 
+# #62: the SAME renamed-parent join, but the child's FK was declared with a STRING target
+# ("Db_column_pk_scratch") instead of the model instance. set_models must have resolved it
+# so the join ON clause targets the parent's db_column ("pk_code") — proving the runtime
+# write-back end-to-end (the table itself was created via the migration prelude in Phase 0).
+@testset "db_column: FK join over a renamed parent PK via a STRING target" begin
+    M.Db_column_pk_strchild_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    try
+        M.Db_column_pk_scratch.objects.create("code" => 600, "label" => "SP")
+        M.Db_column_pk_strchild_scratch.objects.create("parent" => 600, "tag" => "sp-child")
+
+        # Forward join child → parent on the renamed parent PK, projecting a parent field.
+        fwd = M.Db_column_pk_strchild_scratch.objects.
+            filter("parent__label" => "SP").values("tag", "plabel" => "parent__label").first()
+        @test fwd.tag == "sp-child"
+        @test fwd.plabel == "SP"
+
+        # Reverse traversal parent → children over the string-declared FK.
+        rev = M.Db_column_pk_scratch.objects.
+            filter("pkstrchildren__tag" => "sp-child").values("label").first()
+        @test rev.label == "SP"
+    finally
+        M.Db_column_pk_strchild_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
 @testset "db_column: bulk_insert / bulk_update target the db_column" begin
     M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
     M.Db_column_scratch.objects.delete(allow_delete_all=true)

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1065,6 +1065,50 @@ end
     isfile(pending) && rm(pending)
     makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
     @test !isfile(pending)
+
+    # (g) #62: a STRING FK target + an OMITTED pk_field over the renamed-PK parent. The
+    # migration prelude (_load_current_models) must resolve "DbColParent" → the model AND
+    # default pk_field to the parent's PK ("code"), so the FK REFERENCES
+    # "dbcolparent"("parent_code") — not the "id" fallback. migrate() SUCCEEDING is the
+    # assertion: dbcolparent has no "id" column, so an unresolved target / "id" fallback
+    # would raise. (Before #62 this churned + emitted the wrong referenced column.)
+    write_edge_models("""
+    DbColParent = Models.Model("dbcolparent",
+        code = Models.IDField(db_column="parent_code"),
+        label = Models.CharField(null=true)
+    )
+    DbColChild = Models.Model("dbcolchild",
+        id = Models.IDField(),
+        parent = Models.ForeignKey(DbColParent, pk_field="code", db_column="parent_fk", null=true)
+    )
+    DbColStrChild = Models.Model("dbcolstrchild",
+        id = Models.IDField(),
+        parent = Models.ForeignKey("DbColParent", db_column="parent_strfk", null=true)
+    )
+    """)
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+    scols = column_names(pool, "dbcolstrchild")
+    @test "parent_strfk" in scols                              # local FK column = db_column
+    @test !("parent" in scols)                                 # field name is NOT a column
+
+    # Adapter-neutral proof of the REFERENCED column: migrate() raising is a
+    # PostgreSQL-only signal (SQLite validates FK targets lazily at create time), so
+    # introspect the migrated FK and confirm it points at the parent's db_column
+    # ("parent_code"), not the "id" fallback an unresolved target would have produced.
+    strchild_intro = nothing
+    for m in PormG.Migrations.convert_schema_to_models(pool)
+      lowercase(string(m.name)) == "dbcolstrchild" && (strchild_intro = m)
+    end
+    @test strchild_intro !== nothing
+    @test any(f -> hasproperty(f, :to) && hasproperty(f, :pk_field) && f.pk_field == "parent_code",
+              values(strchild_intro.fields))
+
+    # (h) No churn for the string-target + omitted-pk_field model.
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
   end
 
   # ── Cleanup ─────────────────────────────────────────────────────────

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1817,6 +1817,34 @@ end
     @test haskey(M.Result.related_objects, "test_deletion_set_default")
 end
 
+@testset "set_models resolves string FK targets (#62)" begin
+    # Fast, DB-free guard for the runtime write-back: `M` was registered via
+    # set_models above, and Db_column_pk_strchild_scratch declares its FK with the
+    # model-name STRING "Db_column_pk_scratch". set_models must resolve and write it
+    # back to `.to` so fk_target_column honors the parent's renamed PK db_column.
+    fk = M.Db_column_pk_strchild_scratch.fields["parent"]
+    @test fk.to isa PormG.PormGModel                       # string target → resolved model
+    @test fk.to === M.Db_column_pk_scratch                 # resolved to the correct model
+    @test PormG.Models.fk_target_column(fk) == "pk_code"   # → parent's db_column, not "code"
+end
+
+@testset "set_models throws on an unresolvable string FK target (#62)" begin
+    # #62 restructured set_models' resolution (try/catch → _resolve_target_model + explicit
+    # throw); the strict error must remain — a string target naming a model that is not
+    # defined in the module raises ArgumentError rather than silently skipping.
+    BadChild = PormG.Models.Model_Type(
+        name = "bad_fk_child",
+        fields = Dict(
+            "id" => PormG.Models.IDField(),
+            "parent" => PormG.Models.ForeignKey("NoSuchModelXYZ", on_delete="CASCADE", null=true),
+        ),
+        field_names = ["id", "parent"]
+    )
+    bad_mod = Module(:bad_fk_target_module)
+    Core.eval(bad_mod, :(const BadChild = $BadChild))
+    @test_throws ArgumentError PormG.Models.set_models(bad_mod, "mock_sl_path")
+end
+
 @testset "Related Objects - Auto-generated related_name key format" begin
     # Just_a_nested_roll_back has a single FK to Just_a_test_deletion with no
     # explicit related_name. The auto-generated key should be the lowercased

--- a/test/unit/test_db_column.jl
+++ b/test/unit/test_db_column.jl
@@ -50,6 +50,10 @@ Entry = Model("entry_scratch",
 )
 Entry.connect_key = "default"
 
+# #62 string-target fixtures are built FRESH inside each test below (local instances or a
+# throwaway Module), so every subtest is isolated and re-runnable — matching this file's
+# convention of per-subtest fixtures rather than shared mutable module-level state.
+
 @testset "db_column authoritative (#50)" begin
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -252,6 +256,115 @@ Entry.connect_key = "default"
     insp = inspect_query(q)
     @test occursin("\"driver_id\" = \$1", insp[:sql_text])            # WHERE → db_column
     @test occursin("\"driver_id\" as \"driverId\"", insp[:sql_text])  # alias back to the mixed-case field
+  end
+
+end
+
+# ════════════════════════════════════════════════════════════════════════════════════════
+# #62 — string FK targets resolve to model objects, so `db_column` on a REFERENCED parent
+# key is honored for string-declared FKs too (model-instance targets already worked in #50).
+# ════════════════════════════════════════════════════════════════════════════════════════
+@testset "db_column string FK targets (#62)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # _resolve_target_model: name string → model object; model passthrough; unknown
+  # name → nothing (caller decides strictness).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "_resolve_target_model" begin
+    @test PormG.Models._resolve_target_model("DriverRef", @__MODULE__) === DriverRef
+    @test PormG.Models._resolve_target_model(DriverRef, @__MODULE__)   === DriverRef   # passthrough
+    @test PormG.Models._resolve_target_model("NoSuchModelXYZ", @__MODULE__) === nothing
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The #62 gap: an UNRESOLVED string target falls back to the verbatim pk_field name;
+  # once `.to` is a resolved model, fk_target_column returns the parent's db_column —
+  # identical to the model-instance variant. (This tests the resolver ∘ fk_target_column
+  # composition; the production write-back itself is guarded by the set_models test in
+  # test_alignment_sqlite.jl and the integration join test.)
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "resolved string target → parent db_column (fk_target_column)" begin
+    fk = ForeignKey("DriverRef", pk_field="code", db_column="drv")
+    @test fk_target_column(fk) == "code"                       # before: verbatim pk name (the gap)
+    fk.to = PormG.Models._resolve_target_model(fk.to, @__MODULE__)
+    @test fk_target_column(fk) == "driver_code"                # after: parent's db_column
+    @test fk_target_column(fk) == fk_target_column(ForeignKey(DriverRef, pk_field="code"))  # == model-instance
+
+    # OneToOneField shares the resolution path (set_models / prelude branch on
+    # `sForeignKey || sOneToOneField`) — a string-target O2O resolves identically.
+    o2o = OneToOneField("DriverRef", pk_field="code", db_column="prof")
+    @test fk_target_column(o2o) == "code"
+    o2o.to = PormG.Models._resolve_target_model(o2o.to, @__MODULE__)
+    @test fk_target_column(o2o) == "driver_code"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Render: once a string-target FK's `.to` is resolved, create_table renders the FK
+  # constraint with the parent's db_column AND the real table name — matching a
+  # model-instance FK. Fresh local fixture, so the subtest is re-runnable.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "create_table FK constraint renders a resolved string target" begin
+    entry_str = Model("entry_str_local_scratch",
+      id     = IDField(),
+      driver = ForeignKey("DriverRef", pk_field="code", db_column="drv"),
+    )
+    entry_str.fields["driver"].to = PormG.Models._resolve_target_model(entry_str.fields["driver"].to, @__MODULE__)
+    ddl = PormG.Dialect.create_table(MockSQLiteDbColumn(), entry_str)
+    @test occursin("FOREIGN KEY (\"drv\")", ddl)       # local FK column = db_column
+    @test occursin("(\"driver_code\")", ddl)           # referenced parent column resolved (the #62 fix)
+    @test occursin("\"driverref_scratch\"", ddl)       # resolved → real table name, not "driverref"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The migration prelude proper: resolve `.to` AND default a missing pk_field, plus the
+  # best-effort branch (unresolvable target → left as-is, no throw). Built in a throwaway
+  # Module (the dup_test_module idiom) so it's isolated/re-runnable, and tested directly on
+  # `_resolve_fk_targets_and_pk!` so it can't pass via an include-time set_models confound.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "migration prelude resolves string target + defaults pk_field" begin
+    prelude_parent = Model("db62_prelude_parent", code = IDField(db_column="parent_code"), label = CharField(null=true))
+    prelude_child  = Model("db62_prelude_child", id = IDField(),
+      parent = ForeignKey("Db62PreludeParent", db_column="parent_fk", null=true),   # string target, NO pk_field
+    )
+    prelude_orphan = Model("db62_prelude_orphan", id = IDField(),
+      ref = ForeignKey("NoSuchModelABC", db_column="ref_fk", null=true),            # unresolvable target
+    )
+    mod = Module(:db62_prelude_module)
+    Core.eval(mod, :(const Db62PreludeParent = $prelude_parent))   # the FK string target must be a binding in `mod`
+    Core.eval(mod, :(const Db62PreludeChild  = $prelude_child))
+    Core.eval(mod, :(const Db62PreludeOrphan = $prelude_orphan))
+
+    # Pre-conditions (fresh fixtures): unresolved string target, no pk_field.
+    @test prelude_child.fields["parent"].to == "Db62PreludeParent"
+    @test prelude_child.fields["parent"].pk_field === nothing
+
+    current = Dict{Symbol, Dict{Symbol, Union{Bool, PormG.PormGModel}}}(
+      :db62_prelude_parent => Dict{Symbol, Union{Bool, PormG.PormGModel}}(:model => prelude_parent, :exist => false),
+      :db62_prelude_child  => Dict{Symbol, Union{Bool, PormG.PormGModel}}(:model => prelude_child,  :exist => false),
+      :db62_prelude_orphan => Dict{Symbol, Union{Bool, PormG.PormGModel}}(:model => prelude_orphan, :exist => false),
+    )
+    PormG.Migrations._resolve_fk_targets_and_pk!(current, mod)
+
+    # Resolvable string target → resolved model + defaulted pk_field + parent's db_column.
+    @test prelude_child.fields["parent"].to === prelude_parent   # resolved to the model object
+    @test prelude_child.fields["parent"].pk_field == "code"      # defaulted to the parent's PK field name
+    @test fk_target_column(prelude_child.fields["parent"]) == "parent_code"  # → db_column, NOT the "id" fallback
+
+    # Best-effort: an UNRESOLVABLE string target is left as-is (no throw); pk_field untouched.
+    @test prelude_orphan.fields["ref"].to == "NoSuchModelABC"
+    @test prelude_orphan.fields["ref"].pk_field === nothing
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Serializer: a model-instance `.to` serializes to the SAME string a user would have
+  # declared (uppercasefirst(model.name)) — the write-back can't change snapshot output.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "serializer: model-instance .to == its string form" begin
+    fk_model = PormG.Models._model_to_str_foreign_key("driver", ForeignKey(DriverRef, db_column="drv"), :ForeignKey, String[], "")
+    fk_str   = PormG.Models._model_to_str_foreign_key("driver", ForeignKey("Driverref_scratch", db_column="drv"), :ForeignKey, String[], "")
+    @test fk_model == fk_str                                       # byte-identical serialization
+    @test occursin("Models.ForeignKey(\"Driverref_scratch\"", fk_model)
+    @test occursin("db_column=\"drv\"", fk_model)
   end
 
 end


### PR DESCRIPTION
## Summary

Closes #62. Makes **string-declared foreign-key targets** (`ForeignKey("Driver", …)`) resolve to the
model object so `db_column` on a **referenced parent key** is honored everywhere — in the generated FK
constraint **and** in join `ON` clauses — matching the model-instance behavior that already worked
after #50. This was the one corner #50 left open; it's **not a regression** (it produced the same SQL
as pre-#50) but a latent silent-wrong-SQL trap, and a pre-publish "get the semantics right" item.

Django resolves every lazy reference to the model object once, globally, before any query/migration.
PormG now does the same at each of its two model-load lifecycles.

## What changed

- **`src/Models.jl`**
  - New `_resolve_target_model(to, mod)` — resolves a string target to its model (or `nothing`;
    narrowed `catch` to `UndefVarError`).
  - **Runtime path:** `set_models` now **writes the resolved model back to `field.to`** (it previously
    computed the resolved model into a local and discarded it).
  - **Serializer:** `_model_to_str_foreign_key` hardened to emit a model-instance `.to` as its
    `uppercasefirst(name)` string — defensive, so the write-back can't perturb output (the snapshot is
    a `cp` and `Model_to_str` only runs in the import flow, which always has a string `.to`).
- **`src/migrations/planner.jl`** — both `makemigrations` backends now call a shared
  `_load_current_models` prelude that resolves string `.to` **and defaults a missing `pk_field`** to
  the parent's PK. The latter closes a **pre-existing runtime/migration asymmetry**: an omitted-`pk_field`
  FK to a renamed parent PK previously emitted `REFERENCES …("id")` and churned every `makemigrations`.

## Why two resolution points (and not one)

The runtime module and the planner's throwaway `Module(:TemporaryModels)` are deliberately separate —
the planner avoids `set_models`' global side effects (`REGISTERED_MODULES`, `Configuration`,
`__pormg_init_path__`). The logic is single-sourced in `_resolve_target_model`, bound to each
lifecycle's natural collection chokepoint (`set_models`, `_load_current_models`). Fully unifying the
two lifecycles is tracked as **#65** (Django `apps.populate()` analog).

## Follow-ups filed

- **#64** — honor `db_column` on ManyToMany through-table + CTE join keys (db_column completeness; pre-publish).
- **#65** — unify the model-load lifecycle into one "load + resolve" entry point (Phase 2 tech-debt).

## Docs

`docs/src/schema_conventions.md` + `UPGRADING.md`: string targets are now fully `db_column`-aware
(model-instance or string, with or without explicit `pk_field`); the remaining limitation is narrowed
to the ManyToMany/CTE case (#64).

## Tests

Two review passes (correctness + test design); every production branch has a discriminating guard on
at least one backend. New/changed coverage: `_resolve_target_model`, the runtime write-back (DB-free
guard via `set_models` + integration join), the migration prelude (direct + Phase 15 (g)/(h),
incl. omitted-`pk_field` and an adapter-neutral referenced-column introspection proof), the strict
throw on an unresolvable target, the best-effort leave-as-string branch, O2O parity, and the
serializer round-trip.

- Unit: **2015 / 2015**
- SQLite integration (`db_sl`): **1464 / 1464**
- PostgreSQL integration (`db_2`): **1500 / 1500**
- `docs/make.jl`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
