### PR TITLE
fix(#99): valid SQL for distinct counts + terminal count() column/distinct API

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -115,6 +115,14 @@ Focus on:
 - `execution.jl`
 - `deletion.jl`
 
+Gotcha — `do_count` (`execution.jl`): it clears `.values`/`.order` before rendering, so `count()` cannot reuse a `.values()` select. `COUNT(DISTINCT *)` is **invalid SQL on both PostgreSQL and SQLite**, so the count forms diverge:
+
+- `count()` → `COUNT(*)`.
+- query-level distinct (`.distinct().count()` / `count(distinct=true)`) → wrap `SELECT DISTINCT *` in an **outer `COUNT(*)` subquery** (so `count() == length(distinct list())`).
+- `count("col", distinct=true)` → flat, valid `COUNT(DISTINCT col)` by reusing the `Count()` aggregate (single column is legal; `*` is not).
+
+When changing count rendering, verify both dialects execute (not just that the SQL string looks right) — the bug this guards against was a syntax error that only surfaced at execution.
+
 ### Inspection tools
 
 Useful internal tools:

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -117,6 +117,20 @@ count = query.count()
 > [!NOTE]
 > `@icontains` uses `ILIKE` on PostgreSQL. On SQLite (which is case-insensitive for ASCII by default), it uses `LIKE`.
 
+### Prefix / Suffix (`@startswith`, `@endswith`)
+
+Case-sensitive anchored matches — `@startswith` renders `LIKE 'value%'` and `@endswith` renders `LIKE '%value'` (the wildcard is added on one side only):
+
+```julia
+# Surnames beginning with "Ver" (e.g. Verstappen)
+M.Driver.objects.filter("surname__@startswith" => "Ver")
+
+# Surnames ending in "sen" (e.g. Häkkinen → no; Raikkonen → no; Magnussen → yes)
+M.Driver.objects.filter("surname__@endswith" => "sen")
+```
+
+Both escape `%` and `_` in the bound value, so user input is matched literally.
+
 ### Accent-Insensitive (`@iunaccent_contains`, `@iunaccent_exact`)
 
 **PostgreSQL only.** These lookups match while ignoring both diacritics and case, so an ASCII query finds accented data:
@@ -369,6 +383,37 @@ using PormG: Qor
 query = M.Result.objects
 query.filter(Qor("constructorId" => 1, "constructorId" => 9))
 ```
+
+---
+
+## Counting
+
+`count()` is a terminal that returns a scalar `Int` for the current query (filters included). It has four forms:
+
+```julia
+# Total rows
+M.Driver.objects.count()                                 # SELECT COUNT(*)
+
+# Distinct rows — dedupes whole rows (wraps SELECT DISTINCT * in an outer COUNT(*))
+M.Driver.objects.distinct().count()                      # same as:
+M.Driver.objects.count(distinct=true)
+
+# Non-null values of one column
+M.Driver.objects.count("nationality")                    # SELECT COUNT("nationality")
+
+# Distinct values of one column (e.g. "how many nationalities are represented?")
+M.Driver.objects.count("nationality", distinct=true)     # SELECT COUNT(DISTINCT "nationality")
+```
+
+Filters apply to every form:
+
+```julia
+# How many distinct nationalities among drivers who have raced for constructor 1?
+M.Result.objects.filter("constructorid" => 1).count("driverid__nationality", distinct=true)
+```
+
+> [!NOTE]
+> `count("col", distinct=true)` is the scalar, single-query equivalent of the `Count("col", distinct=true)` aggregate used inside [`values()`](#aggregations-and-grouping) — reach for the terminal form when you just want the number, and the aggregate form when you want it grouped alongside other columns.
 
 ---
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -275,7 +275,24 @@ show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(q; show_query=mode)
 # Count or check if exists
 #
 
-function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
+function do_count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} = nothing, distinct::Bool = false,
+                  table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
+  # Column form: COUNT([DISTINCT] column). Reuse the Count() aggregate so column
+  # resolution, joins and dialect rendering are shared with values(Count(...)); we
+  # return the scalar rather than a row. COUNT(DISTINCT col) is valid SQL (unlike
+  # COUNT(DISTINCT *)), so no subquery is needed for this form.
+  if column !== nothing
+    cq = deepcopy(oq)
+    cq.object.order = []
+    cq.object.distinct = false      # DISTINCT belongs to COUNT(col), not the row set
+    cq.object.limit = 0
+    cq.object.offset = 0
+    up_values!(cq.object, Any["__pormg_count" => Count(String(column); distinct = distinct)])
+    show_query !== :execute && return query(cq; table_alias = table_alias, show_query = show_query)
+    rows = list(cq, Val(:dict))
+    return isempty(rows) ? 0 : Base.first(values(Base.first(rows)))
+  end
+
   # Resolve settings
   settings, connection, conn_key = get_settings(oq)
   
@@ -299,13 +316,26 @@ function do_count(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlia
   safe_table_name = safe_table_identifier(q.object.model.name, instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
   
-  resposta = """$(with_clause)SELECT
-      COUNT($(q.object.distinct ? "DISTINCT *" : "*"))
-    FROM $safe_table_name as $safe_alias
+  # Shared FROM / JOIN / WHERE / GROUP BY body for both count forms.
+  body = """FROM $safe_table_name as $safe_alias
     $(join(instruction.join, "\n"))
     $(instruction._where |> length > 0 ? "WHERE" : "") $(join(instruction._where, " AND \n   "))
     $(instruction.agregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "")
     """
+  if distinct || q.object.distinct
+    # COUNT(DISTINCT *) is invalid SQL in both PostgreSQL and SQLite. To count the rows a
+    # DISTINCT select would return, wrap `SELECT DISTINCT *` in an outer COUNT(*) so that
+    # count() == length(distinct list()). Any CTEs stay at the top level and remain in
+    # scope for the subquery; parameter order/count is unchanged by the wrapping.
+    resposta = """$(with_clause)SELECT COUNT(*) FROM (
+    SELECT DISTINCT *
+    $body) as "__pormg_distinct_count"
+    """
+  else
+    resposta = """$(with_clause)SELECT
+      COUNT(*)
+    $body"""
+  end
   # Inspection short-circuit: return SQL/metadata without hitting the database.
   if show_query !== :execute
     return _show_query_result(show_query, resposta, instruction.connection, q.object.model.name, :select;

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -245,7 +245,12 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     # Same dual execute/inspect return contract as :create — see the note above.
     return (args...; kwargs...) -> up_update!(q.object, args; kwargs...)
   elseif sym === :count
-    return (; show_query=:execute) -> do_count(q; show_query=show_query)
+    # count()                         -> COUNT(*)              (total rows)
+    # count(distinct=true)            -> distinct rows         (subquery COUNT(*) over SELECT DISTINCT *)
+    # count("col")                    -> COUNT("col")          (non-null values of a column)
+    # count("col", distinct=true)     -> COUNT(DISTINCT "col") (distinct values of a column, scalar)
+    return (column=nothing; distinct::Bool=false, show_query::Symbol=:execute) ->
+      do_count(q; column=column, distinct=distinct, show_query=show_query)
   elseif sym === :exists
     return (; show_query=:execute) -> do_exists(q; show_query=show_query)
   elseif sym === :first

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -422,6 +422,39 @@ end
     ), eachrow(df))
   end
 
+  @testset "distinct().count() executes and matches plain count" begin
+    # Regression: distinct().count() used to render COUNT(DISTINCT *), which is a
+    # syntax error in both PostgreSQL and SQLite — so this call would throw at
+    # execution. It must now run on a live DB. For a PK'd table every row is unique,
+    # so the distinct count must equal the plain count (cross-check, not just "it ran").
+    @test M.Driver.objects.distinct().count() == M.Driver.objects.count()
+
+    # Same with a WHERE filter: the bound parameter must survive the subquery wrapping.
+    @test M.Driver.objects.filter("nationality" => "British").distinct().count() ==
+          M.Driver.objects.filter("nationality" => "British").count()
+
+    # With a JOIN (FK-traversal filter): the inner `SELECT DISTINCT *` now spans
+    # multiple tables, which can surface duplicate column names in the subquery —
+    # engines differ, so exercise it live on both backends.
+    @test M.Result.objects.filter("driverid__surname" => "Senna").distinct().count() ==
+          M.Result.objects.filter("driverid__surname" => "Senna").count()
+  end
+
+  @testset "count(column, distinct=true) counts distinct column values" begin
+    # COUNT(DISTINCT col) as a scalar Int (the efficient flat form). Cross-check the
+    # value independently and prove dedup actually happens — nationality is non-null,
+    # so many drivers share one, making distinct strictly less than the total.
+    total = M.Driver.objects.count()
+    n_nat = M.Driver.objects.count("nationality", distinct=true)
+
+    nats = (M.Driver.objects.values("nationality") |> DataFrame).nationality
+    @test n_nat == length(unique(nats))   # exact value, computed independently
+    @test n_nat < total                   # dedup genuinely happened
+
+    # count("col") on a non-null column counts every row (no DISTINCT).
+    @test M.Driver.objects.count("nationality") == total
+  end
+
   @testset "Qor fallback branch with impossible id is a no-op" begin
     # Production code uses an impossible id branch as a safe fallback when an
     # input array may be empty. This test ensures that pattern keeps the real

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -651,6 +651,61 @@ PormG.config["default"] = MockSettings
   end
 
   # ───────────────────────────────────────────────────────────────────────────
+  # distinct().count() must render valid SQL. COUNT(DISTINCT *) is a syntax error
+  # in both PostgreSQL and SQLite, so count() on a distinct() query must instead
+  # wrap `SELECT DISTINCT *` in an outer COUNT(*) subquery.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "distinct().count() renders valid SQL (no COUNT(DISTINCT *))" begin
+    q = DriverModel.objects
+    q.filter("nationality" => "British")
+    q.distinct()
+
+    sql = q.count(show_query=:sql)
+    @test sql isa String
+    @test !occursin("COUNT(DISTINCT", sql)   # the invalid form must be gone
+    @test occursin("SELECT DISTINCT", sql)    # inner distinct row-select
+    @test occursin("COUNT(*)", sql)           # outer plain count over the subquery
+
+    # The WHERE parameter survives the subquery wrapping (bound exactly once).
+    meta = q.count(show_query=:dict)
+    @test meta[:parameters] == ["British"]
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Terminal count() column/distinct forms:
+  #   count("col")                -> COUNT("col")           (non-null values)
+  #   count("col", distinct=true) -> COUNT(DISTINCT "col")  (distinct values, scalar; flat, no subquery)
+  #   count(distinct=true)        -> distinct rows          (subquery, like .distinct().count())
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "count() column and distinct forms render valid SQL" begin
+    # count("col", distinct=true) is the efficient flat form — COUNT(DISTINCT col),
+    # not a subquery (COUNT(DISTINCT single_column) is valid SQL, unlike COUNT(DISTINCT *)).
+    sql_cd = DriverModel.objects.count("nationality", distinct=true, show_query=:sql)
+    @test occursin("COUNT(DISTINCT", sql_cd)
+    @test occursin("nationality", sql_cd)
+    @test !occursin("SELECT DISTINCT", sql_cd)      # flat, no subquery wrapping
+
+    # count("col") counts non-null values of the column (no DISTINCT).
+    sql_c = DriverModel.objects.count("nationality", show_query=:sql)
+    @test occursin("COUNT(", sql_c)
+    @test occursin("nationality", sql_c)
+    @test !occursin("DISTINCT", sql_c)
+
+    # count(distinct=true) with no column = distinct rows (subquery form).
+    qd = DriverModel.objects
+    qd.filter("nationality" => "British")
+    sql_dr = qd.count(distinct=true, show_query=:sql)
+    @test occursin("SELECT DISTINCT", sql_dr)
+    @test occursin("COUNT(*)", sql_dr)
+    @test !occursin("COUNT(DISTINCT", sql_dr)
+
+    # WHERE param preserved in the flat column-distinct form.
+    meta_cd = DriverModel.objects.filter("nationality" => "British").
+      count("nationality", distinct=true, show_query=:dict)
+    @test meta_cd[:parameters] == ["British"]
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
   # Terminal-name cleanup (#42): `query.inspect()` is the only surviving inspection
   # terminal. The `query.inspect_query()` alias was removed, so the accessor must
   # fall through to getfield and error.


### PR DESCRIPTION
Closes #99.

**Suggested merge order: 3 of 4** — rebase onto `main` *after* #97 merges (resolves the one expected `test_inspect_query.jl` conflict; keep both testsets).

## What
`distinct().count()` rendered `COUNT(DISTINCT *)` — invalid SQL on both backends, so it threw at execution.

`do_count` now:
- distinct rows (`.distinct().count()` / `count(distinct=true)`) → wrap `SELECT DISTINCT *` in an outer `COUNT(*)` subquery, so `count() == length(distinct list())`;
- adds a terminal column/distinct API symmetric with the `Count()` aggregate:
  - `count()` → `COUNT(*)`
  - `count("col")` → `COUNT("col")`
  - `count("col", distinct=true)` → `COUNT(DISTINCT "col")` (scalar; reuses the aggregate's fail-closed identifier path — no new injection surface).

## Tests + docs
Unit SQL-shape assertions + integration on PG & SQLite with a real dedup cross-check (`count("nationality", distinct=true) == length(unique(...))` and `< count()`). Docs: terminal `count()` forms + previously-undocumented `@startswith`/`@endswith` (examples verified live). Querybuilder skill: `do_count` gotcha note.

Validated: unit 2036, SQLite 1507, PG 1532.

## Note
Touches `docs/src/read/filters_and_aggregates.md` (new lowercase sections) — different region from the #100 sweep; clean merge expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)