### PR TITLE
fix(#108): guard getproperty M2M branch — absent-property access on a field object errors cleanly

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,6 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 - [#70](https://github.com/PingoLee/PormG.jl/issues/70) — `Model_to_str` silently drops a field when rendering throws (swallowed catch)
 - [#73](https://github.com/PingoLee/PormG.jl/issues/73) — `bulk_update` parameters snapshot/restore leaves partial state on mid-chunk failure
 - [#80](https://github.com/PingoLee/PormG.jl/issues/80) — Dead identifier-whitelist helpers + skill-doc claims a contract the code doesn't exercise (`documentation`)
-- [#108](https://github.com/PingoLee/PormG.jl/issues/108) — `getproperty` on a field object (`PormGField`) with an absent property infinitely recurses → `StackOverflowError`
 
 ## 🧮 SQL correctness & dialect alignment
 

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -282,7 +282,13 @@ function Base.getproperty(m::PormGModel, sym::Symbol)
     # M2M accessor names are validated through format_fild_name which rejects reserved
     # names, so a user-defined M2M field cannot shadow a Model_Type struct field.
     return getfield(m, sym)
-  elseif Models.has_many_to_many_accessor(m, String(sym))
+  elseif hasfield(typeof(m), :cache) && hasfield(typeof(m), :related_objects) &&
+         Models.has_many_to_many_accessor(m, String(sym))
+    # Guard the M2M branch on the `cache`/`related_objects` struct fields it reads. Only Model_Type
+    # has them; PormGField subtypes are also <: PormGModel but do NOT, so without this guard
+    # has_many_to_many_accessor would re-enter getproperty on a field's absent `.cache` and recurse
+    # forever — a StackOverflowError on ANY absent-property access to a field object (issue #108).
+    # Fields fall through to the plain getfield below, which raises a clean FieldError.
     Models.ensure_model_initialized(m)
     return ManyToManyDescriptor(m, String(sym), Models.get_many_to_many_relation(m, String(sym)))
   else

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -217,3 +217,43 @@ end
   @test desc_rev isa PormG.QueryBuilder.ManyToManyDescriptor
   @test desc_rev.accessor == "championships"
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression (#108): the getproperty override dispatches M2M accessors by calling
+# has_many_to_many_accessor(m, …), which reads m.cache / m.related_objects. Those are
+# Model_Type struct fields — but PormGField subtypes are ALSO <: PormGModel and do NOT
+# have them, so for a FIELD object the M2M branch used to re-enter getproperty on the
+# absent `.cache` and recurse forever: a StackOverflowError on ANY absent-property access
+# to a field object. The fix guards the M2M branch on `hasfield(…, :cache/:related_objects)`,
+# so field objects fall through to a clean getfield/FieldError.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PormGModel.getproperty: absent property on a field object doesn't recurse (#108)" begin
+  # A field object (PormGField <: PormGModel) that lacks cache/related_objects.
+  cf = Models.CharField(max_length = 5)
+
+  # Real attribute access still works — the guard must not disturb normal field reads.
+  @test cf.max_length == 5
+
+  # Absent property on a FIELD object must raise a clean FieldError. Pre-fix this recursed
+  # through the M2M branch and blew the stack (StackOverflowError, not FieldError).
+  field_err = try
+    getproperty(cf, :nonexistent_xyz)
+    nothing
+  catch e
+    e
+  end
+  @test field_err isa FieldError   # the #108 regression signal (was StackOverflowError)
+
+  # Model_Type still raises a clean FieldError on an absent property too (it HAS
+  # cache/related_objects, so it was never affected — assert it to pin the guard's discrimination).
+  model_err = try
+    getproperty(M2M.Driver_championship, :nonexistent_xyz)
+    nothing
+  catch e
+    e
+  end
+  @test model_err isa FieldError
+
+  # Positive control: the guard did NOT break real M2M accessor dispatch.
+  @test M2M.Driver_championship.drivers isa PormG.QueryBuilder.ManyToManyDescriptor
+end


### PR DESCRIPTION
## Summary

Closes #108.

`Base.getproperty(m::PormGModel, sym)` (`src/querybuilder/object_manager.jl`) dispatches many-to-many accessors via `has_many_to_many_accessor(m, …)`, which reads `m.cache` / `m.related_objects`. Those are `Model_Type` struct fields — but field structs (`s*Field <: PormGField <: PormGModel`) don't have them, so accessing **any absent property on a field object** re-entered `getproperty` on the missing `.cache` and recursed forever: a `StackOverflowError` ("program state may be corrupted") instead of a clean `FieldError`.

Discovered while writing the #69 regression test (`fk_target_column` reads `field.pk_field`).

## Fix

Guard the M2M branch on the struct fields it actually reads:

```julia
elseif hasfield(typeof(m), :cache) && hasfield(typeof(m), :related_objects) &&
       Models.has_many_to_many_accessor(m, String(sym))
```

- `Model_Type` has both fields → its behavior is **unchanged** (m2m accessors still dispatch).
- Field objects lack them → fall through to the plain `getfield(m, sym)`, which raises a clean `FieldError`.
- Robust to any future model type that has the machinery; the only concrete non-field `PormGModel` today is `Model_Type` (CTE custom models are `Model_Type` instances too).
- No hot-path cost: `.objects` and real struct-field access return *before* the guarded branch, so the `hasfield` checks only run on the rare "not a struct field, not `:objects`" path.

## Tests

`test/unit/test_many_to_many.jl` — new regression testset:

- absent property on a **field object** → `FieldError` (was `StackOverflowError`)
- absent property on a **`Model_Type`** → `FieldError` (pins the guard's discrimination)
- real field read still works (`CharField(max_length=5).max_length == 5`)
- **positive control**: real M2M accessor still dispatches to a `ManyToManyDescriptor`

## Verification

Unit: **2196 pass**, zero stack-overflow warnings. Dialect-agnostic core change; the `getproperty` override is exercised pervasively by the unit suite (query building, m2m, field access), all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
