### PR TITLE
fix(#81): make migrate() idempotent + guard mark_applied against fabricated checksums

### DIFF
--- a/docs/src/migrations/advanced.md
+++ b/docs/src/migrations/advanced.md
@@ -24,8 +24,15 @@ custom_entries = OrderedDict{String, String}(
 If a migration fails or requires manual intervention, you can use repair commands to update the history table without re-running SQL:
 
 ```julia
-# Mark a version as manually applied
-PormG.Migrations.mark_applied("db", "20260310120000", "manual_fix")
+# Mark a version as manually applied. Supply the migration's SQL (`sql_content`) so the
+# recorded checksum is computed from — and later verifiable against — the real statements.
+# Passing neither `sql_content` nor an explicit `checksum` is refused: a fabricated digest
+# could never be verified and would silently defeat integrity checks.
+PormG.Migrations.mark_applied("db", "20260310120000", "manual_fix";
+    sql_content = \"\"\"ALTER TABLE drivers ADD COLUMN nationality VARCHAR(255);\"\"\")
+
+# Already have the digest? Pass it explicitly instead of the SQL:
+# PormG.Migrations.mark_applied("db", "20260310120000", "manual_fix"; checksum = "…64-hex…")
 
 # Mark a version as failed
 PormG.Migrations.mark_failed("db", "20260310120000")

--- a/docs/src/migrations/stability.md
+++ b/docs/src/migrations/stability.md
@@ -102,10 +102,12 @@ compute_checksum(sql_content) == bytes2hex(sha256(Vector{UInt8}(sql_content)))
 ```
 
 The input is the migration's full SQL content — every statement in the plan concatenated in
-execution order. Records created without SQL (e.g. a migration registered after the fact with
-`mark_applied()`) use the manual fallback `sha256("manual:" * version * ":" * name)`. Both
-schemes are frozen at format version 1: re-hashing a committed v1 migration must reproduce its
-stored checksum exactly.
+execution order. `mark_applied()` therefore requires either the migration's `sql_content` (from
+which this checksum is computed) or an explicit `checksum`; it will **not** fabricate one, so that
+every recorded digest stays verifiable against real SQL. The legacy manual fallback
+`sha256("manual:" * version * ":" * name)` remains a frozen v1 primitive for reproducing digests of
+records created that way before the requirement was introduced. Both schemes are frozen at format
+version 1: re-hashing a committed v1 migration must reproduce its stored checksum exactly.
 
 ## Tracking table: `pormg_migrations`
 

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -97,6 +97,11 @@ function detect_destructive_actions(statements::Vector{String})::Vector{String}
   return filter(is_destructive, statements)
 end
 
+# Frozen format-v1 primitive (see test/unit/test_migration_format_v1.jl). Retained for format
+# stability, but no longer auto-invoked: `mark_applied` used to call this to *fabricate* a checksum
+# when the caller supplied neither `sql_content` nor `checksum`. A fabricated digest can never be
+# verified against the real migration, silently defeating drift detection (issue #81), so
+# `mark_applied` now refuses that path instead of fabricating.
 function _manual_checksum(version::String, name::String)::String
   return bytes2hex(sha256(Vector{UInt8}("manual:" * version * ":" * name)))
 end
@@ -192,6 +197,32 @@ function _get_applied_migrations(connection::Union{PormGPostgres, PormGSQLite})
   df = DataFrame(fetch(connection, sql))
   # Convert DataFrame rows to NamedTuples for uniform access
   return [NamedTuple(row) for row in eachrow(df)]
+end
+
+"""
+    _latest_applied_checksum(connection) -> Union{String, Nothing}
+
+Return the checksum of the most-recently-applied migration — the `status='applied'` record with
+the greatest `version` — or `nothing` when nothing has been applied yet.
+
+Idempotency guard for `migrate()` (issue #81). `migrate()` mints a fresh timestamp `version` on
+every run, so re-apply detection must key on migration **content** (the checksum), never the
+version. We deliberately compare against the *latest applied* record only, not the full history,
+so a legitimate drop-then-re-add — whose regenerated SQL is byte-identical to the original add —
+is still applied, while a stale `pending_migrations.jl` left behind by a post-commit archive
+failure is recognised as already-applied and skipped instead of being destructively re-run.
+"""
+function _latest_applied_checksum(connection::Union{PormGPostgres, PormGSQLite})::Union{String, Nothing}
+  records = _get_applied_migrations(connection)
+  latest = nothing
+  for r in records
+    # records come back ordered by version ASC, so the last applied row we see is the newest.
+    if r[:status] == "applied"
+      latest = r
+    end
+  end
+  latest === nothing && return nothing
+  return String(latest[:checksum])
 end
 
 """
@@ -802,10 +833,26 @@ end
 
 function _execute_migration_lifecycle(connection::PormGPostgres, settings::SQLConn,
                                       ordered_statements::Vector{String}, all_sql::String,
-                                      version::String, name::String, checksum::String, 
+                                      version::String, name::String, checksum::String,
                                       has_destructive::Bool)
   date_str = Dates.format(Dates.now(), "yyyy-mm-dd_HH-MM-SS")
-  
+
+  # Idempotency guard (issue #81). Runs inside the advisory lock, so the check-and-skip is
+  # serialized against any concurrent migrator. If the pending plan's checksum matches the latest
+  # applied migration, this is a re-run over a `pending_migrations.jl` that a previous apply
+  # COMMITted but then failed to archive — re-executing non-idempotent DDL (a plain ADD COLUMN /
+  # ADD CONSTRAINT / CREATE INDEX) would error and leave a spurious `failed` row. Skip the DDL and
+  # retry the archive so the stale pending file finally clears.
+  if _latest_applied_checksum(connection) == checksum
+    @info(_emsg("\e[32mMigration already applied (checksum match) — skipping re-apply.\e[0m"))
+    try
+      _archive_migration_files(settings, date_str)
+    catch e
+      @error "Error archiving already-applied migration files" exception=e
+    end
+    return nothing
+  end
+
   # Begin transaction
   result, conn = with_transaction(connection, "BEGIN;")
   
@@ -848,9 +895,23 @@ end
 
 function _execute_migration_lifecycle(connection::PormGSQLite, settings::SQLConn,
                                       ordered_statements::Vector{String}, all_sql::String,
-                                      version::String, name::String, checksum::String, 
+                                      version::String, name::String, checksum::String,
                                       has_destructive::Bool)
   date_str = Dates.format(Dates.now(), "yyyy-mm-dd_HH-MM-SS")
+
+  # Idempotency guard (issue #81) — see the PostgreSQL lifecycle for the full rationale. If the
+  # pending plan's checksum matches the latest applied migration, this is a re-run over a
+  # `pending_migrations.jl` a previous apply COMMITted but failed to archive; re-executing
+  # non-idempotent DDL would error. Skip and retry the archive so the stale pending file clears.
+  if _latest_applied_checksum(connection) == checksum
+    @info(_emsg("\e[32mMigration already applied (checksum match) — skipping re-apply.\e[0m"))
+    try
+      _archive_migration_files(settings, date_str)
+    catch e
+      @error "Error archiving already-applied migration files" exception=e
+    end
+    return nothing
+  end
 
   # Serialize the whole BEGIN..COMMIT against any concurrent SQLite writer, like
   # run_in_transaction/delete(). Migrations normally run sequentially at startup,
@@ -946,23 +1007,47 @@ end
 # ==============================================================================
 
 """
+    _resolve_mark_checksum(checksum, sql_content) -> String
+
+Resolve the checksum `mark_applied` will record, or throw if the caller gave nothing to base it on.
+
+Guardrail for issue #81: a manually-reconciled migration must carry a *verifiable* checksum. When
+the caller supplies `sql_content` we hash it; when they supply an explicit `checksum` we trust it;
+when they supply neither we refuse rather than fabricate one, because a made-up digest can never be
+verified against the real migration and would silently defeat drift detection. Pure/DB-free so it
+can be unit-tested directly.
+"""
+function _resolve_mark_checksum(checksum::String, sql_content::String)::String
+  if isempty(checksum) && isempty(sql_content)
+    throw(ArgumentError(
+      "mark_applied requires the migration's `sql_content` (preferred — the checksum is then " *
+      "computed from, and verifiable against, the real SQL) or an explicit `checksum`. Refusing " *
+      "to fabricate one: a made-up checksum can never be verified and silently defeats drift " *
+      "detection (issue #81)."))
+  end
+  return isempty(checksum) ? compute_checksum(sql_content) : checksum
+end
+
+"""
     mark_applied(connection, settings, version, name; checksum, sql_content)
 
 Manually mark a migration version as applied in the history table.
 Useful for reconciliation after manual intervention or interrupted migrations.
+
+Requires either `sql_content` (preferred) or an explicit `checksum` so the recorded digest is
+verifiable — passing neither is refused rather than fabricated (issue #81). Destructiveness is
+classified from `sql_content` when provided instead of being hard-coded, so a manually-reconciled
+destructive migration is still flagged in history.
 """
 function mark_applied(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn,
-                      version::String, name::String; 
+                      version::String, name::String;
                       checksum::String = "", sql_content::String = "")
+  # Validate arguments before touching the DB so a bad call is a pure ArgumentError.
+  checksum = _resolve_mark_checksum(checksum, sql_content)
   init_migrations(connection)
-  
-  if isempty(checksum) && !isempty(sql_content)
-    checksum = compute_checksum(sql_content)
-  elseif isempty(checksum)
-    checksum = _manual_checksum(version, name)
-  end
-  
-  _record_migration(connection, version, name, checksum, sql_content, "applied", false)
+
+  destr = !isempty(sql_content) && is_destructive(sql_content)
+  _record_migration(connection, version, name, checksum, sql_content, "applied", destr)
   @info("Marked version $version as applied.")
 end
 

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -129,7 +129,9 @@ end
   @test legacy[1, :format_version] == 1
 
   # A migration recorded AFTER the upgrade is stamped with the current format version.
-  Migrations.mark_applied(conn, settings, "20250101000001000", "after_upgrade")
+  # mark_applied requires a verifiable checksum basis (issue #81), so pass sql_content.
+  Migrations.mark_applied(conn, settings, "20250101000001000", "after_upgrade";
+                          sql_content = "-- post-upgrade reconciliation (format-version backfill test)")
   fresh = DataFrame(PormG.ConnectionPool.fetch(conn,
     """SELECT "format_version" FROM pormg_migrations WHERE "version" = '20250101000001000';"""))
   @test fresh[1, :format_version] == Migrations.MIGRATION_FORMAT_VERSION
@@ -921,7 +923,10 @@ end
     pool_in_use(p) = length(p.connections) - count(p.available)
     in_use_before = pool_in_use(pool)
 
-    Migrations.mark_applied(pool, edge_settings, "99990101000001", "manual_test_migration")
+    # mark_applied now requires a verifiable checksum basis (issue #81): pass sql_content so the
+    # recorded digest is computed from real SQL rather than fabricated.
+    Migrations.mark_applied(pool, edge_settings, "99990101000001", "manual_test_migration";
+                            sql_content = "-- manual reconciliation (Phase 13 repair test)")
     st = Migrations.status(pool, edge_settings)
     @test "99990101000001" in [m[:version] for m in st.applied]
 
@@ -1109,6 +1114,77 @@ end
     isfile(pending) && rm(pending)
     makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
     @test !isfile(pending)
+  end
+
+  # ── Phase 16: idempotent re-apply / archive-failure landmine (#81) ─
+  # Acceptance criteria 1 & 3: re-running migrate() over a pending_migrations.jl that a previous
+  # apply COMMITted but then failed to archive must be a NO-OP, not a destructive re-apply.
+  #
+  # We reproduce the landmine deterministically. A CREATE TABLE is emitted with IF NOT EXISTS and
+  # would survive a re-run harmlessly, so instead we apply an ADD COLUMN migration (a plain
+  # `ALTER TABLE … ADD COLUMN`, which is NOT idempotent), then hand the engine back the exact
+  # pending file a failed archive would have left and call migrate() again:
+  #   • Pre-fix: the second run re-executes ADD COLUMN, errors on the duplicate column, records a
+  #     spurious `failed` row, and rethrows.
+  #   • Post-fix: the checksum guard recognises the content as already-applied, skips the DDL, and
+  #     retries the archive so the stale pending file finally clears.
+  @testset "Phase 16: Idempotent re-apply (#81)" begin
+    pending_path = joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl")
+
+    # Step 1 — an isolated table to mutate. Replacing the model set drops the Phase-15 tables
+    # (DROP TABLE … CASCADE on PostgreSQL), hence destructive=true.
+    write_edge_models("""
+    Reapply81 = Models.Model(
+        id = Models.IDField(),
+        alpha = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+    @test table_exists(pool, "reapply81")
+    @test !("beta" in column_names(pool, "reapply81"))
+
+    # Step 2 — add a column: the non-idempotent ADD COLUMN whose re-apply would error.
+    write_edge_models("""
+    Reapply81 = Models.Model(
+        id = Models.IDField(),
+        alpha = Models.CharField(null=true),
+        beta = Models.IntegerField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test isfile(pending_path)
+    # Capture the exact pending file that a failed post-commit archive would leave behind.
+    stashed_pending = read(pending_path, String)
+
+    applied_before = length(Migrations.status(pool, edge_settings).applied)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test "beta" in column_names(pool, "reapply81")   # applied
+    @test !isfile(pending_path)                        # archived on success
+
+    st_after = Migrations.status(pool, edge_settings)
+    applied_after = length(st_after.applied)
+    failed_after  = length(st_after.failed)
+    @test applied_after == applied_before + 1          # exactly one new record
+
+    # Step 3 — SIMULATE the archive-failure landmine: restore the stale pending file and re-run.
+    write(pending_path, stashed_pending)
+    @test isfile(pending_path)
+
+    # The re-run must NOT throw. Pre-fix the duplicate ADD COLUMN raises → reapplied_ok = false.
+    reapplied_ok = try
+      migrate(joinpath(@__DIR__, edge_db_name), interactive=false)
+      true
+    catch
+      false
+    end
+    @test reapplied_ok
+
+    st_reapply = Migrations.status(pool, edge_settings)
+    @test "beta" in column_names(pool, "reapply81")            # schema unchanged
+    @test length(st_reapply.applied) == applied_after          # no new applied record
+    @test length(st_reapply.failed) == failed_after            # no spurious 'failed' row (pre-fix bug)
+    @test !isfile(pending_path)                                # archive retry cleared the stale file
   end
 
   # ── Cleanup ─────────────────────────────────────────────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "Discard Pending Migration" include("unit/test_discard_pending_migration.jl")
     @testset "Positive Integer Fields CHECK" include("unit/test_positive_small_integer_check.jl")
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
+    @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")

--- a/test/unit/test_migration_format_v1.jl
+++ b/test/unit/test_migration_format_v1.jl
@@ -44,7 +44,9 @@ const _MANUAL_DIGEST    = "ee7ee5c8ede0b94b23ff384d1f9b2e2f9ac9d87c3be23647d032a
         @test Migrations.compute_checksum(known_sql) == _KNOWN_SQL_DIGEST
         @test length(Migrations.compute_checksum(known_sql)) == 64  # SHA-256 hex
 
-        # Manual fallback used by mark_applied() when no SQL is supplied.
+        # Frozen format-v1 primitive. `mark_applied` no longer auto-invokes it (it now refuses to
+        # fabricate a checksum — issue #81), but the digest algorithm stays pinned for format
+        # stability so any historically manual-checksummed record remains reproducible.
         @test Migrations._manual_checksum("20260101120000000", "freeze_format_v1") == _MANUAL_DIGEST
     end
 

--- a/test/unit/test_migrations_runner.jl
+++ b/test/unit/test_migrations_runner.jl
@@ -13,7 +13,6 @@ using PormG.Models
 using PormG.Migrations
 using OrderedCollections
 using Dates
-using SQLite
 
 # ==============================================================================
 # SECTION 1: Checksum and Version Generation
@@ -287,6 +286,45 @@ using SQLite
         checksum = Migrations._manual_checksum("20260311112233444", "manual_fix")
         @test length(checksum) == 64
         @test all(c -> isdigit(c) || c in ['a','b','c','d','e','f'], checksum)
+    end
+
+    # ==============================================================================
+    # SECTION 6b: mark_applied checksum guardrail (#81)
+    #
+    # mark_applied must never fabricate a checksum. A manually-reconciled migration
+    # has to carry a *verifiable* digest, so the caller must supply either the real
+    # `sql_content` (from which the checksum is computed) or an explicit `checksum`.
+    # Supplying neither is refused with an ArgumentError — a made-up digest can never
+    # be verified and silently defeats drift detection. _resolve_mark_checksum is the
+    # pure, DB-free core of that guardrail, so we can exercise it without a connection.
+    # ==============================================================================
+
+    @testset "mark_applied Checksum Guardrail" begin
+        # Neither sql_content nor checksum → refuse (do NOT fabricate).
+        @test_throws ArgumentError Migrations._resolve_mark_checksum("", "")
+
+        # The refusal message must point the caller at the fix (supply sql_content).
+        err = try
+            Migrations._resolve_mark_checksum("", "")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("sql_content", err.msg)
+
+        # sql_content supplied, no explicit checksum → checksum is COMPUTED from the SQL
+        # and equals compute_checksum of the same content (verifiable, not fabricated).
+        sql = """ALTER TABLE "drivers" ADD COLUMN "points" INTEGER;"""
+        resolved = Migrations._resolve_mark_checksum("", sql)
+        @test resolved == Migrations.compute_checksum(sql)
+        @test length(resolved) == 64
+
+        # Explicit checksum supplied → trusted and returned unchanged, even with no SQL.
+        @test Migrations._resolve_mark_checksum("deadbeef", "") == "deadbeef"
+
+        # When both are supplied the explicit checksum wins (caller's stated intent).
+        @test Migrations._resolve_mark_checksum("deadbeef", sql) == "deadbeef"
     end
 
     @testset "SQLite Statement Splitting" begin


### PR DESCRIPTION
## Summary

Closes #81 (core idempotency scope).

`migrate()` minted a fresh timestamp `version` and executed on every run **without consulting the applied history**. So a `pending_migrations.jl` left behind by a post-commit archive failure — or picked up by a second concurrent migrator — was destructively **re-applied**. Non-idempotent DDL (`ALTER TABLE … ADD COLUMN`, `ADD CONSTRAINT`, `CREATE INDEX`) then errored and recorded a spurious `failed` row.

## What changed

- **Idempotency guard** — new `_latest_applied_checksum` + a guard at the top of both `_execute_migration_lifecycle` methods (inside the PostgreSQL advisory lock / SQLite write lock). If the pending plan's checksum matches the **latest applied** migration, `migrate()` skips the DDL and retries the archive so the stale pending file clears. Keying on latest-applied-only preserves a legitimate drop-then-re-add (whose regenerated SQL is byte-identical to the original add). As a bonus this also closes a latent concurrent double-apply race.
- **`mark_applied` guardrail** — new pure `_resolve_mark_checksum` **refuses** (`ArgumentError`) when given neither `sql_content` nor an explicit `checksum` instead of fabricating one, and classifies destructiveness from the real SQL. `_manual_checksum` is retained (frozen format-v1 primitive) but no longer called.
- **Tests** — wired the previously-orphaned `test/unit/test_migrations_runner.jl` into `runtests.jl` (it never ran) and added a `mark_applied` guardrail testset; added **integration Phase 16** reproducing the archive-failure landmine end-to-end.
- **Docs** — synced `advanced.md` / `stability.md` to the new `mark_applied` contract (the old `mark_applied(...)` example would now throw).

## Acceptance criteria

- [x] Re-running `migrate()` after a successful apply (stale pending file present) is a no-op, not a re-apply.
- [ ] Edited already-applied migration file is detected — **intentionally out of scope** (see below).
- [x] Archive failure does not leave a committed migration eligible for re-application.
- [x] Regression tests: double `migrate()` idempotent + simulated archive failure (Phase 16), plus the `mark_applied` guardrail.

### Why criterion 2 is dropped

PormG's `makemigrations` diffs **live-DB introspection against the models file** and never replays archived migration files (verified in `planner.jl`). Unlike Django, migration files are **not** the source of truth — `applied_migrations/*.jl` and the stored `sql_content`/`checksum` are inert audit artifacts. Editing one has no effect on any future migration, so file-checksum drift detection would guard an audit trail, not correctness. The meaningful drift (live DB vs models) is already surfaced by `makemigrations` re-planning and `status()`.

## Verification

- Unit: **2185 pass** (up from 2081 — the newly-wired runner tests now run).
- Integration: green on **PostgreSQL** (`db_2`) and **SQLite** (`db_sl`) — full bootstrap suite incl. Phase 16; the guard's skip-log observed on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
