### PR TITLE
fix(#82): preserve SQLite secondary indexes across table rebuild + scoped foreign_key_check gate

### DIFF
--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -447,6 +447,28 @@ function get_constraints_index(conn::PormGSQLite, table_name::Symbol, field_name
   return nothing
 end
 
+"""
+    get_secondary_index_ddls(conn::PormGSQLite, table_name) -> Vector{String}
+
+Return the `CREATE INDEX` DDL for every *user-created* secondary index on `table_name`, verbatim from
+`sqlite_master`. Auto-indexes backing column-level `UNIQUE` constraints have a NULL `sql` and are excluded —
+they are recreated automatically by the rebuilt `CREATE TABLE`. Used by the SQLite table-rebuild path to
+re-create the indexes that the rebuild's `DROP TABLE` would otherwise silently lose (#82).
+"""
+function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Symbol})::Vector{String}
+  tname = replace(string(table_name), "'" => "''")
+  rows = fetch(conn, "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '$(tname)' AND sql IS NOT NULL") |> DataFrame
+  isempty(rows) && return String[]
+  ddls = String[]
+  for s in rows.sql
+    s === missing && continue
+    stmt = strip(string(s))
+    isempty(stmt) && continue
+    push!(ddls, endswith(stmt, ";") ? stmt : stmt * ";")
+  end
+  return ddls
+end
+
 function get_constraints_pk(conn::PormGPostgres, table_name::Symbol, field_name::String )
   query = """
   SELECT

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -35,7 +35,22 @@ function _configure_order_dict_migration_plan(migration_plan::OrderedDict{Symbol
   else
     migration_plan[model_name][key] = value
   end
-end  
+end
+
+# #82: wrap a SQLite table-rebuild block so it re-creates the table's existing secondary indexes (the
+# rebuild's DROP TABLE drops them) and gates on `PRAGMA foreign_key_check(<table>)`. The CREATE INDEX DDL
+# is taken verbatim from sqlite_master, so names / uniqueness / partial clauses are preserved exactly.
+# No-op for PostgreSQL (real ALTER COLUMN, no rebuild) or an empty block — callers invoke it
+# unconditionally so every rebuild path (field alteration AND add-NOT-NULL-with-default) is covered the
+# same way. The check is SCOPED to the rebuilt table (not the whole DB) so an unrelated pre-existing orphan
+# elsewhere can't fail this migration; the rename preserves the table name + PKs, so children of this table
+# stay valid and need no check.
+function _sqlite_rebuild_preserving_indexes(conn, table_name::String, rebuild_sql::AbstractString)::String
+  (!(conn isa PormGSQLite) || isempty(rebuild_sql)) && return String(rebuild_sql)
+  idx_ddls = get_secondary_index_ddls(conn, table_name)
+  safe_tbl = replace(table_name, "\"" => "\"\"")
+  return join(String[String(rebuild_sql); idx_ddls; "PRAGMA foreign_key_check(\"$(safe_tbl)\");"], "\n")
+end
 
 function _drop_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, field_name::String, new_field::Union{PormGField, Nothing}, old_field::PormGField)::Nothing
   if hasfield(old_field |> typeof, :to) && old_field.db_constraint && (new_field === nothing || !hasfield(new_field |> typeof, :to) || !new_field.db_constraint)
@@ -174,7 +189,11 @@ function _add_new_field(conn::Union{PormGPostgres, PormGSQLite}, migration_plan:
     if conn isa PormGSQLite && haskey(migration_plan, model_name) && haskey(migration_plan[model_name], alter_key)
       delete!(migration_plan[model_name], alter_key)
     end
-    _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, Dialect.alter_field(conn, model, field_name, field, nothing, [:default]))
+    # #82: this add-NOT-NULL-with-default path also rebuilds the table on SQLite, so it must preserve the
+    # existing secondary indexes too (no-op on PostgreSQL).
+    _configure_order_dict_migration_plan(migration_plan, model_name, alter_key,
+      _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
+        Dialect.alter_field(conn, model, field_name, field, nothing, [:default])))
   end
   return nothing
 end
@@ -273,8 +292,11 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
         # table overwrite each other, producing exactly one recreation statement
         # instead of one per changed field.
         alter_key = conn isa PormGSQLite ? "Alter table: $model_name" : "Alter field: $field_name_stripped"
-        _configure_order_dict_migration_plan(migration_plan, model_name, alter_key,
-        Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal))
+        # #82: on SQLite this preserves the table's secondary indexes across the rebuild and gates on
+        # foreign_key_check (no-op on PostgreSQL). See _sqlite_rebuild_preserving_indexes.
+        alter_sql = _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
+          Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal))
+        _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, alter_sql)
 
         # Check if the field is a foreign key
         _add_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name_stripped, field, old_field, name)
@@ -282,9 +304,15 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
         # Check if the field is also indexed
         if !field.primary_key && field.db_index && !model.fields[original_db_key].db_index
           @pormg_debug false
-          index_name = "$(name)_idx"
-          _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name_stripped", 
-          Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$field_name_stripped\""]))
+          # #82: SQLite introspection can't see db_index, so this branch always fires for an indexed
+          # field; and the table rebuild (alter_field) already re-emits every existing index. Skip the
+          # redundant CREATE INDEX when one already exists in the live DB, or it would duplicate the
+          # rebuilt index (random suffix defeats IF NOT EXISTS). Genuinely-new indexes still get created.
+          if !(conn isa PormGSQLite && get_constraints_index(conn, model_name, field_name_stripped) !== nothing)
+            index_name = "$(name)_idx"
+            _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name_stripped",
+            Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$field_name_stripped\""]))
+          end
         end
 
         # Check if is need to remove the index

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -580,7 +580,19 @@ function _execute_statements_sqlite(connection::PormGSQLite, statements::Vector{
       trimmed = strip(part) |> string
       isempty(trimmed) && continue
       @debug "Executing: $trimmed"
-      with_transaction(connection, trimmed, conn=conn)
+      if occursin(r"^PRAGMA\s+foreign_key_check"i, trimmed)
+        # #82: gate emitted by the SQLite table-rebuild. foreign_key_check returns one row per orphaned
+        # FK reference; any rows mean the rebuild left dangling children, so abort — the surrounding
+        # catch rolls the whole migration back. (PRAGMA foreign_key_check works inside a transaction,
+        # unlike PRAGMA foreign_keys.)
+        result, _ = with_transaction(connection, trimmed, conn=conn)
+        violations = DataFrame(result)
+        if nrow(violations) > 0
+          error("Migration aborted: PRAGMA foreign_key_check found $(nrow(violations)) orphaned foreign-key row(s) after a SQLite table rebuild; rolling back.")
+        end
+      else
+        with_transaction(connection, trimmed, conn=conn)
+      end
     end
   end
 end

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1155,3 +1155,155 @@ end  # @testset "Migration Engine Edge Cases"
   @info "Selected integration DB rebuilt after edge-case migration tests" adapter=adapter_name db=PORMG_DB_FOLDER fallback=edge_db_reuses_selected_db[]
 end
 
+# ── SQLite table-rebuild: preserve secondary indexes + FK-integrity gate (#82) ──
+#
+# Logic: a SQLite field ALTER rebuilds the table (CREATE new → INSERT…SELECT → DROP old → RENAME).
+#        The DROP drops the table's secondary indexes; the fix re-emits their captured CREATE INDEX
+#        DDL after the rename, and a `PRAGMA foreign_key_check` gates the rebuild. After altering an
+#        UNRELATED field, the pre-existing db_index index must still exist, the UNIQUE constraint must
+#        still be enforced, and the seeded row must survive.
+# Why: before the fix the rebuild silently dropped every secondary index (lost uniqueness / slow
+#      queries surfacing much later) — issue #82. PostgreSQL uses real ALTER COLUMN (no rebuild), so
+#      this regression is SQLite-specific.
+if adapter_name == "SQLite"
+  @testset "SQLite rebuild preserves indexes + FK gate (#82)" begin
+    db82 = "db_test_migration_82"
+    db82_path = joinpath(@__DIR__, db82)
+    write82(content::String) = open(joinpath(db82_path, "models.jl"), "w") do f
+      write(f, "module models\nimport PormG.Models\n", content, "\nend")
+    end
+    # Only "_idx" CREATE INDEX entries are at risk; column-level UNIQUE auto-indexes
+    # (sqlite_autoindex_*) are recreated by the rebuilt CREATE TABLE, so isolate the user indexes.
+    user_idx(names) = sort([n for n in names if occursin("idx", lowercase(n))])
+
+    try
+      # ── setup: fresh isolated SQLite DB ──────────────────────────────────────
+      try; PormG.Configuration.close_pool!(db82_path); catch; end
+      try; ispath(db82_path) && rm(db82_path, recursive=true); catch; end
+      PormG.Generator.create_db_folder_and_yml(path=db82_path, adapter="SQLite")
+      yml = joinpath(db82_path, "connection.yml")
+      yml_content = replace(read(yml, String), "database: database.sqlite" => "database: migration_82.sqlite")
+      open(yml, "w") do f; write(f, yml_content); end   # read BEFORE opening "w" (which truncates)
+      PormG.Configuration.load(db82_path)
+      pool82 = PormG.Configuration.get_settings(db82_path).connections
+
+      # ── create: child carries a db_index + UNIQUE field, an FK to parent, and an unrelated field ──
+      write82("""
+      IndexParent82 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField()
+      )
+      IndexChild82 = Models.Model(
+          id = Models.IDField(),
+          code = Models.CharField(db_index=true, unique=true),
+          parent_id = Models.ForeignKey(IndexParent82, pk_field="id", on_delete="CASCADE"),
+          payload = Models.CharField(null=true)
+      )
+      """)
+      makemigrations(db82_path, interactive=false)
+      migrate(db82_path, interactive=false, destructive=true)
+
+      # baseline: the db_index secondary index exists, and seed a valid parent + child.
+      idx_before = user_idx(index_names(pool82, "indexchild82"))
+      @test !isempty(idx_before)
+      PormG.ConnectionPool.fetch(pool82, """INSERT INTO "indexparent82" ("name") VALUES ('p1')""")
+      PormG.ConnectionPool.fetch(pool82, """INSERT INTO "indexchild82" ("code", "parent_id", "payload") VALUES ('c1', 1, 'keep')""")
+
+      # ── alter an UNRELATED field (payload: null=true → NOT NULL) → forces the table rebuild ──
+      write82("""
+      IndexParent82 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField()
+      )
+      IndexChild82 = Models.Model(
+          id = Models.IDField(),
+          code = Models.CharField(db_index=true, unique=true),
+          parent_id = Models.ForeignKey(IndexParent82, pk_field="id", on_delete="CASCADE"),
+          payload = Models.CharField()
+      )
+      """)
+      makemigrations(db82_path, interactive=false)
+      migrate(db82_path, interactive=false, destructive=true)   # would throw if foreign_key_check found orphans
+
+      # (a) the user-created secondary index SURVIVED the rebuild (same name) — the core #82 fix.
+      @test user_idx(index_names(pool82, "indexchild82")) == idx_before
+
+      # (b) uniqueness is still enforced after the rebuild.
+      dup_err = try
+        PormG.ConnectionPool.fetch(pool82, """INSERT INTO "indexchild82" ("code", "parent_id", "payload") VALUES ('c1', 1, 'dup')""")
+        nothing
+      catch e; e; end
+      @test dup_err !== nothing
+      @test any(tok -> occursin(tok, lowercase(string(dup_err))), ["unique", "constraint"])
+
+      # (c) the seeded row survived the rebuild.
+      survivors = PormG.ConnectionPool.fetch(pool82,
+        """SELECT "code" FROM "indexchild82" WHERE "code" = 'c1'""") |> DataFrame
+      @test DataFrames.nrow(survivors) == 1
+
+      # (d) the alteration applied and the migration succeeded (so foreign_key_check passed, no orphans).
+      @test "payload" in column_names(pool82, "indexchild82")
+
+      # (e) the OTHER rebuild path — adding a NOT NULL field with no explicit default forces a
+      #     temp-default backfill + table recreation (planner `_add_new_field`). It must ALSO preserve
+      #     the indexes. (DateField is backfilled with a temp default, mirroring Phase 8f; a plain
+      #     CharField has no temp default and SQLite rejects the NOT NULL add, so it wouldn't rebuild.)
+      write82("""
+      IndexParent82 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField()
+      )
+      IndexChild82 = Models.Model(
+          id = Models.IDField(),
+          code = Models.CharField(db_index=true, unique=true),
+          parent_id = Models.ForeignKey(IndexParent82, pk_field="id", on_delete="CASCADE"),
+          payload = Models.CharField(),
+          added_on = Models.DateField()
+      )
+      """)
+      makemigrations(db82_path, interactive=false)
+      migrate(db82_path, interactive=false, destructive=true)
+      @test "added_on" in column_names(pool82, "indexchild82")
+      @test user_idx(index_names(pool82, "indexchild82")) == idx_before   # add-field rebuild kept the index
+
+      # (f) the FK-check GATE fires: enforcement is off by default, so we can plant an orphan row, and the
+      #     next rebuild's PRAGMA foreign_key_check must abort the migration (rollback) rather than commit.
+      PormG.ConnectionPool.fetch(pool82,
+        """INSERT INTO "indexchild82" ("code", "parent_id", "payload", "added_on") VALUES ('orphan', 999, 'x', '2024-01-01')""")
+      write82("""
+      IndexParent82 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField()
+      )
+      IndexChild82 = Models.Model(
+          id = Models.IDField(),
+          code = Models.CharField(db_index=true, unique=true),
+          parent_id = Models.ForeignKey(IndexParent82, pk_field="id", on_delete="CASCADE"),
+          payload = Models.CharField(null=true),
+          added_on = Models.DateField()
+      )
+      """)
+      makemigrations(db82_path, interactive=false)
+      gate_err = try
+        migrate(db82_path, interactive=false, destructive=true)
+        nothing
+      catch e; e; end
+      @test gate_err !== nothing
+      @test occursin("foreign_key_check", lowercase(string(gate_err))) ||
+            occursin("orphan", lowercase(string(gate_err)))
+      # rollback integrity: the aborted alter (payload NOT NULL → nullable) must NOT have applied, so a
+      # row omitting payload is still rejected by the surviving NOT NULL constraint.
+      rollback_err = try
+        PormG.ConnectionPool.fetch(pool82,
+          """INSERT INTO "indexchild82" ("code", "parent_id", "added_on") VALUES ('rollbackcheck', 1, '2024-01-01')""")
+        nothing
+      catch e; e; end
+      @test rollback_err !== nothing
+    finally
+      try; PormG.Configuration.close_pool!(db82_path); catch; end
+      try; delete!(PormG.config, db82_path); catch; end
+      try; ispath(db82_path) && rm(db82_path, recursive=true); catch; end
+    end
+  end
+end
+


### PR DESCRIPTION
Closes #82.

## Problem
SQLite has no general `ALTER COLUMN`, so PormG alters a field by **rebuilding the table** (CREATE new → `INSERT…SELECT` → DROP old → RENAME). Two data-safety defects:
1. the rebuild re-emitted only columns + FK clauses, so **every secondary index was silently dropped** (lost `db_index`, lost uniqueness, slow queries — surfacing much later);
2. the rebuild ran with FK enforcement off, so an orphan-introducing rebuild went undetected.

## Fix (SQLite-only; PostgreSQL uses real ALTER COLUMN and is untouched)
- **`introspection.jl`** — `get_secondary_index_ddls` captures each user-created index's exact `CREATE INDEX` DDL from `sqlite_master` (names/uniqueness/partial preserved verbatim). `UNIQUE` auto-indexes (`sql IS NULL`) are excluded — the rebuilt `CREATE TABLE` recreates those.
- **`planner.jl`** — a shared `_sqlite_rebuild_preserving_indexes` helper wraps **both** rebuild paths (field alteration *and* add-NOT-NULL-with-default) to re-emit the captured indexes after the rename and append a **`PRAGMA foreign_key_check("<table>")`** scoped to the rebuilt table. It also skips the redundant per-field `CREATE INDEX` when an index already exists in the live DB (SQLite introspection can't see `db_index`), which would otherwise duplicate the rebuilt index.
- **`runner.jl`** — `_execute_statements_sqlite` inspects the `foreign_key_check` result and aborts (rolls back) if it reports orphaned rows.

No global `PRAGMA foreign_keys=ON` (out of scope — broad runtime change; kept as a separate decision). The FK check is **scoped to the rebuilt table**, so an unrelated pre-existing orphan elsewhere can't fail an unrelated migration.

## Tests (`test_migration_bootstrap.jl`, SQLite-only, 11 assertions)
Index survives on **both** rebuild paths (exact name), uniqueness still enforced, seeded data survives, the FK gate **fires on a planted orphan**, and the aborted migration **rolls back** (a `NOT NULL → nullable` alter that was blocked did not apply). Each is a genuine mutation test — it fails if the corresponding fix is reverted.

## Verification
Unit **2031/2031** · SQLite integration **1500/1500** · PostgreSQL migration bootstrap clean (Preflight 8/8, Edge Cases 85/85; #82 testset is SQLite-gated). Two rounds of self-review applied (the planner had a second rebuild path and a global-vs-scoped FK-check issue, both addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)