### PR TITLE
docs(migrations): document the state-based model (not Django-graph)

### DIFF
--- a/.github/skills/pormg-migrations-development/SKILL.md
+++ b/.github/skills/pormg-migrations-development/SKILL.md
@@ -25,6 +25,7 @@ This skill is for the migration subsystem itself, not for ordinary ORM query beh
 
 - Treat `Generator.create_db_folder_and_yml()` as the expected bootstrap path for creating `db/connection.yml` before migration workflows touch project config
 - PormG uses a state-based migration engine that reconciles current Julia model state against the live database schema via introspection
+- **State-based, not Django-graph — do not port Django assumptions.** `makemigrations` computes `diff(live-DB introspection, models file)` and **never reads previous migration files**; there is no dependency graph or replay. `pending_migrations.jl` and `applied_migrations/` are **inert audit artifacts**, not a source of truth — editing an applied file changes nothing downstream. "Drift" that matters is live-schema-vs-models (surfaced by the next `makemigrations` and `status()`), not migration-file checksum divergence. Concept doc: `docs/src/migrations/index.md` → *What this means in practice*.
 - Keep docs, tests, and CLI guidance explicit about unsupported or partial behavior rather than implying Django-style completeness
 
 ## Core Rules
@@ -127,6 +128,7 @@ julia --project=. docs/make.jl
 ## Anti-Patterns
 
 - Do not treat filesystem archives as the only migration truth
+- Do not assume a Django-style migration graph: no ordered dependencies, no file replay, and migration files are audit artifacts (see *Bootstrap and system model*)
 - Do not silently allow destructive SQL
 - Do not broaden docs ahead of implementation
 - Do not test unsupported migration targeting as if it were complete

--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -19,6 +19,18 @@ PormG follows a **State-Based** migration philosophy (similar to modern tools li
 3. **Diffing**: It calculates the exact "delta" required to move the database to the target state defined in your code.
 4. **Generation**: It produces a standalone Julia script (`pending_migrations.jl`) containing the DDL commands.
 
+### What this means in practice
+
+Because every plan is a fresh diff between your models and the **live database**, PormG migrations behave differently from Django's migration graph — and the differences are deliberate:
+
+- **`makemigrations` never reads previous migration files.** Each run compares your models against the live schema *only*; there is no dependency graph and no replay of earlier migrations to reconstruct state. Migration *order* does not accumulate — the database itself is the accumulated state.
+- **Migration files are an audit trail, not the source of truth.** `pending_migrations.jl` and everything under `applied_migrations/` record *what was done*; they are never re-read to plan or apply anything. Editing an already-applied file has **no effect** on future migrations — don't do it, it only desyncs the archive from the authoritative `pormg_migrations` table.
+- **You can regenerate freely.** A pending draft you dislike can be dropped with `discard_pending_migration("db")` and re-generated from scratch; there is no graph to keep consistent.
+- **"Drift" means the live schema diverging from your models** — an out-of-band `ALTER`/`DROP`, say — not an edited migration file. It is surfaced the normal way: the next `makemigrations` plans to reconcile it, and [`status()`](workflow.md) reports drift signals. Verifying old migration-file checksums buys you nothing here.
+
+!!! tip "Coming from Django?"
+    There is no migration graph, no `dependencies` list, and no per-file state replay. Read each `makemigrations` as `diff(your models, the live database)` — closer to Prisma / Atlas / Flyway's declarative diffing than to Django's ordered migration chain.
+
 ---
 
 ## Terminology Mapping


### PR DESCRIPTION
## Summary

Documents PormG's **state-based** migration model explicitly, so the Django mental model isn't accidentally imported. Follow-up to #105 (discussion there established that PormG's `makemigrations` diffs live-DB introspection against the models file and never replays migration files).

## Why

The docs already described "State-Based Reconciliation," but never spelled out the *consequences* — which was enough of a gap that a Django-style follow-up (checksum drift detection of edited applied-migration files) was proposed before we recognized it doesn't fit PormG's architecture. Verified in `src/migrations/planner.jl`: `makemigrations` computes `get_migration_plan(convert_schema_to_models(connection), _load_current_models(path), …)` with no reference to prior migration files, `applied_migrations/`, or the history table.

## Changes

- **`docs/src/migrations/index.md`** — new *"What this means in practice"* subsection under State-Based Reconciliation:
  - `makemigrations` never reads previous migration files (no graph, no replay).
  - Migration files are an audit trail, not the source of truth — editing an applied file is inert.
  - You can regenerate freely (`discard_pending_migration`).
  - "Drift" = live-schema-vs-models, surfaced by the next `makemigrations` and `status()` — not migration-file checksums.
  - A "Coming from Django?" tip.
- **`.github/skills/pormg-migrations-development/SKILL.md`** — one sharp "state-based, not Django-graph" guardrail bullet (pointing at the docs section) + an Anti-Patterns entry. The concept stays single-sourced in the docs.

## Scope

Docs + agent-instruction only; no code paths touched. Every claim is true of `main` today (independent of #105's runtime behavior), and deliberately avoids `stability.md`/`advanced.md` (which #105 changed) so there is no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
