### PR TITLE
feat(#64): honor db_column on M2M through-table and CTE join keys

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -86,8 +86,10 @@ Notes / limits:
   `pk_field` and is resolved through the parent field's own `db_column` — for **both** model-instance
   and string targets (`ForeignKey(Parent, pk_field="code")` or `ForeignKey("Parent", pk_field="code")`),
   and whether or not `pk_field` is spelled out (#62).
-- `ManyToManyField` through-table columns are **not** configurable via `db_column`. A `db_column` on a
-  model's primary key is also **not** yet honored by ManyToMany/CTE join keys (#64).
+- A `db_column` on a model's primary key is honored by **ManyToMany and CTE join keys** too (#64), so
+  M2M traversal and CTE joins on a renamed PK resolve correctly (the base-table side of a CTE join maps
+  to the physical column; the CTE side keeps its projection alias). The only surface that is **not**
+  configurable is the auto-generated `ManyToManyField` **through-table column names** (`<model>_<pk>`).
 
 ### Verify
 

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -107,14 +107,12 @@ Two consequences worth noting:
   not `pk_field` is spelled out — string targets are resolved to the model object once, up front
   ([#62](https://github.com/PingoLee/PormG.jl/issues/62)).
 
-  !!! note "Limitation: db_column on a ManyToMany/CTE key field"
-      `db_column` on a primary key works for ordinary CRUD (create/get/update, bulk, sequence sync)
-      **and** for FK constraints and joins (model-instance or string targets, including a renamed
-      parent PK). One path does not yet resolve a parent key's `db_column` and falls back to the
-      field name — tracked in [#64](https://github.com/PingoLee/PormG.jl/issues/64): a **ManyToMany**
-      or **CTE** join whose participating model's *primary key* uses `db_column`.
-
-      ManyToMany through-table columns are not configurable via `db_column`.
+  !!! note "Limitation: ManyToMany through-table column names"
+      `db_column` is honored across the whole stack — CRUD (create/get/update, bulk, sequence sync),
+      FK constraints and joins (model-instance or string targets, a renamed parent PK), **and**
+      ManyToMany / CTE join keys when a participating model's primary key uses `db_column`
+      ([#64](https://github.com/PingoLee/PormG.jl/issues/64)). The one surface that is **not**
+      configurable is the **auto-generated ManyToMany through-table column names** (`<model>_<pk>`).
 
 !!! note "Imported models differ"
     The Django importer appends `_id` to a `ForeignKey`/`OneToOneField` field and points it at the

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -76,19 +76,26 @@ function _resolve_django_join_field(model::PormGModel, field_name::String, instr
   return field_name
 end
 
-function _resolve_many_to_many_related_model(_module::Module, relation::Models.ManyToManyRelation)::PormGModel
-  binding = Symbol(relation.related_binding)
-  if isdefined(_module, binding)
-    candidate = Base.invokelatest(getfield, _module, binding)
+# Resolve one side of an M2M relation (owner or related) to its PormGModel within `_module`:
+# by binding first, then by formatted model name. Lets the join builder read each side's
+# `db_column` for its PK (#64) — the relation stores only string names/bindings.
+function _resolve_m2m_side_model(_module::Module, binding::String, model_name::String, field_name::String)::PormGModel
+  bsym = Symbol(binding)
+  if isdefined(_module, bsym)
+    candidate = Base.invokelatest(getfield, _module, bsym)
     candidate isa PormGModel && return candidate
   end
 
-  target_name = Models.format_model_name(relation.related_model)
+  target_name = Models.format_model_name(model_name)
   for model in Models.get_all_models(_module)
     Models.format_model_name(model.name) == target_name && return model
   end
 
-  throw(ArgumentError("The many-to-many related model $(relation.related_binding) for accessor $(relation.field_name) is not defined"))
+  throw(ArgumentError("The many-to-many model $(binding) for accessor $(field_name) is not defined"))
+end
+
+function _resolve_many_to_many_related_model(_module::Module, relation::Models.ManyToManyRelation)::PormGModel
+  return _resolve_m2m_side_model(_module, relation.related_binding, relation.related_model, relation.field_name)
 end
 
 function _insert_many_to_many_joins(
@@ -101,10 +108,18 @@ function _insert_many_to_many_joins(
 )
   join_type = previus_how == "LEFT" ? "LEFT" : "INNER"
 
+  # #64: the PARENT-side join keys (owner_pk / related_pk) are field NAMES; resolve each to
+  # its physical column via the owning model's db_column. The through-table columns
+  # (owner_column / related_column) are the through table's own (auto-generated) columns and
+  # stay as-is. `model_column` is a strict no-op when the PK has no db_column.
+  _module = instruct.object.model._module::Module
+  owner_model = _resolve_m2m_side_model(_module, relation.owner_binding, relation.owner_model, relation.field_name)
+  related_model = _resolve_m2m_side_model(_module, relation.related_binding, relation.related_model, relation.field_name)
+
   through_row = sizehint!(Dict{String, Union{String, Vector{FilterType}}}(), 8)
   through_row["a"] = parent_table
   through_row["alias_a"] = parent_alias
-  through_row["key_a"] = relation.owner_pk
+  through_row["key_a"] = Models.model_column(owner_model, relation.owner_pk)
   through_row["b"] = relation.through_model
   through_row["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
   through_row["key_b"] = relation.owner_column
@@ -118,7 +133,7 @@ function _insert_many_to_many_joins(
   related_row["key_a"] = relation.related_column
   related_row["b"] = relation.related_model
   related_row["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
-  related_row["key_b"] = relation.related_pk
+  related_row["key_b"] = Models.model_column(related_model, relation.related_pk)
   related_row["how"] = join_type
 
   return _insert_join(instruct.row_join, related_row, instruct.row_path, join_path)
@@ -197,7 +212,8 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
 
     if (main_table_key in instruct.object.model.field_names)
       row_join["alias_a"] = instruct.alias
-      row_join["key_a"] = main_table_key
+      # #64: resolve the main-model join field to its physical column (db_column).
+      row_join["key_a"] = Models.model_column(instruct.object.model, main_table_key)
     elseif haskey(instruct.cache, main_table_key) || _cache_join(main_table_key, instruct)
       cache_item = instruct.cache[main_table_key]
       v_split = split(cache_item.field |> x -> replace(x,  '"' => ""), ".")
@@ -213,7 +229,11 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     row_join["b"] = cte_name  # CTE name becomes the table name
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
     row_join["how"] = cte_dict["join_type"]::String
-        
+
+    # #64: the CTE side stays the FIELD NAME — a CTE is a derived table whose columns are
+    # the values() projection ALIASES (`"pk_code" AS "code"`), so the join references the
+    # alias "code", not the physical column. Only the main-table side (key_a above) is a
+    # real physical column and is db_column-resolved.
     row_join["key_b"] = cte_table_key
 
     @pormg_debug false

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -375,4 +375,18 @@ Db_column_pk_strchild_scratch = Models.Model("db_column_pk_strchild_scratch",
   tag = Models.CharField(null=true),
 )
 
+# #64: M2M where BOTH participating models' PKs are renamed via db_column. The through-table
+# join must target the physical PK columns ("driver_pk" / "sponsor_pk"), NOT the field name
+# "code" — exercises owner_pk (through key_a) and related_pk (related key_b) resolution.
+M2m_rpk_sponsor_scratch = Models.Model("m2m_rpk_sponsor_scratch",
+  code = Models.IDField(db_column="sponsor_pk"),
+  name = Models.CharField(unique=true),
+)
+
+M2m_rpk_driver_scratch = Models.Model("m2m_rpk_driver_scratch",
+  code = Models.IDField(db_column="driver_pk"),
+  driverref = Models.CharField(unique=true),
+  sponsors = Models.ManyToManyField(M2m_rpk_sponsor_scratch, related_name="rpkdrivers"),
+)
+
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -375,4 +375,18 @@ Db_column_pk_strchild_scratch = Models.Model("db_column_pk_strchild_scratch",
   tag = Models.CharField(null=true),
 )
 
+# #64: M2M where BOTH participating models' PKs are renamed via db_column. The through-table
+# join must target the physical PK columns ("driver_pk" / "sponsor_pk"), NOT the field name
+# "code" — exercises owner_pk (through key_a) and related_pk (related key_b) resolution.
+M2m_rpk_sponsor_scratch = Models.Model("m2m_rpk_sponsor_scratch",
+  code = Models.IDField(db_column="sponsor_pk"),
+  name = Models.CharField(unique=true),
+)
+
+M2m_rpk_driver_scratch = Models.Model("m2m_rpk_driver_scratch",
+  code = Models.IDField(db_column="driver_pk"),
+  driverref = Models.CharField(unique=true),
+  sponsors = Models.ManyToManyField(M2m_rpk_sponsor_scratch, related_name="rpkdrivers"),
+)
+
 end

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -254,3 +254,70 @@ end
         @test true  # SQLite: bulk_copy unsupported; covered by bulk_insert above.
     end
 end
+
+# #64: an M2M where BOTH participating models' PKs are renamed via db_column. The through-table
+# join must target the physical PK columns ("driver_pk"/"sponsor_pk"). `add!` writes the through
+# table regardless of the fix (it uses through-table columns), so the discriminator is the READ:
+# forward/reverse filters join on the parent PK columns and would target a non-existent "code"
+# column without the fix.
+@testset "db_column: M2M join over renamed PKs (#64)" begin
+    M.M2m_rpk_driver_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_rpk_sponsor_scratch.objects.delete(allow_delete_all=true)
+    try
+        sponsor_a = M.M2m_rpk_sponsor_scratch.objects.create("name" => "Petrolux")
+        sponsor_b = M.M2m_rpk_sponsor_scratch.objects.create("name" => "AeroFuel")
+        driver_x  = M.M2m_rpk_driver_scratch.objects.create("driverref" => "ham44")
+
+        manager = M.M2m_rpk_driver_scratch.sponsors(driver_x)
+        @test manager.add!(sponsor_a, sponsor_b) === nothing
+        @test length(manager.all().list()) == 2            # all() routes through the fixed join
+
+        # Forward: driver → sponsors (through-join on "driver_pk", related-join on "sponsor_pk").
+        fwd = M.M2m_rpk_driver_scratch.objects
+        fwd.filter("sponsors__name" => "Petrolux")
+        fwd.values("driverref")
+        fwd_rows = fwd.list()
+        @test length(fwd_rows) == 1
+        @test fwd_rows[1][:driverref] == "ham44"
+
+        # Reverse: sponsor → drivers via related_name "rpkdrivers".
+        rev = M.M2m_rpk_sponsor_scratch.objects
+        rev.filter("rpkdrivers__driverref" => "ham44")
+        rev.values("name")
+        @test Set([row[:name] for row in rev.list()]) == Set(["Petrolux", "AeroFuel"])
+    finally
+        M.M2m_rpk_driver_scratch.objects.delete(allow_delete_all=true)
+        M.M2m_rpk_sponsor_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# #64: a CTE over a renamed-PK model, joined on the renamed PK field ("code"). The main
+# physical-table side resolves "code"→"pk_code"; without the fix the join targets a
+# non-existent "code" column and errors. (The CTE side stays the alias "code".)
+@testset "db_column: CTE join over a renamed PK (#64)" begin
+    # Clear the CASCADE children before the parent so this testset is self-contained and
+    # order-independent (mirrors the renamed-parent-PK testsets above).
+    M.Db_column_pk_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_pk_strchild_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    try
+        M.Db_column_pk_scratch.objects.create("code" => 700, "label" => "CT")
+        M.Db_column_pk_scratch.objects.create("code" => 701, "label" => "other")
+
+        cte = M.Db_column_pk_scratch.objects
+        cte.filter("label" => "CT")
+        cte.values("code", "label")
+
+        main = M.Db_column_pk_scratch.objects
+        main.with("rpk_cte" => cte, join_field="code" => "code", join_type="INNER")
+        main.values("code", "lbl" => "rpk_cte__label")
+        rows = main.list()
+        @test length(rows) == 1                 # INNER join keeps only the matched code (700)
+        @test rows[1][:code] == 700
+        @test rows[1][:lbl] == "CT"
+    finally
+        M.Db_column_pk_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_pk_strchild_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1845,6 +1845,39 @@ end
     @test_throws ArgumentError PormG.Models.set_models(bad_mod, "mock_sl_path")
 end
 
+# ── #64: db_column on M2M / CTE join keys (DB-free render asserts) ─────────────────────────
+@testset "M2M join honors db_column on renamed PKs (#64)" begin
+    # Both participating models' PKs are renamed (driver code→driver_pk, sponsor code→sponsor_pk).
+    # The through-table join must target the physical PK columns, not the field name "code".
+    q = M.M2m_rpk_driver_scratch.objects
+    q.filter("sponsors__name" => "Petrolux")
+    q.values("driverref")
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"driver_pk\"", sql)    # owner PK resolved → through-join key_a
+    @test occursin("\"sponsor_pk\"", sql)   # related PK resolved → related-join key_b
+    @test !occursin("\"code\"", sql)        # the bare field name is never a join column
+end
+
+@testset "CTE join honors db_column on a renamed PK (#64)" begin
+    # Self-CTE over a renamed-PK model. The main physical-table join key resolves code→pk_code;
+    # the CTE side stays the field-name alias ("code" = the CTE's output column).
+    cte = M.Db_column_pk_scratch.objects
+    cte.values("code", "label")
+    main = M.Db_column_pk_scratch.objects
+    main.with("rpk_cte" => cte, join_field="code" => "code")
+    main.values("label", "cval" => "rpk_cte__label")
+    sql = inspect_query(main)[:sql_text]
+    @test occursin("pk_code\" =", sql)      # main physical-table join key resolved (key_a)
+end
+
+@testset "_resolve_m2m_side_model: binding fallback + not-found error (#64)" begin
+    # When the binding isn't a defined module binding, the helper falls back to a name scan
+    # over get_all_models; a name that matches no model raises ArgumentError.
+    resolved = PormG.QueryBuilder._resolve_m2m_side_model(M, "NotABindingXyz", "m2m_rpk_sponsor_scratch", "sponsors")
+    @test resolved === M.M2m_rpk_sponsor_scratch
+    @test_throws ArgumentError PormG.QueryBuilder._resolve_m2m_side_model(M, "NotABindingXyz", "no_such_model_zzz", "sponsors")
+end
+
 @testset "Related Objects - Auto-generated related_name key format" begin
     # Just_a_nested_roll_back has a single FK to Just_a_test_deletion with no
     # explicit related_name. The auto-generated key should be the lowercased


### PR DESCRIPTION
## Summary

Closes #64. Completes `db_column` coverage (after #50 / #62) for the last two **join-key** paths that
still emitted the field **name** where the physical column is needed. When a participating model's
primary key is renamed via `db_column`, the generated join `ON` clause referenced a non-existent column
→ **silent wrong SQL / empty results**. The migration/DDL path was already correct (through-table FK
fields resolve via `fk_target_column`); the gap was **purely in the query/join builder**.

This bites **model-instance** M2M too — it is not about string-vs-model targets.

## What changed (`src/querybuilder/build_joins.jl` only)

- **M2M:** resolve `owner_pk` / `related_pk` to the owning model's physical column at **join-emit
  time** via `model_column`, generalizing the existing related-model resolver into
  `_resolve_m2m_side_model` (owner + related). The through-table columns (`owner_column` /
  `related_column`) stay as-is — they are the through table's own auto-generated columns. Single
  chokepoint covers forward, reverse, and multi-hop M2M; the manager (`add!`/`all`) already routes
  through it. Emit-time (not relation-build) because `owner_pk`/`related_pk` are dual-use: the through
  table's FK fields reuse them as `pk_field=` (field names).
- **CTE:** resolve **only** the main physical-table side (`key_a`) to its `db_column`. The CTE side
  (`key_b`) stays the field-name **alias** — a CTE is a derived table whose columns are the `values()`
  projection aliases, so resolving it would reference a column the CTE doesn't expose.

`model_column` is a strict no-op when the PK has no `db_column`, so existing M2M/CTE are unchanged.
Reuses `field_db_column` / `model_column` (#50). **No struct, no `Models.jl`, no migration changes.**

## Verified (rendered SQL)

```sql
-- M2M: owner→through→related, joining on the physical PK columns
... ON "Tb"."driver_pk" = "Tb_1"."m2m_rpk_driver_scratch_code"
... ON "Tb_1"."m2m_rpk_sponsor_scratch_code" = "Tb_2"."sponsor_pk"
-- CTE: base-table side resolved, CTE side keeps its alias
... ON "R1"."pk_code" = "R1_1"."code"   -- CTE body projects "pk_code" as "code"
```

## Tests

Two review passes (correctness + test design); the test-design reviewer **reverted the fix and
confirmed every unit assert flips** (genuinely discriminating). Coverage:
- Renamed-PK M2M fixtures in both `db_*/models.jl` (both participating PKs renamed).
- DB-free render asserts: M2M join targets `driver_pk`/`sponsor_pk` (never bare `"code"`); CTE main
  side targets `pk_code`.
- End-to-end (both backends): M2M forward + reverse traversal over renamed PKs; CTE `INNER` join on a
  renamed PK.
- `_resolve_m2m_side_model` name-scan fallback + not-found `ArgumentError`.

- Unit: **2021 / 2021**
- SQLite integration (`db_sl`): **1472 / 1472**
- PostgreSQL integration (`db_2`): **1508 / 1508**
- `docs/make.jl`: clean

## Docs

`docs/src/schema_conventions.md` + `UPGRADING.md`: the M2M/CTE limitation is now resolved; the only
remaining non-configurable surface is the auto-generated `ManyToManyField` **through-table column
names** (`<model>_<pk>`).

## Follow-up

The remaining `db_column` follow-up family is complete. The sibling architectural item #65 (unify the
model-load lifecycle) would centralize M2M `.to` resolution alongside FK/O2O — separate, Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
