### PR TITLE
fix(#83): SQLite FK removal via table rebuild; slim TODO.md to release-gating index

### DIFF
--- a/.github/skills/pormg-issue-management/SKILL.md
+++ b/.github/skills/pormg-issue-management/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: pormg-issue-management
-description: Manage the PormG backlog with the gh CLI — create/update/close GitHub issues, bulk-migrate TODO.md items to issues, and keep TODO.md as a linked index. Covers the label taxonomy, the draft-before-create safety flow, and cross-reference discipline.
+description: Manage the PormG backlog with the gh CLI — create/update/close GitHub issues, curate labels, and keep the TODO.md release-gating index (pre-publish issues only) in sync. Covers the label taxonomy, the draft-before-create safety flow, and cross-reference discipline.
 ---
 
 # PormG Issue Management
 
 ## Purpose
 
-Use this skill for any work on the project backlog: creating or editing GitHub issues,
-migrating `TODO.md` items into issues, syncing the `TODO.md` index after issues change, or
-curating labels. It encodes the conventions settled when the backlog was first migrated so the
-tracker stays consistent.
+Use this skill for any work on the project backlog: creating or editing GitHub issues, curating
+labels, or syncing the `TODO.md` **release-gating index** when a `pre-publish` issue changes. It
+encodes the conventions settled when the backlog was first migrated so the tracker stays consistent.
 
 This is a process skill, not a code skill — it does not touch `src/`.
 
@@ -18,22 +17,25 @@ This is a process skill, not a code skill — it does not touch `src/`.
 
 - Creating one or many GitHub issues (especially bulk migration from `TODO.md`)
 - Editing, closing, commenting on, or relabeling existing issues
-- Keeping `TODO.md` in sync with the issue tracker
+- Keeping the `TODO.md` release-gating index in sync (pre-publish issues only)
 - Adding or adjusting labels
 
 ## The TODO.md ↔ Issues model
 
-- **GitHub Issues are the source of truth.** `TODO.md` is a *curated linked index of OPEN work
-  only*: one line per open item, grouped by the historical sections, each linking to its `#issue`.
-- **When an item is solved, remove its line from `TODO.md`** — do not keep a completed list. The full
-  history (discussion, linked commits/PRs, close reason, timestamps) already lives in GitHub's closed
-  issues: `gh issue list --state closed`. A parallel archive in `TODO.md` only duplicates that and
-  drifts. (Work completed *before* the issue tracker existed lives in git history, not GitHub issues.)
+- **GitHub Issues are the source of truth for the entire backlog.** `TODO.md` is **not** a mirror of
+  open issues — it is a **release-gating index only**: it lists just the `pre-publish`-labeled issues
+  (under the required `⚠️ do BEFORE the first General-registry publish` heading), each linking to its
+  `#issue`. Subsystem/priority views come from GitHub labels (`gh issue list --label migrations`), not
+  from sections in this file.
+- **The `pre-publish` label is the source of truth for what's gating.** The `TODO.md` list must equal
+  `gh issue list --label pre-publish`. To make an issue gating, add the `pre-publish` label (then add
+  its line); to un-gate, remove the label (then remove its line).
+- **Touch `TODO.md` only for `pre-publish` issues.** Opening, closing, or (un)labeling a `pre-publish`
+  issue updates the list; every ordinary issue is opened and closed with **no `TODO.md` edit at all**.
 - **Do not delete `TODO.md`.** `.github/instructions/general.instructions.md` references it for the
   `⚠️ do BEFORE the first General-registry publish` release-gating tag. That exact phrase and the
   pre-publish items must remain visible in the index (linking to their issues) so the reference
   resolves.
-- Edit **issues** for status/discussion; touch `TODO.md` only when an item is opened or closed.
 
 ## Tooling
 
@@ -82,13 +84,15 @@ before hitting the API.** A single targeted issue the user asked for can be crea
    otherwise `#11` etc. silently links to an unrelated old issue or PR.
 7. **Verify after.** Check the open count, label assignment, and spot-check that a rich body (task
    lists, blockquotes, code fences) rendered: `gh issue view <n> --json body -q '.body'`.
-8. **Update the index.** Rewrite `TODO.md` to link each item to its issue, keep the section grouping
-   and the `⚠️` gating note, and move shipped work to the Completed archive.
+8. **Update the release-gating index — only for `pre-publish` items.** If any newly-created issue is
+   `pre-publish`-labeled, add its line to `TODO.md` under the `⚠️` heading. Non-gating issues are not
+   listed there — GitHub Issues + labels are their only home.
 
 ## Closing a resolved issue
 
-Closing the issue and syncing the index are **one operation**, not two — never close an issue
-without updating `TODO.md` in the same pass.
+Closing a `pre-publish`-labeled issue and syncing the index are **one operation** — never close a
+gating issue without updating `TODO.md` in the same pass. Closing an **ordinary**
+(non-`pre-publish`) issue needs **no `TODO.md` edit at all**.
 
 1. **Link the fix.** Prefer letting GitHub auto-close: put `Closes #N` (or `Fixes #N`) in the PR
    description or the commit message that lands the work, so the issue closes on merge *with a
@@ -99,19 +103,21 @@ without updating `TODO.md` in the same pass.
    finished boxes (`- [ ]` → `- [x]`) in the body via `gh issue edit <n> --body-file …` and comment
    on what landed. Close only when every box is done — or split the remainder into a new issue and
    close the original with a pointer to it.
-3. **Remove it from `TODO.md`.** Delete the item's line from its section in the same pass — do not
-   archive it in `TODO.md`; its history is the closed GitHub issue. If closing spawned a
-   residual/follow-up issue, make sure that new one is listed in the index. Keep the `⚠️` pre-publish
-   note even as its gated items close.
-4. **Verify.** Confirm the issue is closed (`gh issue view <n> --json state,closed`) and the index no
-   longer lists it.
+3. **Sync the gating index — only if the issue was `pre-publish`.** If the closed issue carried the
+   `pre-publish` label, delete its line from `TODO.md` in the same pass (its history is the closed
+   GitHub issue). Ordinary issues don't appear there, so skip this for them. If closing spawned a
+   `pre-publish` follow-up, add that new one. Keep the `⚠️ do BEFORE the first General-registry
+   publish` note even as its gated items close.
+4. **Verify.** Confirm the issue is closed (`gh issue view <n> --json state,closed`); for a
+   `pre-publish` issue, also confirm the index no longer lists it.
 
 ## Do Not
 
 - Bulk-create issues without showing a draft and getting confirmation first.
 - Close an issue that still has unfinished task-list items — check them off or split them out first.
 - Close an issue without a comment/PR/commit reference saying what resolved it.
-- Close or open an issue without syncing the `TODO.md` index in the same pass.
+- Close or open a `pre-publish` issue without syncing the `TODO.md` gating index in the same pass.
+  (Ordinary issues do **not** touch `TODO.md` — do not re-add per-issue mirror lines.)
 - Delete `TODO.md` or drop the `⚠️ do BEFORE the first General-registry publish` tag from it.
 - Put draft/placeholder numbers in issue bodies and leave them — resolve to real `#numbers`.
 - Inline rich bodies on the command line — use `--body-file`.

--- a/TODO.md
+++ b/TODO.md
@@ -1,100 +1,37 @@
-# TODO — issue index
+# TODO — release-gating index
 
-> **Open work now lives in [GitHub Issues](https://github.com/PingoLee/PormG.jl/issues).**
-> This file is a curated index of **open work only**, grouped by the historical TODO sections, so the
-> roadmap stays readable in-repo. Edit the **issues** for status/discussion; this file only needs
-> updating when an issue is opened or closed. When an issue closes, its line is **removed** here —
-> the history stays on the closed issue.
+> **The backlog lives entirely in [GitHub Issues](https://github.com/PingoLee/PormG.jl/issues).**
+> Browse by label for the subsystem views the old sections used to provide —
+> [`migrations`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Amigrations),
+> [`bug`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Abug),
+> [`postgres`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apostgres),
+> [`sqlite`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Asqlite), etc.
+>
+> This file is **not** a mirror of the open backlog — it deliberately tracks **only** the
+> release-gating items below, which a repo doc (`.github/instructions/general.instructions.md`)
+> references. Ordinary issues never touch this file; only a `pre-publish` issue opening or closing does.
 
-Focus on parity with Django-style ORM capabilities and PostgreSQL power features.
+## ⚠️ do BEFORE the first General-registry publish
 
-## 🚀 High Priority: Core ORM Parity
-
-- [#25](https://github.com/PingoLee/PormG.jl/issues/25) — Advanced Query Expressions: F-expression date arithmetic (`Day(30)`/`Interval`) + cross-DB date/time test coverage
-- [#48](https://github.com/PingoLee/PormG.jl/issues/48) — Query inspection tooling: `:inspection` mode, metadata enrichment, SQL formatting, EXPLAIN
-- [#26](https://github.com/PingoLee/PormG.jl/issues/26) — Full Transaction Control: savepoints + row-level locking (`select_for_update`)
-
-## 🐘 PostgreSQL Specific Enhancements
-
-- [#27](https://github.com/PingoLee/PormG.jl/issues/27) — JSONB support: lookups + containment/overlap operators
-- [#28](https://github.com/PingoLee/PormG.jl/issues/28) — Specialized data types: `ArrayField` + `INET`/`CIDR`
-- [#29](https://github.com/PingoLee/PormG.jl/issues/29) — Advanced indexing: GIN/GiST/BRIN, functional, partial
-- [#30](https://github.com/PingoLee/PormG.jl/issues/30) — Bulk upsert: `update_or_create` via `ON CONFLICT`
-- [#31](https://github.com/PingoLee/PormG.jl/issues/31) — Full-Text Search (`tsvector`/`tsquery`)
-
-## 🛠 Project Infrastructure & Quality
-
-> ⚠️ **do BEFORE the first General-registry publish** — the items below lock in contracts that are
-> cheap to settle now (zero published users) but become breaking/irreversible afterward.
-> **Sequence:** **Tier 1** (irreversible user-data — migration-format / tracking-table contract and
-> the frozen schema conventions) and **Tier 2** (#34 adapter decoupling → #35 export curation) are
-> both settled and merged — as is field-name **case preservation** (#57), its lowercase
-> **convention** (#58), and the full **`db_column` authority** family: authoritative DDL/queries
-> (#50), string FK targets (#62), and ManyToMany/CTE join keys (#64) — all merged. Remaining gating
-> work: the infrastructure items below.
+> These lock in contracts that are cheap to settle now (zero published users on Julia's General
+> registry) but become breaking/irreversible afterward.
+>
+> **Settled & merged:** Tier 1 (migration-format / tracking-table contract, frozen schema
+> conventions) · Tier 2 (#34 adapter decoupling → #35 export curation) · field-name case
+> preservation (#57) + lowercase convention (#58) · the full `db_column` authority family —
+> authoritative DDL/queries (#50), string FK targets (#62), ManyToMany/CTE join keys (#64).
+>
+> **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
+> [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
 - [#36](https://github.com/PingoLee/PormG.jl/issues/36) — Isolated PostgreSQL migration fixture (`db_test_migration_pg/`)
 - [#37](https://github.com/PingoLee/PormG.jl/issues/37) — Investigate PG pool exhaustion under remote-latency integration runs
-
-## 🏗 Phase 2: Operational Maturity
-
-- [#38](https://github.com/PingoLee/PormG.jl/issues/38) — Advanced migration support (renames, targeted execution, rollback, deployment safety, data migrations, schema objects)
-- [#65](https://github.com/PingoLee/PormG.jl/issues/65) — Unify the model-load lifecycle: one "load + resolve" entry point for runtime + migrations (Django `apps.populate()` analog; single-sources FK/O2O/M2M target resolution)
-- [#39](https://github.com/PingoLee/PormG.jl/issues/39) — SQLite parity with PostgreSQL features
-- [#60](https://github.com/PingoLee/PormG.jl/issues/60) — Add MySQL / MariaDB backend support (third driver via the weakdep-extension seam)
-- [#40](https://github.com/PingoLee/PormG.jl/issues/40) — Documentation expansion (F1 examples, PostgreSQL power-user guide)
-- [#41](https://github.com/PingoLee/PormG.jl/issues/41) — Performance & type stability (typed returns, fast JSON, IO allocation, benchmarking, thread-safety audit)
-
-## 🔍 Review possible issues
-
-- [#112](https://github.com/PingoLee/PormG.jl/issues/112) — ⚠️ `.copy()` aliases custom_join state: extending `on()`/`cjoin()` on a copy mutates the original (build-time residual of #43) (pre-publish)
-- [#44](https://github.com/PingoLee/PormG.jl/issues/44) — CTE ergonomics: reference CTE fields via `F()` in the main query
-- [#68](https://github.com/PingoLee/PormG.jl/issues/68) — Refactor `_build_row_join`: collapse duplicated first-hop/loop join resolution (tech debt; behavior-preserving)
-- [#70](https://github.com/PingoLee/PormG.jl/issues/70) — `Model_to_str` silently drops a field when rendering throws (swallowed catch)
-- [#73](https://github.com/PingoLee/PormG.jl/issues/73) — `bulk_update` parameters snapshot/restore leaves partial state on mid-chunk failure
-- [#80](https://github.com/PingoLee/PormG.jl/issues/80) — Dead identifier-whitelist helpers + skill-doc claims a contract the code doesn't exercise (`documentation`)
-
-## 🧮 SQL correctness & dialect alignment
-
-- [#75](https://github.com/PingoLee/PormG.jl/issues/75) — ⚠️ `ORDER BY` NULL placement diverges PG vs SQLite (no `NULLS FIRST/LAST`) (pre-publish)
-- [#76](https://github.com/PingoLee/PormG.jl/issues/76) — `SELECT DISTINCT … ORDER BY <unselected column>` errors on PG, runs on SQLite
-- [#77](https://github.com/PingoLee/PormG.jl/issues/77) — `SQLOrder.orientation` interpolated unvalidated into `ORDER BY` (latent SQL injection; `security`)
-- [#78](https://github.com/PingoLee/PormG.jl/issues/78) — Case-insensitive lookups (`icontains`/`istartswith`/`iendswith`) diverge PG vs SQLite on non-ASCII text
-- [#79](https://github.com/PingoLee/PormG.jl/issues/79) — `DateTimeField` equality/range filters can diverge PG vs SQLite (format-sensitive TEXT comparison)
-
-## 🧱 Migration apply / rollback safety
-
-- [#81](https://github.com/PingoLee/PormG.jl/issues/81) — Migrations are not idempotent and checksum is never verified (re-apply landmine, no drift detection)
-- [#82](https://github.com/PingoLee/PormG.jl/issues/82) — SQLite table-rebuild drops secondary indexes and runs with FK enforcement off (data-loss risk)
-- [#83](https://github.com/PingoLee/PormG.jl/issues/83) — SQLite `drop_foreign_key` is broken (undefined `get_constraints`) and embeds `BEGIN/COMMIT` that breaks migration atomicity
-- [#87](https://github.com/PingoLee/PormG.jl/issues/87) — `migrate()` defaults `interactive=true` and blocks on `readline()` in non-interactive/CI contexts
-- [#89](https://github.com/PingoLee/PormG.jl/issues/89) — Migration statement ordering has no FK-dependency topological sort (`CREATE`/`DROP` order survives by accident)
-- [#90](https://github.com/PingoLee/PormG.jl/issues/90) — Migration advisory lock keyed on config folder, not database identity (two configs on one DB don't mutually exclude)
-
-## 📦 Bulk insert / update / copy
-
-- [#84](https://github.com/PingoLee/PormG.jl/issues/84) — Bulk insert/update has no parameter-limit-aware chunking (overflows SQLite 999 / PG 65535)
-- [#85](https://github.com/PingoLee/PormG.jl/issues/85) — `bulk_update` is non-atomic on SQLite (multi-chunk partial update on mid-chunk failure)
-- [#86](https://github.com/PingoLee/PormG.jl/issues/86) — `bulk_copy` NULL/empty-string collision + formatter bypass (silent data divergence vs `create`/`bulk_insert`)
-- [#114](https://github.com/PingoLee/PormG.jl/issues/114) — Strengthen `bulk_copy` datetime mutation coverage under a non-UTC session (test-strength follow-up to #86; low urgency / medium effort)
-- [#88](https://github.com/PingoLee/PormG.jl/issues/88) — SQLite `allocate_primary_keys` is racy outside `run_in_transaction` (read-then-write; reservation no-op at tx depth 0)
-
-## 🔗 Custom Join (`cjoin`) Gaps
-
-- [#45](https://github.com/PingoLee/PormG.jl/issues/45) — `cjoin` gaps: arbitrary ON clauses, cross-table `F()` in ON, SQL functions in ON (`strftime`/`EXTRACT`)
-
-## 🐞 SQLite worker / pool stability
-
-- [#47](https://github.com/PingoLee/PormG.jl/issues/47) — SQLite connection / file-handle release at teardown (`close_pool!` leased-close + non-idempotent `_close_db!`)
-- [#71](https://github.com/PingoLee/PormG.jl/issues/71) — Failed ROLLBACK returns a possibly-dirty connection to the pool
-- [#72](https://github.com/PingoLee/PormG.jl/issues/72) — `acquire_connection` throws raw `String`s and spins ~30s on a permanently-bad connection
-
-## 🔮 Future Considerations
-
-- [#46](https://github.com/PingoLee/PormG.jl/issues/46) — Parameterize LIMIT/OFFSET
-- [#59](https://github.com/PingoLee/PormG.jl/issues/59) — Model `db_table` option: pin an explicit (mixed/upper-case) table name (Django `Meta.db_table` analog; table-level sibling of #50, pairs with #57)
-- [#92](https://github.com/PingoLee/PormG.jl/issues/92) — 💬 Design: explicit correlated-subquery aggregates (no auto-magic) — the supported fix for #74 fan-out
+- [#75](https://github.com/PingoLee/PormG.jl/issues/75) — `ORDER BY` NULL placement diverges PG vs SQLite (no `NULLS FIRST/LAST` normalization)
+- [#107](https://github.com/PingoLee/PormG.jl/issues/107) — Reconsider `=>` direction/semantics across the query API (predicate vs projection vs mapping)
+- [#112](https://github.com/PingoLee/PormG.jl/issues/112) — `.copy()` aliases custom_join state: extending `on()`/`cjoin()` on a copy mutates the original (build-time residual of #43)
 
 ---
 
-*Completed work is not listed here — see [closed issues](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aissue+is%3Aclosed). (Work that predates the issue tracker lives in git history.)*
+*Release-gating index only. Full backlog: [open issues](https://github.com/PingoLee/PormG.jl/issues) ·
+completed work: [closed issues](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aissue+is%3Aclosed)
+(work predating the tracker lives in git history).*

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -876,32 +876,6 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   return join(sql_statements, "\n")
 end
 
-function alter_field(conn::PormGSQLite, table_name::String, field_name::String, new_field::PormGField)
-  # SQLite does not support altering column types directly.
-  # You need to recreate the table. Here's a simplified example.
-  # Note: This is a complex operation and may require handling additional constraints.
-
-  # Define a unique identifier for the new table
-  new_table_name = "$(table_name)_new"
-
-  # Retrieve existing columns excluding the one to be altered
-  existing_columns = Dialect.get_columns(conn, table_name)  # You need to implement this function
-  columns_sql = join([col == field_name ? field_to_column(field_name, new_field, conn) : "\"$col\"" for col in existing_columns], ", ")
-
-  # Begin transaction
-  migration_sql = [
-    "BEGIN TRANSACTION;",
-    """CREATE TABLE "$new_table_name" ($columns_sql);""",
-    """INSERT INTO "$new_table_name" SELECT * FROM "$table_name";""",
-    """DROP TABLE "$table_name";""",
-    """ALTER TABLE "$new_table_name" RENAME TO "$table_name";""",
-    "COMMIT;"
-  ]
-
-  return join(migration_sql, "\n")
-
-end
-
 function add_field(conn::PormGPostgres, table_name::Union{String,Symbol}, field_name::String, field::PormGField; temporary_default::Any=nothing)
   return """ALTER TABLE "$table_name" ADD COLUMN $(field_to_column(field_name, field, conn, temporary_default=temporary_default));"""
 end
@@ -917,11 +891,6 @@ end
 function drop_field(conn::PormGSQLite, table_name::Union{String,Symbol}, field_name::Union{String,Symbol})
   # Modern SQLite supports DROP COLUMN. If not, we'd need recreation.
   return """ALTER TABLE "$table_name" DROP COLUMN "$field_name";"""
-end
-
-function get_columns(conn::PormGSQLite, table_name::String)
-  res = fetch(conn, "PRAGMA table_info(\"$table_name\")") |> DataFrame
-  return res.name
 end
 
 function alter_field(conn::PormGPostgres, model::PormGModel, field_name::Union{Symbol,String}, new_field::PormGField, old_field::Union{Nothing,PormGField}, colect_not_equal::Vector{Symbol})
@@ -956,11 +925,11 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
   # 2. Build the INSERT column list from model.fields.
   # At execution time every ADD COLUMN statement queued before this recreation
   # has already run, so all model fields are present in the old table.
-  # Using get_columns() at planning time would omit columns that were just
-  # queued via ADD COLUMN (they are not in the live DB yet), causing a NOT NULL
-  # constraint failure when the INSERT tries to populate the new table from the
-  # old one — the new table's CREATE has the column as NOT NULL but the INSERT
-  # simply doesn't mention it.
+  # Reading the live database's columns at planning time would omit columns that
+  # were just queued via ADD COLUMN (they are not in the live DB yet), causing a
+  # NOT NULL constraint failure when the INSERT tries to populate the new table
+  # from the old one — the new table's CREATE has the column as NOT NULL but the
+  # INSERT simply doesn't mention it.
   # Physical column names (db_column when set) — both old and new tables use these,
   # so the column-aligned copy stays correct for db_column-mapped fields (#50).
   model_cols = [field_db_column(f, string(k)) for (k, f) in model.fields]
@@ -983,38 +952,10 @@ function drop_foreign_key(conn::PormGPostgres, table_name::Symbol, constraint_na
   return """ALTER TABLE "$table_name" DROP CONSTRAINT "$constraint_name";"""
 end
 
-function drop_foreign_key(conn::PormGSQLite, table_name::String, constraint_name::String)
-  # SQLite does not support dropping foreign keys directly.
-  # Implement the workaround by recreating the table without the foreign key.
-
-  # Define a unique identifier for the new table
-  new_table_name = "$(table_name)_new"
-
-  # Retrieve existing columns and constraints excluding the foreign key
-  # You need to implement Dialect.get_columns and Dialect.get_constraints excluding the specific foreign key
-  existing_columns = Dialect.get_columns(conn, table_name)  # Implement this function
-  existing_constraints = Dialect.get_constraints(conn, table_name)  # Implement this function
-
-  # Remove the specific foreign key constraint from constraints
-  filtered_constraints = [c for c in existing_constraints if c != constraint_name]
-
-  # Recreate the CREATE TABLE statement without the foreign key constraint
-  columns_sql = join(["\"$col\"" for col in existing_columns], ", ")
-  constraints_sql = isempty(filtered_constraints) ? "" : ", " * join(["FOREIGN KEY ($fk_col) REFERENCES $ref_table($ref_col)" for (fk_col, ref_table, ref_col) in filtered_constraints], ", ")
-
-  # Begin transaction
-  migration_sql = [
-    "BEGIN TRANSACTION;",
-    """CREATE TABLE "$new_table_name" ($columns_sql$constraints_sql);""",
-    """INSERT INTO "$new_table_name" SELECT * FROM "$table_name";""",
-    """DROP TABLE "$table_name";""",
-    """ALTER TABLE "$new_table_name" RENAME TO "$table_name";""",
-    "COMMIT;"
-  ]
-
-  return join(migration_sql, "\n")
-
-end
+# NOTE (#83): there is intentionally no `drop_foreign_key(::PormGSQLite, …)`. SQLite has no
+# `ALTER TABLE DROP CONSTRAINT`, so an FK is removed by rebuilding the table from the desired model
+# (see `alter_field(::PormGSQLite, model, …)` + `_sqlite_rebuild_preserving_indexes`), which omits
+# the FK clause. The planner's `_drop_fk_constraint_in_alteration` is therefore a no-op on SQLite.
 
 function drop_index(conn::PormGPostgres, index_name::String)
   return """DROP INDEX IF EXISTS "$index_name";"""

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -55,10 +55,14 @@ end
 function _drop_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, field_name::String, new_field::Union{PormGField, Nothing}, old_field::PormGField)::Nothing
   if hasfield(old_field |> typeof, :to) && old_field.db_constraint && (new_field === nothing || !hasfield(new_field |> typeof, :to) || !new_field.db_constraint)
     if conn isa PormGSQLite
-      # SQLite doesn't have named FK constraints that can be dropped easily without recreation
-      # For now, we rely on Dialect.drop_foreign_key which might return a recreation script
-      _configure_order_dict_migration_plan(migration_plan, model_name, "Remove foreign key: $field_name", 
-      Dialect.drop_foreign_key(conn, model_name |> string, field_name |> string))
+      # SQLite has no `ALTER TABLE DROP CONSTRAINT`; an FK can only be removed by rebuilding the
+      # table. On the field-alteration path this is a no-op ON PURPOSE: `_alter_table_fields`
+      # already emits a full table rebuild (Dialect.alter_field wrapped by
+      # _sqlite_rebuild_preserving_indexes) from the DESIRED model, and that rebuild simply omits
+      # the FOREIGN KEY clause when the desired field dropped it — so the constraint is already
+      # gone, data + indexes are preserved, and no separate FK-drop DDL exists to emit. (#83)
+      # NOTE: field DELETION (drop_field → DROP COLUMN) and column RENAME do NOT get a rebuild, so
+      # removing an FK *there* is still unsupported on SQLite — tracked separately.
       return nothing
     end
     

--- a/test/integration/common_migration_setup.jl
+++ b/test/integration/common_migration_setup.jl
@@ -272,6 +272,30 @@ function index_names(pool::PormG.PormGPostgres, table_name::String)::Vector{Stri
 end
 
 """
+    foreign_key_count(pool, table_name::String) → Int
+
+Return the number of FOREIGN KEY constraints on `table_name`. Used to assert that a migration
+removed an FK (#83): after the constraint is dropped the count must be 0.
+"""
+function foreign_key_count(pool::PormG.PormGSQLite, table_name::String)::Int
+  conn = PormG.ConnectionPool.acquire_connection(pool)
+  try
+    # PRAGMA foreign_key_list returns one row per (constraint, column) pair; distinct `id` = distinct FK.
+    fks = PormG.ConnectionPool.fetch(pool, "PRAGMA foreign_key_list('$table_name')", conn=conn) |> DataFrame
+    return nrow(fks) == 0 ? 0 : length(unique(fks[!, :id]))
+  finally
+    PormG.ConnectionPool.release_connection(pool, conn)
+  end
+end
+
+function foreign_key_count(pool::PormG.PormGPostgres, table_name::String)::Int
+  rows = PormG.ConnectionPool.fetch(pool,
+    "SELECT count(*) FROM information_schema.table_constraints WHERE table_schema = 'public' AND table_name = '$table_name' AND constraint_type = 'FOREIGN KEY';")
+  df = DataFrame(rows)
+  return nrow(df) > 0 ? Int(df[1, 1]) : 0
+end
+
+"""
     all_table_names(pool) → Vector{String}
 
 Return the names of all user tables in the database.

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -335,6 +335,59 @@ end
     @test "test_id" in cols
   end
 
+  # ── Phase 4b: Remove an FK constraint via field alteration (#83) ──
+  # SQLite's `drop_foreign_key` used to call an undefined `get_constraints` and crash makemigrations,
+  # and it embedded its own BEGIN/COMMIT. FK removal is now routed through the table rebuild (which
+  # omits the FK) with the planner's SQLite FK-drop as a no-op. Seed a parent+child row, flip
+  # `test_id` to `db_constraint=false`, migrate, and assert the FK is gone AND the data survives the
+  # rebuild — with no embedded transaction control in the generated plan. Runs on both backends.
+  @testset "Phase 4b: Remove Foreign Key Constraint (#83)" begin
+    # Baseline: phase 4 left secondtable with an FK on test_id.
+    @assert foreign_key_count(pool, "secondtable") >= 1 "Phase 4b requires the FK created in phase 4"
+
+    # Seed a parent + child row (raw SQL; explicit ids keep the child's parent reference deterministic).
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "migrationtest" ("id", "name") VALUES (900, 'fk-parent-83');""")
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "secondtable" ("id", "test_id", "description") VALUES (901, 900, 'fk-child-83');""")
+
+    # Desired model: keep the column, drop only the DB-level FK constraint.
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    """)
+
+    # Must NOT raise UndefVarError (the old broken SQLite drop_foreign_key path).
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+
+    # AC2: the generated plan must not embed its own transaction control (the old draft did).
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # AC1: the FK constraint is gone, and the column is preserved.
+    @test foreign_key_count(pool, "secondtable") == 0
+    @test "test_id" in column_names(pool, "secondtable")
+
+    # Data fidelity: the child row survived the table rebuild with its values intact.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "test_id", "description" FROM "secondtable" WHERE "id" = 901;""") |> DataFrame
+    @test nrow(surviving) == 1
+    # `isequal` (not `==`) so a would-be NULL never propagates `missing` into `@test` (house convention).
+    @test isequal(surviving[1, :test_id], 900)
+    @test isequal(surviving[1, :description], "fk-child-83")
+
+    # Cleanup: restore the empty-table precondition later phases assume.
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "secondtable" WHERE "id" = 901;""")
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 900;""")
+  end
+
   # ── Phase 5: Indexes and unique constraints ───────────────────────
   @testset "Phase 5: Indexes and Unique Constraints" begin
     write_edge_models("""
@@ -739,9 +792,9 @@ end
   # ── Phase 8f: Data survival when adding NOT NULL temporal to table with rows ──
   #
   # Regression test for the bug where alter_field(conn::PormGSQLite, model::PormGModel, ...)
-  # called get_columns() at PLANNING TIME to build the INSERT column list for the
-  # table-recreation step. Because get_columns() reads the live database, it could
-  # not see columns that were queued via ADD COLUMN but had not yet executed.
+  # built the INSERT column list at PLANNING TIME by reading the live database's
+  # columns for the table-recreation step. Reading the live DB could not see columns
+  # that were queued via ADD COLUMN but had not yet executed.
   #
   # Consequently the generated SQL was:
   #   INSERT INTO "migrationtest_new" ("id", "full_name", ...) -- missing "last_seen"!
@@ -751,9 +804,9 @@ end
   # existing row SQLite raises "NOT NULL constraint failed: migrationtest_new.last_seen"
   # and the entire migration is rolled back.
   #
-  # The fix: use model.fields directly instead of get_columns(). ADD COLUMN statements
-  # are always queued BEFORE the recreation in the migration plan, so at execution time
-  # every model field is present in the old table.
+  # The fix: build the INSERT column list from model.fields directly instead of reading
+  # the live-DB columns. ADD COLUMN statements are always queued BEFORE the recreation in
+  # the migration plan, so at execution time every model field is present in the old table.
   #
   # Assertion strategy:
   #   1. dry_run: the INSERT statement in the plan must reference "last_seen"
@@ -797,8 +850,8 @@ end
 
     # ── SQL-text assertion (both adapters) ──────────────────────────────
     # The INSERT statement in the recreation block must reference "last_seen".
-    # Before the fix it was generated from get_columns() (live DB at planning
-    # time) and would only list columns that existed before the ADD COLUMN ran.
+    # Before the fix it was generated by reading the live-DB columns at planning
+    # time and would only list columns that existed before the ADD COLUMN ran.
     if adapter_name == "SQLite"
       insert_stmts = filter(
         s -> occursin("INSERT INTO", uppercase(s)) && occursin("MIGRATIONTEST_NEW", uppercase(s)),


### PR DESCRIPTION
Two logically distinct commits on this branch — a bugfix and a backlog-process cleanup.

## 1. `fix(#83)` — SQLite `drop_foreign_key` (commit `4edc662`)

**Closes #83.**

On SQLite, removing a foreign key via a field alteration crashed `makemigrations`:
`drop_foreign_key(::PormGSQLite, …)` referenced an undefined `Dialect.get_constraints`
(`UndefVarError` at plan-build time), and it embedded its own `BEGIN/COMMIT` that would prematurely
commit the migration runner's outer transaction.

SQLite has no `ALTER TABLE DROP CONSTRAINT`; an FK is removed by rebuilding the table. The
field-alteration path **already** emits that rebuild from the *desired* model (`alter_field` +
`_sqlite_rebuild_preserving_indexes`), which omits the FK clause, preserves data + indexes, and gates
on `PRAGMA foreign_key_check` — so the separate `drop_foreign_key` call was both broken **and
redundant**. `_drop_fk_constraint_in_alteration` is now a documented no-op on SQLite.

Deleted the broken `drop_foreign_key(::PormGSQLite)`, the dead 4-arg `alter_field(::PormGSQLite,
table_name, …)` (no callers; also embedded `BEGIN/COMMIT`), and the now-orphaned
`get_columns(::PormGSQLite)` helper they shared.

**Testing (both backends):** new `test_migration_bootstrap.jl` "Phase 4b" seeds a parent+child row,
flips `test_id` to `db_constraint=false`, migrates, and asserts the FK is gone, the column + row
survive the rebuild, and the plan embeds no `BEGIN/COMMIT`; new `foreign_key_count` helper.
**Mutation-verified:** reintroducing the broken call turns Phase 4b red (`MethodError`, edge-cases
102 pass / 1 error). SQLite bootstrap 108/108, PostgreSQL bootstrap 103/103, full SQLite integration
suite green.

**Out of scope → follow-up:** deleting an FK *field* (vs. altering it) and renaming an FK field on
SQLite still need their own rebuild — tracked in **#116**.

## 2. `docs(todo)` — slim TODO.md to a release-gating index (commit `d6923c8`)

TODO.md mirrored every open issue, duplicating GitHub Issues (the source of truth) and drifting (the
`#86` line went stale after merge; `#107` pre-publish was missing). It now tracks **only** the
`pre-publish` / release-gating items — the one thing `general.instructions.md` depends on, via the
preserved `⚠️ do BEFORE the first General-registry publish` phrase. The `pre-publish` label is the
source of truth: the list equals `gh issue list --label pre-publish`. Labeled **#36/#37**
`pre-publish` to match their prior gating framing; gating index is now #36, #37, #75, #107, #112. The
`pormg-issue-management` skill was updated to match (touch TODO.md only for `pre-publish` issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
