### PR TITLE
fix(#43): isolate read/copy path — deep-copy CTE state, build reads on a copy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 
 ## 🔍 Review possible issues
 
-- [#43](https://github.com/PingoLee/PormG.jl/issues/43) — ⚠️ Shared mutable state in read/copy path: `.list()` mutates the live query, `.copy()` aliases CTE state (pre-publish)
+- [#112](https://github.com/PingoLee/PormG.jl/issues/112) — ⚠️ `.copy()` aliases custom_join state: extending `on()`/`cjoin()` on a copy mutates the original (build-time residual of #43) (pre-publish)
 - [#44](https://github.com/PingoLee/PormG.jl/issues/44) — CTE ergonomics: reference CTE fields via `F()` in the main query
 - [#68](https://github.com/PingoLee/PormG.jl/issues/68) — Refactor `_build_row_join`: collapse duplicated first-hop/loop join resolution (tech debt; behavior-preserving)
 - [#70](https://github.com/PingoLee/PormG.jl/issues/70) — `Model_to_str` silently drops a field when rendering throws (swallowed catch)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -150,19 +150,9 @@ flowchart TD
 
 ## Known architectural edges
 
-The macro-structure above is sound — Django-shaped layers and a clean backend seam. But a skeptical
-audit also turned up one **confirmed correctness bug** and two characterizations worth stating
-plainly. These are listed first; the maintainability notes follow.
-
-### Confirmed correctness bugs (pre-publish)
-
-- **Shared mutable state in the read/copy path** —
-  [#43](https://github.com/PingoLee/PormG.jl/issues/43). `.list()`/`.first()` build directly on the
-  caller's query object (writing back `q.object.parameters`) and `_build_cte_custom_model` mutates
-  the CTE dict in place, while `Base.deepcopy(::SQLObjectQuery)` does a **shallow** `copy(obj.ctes)`.
-  Result: a read mutates the live query, and `.copy()` does not give an independent query when CTEs
-  are involved. `.count()`/`.exists()` `deepcopy` first and are safe — `.list()` does not, an
-  inconsistency rather than a design.
+The macro-structure above is sound — Django-shaped layers and a clean backend seam. A skeptical
+audit turned up no outstanding confirmed correctness bugs; the notes below are maintainability
+characterizations worth stating plainly.
 
 ### Maintainability edges (no correctness impact)
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -101,6 +101,12 @@ inspection = q |> inspect_query()
 ```
 """
 function inspect_query(q::SQLObjectHandler; connection::Union{Nothing, PormGPostgres, PormGSQLite} = nothing, operation::Union{Nothing, Symbol} = nothing)
+  # #43: inspection must not mutate the caller. The dry-runs below (query/insert/update)
+  # write back onto the handler they build — q.object.parameters, the transient CTE "model"
+  # into q.object.ctes, and update()'s auto-now fields into q.object.insert. Build on a copy
+  # so inspect_query() matches the execution read path (query_list), which already copies.
+  q = deepcopy(q)
+
   # Force builder to run without execution
   # We reuse the internal query building logic
   settings, conn, conn_key = get_settings(q, connection=connection)
@@ -269,7 +275,8 @@ function query(q::SQLObjectHandler;
   end
   return resposta
 end
-show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(q; show_query=mode)
+# #43: build on a copy so inspecting a query never mutates the caller (see inspect_query).
+show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(deepcopy(q); show_query=mode)
 
 # ---
 # Count or check if exists
@@ -1064,11 +1071,18 @@ function query_list(objct::SQLObjectHandler; show_query::Symbol = :execute)
   # Resolve settings
   settings, connection, conn_key = get_settings(objct)
 
-  sql = query(objct, connection=connection, show_query=show_query)
+  # #43: build on a copy so the read path never mutates the caller's handler.
+  # query() writes back q.object.parameters and materializes the per-build CTE
+  # "model" into q.object.ctes; doing that on `objct` would give .list()/.first()
+  # a hidden write side effect and make .copy() aliasing corrupt re-execution.
+  # deepcopy(SQLObjectQuery) now clones CTE state independently (see _copy_ctes),
+  # so the copy is fully isolated. Mirrors do_count/do_exists/get, which already copy.
+  q = deepcopy(objct)
+  sql = query(q, connection=connection, show_query=show_query)
   if show_query !== :execute
      return sql
   end
-  return fetch(settings, sql, objct.object.parameters) 
+  return fetch(settings, sql, q.object.parameters)
 end
 
 """

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -160,6 +160,28 @@ end
 function Base.deepcopy(obj::SQLObjectHandler)
   return ObjectHandler(object=deepcopy(obj.object))
 end
+
+# #43: CTE state must be copied deeply enough that a copy's execution can't mutate
+# the original. A shallow `copy(ctes)` aliases the inner CTEDict values, so
+# materializing the per-build "model" (see _build_cte_custom_model) on one copy
+# clobbers the other. Rebuild each CTEDict with a fresh dict: deep-copy the sub-query
+# handler (recursion covers nested CTEs), carry the scalar join config by reference
+# (Pair/String are immutable), and DROP the transient "model" — it is re-derived on
+# every build and holds a Model_Type → Module reference that deepcopy cannot traverse
+# (the very reason the original copy was shallow).
+function _copy_ctes(ctes::Dict{String,CTEDict})::Dict{String,CTEDict}
+  out = Dict{String,CTEDict}()
+  for (name, cte_dict) in ctes
+    fresh = CTEDict()
+    for (k, v) in cte_dict
+      k == "model" && continue  # transient per-build artifact; re-materialized each build
+      fresh[k] = v isa SQLObjectHandler ? deepcopy(v) : v
+    end
+    out[name] = fresh
+  end
+  return out
+end
+
 function Base.deepcopy(obj::SQLObjectQuery)
   try
     return SQLObjectQuery(
@@ -176,7 +198,7 @@ function Base.deepcopy(obj::SQLObjectQuery)
       list_joins=deepcopy(obj.list_joins),
       row_join=deepcopy(obj.row_join),
       distinct=obj.distinct,
-      ctes=copy(obj.ctes),  # shallow copy: CTEDict values contain PormGModel → Module that deepcopy can't handle
+      ctes=_copy_ctes(obj.ctes),  # #43: independent CTE state (deep sub-query, drop transient "model")
       custom_join=copy(obj.custom_join)  # shallow copy: PormGField refs contain Model_Type → Module that deepcopy can't handle
     )
   catch e

--- a/test/integration/test_cte.jl
+++ b/test/integration/test_cte.jl
@@ -579,3 +579,46 @@ end
     end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared mutable state in the read/copy path (#43)
+# A CTE query must be re-executable and copy-independent: `.list()`/`DataFrame`
+# must not write back onto the caller, and `.copy()` must not alias CTE state.
+# Runs against whichever backend the suite is bound to (db_2 / db_sl), so it
+# exercises both PostgreSQL and SQLite. See test/unit/test_shared_state_readpath.jl
+# for the deterministic SQL-shape counterpart.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "CTE copy-independence and re-execution (#43)" begin
+    dup = M.Result.objects
+    dup.filter("statusid" => 1)
+    dup.values("driverid", "dias" => Count("resultid"))
+
+    q = M.Result.objects
+    q.with("tb_dup" => dup, join_field="driverid" => "driverid")
+    q.filter("resultid__@lte" => 100)
+    q.values("resultid", "driverid", "tb_dup__dias")
+    q.order_by("resultid")   # deterministic row order so DataFrame equality is stable
+
+    # AC4: re-executing the same query returns identical results (no accumulation).
+    # isequal (not ==): tb_dup__dias comes from a LEFT join and can be `missing`, and
+    # DataFrame `==` returns `missing` (not a Bool) when any cell is missing — which
+    # would ERROR @test rather than fail. isequal treats missing == missing and yields Bool.
+    df_first = q |> DataFrame
+    df_second = q |> DataFrame
+    @test nrow(df_first) == 100
+    @test isequal(df_first, df_second)
+
+    # AC1: the read did not mutate the caller (no parameters write-back, no CTE "model" leak).
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["tb_dup"], "model")
+
+    # AC2/AC3: a copy given a divergent filter executes independently; original unaffected.
+    q2 = q.copy()
+    @test q2.object.ctes["tb_dup"] !== q.object.ctes["tb_dup"]   # #43: fresh CTE state, not an alias
+    q2.filter("resultid__@lte" => 10)                            # narrows the copy to 10 rows
+
+    df_copy = q2 |> DataFrame
+    df_orig_again = q |> DataFrame
+    @test nrow(df_copy) == 10
+    @test isequal(df_orig_again, df_first)    # original still renders/returns its own 100-row result
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ end
     @testset "Execution Returns (show_query)" include("unit/test_execution_show.jl")
     @testset "Complex Query Patterns" include("unit/test_complex_queries.jl")
     @testset "Many-to-Many Relationships" include("unit/test_many_to_many.jl")
+    @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")
     @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")

--- a/test/unit/test_shared_state_readpath.jl
+++ b/test/unit/test_shared_state_readpath.jl
@@ -1,0 +1,200 @@
+"""
+Unit coverage for the shared-mutable-state read/copy contract (#43).
+
+A query object is a value the caller can hold, re-execute, and `.copy()`. Two defects
+broke that:
+
+1. The read path (`query()` → `query_list`) wrote `q.object.parameters` back onto the
+   caller and materialized the per-build CTE `"model"` into the caller's `ctes` dict — so
+   a plain `.list()` had a hidden write side effect (`do_count`/`do_exists`/`get` already
+   `deepcopy` first; `.list()` did not).
+2. `deepcopy(::SQLObjectQuery)` shallow-copied `ctes` (`copy(obj.ctes)`), so `.copy()` and
+   its inner `CTEDict` values were shared by reference — materializing the CTE model on one
+   copy clobbered the other.
+
+The fix builds the read path on a copy (`query_list`, `inspect_query`) and makes `deepcopy`
+clone CTE state independently (`_copy_ctes`), dropping the transient `"model"`. These
+deterministic checks pin both directions without a live database, using `show_query`
+(`:sql`/`:dict`) and inspection modes that short-circuit before any fetch.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+import PormG: PormGModel
+import PormG.QueryBuilder: Count
+
+struct SharedStateMockPostgres <: PormG.PormGPostgres end
+
+PormG.config["ss_mock"] = PormG.Configuration.Settings(
+  connections = SharedStateMockPostgres(),
+  change_data = true,
+  db_def_folder = "ss_mock",
+)
+
+module SharedStateReadPathModels
+import PormG
+import PormG.Models
+
+Result = Models.Model("ss_results",
+  id = Models.IDField(),
+  driverid = Models.IntegerField(),
+  points = Models.IntegerField(null=true),
+)
+
+PormG.Models.set_models(@__MODULE__, "ss_mock")
+end
+
+const SS = SharedStateReadPathModels
+
+# Build a fresh CTE query each time so one testset can't leak state into the next.
+function _cte_query()
+  agg = SS.Result.objects
+  agg.values("driverid", "total" => Count("id"))
+
+  q = SS.Result.objects
+  q.with("agg" => agg, join_field = "driverid" => "driverid")
+  q.filter("id__@lte" => 100)
+  q.values("id", "driverid", "agg__total")
+  q.order_by("id")
+  return q
+end
+
+@testset "Shared-state read/copy path (#43)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # AC1: executing the read path must NOT mutate the caller. Pre-fix, query() wrote
+  # q.object.parameters and materialized q.object.ctes["agg"]["model"] onto the caller.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "read path does not mutate the caller" begin
+    q = _cte_query()
+
+    # Guard: a freshly-built query has not collected parameters yet.
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["agg"], "model")
+
+    sql1 = q.list(show_query = :sql)
+    @test sql1 isa String
+    @test occursin("WITH", sql1)
+
+    # The write-backs must have landed on the internal build copy, not on `q`.
+    @test q.object.parameters === nothing          # pre-fix: became a param collector
+    @test !haskey(q.object.ctes["agg"], "model")   # pre-fix: "model" leaked onto caller
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # AC4: re-executing the same query renders identical SQL (no accumulation / drift).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "re-execution is idempotent" begin
+    q = _cte_query()
+    sql1 = q.list(show_query = :sql)
+    sql2 = q.list(show_query = :sql)
+    @test sql1 == sql2
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # AC2: `.copy()` must produce an independent query — its inner CTEDict values are
+  # fresh objects, not aliases. Pre-fix (`copy(obj.ctes)`), they were the SAME object.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "copy produces independent CTE state" begin
+    q = _cte_query()
+    q2 = q.copy()
+
+    # Distinct outer dict AND distinct inner CTEDict (the #43 aliasing signal).
+    @test q2.object.ctes !== q.object.ctes
+    @test q2.object.ctes["agg"] !== q.object.ctes["agg"]
+    # The transient per-build "model" is not carried into the copy.
+    @test !haskey(q2.object.ctes["agg"], "model")
+
+    # AC3 (deterministic form): a divergent filter on the copy renders its own SQL,
+    # and rendering the copy leaves the original untouched.
+    sql_before = q.list(show_query = :sql)
+    q2.filter("id__@lte" => 10)
+    sql_copy = q2.list(show_query = :sql)
+    sql_after = q.list(show_query = :sql)
+
+    @test sql_copy != sql_before        # copy diverged
+    @test sql_after == sql_before       # original unchanged by building the copy
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["agg"], "model")
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The inspection API must also leave the caller untouched. inspect_query() /
+  # show_query() call query() directly (not via query_list), so they need their own
+  # copy — otherwise `q.inspect()` writes back parameters + the CTE "model" onto `q`
+  # while `q.list(show_query=:dict)` (through query_list) does not.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "inspection API does not mutate the caller" begin
+    q = _cte_query()
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["agg"], "model")
+
+    insp = q.inspect()          # .inspect terminal → inspect_query(q)
+    @test insp isa Dict
+    @test occursin("WITH", insp[:sql_text])
+    @test q.object.parameters === nothing          # pre-fix: leaked a param collector
+    @test !haskey(q.object.ctes["agg"], "model")   # pre-fix: leaked the transient "model"
+
+    # The show_query() free helper builds on a copy too.
+    sql = PormG.QueryBuilder.show_query(q, :sql)
+    @test sql isa String && occursin("WITH", sql)
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["agg"], "model")
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # count()/exists() build the CTE via build_cte_clause on their OWN deepcopy
+  # (do_count/do_exists), a DIFFERENT path than query_list. Pre-#43 that deepcopy was
+  # shallow for ctes, so _build_cte_custom_model still wrote the transient "model" into
+  # the caller's shared inner CTEDict. :dict mode short-circuits before fetch, so this
+  # is deterministic without a live database.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "count()/exists() do not mutate the caller (CTE)" begin
+    q = _cte_query()
+    @test !haskey(q.object.ctes["agg"], "model")
+
+    q.count(show_query = :dict)                     # builds the CTE, returns metadata (no fetch)
+    @test !haskey(q.object.ctes["agg"], "model")   # pre-fix: "model" leaked onto the caller
+    @test q.object.parameters === nothing
+
+    q.exists(show_query = :dict)
+    @test !haskey(q.object.ctes["agg"], "model")
+    @test q.object.parameters === nothing
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # AC1 names .first() explicitly. It intentionally mutates the caller's limit (documented
+  # last-call semantics) but must NOT leak parameters or the CTE "model" — the two must
+  # coexist. .first() funnels through query_list, so the read-path copy covers it.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "first() mutates only its documented limit(1), nothing else" begin
+    q = _cte_query()
+    @test q.object.parameters === nothing
+    @test !haskey(q.object.ctes["agg"], "model")
+
+    sql = q.first(show_query = :sql)
+    @test sql isa String && occursin("WITH", sql)
+    @test occursin("LIMIT 1", sql)                 # first() applied limit(1) to the build
+    @test q.object.limit == 1                       # documented: limit(1) persists on the caller
+    @test q.object.parameters === nothing           # but parameters did NOT leak (fixed)
+    @test !haskey(q.object.ctes["agg"], "model")    # and the CTE "model" did NOT leak (fixed)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Positive control: the non-CTE read path is likewise non-mutating and stable, so
+  # the guarantees above are not specific to CTE queries.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "plain (non-CTE) read path is non-mutating" begin
+    q = SS.Result.objects
+    q.filter("driverid" => 44)
+    q.values("id", "driverid")
+
+    sql1 = q.list(show_query = :sql)
+    sql2 = q.list(show_query = :sql)
+    @test sql1 == sql2
+    @test q.object.parameters === nothing   # pre-fix: write-back set this to a collector
+  end
+
+end


### PR DESCRIPTION
## Summary

Fixes the shared-mutable-state defects in the read/copy path (#43). A query object should be a value
you can hold, re-execute, and `.copy()` — but it wasn't:

- `.list()`/`.first()` built directly on the caller's query object, writing back
  `q.object.parameters` **and** materializing the transient CTE `"model"` into `q.object.ctes`. A
  plain read had a hidden write side effect (`count`/`exists`/`get` already `deepcopy` first — `.list()`
  did not, an inconsistency rather than a design).
- `deepcopy(::SQLObjectQuery)` shallow-copied `ctes` (`copy(obj.ctes)`), so `.copy()` and its inner
  `CTEDict` values were shared by reference — materializing the CTE model on one copy could clobber the
  other.

## Fix (two parts)

- **`_copy_ctes` (`src/querybuilder/types.jl`)** — the linchpin. `deepcopy(::SQLObjectQuery)` now clones
  CTE state independently: a fresh inner `CTEDict`, a deep-copied sub-query handler (recursion covers
  nested CTEs), scalar join config by reference, and it **drops the transient `"model"`** (re-derived on
  every build; it holds a `Model_Type → Module` ref `deepcopy` cannot traverse — the very reason the copy
  was shallow). This fixes `.copy()` **and** `count`/`exists`/`get`, which the shallow copy had silently
  affected too.
- **Read path builds on a copy (`src/querybuilder/execution.jl`)** — `query_list` now `deepcopy`s the
  handler, so `.list()`/`.first()`/`DataFrame` never write back onto the caller. `inspect_query` and the
  `show_query` helper copy for the same reason (they call `query()` directly, not via `query_list`).

`custom_join` is left shallow-copied on purpose — it is not rewritten during execution, so it doesn't
affect the execution-independence contract; the remaining **build-time** aliasing (extending
`on()`/`cjoin()` on a copy) is tracked as a residual in #112.

## Tests

- **`test/unit/test_shared_state_readpath.jl`** (new) — 37 deterministic assertions (no DB): read-path
  non-mutation, idempotent re-execution, `.copy()` independence, the inspection API
  (`inspect_query`/`show_query`), the **distinct `do_count`/`do_exists` build path**, and the
  AC-named `.first()` terminal (its documented `limit(1)` coexisting with the fixed non-mutation).
- **`test/integration/test_cte.jl`** — execute-twice + copy-diverge-execute-both, exercised on both
  backends. Uses `isequal` (LEFT-join columns can be `missing`, where `==` returns `missing` and would
  error `@test`).

Every load-bearing assertion was **mutation-tested** — reverting `_copy_ctes` reddens list/copy/count/
exists/first; reverting the `query_list` copy reddens the read-path set; reverting the `inspect_query`
copy reddens the inspection set.

## Verification

| Check | Result |
|---|---|
| Unit (`test_shared_state_readpath.jl`) | 37/37 |
| PostgreSQL integration (`db_2`) | 1551/1551 |
| SQLite integration (`db_sl`) | 1526/1526 |
| Docs build (`--project=docs`) | clean (pre-existing size warnings only) |

## Notes

- `docs/src/architecture.md` — removed the now-resolved #43 "confirmed correctness bug" entry.
- `TODO.md` — #43 removed, residual #112 added.
- Follow-ups: #112 (custom_join build-time aliasing), #41 (read-path per-execution `deepcopy` cost).

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
