### PR TITLE
fix(#98): consistent, actionable error for invalid filter operators

### DIFF
--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -106,6 +106,85 @@ function _check_function(x::FExpression)
   return x
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Invalid filter-operator diagnostics (#98)
+#
+# The scalar/function path (_check_function) already emits a rich "valid function
+# / valid operator" message. The vector, subquery, and tuple value paths used to
+# throw a terse message that neither listed the valid operators nor distinguished
+# a typo (unknown operator, e.g. @notin) from a known operator that simply is not
+# valid for that value shape (e.g. @gte with a vector). _raise_invalid_filter_operator
+# gives all three shapes one consistent, actionable error, with a nearest-match
+# "did you mean" suggestion for typos.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Iterative Levenshtein edit distance (two-row, O(min(m,n)) memory). Runs only when
+# building a typo suggestion, never on the happy path.
+function _levenshtein(a::AbstractString, b::AbstractString)::Int
+  av, bv = collect(a), collect(b)
+  m, n = length(av), length(bv)
+  m == 0 && return n
+  n == 0 && return m
+  prev = collect(0:n)
+  curr = Vector{Int}(undef, n + 1)
+  for i in 1:m
+    curr[1] = i
+    @inbounds for j in 1:n
+      cost = av[i] == bv[j] ? 0 : 1
+      curr[j + 1] = min(curr[j] + 1, prev[j + 1] + 1, prev[j] + cost)
+    end
+    prev, curr = curr, prev
+  end
+  return prev[n + 1]
+end
+
+# Nearest valid operator suffix to `suffix`, or nothing when nothing is close enough
+# to be a plausible typo (so garbage input does not get a nonsense suggestion).
+function _suggest_operator(suffix::AbstractString)::Union{Nothing,String}
+  best = nothing
+  best_d = typemax(Int)
+  for k in keys(PormGsuffix)
+    d = _levenshtein(suffix, k)
+    if d < best_d
+      best_d = d
+      best = k
+    end
+  end
+  # Suggest only when the edit is small relative to the typed length: keeps real
+  # near-misses (@notin→@nin, @containx→@contains) but rejects short garbage
+  # (@xy is 2 edits from @in — the whole word — so no suggestion).
+  return 2 * best_d <= length(suffix) ? best : nothing
+end
+
+# Consistent, actionable error for a filter operator that is not valid for the given
+# value shape. `field_path` is the split lookup (…, suffix); `shape` is a human word
+# ("vector", "subquery", "tuple"); `allowed` is the operator subset valid for that shape.
+function _raise_invalid_filter_operator(field_path::Vector{String}, shape::AbstractString, allowed::Vector{String})
+  all_opers = join(map(k -> "@" * k, sort!(collect(keys(PormGsuffix)))), ", ")
+  allowed_opers = join(map(a -> "@" * a, allowed), ", ")
+  if length(field_path) < 2
+    # No __@ suffix at all: a bare field was paired with a $shape value.
+    field = field_path[end]
+    examples = join(map(a -> "$(field)__@" * a, allowed), ", ")
+    throw(_argerr("Error in filter: field \e[31m$(field)\e[0m was given a $(shape) value but no operator.\n" *
+                  "With a $(shape) value, use one of: $(examples)"))
+  end
+  suffix = field_path[end]
+  if !haskey(PormGsuffix, suffix)
+    # Unknown operator — typo or nonexistent. List every valid operator and, when the
+    # input looks like a near-miss, suggest the intended one (e.g. @notin → @nin).
+    suggestion = _suggest_operator(suffix)
+    hint = suggestion === nothing ? "" : " Did you mean \e[32m@$(suggestion)\e[0m?"
+    throw(_argerr("Error in filter: \e[31m@$(suffix)\e[0m is not a valid operator.$(hint)\n" *
+                  "Valid operators: $(all_opers)\n" *
+                  "With a $(shape) value, use one of: $(allowed_opers)"))
+  else
+    # Known operator, but not valid for this value shape (e.g. @gte with a vector).
+    throw(_argerr("Error in filter: operator \e[31m@$(suffix)\e[0m is not valid with a $(shape) value.\n" *
+                  "With a $(shape) value, use one of: $(allowed_opers)"))
+  end
+end
+
 """
   _get_pair_to_oper(x::Pair)
 
@@ -137,7 +216,7 @@ function _get_pair_to_oper(x::Pair{Vector{String},T}) where T<:SQLObjectHandler
     # @pormg_debug
     return OperObject(operator=PormGsuffix[x.first[end]], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    throw(_argerr("Error in filter, Invalid operator for \e[31m$(x.first[end])\e[0m, only \e[32m'in and nin'\e[0m is allowed with a object"))
+    _raise_invalid_filter_operator(x.first, "subquery", ["in", "nin"])
   end
 end
 function _get_pair_to_oper(x::Pair{Vector{String},T}) where T<:SQLTypeF
@@ -161,18 +240,18 @@ function _get_pair_to_oper(x::Pair{Vector{String},Vector{T}}) where T<:Union{Mis
     return OperObject(operator=PormGsuffix[x.first[end]], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   elseif x.first[end] == "range"
     if length(x.second) != 2
-      throw(ArgumentError("Error in filter, 'range' operator requires exactly 2 values, got $(length(x.second))"))
+      throw(_argerr("Error in filter, 'range' operator requires exactly 2 values, got $(length(x.second))"))
     end
     return OperObject(operator=PormGsuffix[x.first[end]], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    throw(_argerr("Error in filter, Invalid operator for \e[31m$(x.first[end])\e[0m, only \e[32m'in, nin and range'\e[0m is allowed with a vector of values"))
+    _raise_invalid_filter_operator(x.first, "vector", ["in", "nin", "range"])
   end
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Tuple{T,T}}) where T
   if x.first[end] == "range"
     return OperObject(operator=PormGsuffix[x.first[end]], values=[x.second[1], x.second[2]], column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    throw(_argerr("Error in filter, Invalid operator for \e[31m$(x.first[end])\e[0m, only \e[32m'range'\e[0m is allowed with a tuple of values"))
+    _raise_invalid_filter_operator(x.first, "tuple", ["range"])
   end
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Date})

--- a/test/unit/test_operators.jl
+++ b/test/unit/test_operators.jl
@@ -17,6 +17,7 @@ using PormG
 using PormG.Models: Model, CharField, IDField, IntegerField, DateField, DateTimeField
 using PormG.QueryBuilder: Q
 using Dates
+import Logging
 
 # ---------------------------------------------------------------------------
 # Minimal test models — same shape as test_complex_queries.jl so both files
@@ -387,6 +388,98 @@ const _E = _OperTestEvent
     @test contains(sql_left_shl, "SELECT")
     @test contains(sql_left_shl, "(\$1::integer << \"Tb\".\"number\") as \"index_mask\"")
     @test res_left_shl[:parameters] == [1]
+  end
+
+  # =========================================================================
+  # Invalid operator diagnostics (#98)
+  # An unknown or shape-incompatible operator must give one consistent,
+  # actionable error across every value shape (scalar/vector/subquery/tuple):
+  # list the valid operators, suggest the nearest match for a typo (e.g.
+  # @notin → @nin), and clearly distinguish a typo from a *known* operator that
+  # simply is not valid for that value shape (e.g. @gte with a vector). Before
+  # this fix the vector/subquery/tuple paths threw a terse message with none of
+  # that, so a one-character typo like @notin was a latent runtime bug.
+  # =========================================================================
+  @testset "Invalid operator diagnostics (#98)" begin
+    # Run a filter that is expected to throw and return the exception, silencing
+    # the @error _check_filter logs on the way out (keeps test output clean).
+    grab(f) = try
+      Logging.with_logger(Logging.NullLogger()) do
+        f()
+      end
+      nothing
+    catch e
+      e
+    end
+
+    # --- vector value, UNKNOWN operator: the exact @notin → @nin typo from #98 ---
+    e_vec = grab(() -> _D.objects.filter("id__@notin" => [1, 2]))
+    @test e_vec isa ArgumentError
+    m_vec = e_vec.msg
+    @test occursin("is not a valid operator", m_vec)  # unknown-operator branch
+    @test occursin("Did you mean", m_vec)             # nearest-match suggestion offered
+    @test occursin("@nin", m_vec)                     # …and it is the intended operator
+    @test occursin("Valid operators", m_vec)          # full valid-operator list present
+    @test occursin("@gte", m_vec)                     # (spot-check an entry in that list)
+
+    # --- vector value, KNOWN but shape-incompatible operator (@gte with a vector) ---
+    e_known = grab(() -> _D.objects.filter("id__@gte" => [1, 2]))
+    @test e_known isa ArgumentError
+    m_known = e_known.msg
+    @test occursin("not valid with a vector value", m_known)  # distinct from the typo branch
+    @test !occursin("Did you mean", m_known)                  # no suggestion for a real operator
+    @test occursin("use one of", m_known)                     # still points to the valid subset
+    @test occursin("@in", m_known)
+
+    # --- tuple value, unknown operator: message names the shape and its valid op ---
+    e_tup = grab(() -> _D.objects.filter("id__@betwen" => (1, 2)))
+    @test e_tup isa ArgumentError
+    m_tup = e_tup.msg
+    @test occursin("is not a valid operator", m_tup)
+    @test occursin("tuple", m_tup)
+    @test occursin("@range", m_tup)   # the only tuple-valid operator
+
+    # --- subquery value, unknown operator: same treatment, shape = "subquery" ---
+    sub = _D.objects.values("id")
+    e_sub = grab(() -> _D.objects.filter("id__@notin" => sub))
+    @test e_sub isa ArgumentError
+    m_sub = e_sub.msg
+    @test occursin("is not a valid operator", m_sub)
+    @test occursin("@nin", m_sub)
+    @test occursin("subquery", m_sub)
+
+    # --- bare field + collection value, no __@ operator at all ---
+    # Reaches the length(field_path) < 2 branch: the message must name the field
+    # and show actionable examples, not treat the field name as a bogus operator.
+    e_bare = grab(() -> _D.objects.filter("id" => [1, 2]))
+    @test e_bare isa ArgumentError
+    m_bare = e_bare.msg
+    @test occursin("was given a vector value but no operator", m_bare)
+    @test occursin("id__@in", m_bare)   # actionable example uses the real field name
+
+    # --- short garbage suffix: unknown-operator error but NO nonsense suggestion ---
+    # @xy is exactly 2 edits from @in/@ne/@gt (the whole word), so the relative
+    # threshold must refuse a "did you mean"; the old floor-of-2 threshold would not.
+    e_garb = grab(() -> _D.objects.filter("id__@xy" => [1, 2]))
+    @test e_garb isa ArgumentError
+    @test occursin("is not a valid operator", e_garb.msg)
+    @test !occursin("Did you mean", e_garb.msg)
+
+    # --- @range with the wrong number of values: explicit, actionable arity error ---
+    # A valid operator on the right shape, but @range requires exactly 2 bounds; the
+    # error must state that (and the count) rather than a generic "invalid operator".
+    e_range = grab(() -> _D.objects.filter("id__@range" => [1, 2, 3]))
+    @test e_range isa ArgumentError
+    @test occursin("requires exactly 2 values", e_range.msg)
+    @test occursin("got 3", e_range.msg)
+
+    # --- no regression: the valid operator on each shape still builds fine ---
+    ok_in    = _D.objects.filter("id__@in" => [1, 2]).list(show_query=:dict)
+    @test ok_in isa Dict
+    @test occursin("ANY", ok_in[:sql_text])   # PostgreSQL renders IN as "= ANY($1)"
+    ok_range = _D.objects.filter("id__@range" => (1, 9)).list(show_query=:dict)
+    @test ok_range isa Dict
+    @test occursin("BETWEEN", ok_range[:sql_text])
   end
 
 end  # end "PormGsuffix — Operator SQL Generation"


### PR DESCRIPTION
Closes #98.

**Suggested merge order: 1 of 4** — fully isolated (`build_helpers.jl` + `test_operators.jl`), no overlap with the other PRs.

## What
The scalar/function filter path already produced a rich "valid operator" error, but the vector, subquery, and tuple value paths threw a terse message — no valid-op list, no distinction between a typo (`@notin`) and a known-but-shape-incompatible operator (`@gte` with a vector).

A shared `_raise_invalid_filter_operator` now gives all value-shape paths one consistent error:
- unknown operator → lists valid operators + nearest-match "did you mean" (small local Levenshtein, error-path only),
- known-but-incompatible → "not valid with a `<shape>` value" + the operators that are,
- bare field + collection (no `__@`) → names the field and shows examples.

Also aligns the `range` arity error with `_argerr`.

## Tests
`test/unit/test_operators.jl`: vector/subquery/tuple typo suggestions, known-but-wrong-shape, short-garbage (no nonsense suggestion), `range` arity, and no-regression on valid operators. Full unit suite green; SQLite integration green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)