### PR TITLE
feat(migrations): stage foreign Django apps (output_path/django_prefix) + fix default=None crash

### DIFF
--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -221,24 +221,33 @@ end
   
 
 """
-  import_models_from_django(model_py_string::String; db::Union{PormGSQLite, PormGPostgres} = connection(), force_replace::Bool = false, ignore_table::Vector{String} = postgres_ignore_table, file::String = "automatic_models.jl", autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
+  import_models_from_django(model_py_string::String; db::String = DB_PATH, force_replace::Bool = false, ignore_table::Vector{String} = postgres_ignore_table, file::String = "automatic_models.jl", output_path::Union{Nothing, String} = nothing, django_prefix::Union{Nothing, String, Missing} = missing, autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
 
 Imports Django models from a given `model.py` file content string and generates corresponding Julia models.
 
 # Arguments
 - `model_py_string::String`: The content of the `model.py` file as a string; user django_to_string(path) to read the file; or insert the file path.
-- `db::String`: The configuration key used to resolve settings (usually the db folder path). The generated file is written to that configuration's `db_def_folder`. Defaults to `DB_PATH`.
+- `db::String`: The configuration key used to resolve settings (usually the db folder path). The generated file is written to that configuration's `db_def_folder` unless `output_path` overrides it, and the table-name prefix comes from that configuration's `django_prefix` unless `django_prefix` overrides it. Defaults to `DB_PATH`.
 - `force_replace::Bool`: If `true`, forces replacement of the existing models file. Defaults to `false`.
 - `ignore_table::Vector{String}`: Tables to ignore during the import process. Defaults to `postgres_ignore_table`.
 - `file::String`: The name of the file to save the generated models. Defaults to `"automatic_models.jl"`.
+- `output_path::Union{Nothing, String}`: Directory to write the generated file into, overriding the resolved config's `db_def_folder`. Use this to stage a *foreign* Django app's models next to their copied `model.py` (e.g. `"db_gal"`) while still resolving `db` for its Settings. Defaults to `nothing` (use `db_def_folder`).
+- `django_prefix::Union{Nothing, String, Missing}`: Overrides the generated table-name prefix. `missing` inherits the resolved config's `django_prefix`; `nothing` emits unprefixed table names; a `String` (e.g. `"estoque"`) forces `<prefix>_<table>`. Use this when the imported app uses a different Django `app_label` than the `db` config's. Defaults to `missing` (inherit).
 - `autofields_ignore::Vector{String}`: Fields to ignore automatically. Defaults to `["Manager"]`.
 - `parameters_ignore::Vector{String}`: Parameters to ignore during field processing. Defaults to `["help_text"]`.
 
 # Description
 This function checks if the specified models file already exists and creates it if necessary. It parses the provided `model.py` content string to extract Django model classes and their fields. For each class, it processes the fields, adds a primary key if none exists, and generates the corresponding Julia model code. The generated models are then saved to the specified file.
 
+`output_path` and `django_prefix` never mutate the shared `db` config: when either is set, a
+throwaway render-only `Settings` (no database connection) drives the output directory and prefix.
+
 # Example
 import_models_from_django(django_to_string("/home/user/models.py"))
+
+# Stage a foreign Django app (its models.py copied into db_gal/) with its own folder and prefix:
+import_models_from_django("db_gal/models.py"; db="db", file="gal_models.jl",
+                          output_path="db_gal", django_prefix="estoque", force_replace=true)
 """
 function import_models_from_django(
     model_py_string::String;
@@ -246,6 +255,8 @@ function import_models_from_django(
     force_replace::Bool = false,
     ignore_table::Vector{String} = postgres_ignore_table,
     file::String = "automatic_models.jl",
+    output_path::Union{Nothing, String} = nothing,
+    django_prefix::Union{Nothing, String, Missing} = missing,
     autofields_ignore::Vector{String} = ["Manager"],
     parameters_ignore::Vector{String} = ["help_text"]
   )
@@ -258,10 +269,21 @@ function import_models_from_django(
     return
   end
 
-  # `db` is the config key; the output directory comes from the resolved settings,
-  # matching import_models_from_postgres. Key and folder usually coincide, but
-  # manually registered Settings may point elsewhere.
-  model_path = settings.db_def_folder
+  # `db` is the config key used to resolve Settings; by default the output directory
+  # and table-name prefix come from that config (matching import_models_from_postgres).
+  # When importing a *foreign* Django app staged elsewhere, `output_path`/`django_prefix`
+  # override those without mutating the shared config — a throwaway render-only Settings
+  # (no DB connection) carries the overrides. `django_prefix === missing` inherits the
+  # config's prefix; `nothing` emits unprefixed tables; a String forces that prefix.
+  render_settings = if output_path === nothing && django_prefix === missing
+    settings
+  else
+    Configuration.Settings(
+      db_def_folder = output_path === nothing ? settings.db_def_folder : output_path,
+      django_prefix = django_prefix === missing ? settings.django_prefix : django_prefix,
+    )
+  end
+  model_path = render_settings.db_def_folder
   model_output_path = joinpath(model_path, file)
 
   # Check if the generated models file already exists.
@@ -312,12 +334,12 @@ function import_models_from_django(
 
     # Collect all create instructions
     if !isempty(fields_dict)
-        push!(Instructions, Models.Model_to_str(Models.Model(class_name, fields_dict), settings))
+        push!(Instructions, Models.Model_to_str(Models.Model(class_name, fields_dict), render_settings))
     end
-    
+
   end
 
-  generate_models_from_db(file, Instructions, settings, path=model_path)
+  generate_models_from_db(file, Instructions, render_settings, path=model_path)
 end
 
 function parse_class(model_py_string::String)
@@ -485,6 +507,11 @@ function parse_value(value::AbstractString)
       return true
   elseif value == "False"
       return false
+  elseif value == "None"
+      # Python's None literal (e.g. default=None) is a null value; map it to
+      # Julia's `nothing`. Passing "None" verbatim would crash typed converters
+      # such as ForeignKey's default (parse(Int64, "None")).
+      return nothing
   elseif value == "list"
       return "[]"
   elseif value == "dict"

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -243,6 +243,101 @@ class ReporteProblema(models.Model):
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: output_path and django_prefix overrides for foreign apps
+# When staging a foreign Django app (its models.py copied into a sibling folder),
+# the caller resolves Settings via `db` but must be able to redirect the output
+# directory and the generated table-name prefix without mutating the shared
+# config. This verifies both overrides and that the resolved config is untouched.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer honors output_path and django_prefix overrides" begin
+    # A named config whose Settings carry the "main app" folder and prefix.
+    folder = mktempdir()
+    out_folder = mktempdir()
+    config_key = "unit_django_import_override_key"
+    db_dir_existed = isdir(PormG.MODEL_PATH)
+    PormG.config[config_key] = PormG.Configuration.Settings(
+        db_def_folder = folder,
+        django_prefix = "dash",
+    )
+    output_file = "override_django_unit.jl"
+
+    django_text = """
+from django.db import models
+
+class Dim_ibge(models.Model):
+    cidade = models.CharField(max_length=250)
+"""
+
+    try
+        import_models_from_django(
+            django_text;
+            db = config_key,
+            file = output_file,
+            output_path = out_folder,       # redirect away from db_def_folder
+            django_prefix = "estoque",      # override the config's "dash" prefix
+            force_replace = true,
+        )
+
+        # The file lands in the override folder, not the config's db_def_folder.
+        @test isfile(joinpath(out_folder, output_file))
+        @test !isfile(joinpath(folder, output_file))
+
+        generated = read(joinpath(out_folder, output_file), String)
+        # Table name uses the overridden prefix...
+        @test occursin("Models.Model(\"estoque_dim_ibge\"", generated)
+        # ...never the config's "dash" prefix.
+        @test !occursin("dash_dim_ibge", generated)
+
+        # The shared config Settings must be left untouched by the overrides.
+        @test PormG.config[config_key].db_def_folder == folder
+        @test PormG.config[config_key].django_prefix == "dash"
+    finally
+        delete!(PormG.config, config_key)
+        isdir(folder) && rm(folder; recursive = true)
+        isdir(out_folder) && rm(out_folder; recursive = true)
+        if !db_dir_existed && isdir(PormG.MODEL_PATH) && isempty(readdir(PormG.MODEL_PATH))
+            rm(PormG.MODEL_PATH)
+        end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: Python None defaults map to a null (nothing) default
+# Regression for default=None on a ForeignKey, which crashed the importer:
+# parse_value returned the literal "None" string, and ForeignKey's typed default
+# converter then tried parse(Int64, "None"). None must import as a null default
+# (nothing) and be omitted from the generated field, never leaked as a string.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer maps Python None defaults to nothing" begin
+    django_text = """
+from django.db import models
+
+class Bm2_map_ext_am(models.Model):
+    ord = models.IntegerField(default=0)
+
+class Bm2_map_aliq_am(models.Model):
+    plan = models.ForeignKey('Bm2_map_ext_am', on_delete=models.SET_DEFAULT, default=None, blank=True, null=True, db_constraint=False)
+"""
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        django_text;
+        output_file = "none_default_django_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+        # The foreign key still imports, keeping its non-null options...
+        @test occursin("plan_id = Models.ForeignKey(\"Bm2_map_ext_am\"", generated)
+        @test occursin("on_delete=SET_DEFAULT", generated)
+        @test occursin("db_constraint=false", generated)
+        # ...but None must never surface as a literal default value.
+        @test !occursin("default=None", generated)
+        @test !occursin("default=\"None\"", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Django Importer: positive small integers map to PositiveSmallIntegerField
 # This covers Django's PositiveSmallIntegerField (a real PormG SMALLINT field)
 # plus callable JSON defaults such as default=list, which import to a concrete


### PR DESCRIPTION
## Summary

Two gaps in the Django importer surfaced while importing a **foreign** Django app's `models.py` staged into a sibling folder (its source lives on another server; only the `models.py` is copied over).

### 1. `default=None` crashed the import
`parse_value` had cases for `True`/`False`/`list`/`dict` but not Python's `None` singleton, so `default=None` fell through and returned the literal string `"None"`. That string flowed into `ForeignKey(...; default="None")`, whose typed converter ran `parse(Int64, "None")` → `ArgumentError: invalid base 10 digit 'N'`.

**Fix:** map Python's `None` → Julia `nothing`, consistent with the existing `True`/`False` handling. This is a clean null default for *every* field kind — `validate_default` short-circuits on `nothing isa Union{…, Nothing}` before any converter runs. Quoted `'None'` still stays the string `"None"` (hits the quote branch).

### 2. Output folder + table prefix were locked to the `db` config
The generated file's directory and table-name prefix came only from the resolved `db` config's `db_def_folder` / `django_prefix`. A foreign app couldn't write next to its own `models.py`, nor get its own `app_label` prefix (it inherited the main app's, e.g. `dash_`).

**Fix:** add two optional kwargs to `import_models_from_django`:
- `output_path::Union{Nothing,String}` — directory override for the generated file.
- `django_prefix::Union{Nothing,String,Missing}` — table-prefix override (`missing` inherits, `nothing` emits unprefixed, a `String` forces `<prefix>_<table>`).

When either is set, a **throwaway render-only `Settings`** (no DB connection) carries the overrides — the shared `db` config is never mutated.

```julia
import_models_from_django("db_gal/models.py"; db="db", file="gal_models.jl",
                          output_path="db_gal", django_prefix="estoque", force_replace=true)
```

## Testing

- New regression testset for `default=None` on a ForeignKey (imports cleanly, no `None` leaked).
- New regression testset for `output_path`/`django_prefix` overrides (file lands in the override dir, tables use the overridden prefix, **and** the shared config is asserted untouched).
- Full `test/unit/test_import_django_models.jl` slice green.
- Verified end-to-end against a real foreign app's `models.py` (~76 KB generated, correct folder + `estoque_` prefix).

## Review

Reviewed with two independent adversarial verifiers: no correctness defects. Confirmed `Model_to_str` reads only `django_prefix`, `generate_models_from_db` ignores its `settings` arg, the no-override path is byte-identical (reuses the shared object), and the render `Settings` constructor is a pure value (no connection/registration/hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
