### PR TITLE
docs: Architecture page (mermaid) + sync TODO backlog index (#68–#90)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,8 +47,38 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 
 ## 🔍 Review possible issues
 
-- [#43](https://github.com/PingoLee/PormG.jl/issues/43) — `deepcopy(ctes)` → `copy(ctes)` shared-state risk
+- [#43](https://github.com/PingoLee/PormG.jl/issues/43) — ⚠️ Shared mutable state in read/copy path: `.list()` mutates the live query, `.copy()` aliases CTE state (pre-publish)
+- [#69](https://github.com/PingoLee/PormG.jl/issues/69) — ⚠️ Migration diff fails open: `_compare_model_field` swallows comparison errors and reports fields equal (pre-publish)
 - [#44](https://github.com/PingoLee/PormG.jl/issues/44) — CTE ergonomics: reference CTE fields via `F()` in the main query
+- [#68](https://github.com/PingoLee/PormG.jl/issues/68) — Refactor `_build_row_join`: collapse duplicated first-hop/loop join resolution (tech debt; behavior-preserving)
+- [#70](https://github.com/PingoLee/PormG.jl/issues/70) — `Model_to_str` silently drops a field when rendering throws (swallowed catch)
+- [#73](https://github.com/PingoLee/PormG.jl/issues/73) — `bulk_update` parameters snapshot/restore leaves partial state on mid-chunk failure
+- [#80](https://github.com/PingoLee/PormG.jl/issues/80) — Dead identifier-whitelist helpers + skill-doc claims a contract the code doesn't exercise (`documentation`)
+
+## 🧮 SQL correctness & dialect alignment
+
+- [#74](https://github.com/PingoLee/PormG.jl/issues/74) — ⚠️ Aggregates over to-many joins silently inflate `Count`/`Sum`/`Avg` (no auto-DISTINCT/subquery) (pre-publish)
+- [#75](https://github.com/PingoLee/PormG.jl/issues/75) — ⚠️ `ORDER BY` NULL placement diverges PG vs SQLite (no `NULLS FIRST/LAST`) (pre-publish)
+- [#76](https://github.com/PingoLee/PormG.jl/issues/76) — `SELECT DISTINCT … ORDER BY <unselected column>` errors on PG, runs on SQLite
+- [#77](https://github.com/PingoLee/PormG.jl/issues/77) — `SQLOrder.orientation` interpolated unvalidated into `ORDER BY` (latent SQL injection; `security`)
+- [#78](https://github.com/PingoLee/PormG.jl/issues/78) — Case-insensitive lookups (`icontains`/`istartswith`/`iendswith`) diverge PG vs SQLite on non-ASCII text
+- [#79](https://github.com/PingoLee/PormG.jl/issues/79) — `DateTimeField` equality/range filters can diverge PG vs SQLite (format-sensitive TEXT comparison)
+
+## 🧱 Migration apply / rollback safety
+
+- [#81](https://github.com/PingoLee/PormG.jl/issues/81) — Migrations are not idempotent and checksum is never verified (re-apply landmine, no drift detection)
+- [#82](https://github.com/PingoLee/PormG.jl/issues/82) — SQLite table-rebuild drops secondary indexes and runs with FK enforcement off (data-loss risk)
+- [#83](https://github.com/PingoLee/PormG.jl/issues/83) — SQLite `drop_foreign_key` is broken (undefined `get_constraints`) and embeds `BEGIN/COMMIT` that breaks migration atomicity
+- [#87](https://github.com/PingoLee/PormG.jl/issues/87) — `migrate()` defaults `interactive=true` and blocks on `readline()` in non-interactive/CI contexts
+- [#89](https://github.com/PingoLee/PormG.jl/issues/89) — Migration statement ordering has no FK-dependency topological sort (`CREATE`/`DROP` order survives by accident)
+- [#90](https://github.com/PingoLee/PormG.jl/issues/90) — Migration advisory lock keyed on config folder, not database identity (two configs on one DB don't mutually exclude)
+
+## 📦 Bulk insert / update / copy
+
+- [#84](https://github.com/PingoLee/PormG.jl/issues/84) — Bulk insert/update has no parameter-limit-aware chunking (overflows SQLite 999 / PG 65535)
+- [#85](https://github.com/PingoLee/PormG.jl/issues/85) — `bulk_update` is non-atomic on SQLite (multi-chunk partial update on mid-chunk failure)
+- [#86](https://github.com/PingoLee/PormG.jl/issues/86) — `bulk_copy` NULL/empty-string collision + formatter bypass (silent data divergence vs `create`/`bulk_insert`)
+- [#88](https://github.com/PingoLee/PormG.jl/issues/88) — SQLite `allocate_primary_keys` is racy outside `run_in_transaction` (read-then-write; reservation no-op at tx depth 0)
 
 ## 🔗 Custom Join (`cjoin`) Gaps
 
@@ -57,6 +87,8 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 ## 🐞 SQLite worker / pool stability
 
 - [#47](https://github.com/PingoLee/PormG.jl/issues/47) — SQLite connection / file-handle release at teardown (`close_pool!` leased-close + non-idempotent `_close_db!`)
+- [#71](https://github.com/PingoLee/PormG.jl/issues/71) — Failed ROLLBACK returns a possibly-dirty connection to the pool
+- [#72](https://github.com/PingoLee/PormG.jl/issues/72) — `acquire_connection` throws raw `String`s and spins ~30s on a permanently-bad connection
 
 ## 🔮 Future Considerations
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,8 +3,10 @@ uuid = "c2b6f8a6-4df6-4f4f-b8a1-6e3a2b91f123"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterMermaid = "a078cd44-4d9c-4618-b545-3ab9d77f9177"
 PormG = "7d8d7541-4d3d-4580-80a2-17064efb0993"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 Documenter = "1"
+DocumenterMermaid = "0.2.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,5 @@
 using Documenter
+using DocumenterMermaid
 using PormG
 using Dates
 using TimeZones
@@ -55,6 +56,7 @@ makedocs(
         ],
         "Import from Django" => "import_django.md",
 
+        "Architecture" => "architecture.md",
         "Advisory Locks" => "advisory_lock.md",
         "Extending PormG" => "extending.md",
         "Contributing" => "contributing.md",

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,0 +1,220 @@
+# Architecture & Request Flow
+
+A map of how a query travels from your fluent call to the database and back. File references
+point at the real definitions so you can jump in and read the body.
+
+!!! note "Type naming"
+    The **abstract** types are `SQLObject`, `SQLObjectHandler`, `SQLInstruction`; the **concrete**
+    ones you actually hold are `SQLObjectQuery` (the query state), `ObjectHandler` (the chainable
+    wrapper), and `InstrucObject` (the per-query SQL builder).
+
+## Layers (who depends on whom)
+
+```mermaid
+flowchart TD
+  U["Your code<br/>M.Result.objects.filter(...).values(...).list()"]
+
+  subgraph API["Public API"]
+    OBJ["object(model) → ObjectHandler<br/>wraps SQLObjectQuery (query state)<br/>querybuilder/types.jl"]
+    CHAIN["fluent methods: filter! / values!<br/>order_by! / annotate! / with! ...<br/>querybuilder/object_manager.jl"]
+  end
+
+  subgraph QB["QueryBuilder — src/querybuilder/"]
+    Q["query() — execution.jl"]
+    B["build() → InstrucObject<br/>build_query.jl"]
+    J["_build_row_join (joins)<br/>build_joins.jl"]
+    P["parameters.jl<br/>$1.. (PG) / ? buckets (SQLite)"]
+    F["functions.jl / operators.jl / ctes.jl"]
+  end
+
+  DI["Dialect.jl<br/>per-backend SQL rendering"]
+
+  subgraph CP["ConnectionPool.jl"]
+    FE["fetch() → fetch_async()"]
+    POOL["pool + ReentrantLock<br/>acquire / release"]
+  end
+
+  BK["Backend.jl<br/>backend_* generics (no driver type named)"]
+  subgraph EXT["weakdep extensions — ext/"]
+    PG["PormGLibPQExt.jl → LibPQ"]
+    SL["PormGSQLiteExt.jl → SQLite"]
+  end
+  DB[("PostgreSQL / SQLite")]
+
+  U --> OBJ --> CHAIN --> Q --> B
+  B --> J
+  B --> P
+  B --> F
+  B --> DI
+  Q --> FE --> POOL --> BK
+  BK --> PG --> DB
+  BK --> SL --> DB
+  DB -->|rows| FE -->|results| U
+```
+
+The key idea: **core never names a concrete driver type.** `Backend.jl` declares `backend_*`
+generics; the real bodies live in the `ext/` weak-dependency extensions, loaded only when `LibPQ`
+or `SQLite` is present.
+
+## Read path — the query lifecycle
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant App as Your code
+  participant OH as ObjectHandler
+  participant EX as execution.jl
+  participant BQ as build_query.jl
+  participant CP as ConnectionPool
+  participant BE as Backend + ext
+  participant DB as Database
+
+  App->>OH: .objects.filter(...).values(...)
+  Note over OH: each call MUTATES the SQLObjectQuery<br/>state (filter, values, order, joins, ctes...)<br/>nothing hits the DB yet — it is lazy
+  App->>EX: .list()  (terminal)
+  EX->>EX: query() — resolve settings + param collector
+  EX->>BQ: build(object)
+  BQ->>BQ: get_select_query / get_filter_query<br/>_build_row_join / order / build_cte_clause
+  Note over BQ: fills an InstrucObject:<br/>SQL text + ordered parameters
+  BQ-->>EX: SQL string + parameters
+  EX->>CP: fetch(conn, sql, params)
+  CP->>CP: fetch_async() → acquire_connection (under lock)
+  CP->>BE: backend_execute_async(conn, sql, params)
+  BE->>DB: $1.. (PG)  /  ? (SQLite)
+  DB-->>BE: rows
+  BE-->>CP: result
+  CP->>CP: await_result → release connection
+  CP-->>EX: rows
+  EX-->>App: Vector / DataFrame / dicts
+```
+
+The two things worth internalizing:
+
+1. **Lazy until a terminal.** `filter/values/order_by/...` only mutate the `SQLObjectQuery`. No SQL
+   exists until a terminal (`list/first/get/count/exists/create/update/delete`) calls `query()`.
+2. **Sync wraps async.** `fetch()` is a thin wrapper over `fetch_async()`. The pool is guarded by a
+   `ReentrantLock`; the connection is returned to the pool in `await_result` once the rows are
+   materialized.
+
+## Terminals — read vs write
+
+```mermaid
+flowchart LR
+  subgraph Read
+    L[".list() / .first() / .get()"]
+    C[".count() / .exists()"]
+  end
+  subgraph Write
+    CR[".create()"]
+    UP[".update()"]
+    DE[".delete()"]
+  end
+  L --> QRY["query() → build() → fetch()"]
+  C --> QRY
+  CR --> INS["insert path<br/>execution.jl / execution_bulk.jl"]
+  UP --> UPD["update path<br/>execution.jl"]
+  DE --> DEL["deletion.jl<br/>cascade planning (CASCADE/SET_NULL/...)"]
+  QRY --> FE["fetch()"]
+  INS --> FE
+  UPD --> FE
+  DEL --> FE
+  FE --> DB[("DB")]
+```
+
+Every terminal funnels through the same `build → parameters → Dialect → fetch` machinery; only the
+clause it emits (SELECT vs INSERT vs UPDATE vs DELETE) differs.
+
+## Migrations — a separate flow
+
+State-based reconciliation: compare model definitions against the live schema, emit DDL, track it.
+
+```mermaid
+flowchart TD
+  M["models (db/models.jl)<br/>PormGModel definitions"]
+  MM["makemigrations()<br/>migrations/planner.jl"]
+  INTRO["introspection.jl<br/>read live DB schema"]
+  DIFF["diff: desired models vs current schema"]
+  FILE["migration .jl file<br/>(OrderedDict of SQL DDL)"]
+  MIG["migrate()<br/>migrations/runner.jl"]
+  LOCK["advisory lock (PG) / write-lock (SQLite)"]
+  DDL["Dialect.jl renders CREATE / ALTER / DROP"]
+  TRACK["pormg_migrations table<br/>version + checksum + status"]
+  DB[("Database")]
+
+  M --> MM
+  M --> DIFF
+  MM --> INTRO --> DIFF --> FILE
+  FILE --> MIG --> LOCK --> DDL --> DB
+  MIG --> TRACK
+```
+
+## Known architectural edges
+
+The macro-structure above is sound — Django-shaped layers and a clean backend seam. But a skeptical
+audit also turned up two **confirmed correctness bugs** and two characterizations worth stating
+plainly. These are listed first; the maintainability notes follow.
+
+### Confirmed correctness bugs (pre-publish)
+
+- **Shared mutable state in the read/copy path** —
+  [#43](https://github.com/PingoLee/PormG.jl/issues/43). `.list()`/`.first()` build directly on the
+  caller's query object (writing back `q.object.parameters`) and `_build_cte_custom_model` mutates
+  the CTE dict in place, while `Base.deepcopy(::SQLObjectQuery)` does a **shallow** `copy(obj.ctes)`.
+  Result: a read mutates the live query, and `.copy()` does not give an independent query when CTEs
+  are involved. `.count()`/`.exists()` `deepcopy` first and are safe — `.list()` does not, an
+  inconsistency rather than a design.
+
+- **Migration diff fails open** — [#69](https://github.com/PingoLee/PormG.jl/issues/69).
+  `_compare_model_field` wraps each attribute comparison in a `try/catch` that swallows the error and
+  falls through to "fields equal", so a comparison that throws can silently classify a changed field
+  as unchanged and **skip a migration**. A schema-diff must fail *toward* generating a migration.
+
+### Maintainability edges (no correctness impact)
+
+- **Model-load lifecycle (the one genuine flow gap)** —
+  [#65](https://github.com/PingoLee/PormG.jl/issues/65). FK / one-to-one / many-to-many / CTE
+  *target resolution* happens lazily and ad-hoc in several places (the join builder resolves
+  bindings inline via `getfield(module, …)` / `invokelatest`, M2M scans all models, CTEs resolve
+  their own way). There is no single "load + resolve" pass between *models defined* and
+  *queries/migrations run* (Django's `apps.populate()` analog). Highest-leverage improvement — it
+  removes *why* the join builder does resolution inline, and retires the world-age-risky reflection.
+
+- **Join builder shape** — [#68](https://github.com/PingoLee/PormG.jl/issues/68). `_build_row_join`
+  resolves the first hop and each subsequent hop with near-duplicate branch chains, and the join
+  plan is carried as stringly-typed `Vector{Dict{String, …}}`. The tracked refactor is
+  behavior-preserving (collapse the duplication) and optionally introduces a typed `JoinPlan`/
+  `JoinNode` struct. Best done *after* #65, which simplifies the resolution it depends on.
+
+- **Type stability is structural, not cosmetic** —
+  [#41](https://github.com/PingoLee/PormG.jl/issues/41). The query state is built on
+  `Dict{String, Any}` + heavy `Union` fields, the fluent API dispatches via a runtime
+  `sym === :filter` ladder, SQL rendering runs through `getfield(Module, Symbol(...))` reflection
+  per query, and `fetch` returns `Any`. This is baked into the core types — not fixable in function
+  bodies. Honest nuance: low-leverage for *runtime latency* (it runs once per query to produce a
+  string), but it drives TTFX/allocations and the `invokelatest` world-age fragility on the join path.
+
+- **Positional-parameter buckets (deliberate, contained)** — for SQLite the positional `?` markers
+  are collected into per-clause buckets and flattened in SQL-clause order
+  (`:cte → :select → :update → :join → :where → :having`). The flatten order is single-sourced in
+  `get_final_parameters` and guarded by `test_alignment_sqlite.jl` / `test_parameters.jl`; the only
+  cost is that *adding a new bucket* is a documented multi-site edit (see the QueryBuilder skill's
+  maintenance checklist). Noted here so it is not mistaken for accidental coupling.
+
+!!! note "\"Async-first\" is backend-specific"
+    For **PostgreSQL** the async path is genuine: the pool lock is released before the round-trip and
+    `LibPQ.async_execute` is real non-blocking I/O, so queries on separate connections overlap. For
+    **SQLite**, every statement is funnelled through a single global worker (serialized), with write
+    transactions further pinned behind a process-wide lock — pool size buys no query-level
+    concurrency. "Async-first" is a real PostgreSQL capability, not a blanket ORM property.
+
+## Where to look next
+
+| You want to understand… | Start at |
+|---|---|
+| How `.objects` and chaining work | `src/querybuilder/object_manager.jl`, `types.jl` (`SQLObjectQuery`, `object()`) |
+| How SQL text is assembled | `src/querybuilder/build_query.jl` (`build`), `build_joins.jl`, `ctes.jl` |
+| Parameter ordering (PG `$1` vs SQLite `?` buckets) | `src/querybuilder/parameters.jl` |
+| Backend-specific SQL | `src/Dialect.jl` |
+| Pool, async, transactions | `src/ConnectionPool.jl` |
+| Driver bodies | `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl` |
+| Schema reconciliation | `src/Migrations.jl`, `src/migrations/` |


### PR DESCRIPTION
## What

Two review outputs, one commit:

1. **New `Architecture` docs page** (`docs/src/architecture.md`) — Mermaid diagrams for the layered
   architecture, the read-query lifecycle, read/write terminals, and the migration flow, plus a **"Known
   architectural edges"** section that links the issues raised during the review. Wired up via the
   `DocumenterMermaid` plugin (`docs/make.jl` + `docs/Project.toml`) with a nav entry. Docs build verified
   green locally (`julia --project=docs -e 'include("docs/make.jl")'`).

2. **`TODO.md` backlog index sync** — indexes the issues filed during the architecture review (#68–#90),
   grouped into new sections: *SQL correctness & dialect alignment*, *Migration apply/rollback safety*, and
   *Bulk insert/update/copy*.

## Context

These are the documentation/index artifacts of a full skeptical architecture review. The review itself
produced **20 new issues (#68–#90)** and enriched **3 existing ones (#41, #43, #65)** across querybuilder
internals, concurrency/async, type stability, error-handling/shared-state, security/parameterization,
SQL-correctness/dialect divergence, and the migration apply/rollback + bulk paths. Every finding was verified
against the source before filing. This PR contains **only the docs + index** — no `src/` behavior changes.

## Notes

- `docs/Manifest.toml` is gitignored; CI re-resolves `DocumenterMermaid` via `Pkg.instantiate`.
- No code under `src/` is touched — zero runtime/behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
