### PR TITLE
fix(#86): bulk_copy applies field formatter and disambiguates "" from NULL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,6 +76,7 @@ Focus on parity with Django-style ORM capabilities and PostgreSQL power features
 - [#84](https://github.com/PingoLee/PormG.jl/issues/84) — Bulk insert/update has no parameter-limit-aware chunking (overflows SQLite 999 / PG 65535)
 - [#85](https://github.com/PingoLee/PormG.jl/issues/85) — `bulk_update` is non-atomic on SQLite (multi-chunk partial update on mid-chunk failure)
 - [#86](https://github.com/PingoLee/PormG.jl/issues/86) — `bulk_copy` NULL/empty-string collision + formatter bypass (silent data divergence vs `create`/`bulk_insert`)
+- [#114](https://github.com/PingoLee/PormG.jl/issues/114) — Strengthen `bulk_copy` datetime mutation coverage under a non-UTC session (test-strength follow-up to #86; low urgency / medium effort)
 - [#88](https://github.com/PingoLee/PormG.jl/issues/88) — SQLite `allocate_primary_keys` is racy outside `run_in_transaction` (read-then-write; reservation no-op at tx depth 0)
 
 ## 🔗 Custom Join (`cjoin`) Gaps

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -763,6 +763,13 @@ bulk_insert(model::PormGModel, df::DataFrames.DataFrame; kwargs...) = bulk_inser
 bulk_insert(df::DataFrames.DataFrame; kwargs...) = (objct) -> bulk_insert(objct, df; kwargs...)
 bulk_insert(objct::SQLObjectHandler; kwargs...) = (df) -> bulk_insert(objct, df; kwargs...)
 
+# bulk_copy NULL sentinel (#86) — PostgreSQL's conventional NULL marker. Safe because bulk_copy
+# force-quotes every string value (CSV.write quotestrings=true): a genuine string equal to this
+# sentinel is written *quoted* and read back as the literal string, while a `missing`/`nothing`
+# is written *unquoted* and read as NULL. So "" (quoted) ≠ NULL (unquoted \N). The COPY `NULL '…'`
+# clause and CSV.write's `missingstring` must use this same value.
+const _BULK_COPY_NULL = "\\N"
+
 """
     bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame; kwargs...)
 
@@ -814,8 +821,9 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   safe_table_name = safe_table_identifier(string(model.name), connection)
   quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields_df]
 
-  # Construct the COPY command (using CSV format for safety)
-  sql = "COPY $(safe_table_name) ($(join(quoted_fields, ", "))) FROM STDIN WITH (FORMAT CSV, HEADER FALSE)"
+  # Construct the COPY command (CSV format for safety). NULL marker disambiguates ""
+  # (quoted, an empty string) from missing (unquoted sentinel, NULL) — see _BULK_COPY_NULL (#86).
+  sql = "COPY $(safe_table_name) ($(join(quoted_fields, ", "))) FROM STDIN WITH (FORMAT CSV, HEADER FALSE, NULL '$(_BULK_COPY_NULL)')"
   
   if show_query !== :execute
     return _show_query_result(show_query, sql, connection, model, Symbol("bulk_copy"))
@@ -829,28 +837,32 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
     for i in 1:chunk_size:total_rows
       end_idx = min(i + chunk_size - 1, total_rows)
 
-      for row_index in i:end_idx
-        row = df[row_index, :]
-        try
-          for field in fields_df
-            validate_field_data(model, field, row[mapping[field]], "bulk_copy"; allow_primary_key = true)
-            model.fields[field].formater(row[mapping[field]])
+      # Build a FORMATTED chunk so COPY stores the SAME values as bulk_insert/create().
+      # Each cell is validated and then serialized through the field formatter (as bulk_insert
+      # does) — missing/nothing stays missing (every formatter returns missing for it) and is
+      # written as the NULL sentinel. Columns are built in fields_df order so they align
+      # positionally with the COPY column list (HEADER FALSE). #86
+      formatted = DataFrames.DataFrame()
+      for field in fields_df
+        src = df[i:end_idx, mapping[field]]
+        formatted[!, field] = map(eachindex(src)) do offset
+          value = src[offset]
+          row_index = i + offset - 1
+          try
+            validate_field_data(model, field, value, "bulk_copy"; allow_primary_key = true)
+            model.fields[field].formater(value)
+          catch e
+            throw(ErrorException("Error in bulk_copy, row $(row_index) for model $(model.name) failed validation or formatting: $(e)"))
           end
-        catch e
-          throw(ErrorException("Error in bulk_copy, row $(row_index) for model $(model.name) failed validation or formatting: $(e)"))
         end
       end
-      
-      # Select columns based on mapping and ensure they are in the correct order for the COPY command
-      df_chunk = df[i:end_idx, [mapping[f] for f in fields_df]]
-      # Rename columns in the chunk to match model field names (for CSV writer)
-      DataFrames.rename!(df_chunk, [mapping[f] => f for f in fields_df])
-      
-      # Use CSV to format the data safely as a block
+
+      # Force-quote strings and mark missing with the NULL sentinel so an empty string ("")
+      # round-trips as "" (quoted) while missing round-trips as NULL (unquoted \N). #86
       io = IOBuffer()
-      CSV.write(io, df_chunk; header=false)
+      CSV.write(io, formatted; header=false, quotestrings=true, missingstring=_BULK_COPY_NULL)
       csv_data = String(take!(io))
-      
+
       fetch_copy(settings, sql, [csv_data])
     end
 

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -232,6 +232,18 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   nullable_int = Models.IntegerField(null = true)
 )
 
+# Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME
+# values as bulk_insert/create() (the field formatter is applied — e.g. a naive DateTime is
+# labelled UTC) and must distinguish an empty string from NULL. Nullable char/float/bool/datetime
+# cover the parity cases.
+Bulk_copy_fidelity_scratch = Models.Model("bulk_copy_fidelity_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(null = true),
+  amount = Models.FloatField(null = true),
+  active = Models.BooleanField(null = true),
+  event_time = Models.DateTimeField(null = true)
+)
+
 # Scratch models exercising the ManyToManyField API (auto-generated through
 # table) against the F1 scenario "drivers endorsed by sponsors".
 M2m_sponsor_scratch = Models.Model("m2m_sponsor_scratch",

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -232,6 +232,18 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   nullable_int = Models.IntegerField(null = true)
 )
 
+# Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME
+# values as bulk_insert/create() (the field formatter is applied — e.g. a naive DateTime is
+# labelled UTC) and must distinguish an empty string from NULL. Nullable char/float/bool/datetime
+# cover the parity cases.
+Bulk_copy_fidelity_scratch = Models.Model("bulk_copy_fidelity_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(null = true),
+  amount = Models.FloatField(null = true),
+  active = Models.BooleanField(null = true),
+  event_time = Models.DateTimeField(null = true)
+)
+
 # Scratch models exercising the ManyToManyField API (auto-generated through
 # table) against the F1 scenario "drivers endorsed by sponsors".
 M2m_sponsor_scratch = Models.Model("m2m_sponsor_scratch",

--- a/test/integration/test_bulk_copy.jl
+++ b/test/integration/test_bulk_copy.jl
@@ -376,5 +376,81 @@ end
     @test occursin("expected Int64 or an integer string", string(err_type))
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# bulk_copy data fidelity (#86)
+# bulk_copy must store the SAME values as bulk_insert / create(): it now serializes
+# through the field formatter (so a naive DateTime becomes UTC, matching the other
+# paths) and it disambiguates an empty string from NULL (an unquoted \N sentinel is
+# NULL; a quoted "" is the empty string). Pre-fix, bulk_copy wrote the raw DataFrame
+# values (naive datetime) and let "" collapse to NULL — a silent divergence.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "bulk_copy stores identical values to bulk_insert / create() (#86)" begin
+    scratch = () -> M.Bulk_copy_fidelity_scratch.objects
+
+    # A naive DateTime: the DateTimeField formatter converts it to UTC (format_timezone_sql).
+    # Pre-fix bulk_copy wrote the naive value → a different stored instant than bulk_insert.
+    dt = DateTime(2021, 3, 14, 9, 26, 53)
+
+    # Row 1 exercises "" (empty string, must stay "") and the naive-datetime conversion.
+    # Row 2 exercises missing across char/float/datetime (must become NULL) and bool false.
+    # Row 3 is a second populated row so id-order comparison covers more than one live row.
+    df = DataFrames.DataFrame(
+        name       = Union{Missing, String}["", missing, "brake bias"],
+        amount     = Union{Missing, Float64}[1.5, missing, 0.1],
+        active     = Union{Missing, Bool}[true, false, missing],
+        event_time = Union{Missing, DateTime}[dt, missing, dt],
+    )
+
+    read_back = () -> begin
+        q = scratch()
+        q.order_by("id")                                   # ids assigned in insert order == df order
+        q.values("name", "amount", "active", "event_time")
+        q.list(:dict)
+    end
+
+    # ── bulk_insert baseline ──────────────────────────────────────────────────
+    scratch().exists() && scratch().delete(allow_delete_all = true)
+    bulk_insert(scratch(), df)
+    insert_rows = read_back()
+
+    # ── bulk_copy under test ──────────────────────────────────────────────────
+    scratch().delete(allow_delete_all = true)
+    bulk_copy(scratch(), df)
+    copy_rows = read_back()
+
+    @test length(insert_rows) == 3
+    @test length(copy_rows) == 3
+
+    # AC1/AC3: identical stored values across every field (datetime/bool/float/string),
+    # row for row. isequal so a NULL (missing) matches a NULL. Pre-fix the datetime and
+    # empty-string columns diverged here.
+    for f in (:name, :amount, :active, :event_time)
+        @test isequal([r[f] for r in copy_rows], [r[f] for r in insert_rows])
+    end
+
+    # AC2: an empty string round-trips as "" (NOT NULL); a missing round-trips as NULL.
+    # isequal (not ==): pre-fix this value is `missing`, and `missing == ""` is `missing`,
+    # which would ERROR @test rather than fail cleanly. isequal yields a Bool.
+    @test isequal(copy_rows[1][:name], "")     # pre-fix: became missing/NULL (or NOT NULL error)
+    @test ismissing(copy_rows[2][:name])       # genuine missing → NULL
+
+    # Three-way parity: create() (the canonical single-row path) agrees with bulk_copy on the
+    # divergence-prone fields (naive datetime → UTC, empty string, bool, float).
+    scratch().delete(allow_delete_all = true)
+    created = scratch().create("name" => "", "amount" => 1.5, "active" => true, "event_time" => dt)
+    cq = scratch()
+    cq.filter("id" => created[:id])
+    cq.values("name", "amount", "active", "event_time")
+    created_row = cq.list(:dict) |> first
+
+    @test isequal(created_row[:name], "")
+    @test isequal(created_row[:event_time], copy_rows[1][:event_time])   # same UTC instant
+    @test isequal(created_row[:active], copy_rows[1][:active])
+    @test isequal(created_row[:amount], copy_rows[1][:amount])
+
+    # Cleanup
+    scratch().exists() && scratch().delete(allow_delete_all = true)
+end
+
 end # End of if adapter_name != "SQLite"
 


### PR DESCRIPTION
## Summary

`bulk_copy` had two silent data-fidelity defects versus `bulk_insert`/`create()`. This PR fixes both and adds a PostgreSQL regression.

**Closes #86.**

### 1. Formatter bypass

`bulk_copy` ran each value through the field formatter for **validation** but then wrote the **raw** DataFrame value into the COPY stream — the formatted result was discarded. `bulk_insert`/`create()` write the *formatted* value. So the same input could be stored differently depending on which API you used (datetime labeling, bool, float rendering).

Now `bulk_copy` builds a formatted chunk exactly like `bulk_insert` — `validate_field_data` + `model.fields[field].formater(value)` per cell — and writes that.

### 2. Empty-string ↔ NULL collision

COPY carried no NULL marker and `CSV.write` left empty strings unquoted, so `""` and `missing` both serialized to bare empty fields and both came back as `NULL`.

Now serialization uses a `\N` sentinel:

- `COPY … WITH (FORMAT CSV, HEADER FALSE, NULL '\N')`
- `CSV.write(io, formatted; header=false, quotestrings=true, missingstring="\\N")`

Force-quoting every string makes `""` write as a quoted empty field (round-trips as `""`), while `missing` writes as an **unquoted** `\N` (round-trips as `NULL`). Force-quoting is superset-safe: PostgreSQL reads quoted and unquoted strings identically, so a genuine value equal to `\N` is written quoted and stays literal.

## Testing

- **New regression** (`test/integration/test_bulk_copy.jl`, PostgreSQL): `bulk_copy` stores identical values to `bulk_insert`/`create()` across nullable char/float/bool/datetime, and `""` round-trips as `""` while `missing` round-trips as `NULL`. Fixture `Bulk_copy_fidelity_scratch` added to both backends' `models.jl` (kept byte-identical).
- **Mutation-verified**: reverting the fix turns the empty-string↔NULL assertions red.
- PG `db_2` **1563/1563** green; SQLite `db_sl` **1526/1526** green (COPY is PG-only; SQLite path unaffected).

## Known limitation → follow-up #114

The datetime half of the parity claim is **asserted but not mutation-proven** under UTC CI: a raw naive `DateTime` interpreted by an unlabeled COPY in a UTC session lands on the same instant the formatter produces, so reverting the formatter doesn't flip the datetime assertion. The behavior is correct by parity with `bulk_insert`; hardening the test requires a non-UTC session and is tracked in **#114** (low urgency / medium effort) so the fragile connection-pool timezone handling gets its own isolated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
