### PR TITLE
fix(#85): wrap SQLite bulk_update chunk loop in a transaction

### DIFF
--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -1121,8 +1121,14 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
     end
   end
 
+  # Wrap the whole chunk loop in one transaction on BOTH backends so a mid-chunk
+  # failure rolls back every already-flushed chunk (#85). This mirrors bulk_insert
+  # (`:749`) and bulk_copy (`:873`); a prior `!(connection isa PormGPostgres)` term
+  # here routed SQLite to the bare loop, leaving chunks 1…K-1 committed on a chunk-K
+  # failure. Skip the wrap only for dry-runs (`show_query !== :execute`) or when an
+  # outer transaction is already open (`has_active_tx`, to avoid a nested BEGIN).
   has_active_tx = transaction_connection_for(settings) !== nothing
-  if show_query !== :execute || !(connection isa PormGPostgres) || has_active_tx
+  if show_query !== :execute || has_active_tx
     update_loop()
   else
     run_in_transaction(update_loop, settings)

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -950,6 +950,102 @@ end
         end
 
         # ─────────────────────────────────────────────────────────────────────────────
+        # Bulk Update: a mid-chunk DB failure rolls back every chunk (#85)
+        #
+        # bulk_update wraps its multi-chunk loop in a single transaction on both
+        # backends, so if a later chunk fails, the already-flushed earlier chunks roll
+        # back too. Before the fix this wrap was gated to PostgreSQL only, so on SQLite
+        # each chunk auto-committed and chunk-K's failure left chunks 1…K-1 persisted.
+        #
+        # Trigger choice: a UNIQUE index, not an FK. The runtime SQLite connection does
+        # not enable PRAGMA foreign_keys, so an FK violation is not a reliable mid-chunk
+        # failure there; a UNIQUE index is enforced by default. And unlike a pre-flight
+        # validation error (bad length / wrong type), a UNIQUE collision passes
+        # validation (999 is a valid integer) and only fails once the chunk hits the DB —
+        # which is exactly the transactional path under test. On PostgreSQL this passes
+        # both before and after the fix (already wrapped); on SQLite it fails before the
+        # fix and passes after.
+        # ─────────────────────────────────────────────────────────────────────────────
+        @testset "Bulk Update is atomic on a mid-chunk DB failure" begin
+            _clear_bulk_update_scratch_rows!()
+            pool = PormG.config[PORMG_DB_FOLDER].connections
+            unique_index_name = "ux_bulk_update_payload_atomic"
+
+            try
+                # Seed one required parent plus five payload rows with distinct
+                # nullable_int values (101..105) and known labels ("orig-1".."orig-5").
+                required_ids, _ = _seed_bulk_update_scratch_parents!(["req-atomic"], String[])
+                req_id = required_ids["req-atomic"]
+
+                seeded_rows = [
+                    M.Bulk_update_payload_scratch.objects.create(
+                        "label" => "orig-$(index)",
+                        "required_parent_id" => req_id,
+                        "nullable_int" => 100 + index,
+                    )
+                    for index in 1:5
+                ]
+                seeded_ids = [Int64(row[:id]) for row in seeded_rows]
+
+                # Enforce uniqueness on nullable_int at the DB. Created after seeding, when
+                # the values are already distinct, so the index builds cleanly.
+                PormG.ConnectionPool.fetch(pool,
+                    "CREATE UNIQUE INDEX IF NOT EXISTS \"$(unique_index_name)\" " *
+                    "ON \"bulk_update_payload_scratch\" (\"nullable_int\")")
+
+                # chunk_size=2 → chunk 1 = rows 1-2, chunk 2 = rows 3-4, chunk 3 = row 5.
+                # Row 1 sets nullable_int=999 (chunk 1, succeeds); row 3 also sets 999
+                # (chunk 2), colliding with row 1 → UNIQUE violation mid-operation.
+                update_df = DataFrame(
+                    id = seeded_ids,
+                    label = ["upd-$(index)" for index in 1:5],
+                    nullable_int = [index in (1, 3) ? 999 : 100 + index for index in 1:5],
+                )
+
+                err = try
+                    Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
+                        bulk_update(
+                            M.Bulk_update_payload_scratch.objects,
+                            update_df,
+                            columns = ["label", "nullable_int"],
+                            match_on = ["id"],
+                            chunk_size = 2,
+                        )
+                    end
+                    nothing
+                catch e
+                    e
+                end
+                @test err !== nothing
+                # Assert the throw is the UNIQUE collision itself (raw DB error propagates
+                # unwrapped through run_in_transaction), not a pre-flight reject — otherwise a
+                # future validation that rejected 999 before any chunk ran would leave every row
+                # unchanged and pass the atomicity checks below trivially. SQLite: "UNIQUE
+                # constraint failed"; PostgreSQL: "duplicate key value violates unique constraint".
+                @test occursin(r"unique|duplicate"i, string(err))
+
+                # Atomicity: the mid-chunk failure must roll back EVERY chunk, including the
+                # already-flushed first chunk. Pre-fix on SQLite, chunk 1 auto-committed and
+                # row 1 would read back as "upd-1" / 999.
+                persisted = M.Bulk_update_payload_scratch.objects.order_by("id").list()
+                by_id = Dict(Int64(row[:id]) => row for row in persisted)
+                for (index, id) in enumerate(seeded_ids)
+                    row = by_id[id]
+                    @test row[:label] == "orig-$(index)"
+                    @test row[:nullable_int] == 100 + index
+                end
+            finally
+                try
+                    PormG.ConnectionPool.fetch(pool,
+                        "DROP INDEX IF EXISTS \"$(unique_index_name)\"")
+                catch
+                    # Index may never have been created (e.g. seeding failed) — safe to ignore.
+                end
+                _clear_bulk_update_scratch_rows!()
+            end
+        end
+
+        # ─────────────────────────────────────────────────────────────────────────────
         # Bulk Update: combined DateTimeField + nullable IntegerField + FK + BooleanField
         #
         # This mirrors the production call shape that prompted the test:


### PR DESCRIPTION
## Summary

Fixes #85 — `bulk_update` was non-atomic on SQLite. Its multi-chunk loop wrapped in a transaction **only for PostgreSQL**, via a stray `!(connection isa PormGPostgres)` term in the transaction gate. On SQLite with no outer transaction, each chunk auto-committed independently, so if chunk K of N failed, chunks 1…K-1 were already committed — a partial update with no rollback and no signal to the caller.

## Fix

Drop the `!(connection isa PormGPostgres)` term so the chunk loop wraps in one transaction on **both** backends, matching `bulk_insert` (`:749`) and `bulk_copy` (`:873`). Both existing short-circuits are preserved: dry-runs (`show_query !== :execute`) and an already-open outer transaction (`has_active_tx`, avoiding a nested `BEGIN`). `run_in_transaction` already fully supports SQLite (`BEGIN IMMEDIATE … COMMIT/ROLLBACK`, serialized by a reentrant write-lock), and the per-chunk `fetch` honors the ambient transaction connection — so wrapping SQLite is safe and needs no other change.

## Regression test

`test/integration/test_updates.jl` — a multi-chunk `bulk_update` where a later chunk hits a **UNIQUE-constraint** collision mid-execution, asserting every chunk rolled back.

- Uses a UNIQUE index, **not** an FK: the runtime SQLite connection doesn't enable `PRAGMA foreign_keys`, so an FK violation isn't a reliable trigger there. A UNIQUE index is enforced by default, and unlike a pre-flight validation error it fails only once the chunk reaches the DB — exactly the transactional path under test.
- Self-contained: creates and drops its own index in a `try/finally`; no schema or model changes.
- The error assertion checks the cause (`unique|duplicate`) so a future pre-flight reject can't silently turn it into a green no-op.

## Verification

| Backend | Result |
|---|---|
| SQLite, fix applied | **1544 / 1544** ✅ |
| SQLite, fix reverted | regression test **fails 3/12** — the exact partial-state leak (`"upd-1" == "orig-1"`, `999 == 101`, `"upd-2" == "orig-2"`) ✅ gating proven |
| PostgreSQL, fix applied | **1581 / 1581** ✅ |

Acceptance criteria from #85:
- [x] Multi-chunk `bulk_update` on SQLite is atomic: a mid-chunk failure rolls back all chunks.
- [x] Behavior matches `bulk_insert` / `bulk_copy` across both backends.
- [x] Regression test forces a later-chunk failure on SQLite and asserts no rows changed.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)