### PR TITLE
fix(#74): fail-loud guard for aggregate fan-out over to-many joins

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,6 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 
 ## 🧮 SQL correctness & dialect alignment
 
-- [#74](https://github.com/PingoLee/PormG.jl/issues/74) — ⚠️ Aggregates over to-many joins silently inflate `Count`/`Sum`/`Avg` (no auto-DISTINCT/subquery) (pre-publish)
 - [#75](https://github.com/PingoLee/PormG.jl/issues/75) — ⚠️ `ORDER BY` NULL placement diverges PG vs SQLite (no `NULLS FIRST/LAST`) (pre-publish)
 - [#76](https://github.com/PingoLee/PormG.jl/issues/76) — `SELECT DISTINCT … ORDER BY <unselected column>` errors on PG, runs on SQLite
 - [#77](https://github.com/PingoLee/PormG.jl/issues/77) — `SQLOrder.orientation` interpolated unvalidated into `ORDER BY` (latent SQL injection; `security`)
@@ -94,6 +93,7 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 
 - [#46](https://github.com/PingoLee/PormG.jl/issues/46) — Parameterize LIMIT/OFFSET
 - [#59](https://github.com/PingoLee/PormG.jl/issues/59) — Model `db_table` option: pin an explicit (mixed/upper-case) table name (Django `Meta.db_table` analog; table-level sibling of #50, pairs with #57)
+- [#92](https://github.com/PingoLee/PormG.jl/issues/92) — 💬 Design: explicit correlated-subquery aggregates (no auto-magic) — the supported fix for #74 fan-out
 
 ---
 

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -442,6 +442,38 @@ The `WHERE` filter still applies row-by-row *before* aggregation; it is the abse
 
 These aggregates can carry arithmetic too — e.g. `"id_span" => Max("resultid") - Min("resultid")`, or subtract a constant like `Max("resultid") - 1000`. See [Aggregate Arithmetic](field_expressions.md#aggregate-arithmetic).
 
+### Aggregating Across To-Many Relations (Fan-Out Guard)
+
+Joining a **to-many** relation — a reverse foreign key (one parent → many children) or a many-to-many — repeats each parent row once per related row *before* aggregation. An aggregate over a **parent/base** column would therefore be silently multiplied. PormG refuses this at build time rather than return a confidently-wrong number:
+
+```julia
+# ✗ raises: counts the DRIVER pk, but the driver_standings join repeats each driver row once per standing
+query = M.Driver.objects
+query.values("nationality", "n" => Count("driverid"))
+query.filter("driver_standings__position__@gte" => 1)
+query |> DataFrame   # ArgumentError: PormG fan-out guard (#74) — the aggregate n is inflated …
+```
+
+The legitimate case — aggregating the **related** table's own column (e.g. counting the related rows) — is exactly the intended fan-out and works normally:
+
+```julia
+# ✓ counts each driver's standings rows — the fan-out IS the answer
+query = M.Driver.objects
+query.values("driverid", "standings" => Count("driver_standings__driverid"))
+df = query |> DataFrame
+```
+
+**The rule.** When a to-many join is present, `COUNT` / `SUM` / `AVG` raise if they aggregate a column the join row-multiplies (a base/parent column, or *any* column when two or more to-many relations are joined). To resolve it, pick one:
+
+1. **Aggregate the related table's own column** — count/sum the related rows directly, as above.
+2. **Pass `distinct=true`** if de-duplicated counting is what you want: `Count("driverid", distinct=true)` renders `COUNT(DISTINCT …)`.
+3. **Compute the aggregate in a correlated subquery** so the base rows are never multiplied.
+
+**Exemptions.** `Max` and `Min` are immune to row duplication and are never blocked; an aggregate built with `distinct=true` is treated as an explicit opt-in.
+
+!!! note
+    The guard is deliberately fail-loud: an aggregate it cannot prove safe (for example one wrapping a multi-column expression) raises rather than risk a silent wrong number. A first-class, explicit correlated-subquery construct for pattern 3 is under design discussion ([#92](https://github.com/PingoLee/PormG.jl/issues/92)).
+
 ---
 
 ## HAVING Clauses

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -451,7 +451,7 @@ Joining a **to-many** relation — a reverse foreign key (one parent → many ch
 query = M.Driver.objects
 query.values("nationality", "n" => Count("driverid"))
 query.filter("driver_standings__position__@gte" => 1)
-query |> DataFrame   # ArgumentError: PormG fan-out guard (#74) — the aggregate n is inflated …
+query |> DataFrame   # ArgumentError: PormG fan-out guard (#74): the aggregate n is inflated because …
 ```
 
 The legitimate case — aggregating the **related** table's own column (e.g. counting the related rows) — is exactly the intended fan-out and works normally:
@@ -468,6 +468,16 @@ df = query |> DataFrame
 1. **Aggregate the related table's own column** — count/sum the related rows directly, as above.
 2. **Pass `distinct=true`** if de-duplicated counting is what you want: `Count("driverid", distinct=true)` renders `COUNT(DISTINCT …)`.
 3. **Compute the aggregate in a correlated subquery** so the base rows are never multiplied.
+
+**Not affected.** Ordinary forward (to-one) `ForeignKey` traversals never trip the guard — only *to-many* joins (reverse FK / many-to-many) multiply rows. Aggregating across a normal FK is always fine:
+
+```julia
+# ✓ to-one join (Result → Constructor); no fan-out — results per constructor
+query = M.Result.objects
+query.values("constructorid__name", "n" => Count("resultid"))
+query.filter("raceid" => 1)
+df = query |> DataFrame
+```
 
 **Exemptions.** `Max` and `Min` are immune to row duplication and are never blocked; an aggregate built with `distinct=true` is treated as an explicit opt-in.
 

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -619,6 +619,16 @@ function _get_select_query(v::WindowFunction, instruc::SQLInstruction; _as::Unio
     return getfield(Dialect, func_name)(resolved_column, over_sql, instruc.connection)
   end
 end
+# #74: extract the single source table alias from a fully-resolved bare column reference like
+# `"Tb_1"."points"` or `"Tb".*`. Returns the unquoted alias, or `nothing` for anything that is not a
+# single column (nested aggregate, F-expression, multi-column) — the fan-out guard treats `nothing`
+# as ambiguous and conservatively refuses. Both backends quote identifiers with double quotes.
+function _extract_leading_alias(s)
+  s isa AbstractString || return nothing
+  m = match(r"^\"((?:[^\"]|\"\")+)\"\.(?:\"(?:[^\"]|\"\")+\"|\*)$", s)
+  m === nothing ? nothing : replace(m.captures[1], "\"\"" => "\"")
+end
+
 function _get_select_query(v::SQLTypeFunction, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
   # Parameterize scalar kwargs instead of rendering them as SQL literals.
   # IMPORTANT: these must be parameterized AFTER the column is resolved, because the SQL text order
@@ -656,6 +666,18 @@ function _get_select_query(v::SQLTypeFunction, instruc::SQLInstruction; _as::Uni
 
   # Phase 2: Resolve column (conditions) — this adds condition params in SQL text order
   resolved_column = _get_select_query(v.column, instruc, _as=_as)
+
+  # #74 fan-out guard: record COUNT/SUM/AVG and the source alias of their column so build() can
+  # refuse aggregates a to-many join would silently inflate. MAX/MIN are immune and omitted; a
+  # `distinct=true` aggregate is an explicit opt-in and is exempted by the check.
+  if v.function_name in ("COUNT", "SUM", "AVG")
+    src = _extract_leading_alias(resolved_column)
+    push!(instruc.agg_sources, (
+      alias = src === nothing ? "\0AMBIGUOUS" : src,
+      func = v.function_name,
+      label = _as === nothing ? string(v.function_name, "(", resolved_column, ")") : _as,
+      distinct = get(v.kwargs, "distinct", false) === true))
+  end
 
   # Phase 3: Now parameterize deferred kwargs (they appear AFTER conditions in SQL)
   # Order matters for positional backends: then → else → precision

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -170,6 +170,9 @@ function _apply_many_to_many_branch(
   last_field = size(vector, 1) == 2 ? foreign_model.fields[vector[2]] : nothing
   tb_alias = _insert_many_to_many_joins(relation, instruct, parent_table, parent_alias, join_path, previus_how=previus_how)
   row_join = _row_join_for_alias(instruct.row_join, tb_alias)
+  # #74: the related table reached through a many-to-many is the "many-side". Flag the (deduped)
+  # row_join entry so the fan-out guard can refuse silently-inflated aggregates over base columns.
+  row_join["to_many"] = "1"
   return (tb_alias, row_join, foreign_model, last_field)
 end
 
@@ -304,6 +307,8 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     # column; both honor db_column (resolved in their own model, no-op without it) (#50).
     row_join["key_a"] = Models.model_column(instruct.object.model, instruct.object.model.related_objects[vector[1]][2] |> String)
     row_join["key_b"] = Models.model_column(reverse_model, instruct.object.model.related_objects[vector[1]][1] |> String)
+    # #74: a reverse foreign key (one-to-many) makes the child table the many-side.
+    row_join["to_many"] = "1"
     foreign_table_name = s_model |> string
     @pormg_debug false
     end
@@ -405,6 +410,8 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       # column; both honor db_column (resolved in their own model, no-op without it) (#50).
       row_join["key_a"] = Models.model_column(new_object, new_object.related_objects[vector[1]][2] |> String)
       row_join["key_b"] = Models.model_column(reverse_model, new_object.related_objects[vector[1]][1] |> String)
+      # #74: a reverse foreign key (one-to-many) makes the child table the many-side.
+      row_join["to_many"] = "1"
       foreign_table_name = s_model |> string
       vector = vector[2:end]
       _reverse_advanced = true

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -324,7 +324,51 @@ function build(object::SQLObject;
   set_contexts && set_context!(instruct, :join)
   build_row_join_sql_text(instruct)
 
-  get_order_query(object, instruct)  # ORDER BY has no parameters  
+  get_order_query(object, instruct)  # ORDER BY has no parameters
+
+  _check_aggregate_fanout(instruct)  # #74: refuse silently-inflated aggregates over to-many joins
 
   return instruct
+end
+
+# #74 fan-out guard ------------------------------------------------------------------------------
+# A to-many join (reverse FK / many-to-many) repeats base-table rows, so COUNT/SUM/AVG over a column
+# from a row-multiplied table silently inflates the result. We refuse those at build time rather than
+# return a confidently-wrong number. The legitimate case — aggregating the to-many table's OWN column
+# (the sole many-side) — is preserved. MAX/MIN are immune; `distinct=true` is an explicit opt-in.
+function _check_aggregate_fanout(instruct::SQLInstruction)
+  isempty(instruct.agg_sources) && return nothing
+  # Derive the many-side aliases from the *deduped* row_join. A join can be built more than once
+  # (e.g. _cache_join pre-builds a filter join, then it is built again for real); _insert_join keeps
+  # only one entry, so deriving here counts each actual to-many join exactly once.
+  many = Set{String}()
+  for r in instruct.row_join
+    get(r, "to_many", "") == "1" && push!(many, string(r["alias_b"]))
+  end
+  isempty(many) && return nothing
+  n = length(many)
+  for a in instruct.agg_sources
+    a.distinct && continue
+    ambiguous = a.alias == "\0AMBIGUOUS"
+    # Safe only when the aggregate targets the sole to-many table's own column.
+    (!ambiguous && a.alias in many && n == 1) && continue
+    throw(_argerr(_fanout_error_msg(a, many, ambiguous)))
+  end
+  return nothing
+end
+
+function _fanout_error_msg(a, many, ambiguous::Bool)
+  paths = join(sort!(collect(many)), ", ")
+  reason = ambiguous ?
+    "the aggregated expression spans more than one source, so it cannot be proven safe under a row-multiplying (to-many) join" :
+    "it aggregates a column from a table that a to-many join row-multiplies"
+  string(
+    "PormG fan-out guard (#74): the aggregate \e[4m\e[31m", a.label, "\e[0m is inflated because ", reason, ".\n",
+    "  A to-many join (reverse foreign key or many-to-many) repeats base-table rows, so ", a.func,
+    " would count/sum each base row once per related row.\n",
+    "  To-many table alias(es) in this query: \e[33m", paths, "\e[0m.\n",
+    "  Fix one of:\n",
+    "    \e[32m1.\e[0m Aggregate the RELATED table's own column instead (e.g. count related rows: Count(\"reverse_relation__id\")).\n",
+    "    \e[32m2.\e[0m Pass \e[32mdistinct=true\e[0m to the aggregate if de-duplicated counting is what you want.\n",
+    "    \e[32m3.\e[0m Compute the aggregate in a correlated subquery so the base rows are not multiplied.\n")
 end

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -77,6 +77,12 @@ end
   django::OptionalString = nothing
   parameters::Union{Nothing,AbstractPormGParam} = nothing # parameters to be used in the query
   outer::Union{Nothing,SQLInstruction} = nothing # parent query instruction for correlated subqueries
+  # #74 fan-out guard: record each at-risk aggregate's source alias so build() can refuse
+  # silently-inflated COUNT/SUM/AVG. To-many joins are flagged in-place on their row_join dict (a
+  # "to_many" key) and the many-side alias set is derived from the *deduped* row_join at check time
+  # (deriving avoids over-counting when _cache_join builds the same join twice). See _check_aggregate_fanout.
+  agg_sources::Vector{NamedTuple{(:alias, :func, :label, :distinct),Tuple{String,String,String,Bool}}} =
+    NamedTuple{(:alias, :func, :label, :distinct),Tuple{String,String,String,Bool}}[]
 end
 
 # Store information to decide the name from table alias in subquery

--- a/test/integration/test_sql_functions.jl
+++ b/test/integration/test_sql_functions.jl
@@ -1040,55 +1040,120 @@ end
 end
 
 @testset "#74 Aggregate fan-out guard" begin
-    # Logic: COUNT/SUM/AVG over a column that a to-many join (reverse FK / M2M) row-multiplies must
-    #        RAISE rather than silently inflate; aggregating the to-many table's OWN column still works;
-    #        MAX/MIN and distinct=true are exempt; a plain aggregate with no to-many join is unaffected.
+    # Logic: COUNT/SUM/AVG over a column a to-many join (reverse FK / M2M) row-multiplies must RAISE the
+    #        #74 guard *specifically* (cause-checked, not just any ArgumentError); aggregating the
+    #        to-many table's OWN column under a single to-many returns the CORRECT recomputed value;
+    #        MAX/MIN and distinct=true are exempt; two to-many joins (n>=2), M2M, and un-attributable
+    #        expressions raise; a plain aggregate is correct and unaffected.
     # Why: a base/parent column aggregated under a to-many join returns a confidently-wrong number
     #      (verified 36x inflation on driver_standings). Fail-loud guard for issue #74.
 
-    # CASE B — base-table column under a to-many join → inflated → raise.
+    # Returns the thrown error (or nothing). is_fanout confirms it is the #74 guard, so an unrelated
+    # ArgumentError (e.g. a bad field path) cannot masquerade as a passing raise.
+    fanout_err(f) = try; f(); nothing; catch e; e; end
+    is_fanout(e)  = e isa ArgumentError && occursin("fan-out", e.msg)
+
+    did = 1  # F1 dataset: driver 1 (Hamilton) has many driver_standings rows.
+
+    # CASE B — base-table pk under a to-many join → inflated → raise (cause-checked).
     qB = M.Driver.objects
     qB.values("nationality", "n" => Count("driverid"))
     qB.filter("driver_standings__position__@gte" => 1)
-    @test_throws ArgumentError (qB |> DataFrame)
+    @test is_fanout(fanout_err(() -> (qB |> DataFrame)))
 
-    # CASE A — aggregate the to-many table's OWN column (single to-many) → intended fan-out → allowed.
+    # SUM / AVG over a BASE column under a to-many must also raise — the guard is not COUNT-only.
+    qSum = M.Driver.objects
+    qSum.values("nationality", "s" => Sum("number"))     # `number` is a base Driver column
+    qSum.filter("driver_standings__position__@gte" => 1)
+    @test is_fanout(fanout_err(() -> inspect_query(qSum)))
+
+    qAvg = M.Driver.objects
+    qAvg.values("nationality", "a" => Avg("number"))
+    qAvg.filter("driver_standings__position__@gte" => 1)
+    @test is_fanout(fanout_err(() -> inspect_query(qAvg)))
+
+    # CASE A — aggregate the to-many table's OWN column (single to-many) → allowed AND correct.
     qA = M.Driver.objects
-    qA.values("driverid", "n" => Count("driver_standings__driverid"))
-    qA.filter("nationality" => "British")
+    qA.values("driverid", "n" => Count("driver_standings__driverstandingsid"))
+    qA.filter("driverid" => did)
     dfA = qA |> DataFrame
-    @test nrow(dfA) > 0
-    @test all(dfA.n .>= 1)  # each grouped driver has at least one standing counted
+    expectedA = M.Driver_standings.objects.filter("driverid" => did).count()
+    @test expectedA > 0                                  # guard against a vacuous 0 == 0
+    @test nrow(dfA) == 1 && dfA[1, :n] == expectedA       # recomputed value, not just "it ran"
 
-    # CASE A' — related column AND a filter on the SAME relation must NOT raise. The join is built
-    #           twice internally (cache + real) but the guard derives from the deduped row_join, so it
-    #           counts once. Regression for the dedup-derived detection.
+    # CASE A' — related column AND a filter on the SAME relation must NOT raise, and stay correct. The
+    #           join is built twice (cache + real); the guard derives from the deduped row_join.
     qAp = M.Driver.objects
-    qAp.values("driverid", "n" => Count("driver_standings__driverid"))
-    qAp.filter("driver_standings__position__@gte" => 1)
-    @test (qAp |> DataFrame) isa DataFrame
+    qAp.values("driverid", "n" => Count("driver_standings__driverstandingsid"))
+    qAp.filter("driverid" => did, "driver_standings__position__@gte" => 1)
+    dfAp = qAp |> DataFrame
+    expectedAp = M.Driver_standings.objects.filter("driverid" => did, "position__@gte" => 1).count()
+    @test (nrow(dfAp) == 1 ? dfAp[1, :n] : 0) == expectedAp
 
-    # MAX over a to-many column is immune to row duplication → allowed.
+    # MAX over a to-many column is immune to duplication → allowed AND equals the true max.
     qMax = M.Driver.objects
-    qMax.values("nationality", "m" => Max("driver_standings__points"))
-    qMax.filter("driver_standings__position__@gte" => 1)
-    @test (qMax |> DataFrame) isa DataFrame
+    qMax.values("driverid", "m" => Max("driver_standings__points"))
+    qMax.filter("driverid" => did)
+    pts = (M.Driver_standings.objects.filter("driverid" => did).values("points") |> DataFrame).points
+    @test (qMax |> DataFrame)[1, :m] == maximum(pts)
 
-    # distinct=true is an explicit opt-in → allowed even on a base column under a to-many.
+    # MIN is exempt too (symmetric to MAX) → allowed AND equals the true min.
+    qMin = M.Driver.objects
+    qMin.values("driverid", "m" => Min("driver_standings__points"))
+    qMin.filter("driverid" => did)
+    @test (qMin |> DataFrame)[1, :m] == minimum(pts)
+
+    # distinct=true → renders COUNT(DISTINCT …) and counts the single grouped driver once.
     qDist = M.Driver.objects
-    qDist.values("nationality", "n" => Count("driverid", distinct=true))
-    qDist.filter("driver_standings__position__@gte" => 1)
-    @test (qDist |> DataFrame) isa DataFrame
+    qDist.values("driverid", "n" => Count("driverid", distinct=true))
+    qDist.filter("driverid" => did, "driver_standings__position__@gte" => 1)
+    @test occursin("COUNT(DISTINCT", inspect_query(qDist)[:sql_text])   # cause: opt-in rendered
+    @test (qDist |> DataFrame)[1, :n] == 1
 
-    # COUNT(*) under a to-many join → also inflated → raise.
+    # COUNT(*) under a to-many join → inflated → raise (cause-checked).
     qStar = M.Driver.objects
     qStar.values("nationality", "n" => Count("*"))
     qStar.filter("driver_standings__position__@gte" => 1)
-    @test_throws ArgumentError (qStar |> DataFrame)
+    @test is_fanout(fanout_err(() -> (qStar |> DataFrame)))
 
-    # No to-many join (plain forward-FK / base aggregate) → unaffected.
+    # n >= 2 — aggregating ONE many-side column while a SECOND to-many relation is also joined still
+    #          inflates (the grains multiply), so even the many-side aggregate must raise.
+    qN2 = M.Driver.objects
+    qN2.values("driverid", "n" => Count("driver_standings__driverstandingsid"))
+    qN2.filter("lap_times__lap__@gte" => 1)              # second reverse to-many relation
+    @test is_fanout(fanout_err(() -> inspect_query(qN2)))
+
+    # Many-to-many — counting the BASE row while joining an M2M relation inflates → raise; counting the
+    # M2M-related table's own column (single to-many) is allowed. Build-level (needs no M2M data).
+    qM2M = M.M2m_driver_endorsement_scratch.objects
+    qM2M.values("driverref", "n" => Count("id"))
+    qM2M.filter("sponsors__name__@icontains" => "x")
+    @test is_fanout(fanout_err(() -> inspect_query(qM2M)))
+
+    qM2Mok = M.M2m_driver_endorsement_scratch.objects
+    qM2Mok.values("driverref", "n" => Count("sponsors__id"))
+    @test fanout_err(() -> inspect_query(qM2Mok)) === nothing   # related-col M2M aggregate is fine
+
+    # Ambiguous — an aggregate over a multi-column expression cannot be attributed to one table, so the
+    # guard conservatively raises under a to-many rather than risk a silent wrong number.
+    qAmb = M.Driver.objects
+    qAmb.values("nationality", "s" => Sum(F("driver_standings__points") + F("driver_standings__wins")))
+    qAmb.filter("driver_standings__position__@gte" => 1)
+    @test is_fanout(fanout_err(() -> inspect_query(qAmb)))
+
+    # Forward FK (to-one) join present → NOT a fan-out → guard must allow. This is the key
+    # discrimination: a to-one join must never be marked to-many. Counts stay correct.
+    qFk = M.Result.objects
+    qFk.values("constructorid__name", "n" => Count("resultid"))
+    qFk.filter("raceid" => 1)
+    @test fanout_err(() -> inspect_query(qFk)) === nothing            # to-one join does not trip the guard
+    dfFk = qFk |> DataFrame
+    @test sum(dfFk.n) == M.Result.objects.filter("raceid" => 1).count()  # per-constructor counts sum to the race total
+
+    # No to-many join (plain aggregate) → unaffected AND correct.
     qPlain = M.Result.objects
-    qPlain.values("constructorid", "n" => Count("resultid"))
-    @test (qPlain |> DataFrame) isa DataFrame
+    qPlain.values("raceid", "n" => Count("resultid"))
+    qPlain.filter("raceid" => 1)
+    @test (qPlain |> DataFrame)[1, :n] == M.Result.objects.filter("raceid" => 1).count()
 end
 

--- a/test/integration/test_sql_functions.jl
+++ b/test/integration/test_sql_functions.jl
@@ -1039,3 +1039,56 @@ end
     end
 end
 
+@testset "#74 Aggregate fan-out guard" begin
+    # Logic: COUNT/SUM/AVG over a column that a to-many join (reverse FK / M2M) row-multiplies must
+    #        RAISE rather than silently inflate; aggregating the to-many table's OWN column still works;
+    #        MAX/MIN and distinct=true are exempt; a plain aggregate with no to-many join is unaffected.
+    # Why: a base/parent column aggregated under a to-many join returns a confidently-wrong number
+    #      (verified 36x inflation on driver_standings). Fail-loud guard for issue #74.
+
+    # CASE B — base-table column under a to-many join → inflated → raise.
+    qB = M.Driver.objects
+    qB.values("nationality", "n" => Count("driverid"))
+    qB.filter("driver_standings__position__@gte" => 1)
+    @test_throws ArgumentError (qB |> DataFrame)
+
+    # CASE A — aggregate the to-many table's OWN column (single to-many) → intended fan-out → allowed.
+    qA = M.Driver.objects
+    qA.values("driverid", "n" => Count("driver_standings__driverid"))
+    qA.filter("nationality" => "British")
+    dfA = qA |> DataFrame
+    @test nrow(dfA) > 0
+    @test all(dfA.n .>= 1)  # each grouped driver has at least one standing counted
+
+    # CASE A' — related column AND a filter on the SAME relation must NOT raise. The join is built
+    #           twice internally (cache + real) but the guard derives from the deduped row_join, so it
+    #           counts once. Regression for the dedup-derived detection.
+    qAp = M.Driver.objects
+    qAp.values("driverid", "n" => Count("driver_standings__driverid"))
+    qAp.filter("driver_standings__position__@gte" => 1)
+    @test (qAp |> DataFrame) isa DataFrame
+
+    # MAX over a to-many column is immune to row duplication → allowed.
+    qMax = M.Driver.objects
+    qMax.values("nationality", "m" => Max("driver_standings__points"))
+    qMax.filter("driver_standings__position__@gte" => 1)
+    @test (qMax |> DataFrame) isa DataFrame
+
+    # distinct=true is an explicit opt-in → allowed even on a base column under a to-many.
+    qDist = M.Driver.objects
+    qDist.values("nationality", "n" => Count("driverid", distinct=true))
+    qDist.filter("driver_standings__position__@gte" => 1)
+    @test (qDist |> DataFrame) isa DataFrame
+
+    # COUNT(*) under a to-many join → also inflated → raise.
+    qStar = M.Driver.objects
+    qStar.values("nationality", "n" => Count("*"))
+    qStar.filter("driver_standings__position__@gte" => 1)
+    @test_throws ArgumentError (qStar |> DataFrame)
+
+    # No to-many join (plain forward-FK / base aggregate) → unaffected.
+    qPlain = M.Result.objects
+    qPlain.values("constructorid", "n" => Count("resultid"))
+    @test (qPlain |> DataFrame) isa DataFrame
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
     @testset "Complex Query Patterns" include("unit/test_complex_queries.jl")
     @testset "Many-to-Many Relationships" include("unit/test_many_to_many.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")
+    @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")
     @testset "Deep FK Traversal (3 hops)" include("unit/test_deep_fk_traversal.jl")
     @testset "Window Function SQL Generation" include("unit/test_window_functions.jl")

--- a/test/unit/test_aggregate_fanout.jl
+++ b/test/unit/test_aggregate_fanout.jl
@@ -1,0 +1,34 @@
+# test/unit/test_aggregate_fanout.jl
+# Unit coverage for the #74 fan-out guard's alias-extraction helper. `_extract_leading_alias` must
+# recover the single source table alias from a fully-resolved bare column reference, and return
+# `nothing` for any expression spanning more than one column so the guard conservatively refuses.
+
+using Test
+using PormG
+import PormG.QueryBuilder: _extract_leading_alias
+
+@testset "_extract_leading_alias (#74)" begin
+    # Logic: a bare "alias"."col" reference yields its (unquoted) alias.
+    # Why: the guard maps an aggregate's resolved column to the table alias it reads.
+    @test _extract_leading_alias("\"Tb\".\"driverid\"") == "Tb"
+    @test _extract_leading_alias("\"Tb_1\".\"points\"") == "Tb_1"
+
+    # Logic: a COUNT(*)-style "alias".* reference also resolves to the alias.
+    # Why: Count("*") and Count("rel__*") must be attributable to detect/permit correctly.
+    @test _extract_leading_alias("\"Tb\".*") == "Tb"
+    @test _extract_leading_alias("\"Tb_2\".*") == "Tb_2"
+
+    # Logic: anything that is not a single column → nothing (ambiguous → conservative raise).
+    # Why: nested aggregates / F-expressions can't be attributed to one table; the guard must not guess.
+    @test _extract_leading_alias("\"Tb\".\"a\" + \"Tb\".\"b\"") === nothing
+    @test _extract_leading_alias("SUM(\"Tb\".\"x\")") === nothing
+    @test _extract_leading_alias("COUNT(DISTINCT \"Tb\".\"x\")") === nothing
+    @test _extract_leading_alias("") === nothing
+
+    # Logic: non-string input (e.g. a Vector column for multi-arg functions) → nothing.
+    @test _extract_leading_alias(["a", "b"]) === nothing
+
+    # Logic: an identifier containing escaped (doubled) quotes is unescaped in the returned alias.
+    # Why: quote_identifier escapes embedded quotes as "" — extraction must reverse that faithfully.
+    @test _extract_leading_alias("\"we\"\"ird\".\"c\"") == "we\"ird"
+end


### PR DESCRIPTION
Closes #74.

## Problem

`COUNT`/`SUM`/`AVG` over a column that a **to-many** join (reverse FK / many-to-many) row-multiplies
returned a silently-inflated number. Verified on the F1 data: counting drivers while joined to
`driver_standings` reported **5980 vs 165** real distinct drivers (36×), with no error.

## Approach — detect & raise (fail-loud)

Chosen over auto-`DISTINCT` / auto-rewrite (the maintainer prefers explicit behavior over magic). The
guard stops the wrong numbers now; the principled fix (explicit correlated-subquery aggregates) is a
separate design discussion — **#92**.

- **Mark to-many joins** — reverse-FK and M2M join sites flag their (deduped) `row_join` entry with a
  `"to_many"` key (`build_joins.jl`). The many-side alias set is derived from `row_join` at check time,
  so a join built twice (`_cache_join` pre-build + real build) is counted **once** — this fixes a
  false-positive I caught where "count related rows + filter on the same relation" wrongly raised.
- **Capture aggregate source alias** — each `COUNT`/`SUM`/`AVG` records the alias of its column,
  extracted from the bare `"alias"."col"` *before* the Dialect wrap (`build_helpers.jl`,
  `_extract_leading_alias`).
- **Check at end of `build()`** (`_check_aggregate_fanout`, `build_query.jl`): raise unless the
  aggregate targets the **sole** to-many table's own column.

### Detection rule
With `n` = number of to-many joins, an aggregate over alias `A` raises when `n ≥ 1` **unless**
(`A` is the many-side **and** `n == 1`). Exemptions: **`MAX`/`MIN`** (immune to duplication),
**`distinct=true`** (explicit opt-in). A column it can't attribute to a single alias (nested aggregate
/ multi-column expression) **conservatively raises**.

### Preserved
The legitimate "count the related table's own rows" case (`Count("driver_standings__driverid")`) and
forward-FK (to-one) aggregates are unaffected.

## What users see
```
PormG fan-out guard (#74): the aggregate n is inflated because it aggregates a column from a table
that a to-many join row-multiplies.
  ... To-many table alias(es) in this query: Tb_1.
  Fix one of:
    1. Aggregate the RELATED table's own column instead (...).
    2. Pass distinct=true ...
    3. Compute the aggregate in a correlated subquery ...
```

## Tests
- **Unit**: `_extract_leading_alias` (`test/unit/test_aggregate_fanout.jl`, 10 cases) — registered in `test/runtests.jl`.
- **Integration**: `@testset "#74 Aggregate fan-out guard"` (8 cases: raise on base-col/COUNT(*); allow related-col, related-col+same-relation-filter, MAX, distinct opt-out, plain aggregate).
- **Verified green**: unit suite **2031/2031**; SQLite integration **1480/1480**; PostgreSQL `test_sql_functions.jl` (guard 8/8 on both backends). No regression in existing aggregate tests.

## Docs
"Aggregating Across To-Many Relations (Fan-Out Guard)" in `docs/src/read/filters_and_aggregates.md` (rule, three workarounds, exemptions; links #92). Docs build green.

## Scope / risk
Behavior-changing (some currently-silent-wrong queries now error) — intended and acceptable pre-publish.
No public API change. New `InstrucObject` fields are per-build (`@kwdef`, defaulted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
