### PR TITLE
fix(#97): OrderedDict-backed create()/update() column order (deterministic SQL)

### DIFF
--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -1,6 +1,6 @@
 module QueryBuilder
 
-import DataFrames, Tables, JSON, CSV
+import DataFrames, Tables, JSON, CSV, OrderedCollections
 using Dates, TimeZones, Intervals, Decimals, UUIDs
 
 import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -56,7 +56,8 @@ function up_values!(q::SQLObject, values)
 end
 
 function up_create!(q::SQLObject, values; kwargs...)
-  q.insert = Dict()
+  # OrderedDict so the rendered INSERT column list follows call order deterministically (#97)
+  q.insert = OrderedCollections.OrderedDict{String,Any}()
   for (k, v) in values
     q.insert[k] = v
   end
@@ -76,7 +77,8 @@ function up_update!(q::SQLObject, values; kwargs...)
       end
     end
   end
-  q.insert = Dict()
+  # OrderedDict so the rendered UPDATE SET list follows call order deterministically (#97)
+  q.insert = OrderedCollections.OrderedDict{String,Any}()
   for (k, v) in values
     q.insert[k] = v
   end

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -139,7 +139,7 @@ mutable struct SQLObjectQuery <: SQLObject
   connect_key::OptionalString # Override for multi-tenant scenarios
   values::Vector{Union{SQLTypeText,SQLTypeField}}
   filter::Vector{FilterType} # filters to be used in the query
-  insert::Dict{String,Any} # values to be used to create or insert
+  insert::OrderedCollections.OrderedDict{String,Any} # values to be used to create or insert (ordered so INSERT/UPDATE column lists follow call order — #97)
   limit::Integer
   offset::Integer
   order::Vector{SQLTypeOrder}
@@ -152,7 +152,7 @@ mutable struct SQLObjectQuery <: SQLObject
   custom_join::Dict{String,Any}
   parameters::Union{Nothing,AbstractPormGParam}
 
-  SQLObjectQuery(; model=nothing, connect_key=nothing, values=[], filter=[], insert=Dict(), limit=0, offset=0,
+  SQLObjectQuery(; model=nothing, connect_key=nothing, values=[], filter=[], insert=OrderedCollections.OrderedDict{String,Any}(), limit=0, offset=0,
     order=[], group=[], having=[], list_joins=[], row_join=[], distinct=false, ctes=Dict{String,CTEDict}(), custom_join=Dict{String,Any}(), parameters=nothing) = # Add ctes and custom_join to constructor
     new(model, connect_key, values, filter, insert, limit, offset, order, group, having, list_joins, row_join, distinct, ctes, custom_join, parameters) # Add ctes and custom_join to new
 end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1251,6 +1251,45 @@ end
     @test contains(insp[:sql_text], "INSERT INTO")
 end
 
+@testset "Alignment Verification - INSERT column order follows call order (#97)" begin
+    # The test above only checks parameter *membership* in the :select bucket, which
+    # passes for any permutation. #97 is specifically about determinism: because
+    # q.insert is now an OrderedDict, the emitted column list must follow the *call*
+    # order on the positional (SQLite `?`) backend too, not hash order. This is the
+    # property that lets create() be golden-tested as an exact string.
+    #
+    # Columns and their bound values are pushed in lockstep (execution.jl), so once
+    # the column order is pinned the params are pinned with it. We assert the column
+    # order directly, which is what a plain Dict would scramble.
+    call_order = ["statusid", "laps", "raceid", "points",
+                  "driverid", "positionorder", "constructorid", "positiontext", "grid"]
+
+    insp = M.Result.objects.create(
+        "statusid"      => 91,
+        "laps"          => 92,
+        "raceid"        => 93,
+        "points"        => 94,
+        "driverid"      => 95,
+        "positionorder" => 96,
+        "constructorid" => 97,
+        "positiontext"  => "98",
+        "grid"          => 99,
+        show_query=:inspection
+    )
+
+    sql = insp[:sql_text]
+    # Column list is the first parenthesised group: INSERT INTO "results" ( ... ) VALUES ...
+    lo = findfirst('(', sql)
+    hi = findnext(')', sql, lo)
+    colsec = sql[lo:hi]
+    col_order = [m.captures[1] for m in eachmatch(r"\"([^\"]+)\"", colsec)]
+
+    # Deterministic and equal to the call order — the exact behavior a plain Dict breaks.
+    @test col_order == call_order
+    # One positional marker per column, and no extras.
+    @test count(==('?'), sql) == length(call_order)
+end
+
 @testset "Alignment Verification - UPDATE with JOIN Alignment" begin
     # Test UPDATE with JOIN: parameters should be ordered: :update -> :join -> :where
     # Scenario: Update Result points to 25 for drivers from Brazil in 1990

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -571,6 +571,86 @@ PormG.config["default"] = MockSettings
   end
 
   # ───────────────────────────────────────────────────────────────────────────
+  # create()/update() column order follows call order (#97): q.insert is backed
+  # by an OrderedDict, so the rendered INSERT column list (and matching params)
+  # and the UPDATE SET list appear in the exact order fields were passed. With
+  # the previous plain-Dict backing these came out in hash order, so create()/
+  # update() could only be asserted structurally; now they are exact-string
+  # golden-testable, which is what the offline golden-SQL suites need.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "create()/update() column order follows call order" begin
+    # Pass fields in a deliberately non-alphabetical, non-model-declaration order.
+    # (DriverModel declares id, forename, surname, nationality — none of which
+    # matches the call order below.) id is the primary key and is auto-skipped,
+    # and every other passed field is non-null, so no auto-fill reordering occurs:
+    # the rendered order must be exactly nationality, surname, forename.
+
+    # --- create(): INSERT column list ---
+    create_sql = DriverModel.objects.create(
+      "nationality" => "Brazilian",
+      "surname"     => "Senna",
+      "forename"    => "Ayrton",
+      show_query = :sql
+    )
+    @test create_sql isa String
+    # Each column name appears exactly once (INSERT has no WHERE), so first-index
+    # ordering is a robust, whitespace/newline-agnostic check of column order.
+    pos_nat = findfirst("\"nationality\"", create_sql)
+    pos_sur = findfirst("\"surname\"", create_sql)
+    pos_for = findfirst("\"forename\"", create_sql)
+    @test pos_nat !== nothing && pos_sur !== nothing && pos_for !== nothing
+    @test pos_nat.start < pos_sur.start < pos_for.start
+
+    # The strongest check: bound params must line up with the call order, so a
+    # positional backend inserts each value into its intended column.
+    create_meta = DriverModel.objects.create(
+      "nationality" => "Brazilian",
+      "surname"     => "Senna",
+      "forename"    => "Ayrton",
+      show_query = :dict
+    )
+    @test create_meta[:operation] === :insert
+    @test create_meta[:parameters] == ["Brazilian", "Senna", "Ayrton"]
+
+    # --- update(): SET clause list (same OrderedDict backing) ---
+    # update() enforces a filter guard (no accidental update-all), so attach one.
+    # The filter is on `id`, which never collides with the SET column names below.
+    uq = DriverModel.objects
+    uq.filter("id" => 44)
+    update_sql = uq.update(
+      "nationality" => "British",
+      "surname"     => "Hamilton",
+      "forename"    => "Lewis",
+      show_query = :sql
+    )
+    @test update_sql isa String
+    u_nat = findfirst("\"nationality\"", update_sql)
+    u_sur = findfirst("\"surname\"", update_sql)
+    u_for = findfirst("\"forename\"", update_sql)
+    @test u_nat !== nothing && u_sur !== nothing && u_for !== nothing
+    @test u_nat.start < u_sur.start < u_for.start
+
+    uq2 = DriverModel.objects
+    uq2.filter("id" => 44)
+    update_meta = uq2.update(
+      "nationality" => "British",
+      "surname"     => "Hamilton",
+      "forename"    => "Lewis",
+      show_query = :dict
+    )
+    @test update_meta[:operation] === :update
+    # The WHERE param may flatten before or after the SET params depending on
+    # backend/bucketing, so assert the SET values keep their call order relative
+    # to each other rather than pinning absolute positions.
+    params = update_meta[:parameters]
+    i_br = findfirst(==("British"), params)
+    i_ha = findfirst(==("Hamilton"), params)
+    i_le = findfirst(==("Lewis"), params)
+    @test i_br !== nothing && i_ha !== nothing && i_le !== nothing
+    @test i_br < i_ha < i_le
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
   # Terminal-name cleanup (#42): `query.inspect()` is the only surviving inspection
   # terminal. The `query.inspect_query()` alias was removed, so the accessor must
   # fall through to getfield and error.


### PR DESCRIPTION
Closes #97.

**Suggested merge order: 2 of 4** — independent of #98. Touches core types + `object_manager.jl` (the `up_create!`/`up_update!` region) + `test_inspect_query.jl`.

## What
`q.insert` was a plain `Dict`, so INSERT column lists (and matching params) and UPDATE SET lists came out in hash order — non-deterministic, blocking exact-string golden tests. (Value↔column alignment was never at risk: columns and params are pushed in lockstep; the bug was purely order.)

Switches `SQLObjectQuery.insert` to `OrderedCollections.OrderedDict{String,Any}` so column order follows call order. `update()` shares the same backing and is fixed alongside `create()`.

## Tests
- `test_inspect_query.jl`: create()/update() render columns + bind params in exact call order (MockPostgres).
- `test_alignment_sqlite.jl`: same determinism on the positional SQLite `?` backend (the existing INSERT test only checked param *membership*).

Full unit suite green; PG **1526** + SQLite **1501** integration green.

## Note
Overlaps PR for #99 in one spot: both append a `@testset` to `test_inspect_query.jl` after the `count()/exists()` block. Whichever merges second gets one trivial conflict — resolution is "keep both testsets".

🤖 Generated with [Claude Code](https://claude.com/claude-code)