### PR TITLE
fix(#84): parameter-limit-aware chunking for bulk_insert / bulk_update

### DIFF
--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -9,6 +9,7 @@ import PormG: config
 import PormG: SQLType, SQLConn, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
 import PormG: PormGsuffix, PormGtransform, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
+import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -641,6 +641,58 @@ function _resolve_bulk_update_keys!(df::DataFrames.DataFrame, model::PormGModel,
 end
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Parameter-limit-aware chunking (#84)
+#
+# Each bulk row binds one parameter per mapped field, so a flushed statement carries
+# `chunk_rows × ncols` bind parameters. Backends cap that per statement, and the fixed
+# `chunk_size = 1000` default ignores column count — a wide table (PG) or the SQLite
+# 999-variable build silently overflows with only a raw driver error. We derive the
+# *effective* chunk from the column count and the backend's ceiling so the caller never
+# has to hand-tune `chunk_size` per table width. `bulk_copy` is exempt (it streams CSV
+# over COPY, not bind params).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# SQLITE_MAX_VARIABLE_NUMBER default: 999 before 3.32.0, 32766 from 3.32.0 on. Split out as a
+# pure function of the packed library version (e.g. 3039000) so the boundary is unit-testable
+# without an old SQLite build.
+_sqlite_param_limit(version_number::Integer) = version_number >= 3032000 ? 32766 : 999
+
+# Max bind parameters one prepared statement accepts, dispatched on the pool MARKER type so
+# core never names a concrete driver (see src/Backend.jl). PostgreSQL: 65535 (the Int16 param
+# count in the wire-protocol Bind message). SQLite: probed from the library version.
+_backend_parameter_limit(::PormGPostgres) = 65535
+_backend_parameter_limit(conn::PormGSQLite) = _sqlite_param_limit(backend_sqlite_version(conn))
+
+# Cap the requested chunk so that `fixed + effective × per_row` never exceeds `limit` (#84).
+# `per_row` is the parameters each row binds; `fixed` is the per-statement constant params
+# (bulk_update WHERE filters; 0 for insert). If a single row already blows the budget, no
+# chunk_size can help, so we fail closed with an actionable error naming the counts and limit.
+#
+# Note: array-valued fields on SQLite expand to multiple positional params per value
+# (parameters.jl `add_parameter!(::PormGSQLiteParam, ::AbstractArray)`), so `per_row = ncols`
+# under-counts them. That is a rare edge case outside #84's "one parameter per field" framing
+# and is not handled here.
+function _effective_chunk_size(requested::Integer, per_row::Integer, fixed::Integer,
+                               limit::Integer, op::Symbol, backend::AbstractString)
+  per_row <= 0 && return requested            # nothing bound per row → no cap possible or needed
+  max_rows = fld(limit - fixed, per_row)
+  if max_rows < 1
+    throw(_argerr("Error in $op: each row binds $per_row parameter(s)" *
+      (fixed > 0 ? " plus $fixed constant filter parameter(s)" : "") *
+      ", exceeding the $backend limit of $limit bind parameters per statement — no chunk_size " *
+      "can fit a single row. Reduce the columns per $op call (split the column set or the table)."))
+  end
+  # A non-positive `requested` (degenerate chunk_size) must still be capped to the
+  # backend-safe maximum, not collapse to a single un-chunked statement that overflows.
+  return requested < 1 ? max_rows : min(requested, max_rows)
+end
+
+# Backend label used only in the error text above.
+_backend_label(::PormGPostgres) = "PostgreSQL"
+_backend_label(::PormGSQLite) = "SQLite"
+
+
 """
 Inserts multiple rows into the database in bulk from a DataFrame.
 
@@ -706,6 +758,14 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   _columns = _normalize_bulk_columns(columns)
   mapping, fields_df, pk_exist, pk_field = _prepare_bulk_df!(df, model, _columns, :insert, settings)
 
+  # Cap the chunk so `effective_chunk × ncols` stays under the backend's bind-parameter limit
+  # (#84). Each INSERT row binds one param per field and adds nothing else, so per_row = ncols
+  # and there is no fixed per-statement overhead.
+  effective_chunk = _effective_chunk_size(chunk_size, length(fields_df), 0,
+    _backend_parameter_limit(connection), :bulk_insert, _backend_label(connection))
+  effective_chunk < chunk_size &&
+    @debug "bulk_insert: capped chunk_size $chunk_size → $effective_chunk to respect the backend bind-parameter limit" model = model.name
+
   # Build a list of row value strings by applying each model field formatter.
   results = []
   insert_loop = () -> begin
@@ -733,7 +793,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
       end
       push!(rows, "($(join(param_placeholders, ", ")))")
       count += 1
-      if count == chunk_size || index == total
+      if count == effective_chunk || index == total
         # @pormg_debug
         res = _bulk_insert(model, connection, fields_df, rows, pk_exist, pk_field, settings, django_prefix, show_query, parameters)
         push!(results, res)
@@ -1083,6 +1143,16 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
   parameters_initial =  deepcopy(instruction.parameters)
   joined_columns = unique(vcat(fields_df, dinanic_filters))
 
+  # Cap the chunk so `fixed + effective_chunk × ncols` stays under the backend's bind-parameter
+  # limit (#84). Each row binds one param per set column *and* per match key (joined_columns);
+  # the static-filter WHERE params in `parameters_initial` are re-included on every chunk, so
+  # they are the per-statement fixed overhead.
+  effective_chunk = _effective_chunk_size(chunk_size, length(joined_columns),
+    parameters_initial.parameter_count, _backend_parameter_limit(connection), :bulk_update,
+    _backend_label(connection))
+  effective_chunk < chunk_size &&
+    @debug "bulk_update: capped chunk_size $chunk_size → $effective_chunk to respect the backend bind-parameter limit" model = model.name
+
   results = []
   update_loop = () -> begin
     count::Integer = 0
@@ -1109,7 +1179,7 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
       end
       push!(rows, "($(join(param_placeholders, ", ")))")
       count += 1
-      if count == chunk_size || index == total      
+      if count == effective_chunk || index == total
         res = _bulk_update(model, settings, connection, joined_columns, rows, safe_set_clause, dinanic_filters, show_query, instruction)
         push!(results, res)
         count = 0

--- a/test/integration/test_inserts.jl
+++ b/test/integration/test_inserts.jl
@@ -663,4 +663,93 @@ end
             _clear_bulk_update_scratch_rows!()
         end
     end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # bulk_insert auto-chunks below the backend bind-parameter limit (#84)
+    #
+    # Each row binds one param per field, so a flushed statement carries
+    # chunk_rows × ncols bind params. bulk_insert must derive an effective chunk of
+    # fld(limit, ncols) from the backend ceiling instead of blindly using chunk_size.
+    # The 8-column payload table with chunk_size == nrows (== fld(limit, 8) + 1) is
+    # exactly one row past a single capped chunk, so the fix must split it into two.
+    #
+    # Two assertions with distinct jobs:
+    #   1. show_query=:sql — builds the INSERTs WITHOUT a DB round-trip and returns one
+    #      entry per chunk. This gates the wiring on BOTH backends independently of the
+    #      driver's true limit: post-fix → a 2-element Vector; pre-fix (uncapped) → a
+    #      single un-split SQL String, so `res isa Vector` fails (mutation gate).
+    #   2. execute — proves the auto-split writes the FULL row set correctly across the
+    #      chunk boundary. On PostgreSQL 65535 is a hard wire-protocol limit, so pre-fix
+    #      this also overflows the driver; on SQLite the runtime limit can exceed our
+    #      conservative 32766 default, so there the execute is a correctness check (the
+    #      show_query assertion is the SQLite gate).
+    #
+    # nrows tracks the live backend limit: 4096 rows on SQLite (32766), 8192 on PG.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "auto-chunks to respect the backend bind-parameter limit (#84)" begin
+        _clear_bulk_update_scratch_rows!()
+
+        pool  = PormG.config[PORMG_DB_FOLDER].connections
+        limit = PormG.QueryBuilder._backend_parameter_limit(pool)
+
+        # Pin the CONCRETE limit value. Every other assertion here derives from `limit`
+        # (nrows, chunk count), so it would stay self-consistent — and silently green —
+        # even if _backend_parameter_limit returned a wrong (especially under-estimated)
+        # value. This is the one check that actually fails if the constant is wrong.
+        # SQLite: the shipped SQLite.jl is ≥3.32.0, so the default is 32766 (a regression
+        # to 999 on an ancient build would fail here, which is the correct signal).
+        @test limit == (PORMG_DB_FOLDER == "db_sl" ? 32766 : 65535)
+
+        ncols = 8                              # all payload columns, incl. the explicit id
+        nrows = fld(limit, ncols) + 1          # one row past a single capped chunk
+
+        try
+            required_ids, optional_ids = _seed_bulk_update_scratch_parents!(
+                ["req-84-autochunk"], ["opt-84-autochunk"],
+            )
+            req_id = required_ids["req-84-autochunk"]
+            opt_id = optional_ids["opt-84-autochunk"]
+
+            base_id = 5_000_000
+            columns = ["id", "label", "required_parent_id", "optional_parent_id",
+                       "event_date", "is_active", "event_time", "nullable_int"]
+            insert_df = DataFrame(
+                id                 = [base_id + i for i in 1:nrows],
+                label              = ["autochunk-$(i)" for i in 1:nrows],
+                required_parent_id = fill(req_id, nrows),
+                optional_parent_id = fill(opt_id, nrows),
+                event_date         = fill(Date(2024, 1, 1), nrows),
+                is_active          = fill(true, nrows),
+                event_time         = fill(DateTime(2024, 1, 1, 0, 0, 0), nrows),
+                nullable_int       = collect(1:nrows),
+            )
+
+            # (1) Driver-independent wiring gate: chunk_size == nrows must still split
+            # into exactly two statements because the cap trims it to fld(limit, 8).
+            res = bulk_insert(
+                M.Bulk_update_payload_scratch.objects, insert_df,
+                columns = columns, chunk_size = nrows, show_query = :sql,
+            )
+            @test res isa Vector       # pre-fix returns one un-split SQL String → gate
+            @test length(res) == 2     # effective rows + 1 → two capped chunks
+
+            # (2) End-to-end correctness: the auto-split writes the full set, not a subset.
+            bulk_insert(
+                M.Bulk_update_payload_scratch.objects, insert_df,
+                columns = columns, chunk_size = nrows,
+            )
+            @test M.Bulk_update_payload_scratch.objects.count() == nrows
+
+            # Spot-check the first and last rows (they straddle the chunk boundary)
+            # persisted with the correct values, not just that the count matched.
+            first_row = M.Bulk_update_payload_scratch.objects.filter("id" => base_id + 1).list() |> first
+            last_row  = M.Bulk_update_payload_scratch.objects.filter("id" => base_id + nrows).list() |> first
+            @test first_row[:label] == "autochunk-1"
+            @test first_row[:nullable_int] == 1
+            @test last_row[:label] == "autochunk-$(nrows)"
+            @test last_row[:nullable_int] == nrows
+        finally
+            _clear_bulk_update_scratch_rows!()
+        end
+    end
 end

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -1046,6 +1046,54 @@ end
         end
 
         # ─────────────────────────────────────────────────────────────────────────────
+        # Bulk Update auto-chunks below the backend bind-parameter limit (#84)
+        #
+        # bulk_update wires the parameter-limit cap at its own flush site, separate from
+        # bulk_insert's — so the pure-math unit test alone can't prove bulk_update uses
+        # it. This gates that wiring cheaply: `show_query = :sql` builds the UPDATE
+        # statements WITHOUT a DB round-trip (no rows to seed) and returns one entry per
+        # chunk. Each row binds one param per SET column plus the id match key (8 total),
+        # so a single un-chunked statement of nrows × 8 would exceed the backend ceiling.
+        # With chunk_size == nrows: pre-fix (uncapped) that is one statement → a lone SQL
+        # String; post-fix the chunk auto-caps to fld(limit, 8) so nrows splits into
+        # exactly two chunks → a 2-element Vector. Reverting the cap makes `res` a String
+        # and fails the `isa Vector` assertion (mutation gate).
+        # ─────────────────────────────────────────────────────────────────────────────
+        @testset "Bulk Update auto-chunks to respect the bind-parameter limit (#84)" begin
+            pool    = PormG.config[PORMG_DB_FOLDER].connections
+            limit   = PormG.QueryBuilder._backend_parameter_limit(pool)
+            per_row = 8                          # 7 SET columns + the id match key
+            effective = fld(limit, per_row)      # 4095 on SQLite (32766), 8191 on PG (65535)
+            nrows   = effective + 1              # one row past a single capped chunk
+
+            # No static filters ⇒ zero fixed WHERE overhead, so the effective chunk is
+            # exactly fld(limit, 8) and nrows splits into precisely two chunks.
+            update_df = DataFrame(
+                id                 = collect(1:nrows),
+                label              = ["upd-$(i)" for i in 1:nrows],
+                required_parent_id = fill(1, nrows),
+                optional_parent_id = fill(1, nrows),
+                event_date         = fill(Date(2024, 1, 1), nrows),
+                is_active          = fill(true, nrows),
+                event_time         = fill(DateTime(2024, 1, 1, 0, 0, 0), nrows),
+                nullable_int       = collect(1:nrows),
+            )
+
+            res = bulk_update(
+                M.Bulk_update_payload_scratch.objects,
+                update_df,
+                columns    = ["label", "required_parent_id", "optional_parent_id",
+                              "event_date", "is_active", "event_time", "nullable_int"],
+                match_on   = ["id"],
+                chunk_size = nrows,
+                show_query = :sql,
+            )
+
+            @test res isa Vector       # pre-fix returns one un-split SQL String → gate
+            @test length(res) == 2     # effective rows + 1 → two capped chunks
+        end
+
+        # ─────────────────────────────────────────────────────────────────────────────
         # Bulk Update: combined DateTimeField + nullable IntegerField + FK + BooleanField
         #
         # This mirrors the production call shape that prompted the test:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
     @testset "Reload Regressions" include("unit/test_reload.jl")
     @testset "Configuration API" include("unit/test_configuration_api.jl")
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
+    @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_bulk_param_limit.jl
+++ b/test/unit/test_bulk_param_limit.jl
@@ -1,0 +1,112 @@
+# ============================================================
+# test/unit/test_bulk_param_limit.jl
+#
+# Parameter-limit-aware chunking (#84).
+#
+# CONTRACT being tested:
+#   Bulk insert/update flush `chunk_rows × ncols` bind parameters per statement.
+#   Backends cap that per statement (PostgreSQL 65535; SQLite 999 before v3.32.0,
+#   32766 from v3.32.0 on). The effective chunk must be derived from the column
+#   count and the backend ceiling so a wide table (PG) or the SQLite 999 build no
+#   longer overflows the driver at the default chunk_size. When a single row cannot
+#   fit under the limit no matter the chunk size, the helper must fail closed with an
+#   actionable error naming the limit — never silently truncate.
+#
+# These are pure-function tests of the chunking math: they take the backend limit as
+# an argument, so they gate BOTH backends' ceilings without a live database and fail
+# the moment the cap is reverted.
+# ============================================================
+
+using Test
+using PormG
+
+# Internal helpers live in the QueryBuilder submodule (execution_bulk.jl), unexported.
+const _sqlite_param_limit    = PormG.QueryBuilder._sqlite_param_limit
+const _effective_chunk_size  = PormG.QueryBuilder._effective_chunk_size
+
+@testset "Bulk parameter-limit-aware chunking (#84)" begin
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # SQLite variable-limit version boundary.
+    # SQLITE_MAX_VARIABLE_NUMBER default jumped 999 → 32766 at v3.32.0 (packed
+    # integer 3032000). The helper is a pure function of the packed version so the
+    # exact boundary is provable without an old SQLite build.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "SQLite param limit tracks the 3.32.0 boundary" begin
+        @test _sqlite_param_limit(3031999) == 999      # 3.31.x → old default
+        @test _sqlite_param_limit(3032000) == 32766    # exactly 3.32.0 → new default
+        @test _sqlite_param_limit(3039000) == 32766    # 3.39.0 → new default
+        @test _sqlite_param_limit(3000000) == 999      # very old
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Effective chunk = min(requested, fld(limit - fixed, per_row)).
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "Effective chunk caps to the bind-parameter budget" begin
+        # PostgreSQL, wide table (66 columns) at the default chunk_size: 66 × 1000 =
+        # 66000 > 65535 pre-fix. The cap must bring it to fld(65535, 66) = 992
+        # (66 × 993 = 65538 would overflow).
+        @test _effective_chunk_size(1000, 66, 0, 65535, :bulk_insert, "PostgreSQL") == 992
+
+        # SQLite old build (limit 999), single-column table: 1 × 1000 = 1000 > 999.
+        # Cap must land at exactly 999, one below the requested 1000.
+        @test _effective_chunk_size(1000, 1, 0, 999, :bulk_insert, "SQLite") == 999
+
+        # No cap needed: 8 columns on the modern SQLite build (32766) fits 1000 rows
+        # (8 × 1000 = 8000 < 32766) → the requested chunk_size passes through untouched.
+        @test _effective_chunk_size(1000, 8, 0, 32766, :bulk_insert, "SQLite") == 1000
+
+        # Cap needed: a larger requested chunk on the same table gets trimmed to
+        # fld(32766, 8) = 4095.
+        @test _effective_chunk_size(5000, 8, 0, 32766, :bulk_insert, "SQLite") == 4095
+
+        # Degenerate requested chunk (0 or negative) must NOT collapse to a single
+        # un-chunked statement — the cap stays unconditional at the backend-safe max.
+        @test _effective_chunk_size(0,  8, 0, 32766, :bulk_insert, "SQLite") == 4095
+        @test _effective_chunk_size(-5, 8, 0, 32766, :bulk_insert, "SQLite") == 4095
+
+        # Defensive branch: nothing bound per row (empty field set) → no cap applies and
+        # the requested chunk passes through unchanged (no division by zero).
+        @test _effective_chunk_size(1000, 0, 0, 999, :bulk_insert, "SQLite") == 1000
+
+        # bulk_update carries a per-statement fixed overhead (static WHERE filters
+        # re-included on every chunk). With 5 fixed params the budget is 65535 - 5 =
+        # 65530, so 8-column rows cap at fld(65530, 8) = 8191.
+        @test _effective_chunk_size(1000, 8, 5, 65535, :bulk_update, "PostgreSQL") ==
+              min(1000, fld(65530, 8))
+        @test _effective_chunk_size(20000, 8, 5, 65535, :bulk_update, "PostgreSQL") == 8191
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Fail-closed: a single row that can't fit under the limit. No chunk_size can
+    # help, so the helper must throw an actionable error — never return 0 and never
+    # silently drop columns.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "Impossible single row raises an actionable error" begin
+        # 1000-column table on the SQLite 999 build: even one row (1000 params) blows
+        # the 999 ceiling. Assert both that it throws AND that the message names the
+        # concrete limit — a bare @test_throws would pass on any unrelated ArgumentError.
+        err = try
+            _effective_chunk_size(1000, 1000, 0, 999, :bulk_insert, "SQLite")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("999", string(err))              # names the backend limit
+        @test occursin("chunk_size", string(err))        # points at the lever
+        @test occursin(r"bulk_insert"i, string(err))     # names the operation
+
+        # The fixed overhead alone can exhaust the budget too (per_row still ≥ 1) —
+        # assert the message, not just the type, so an unrelated ArgumentError can't pass.
+        err_fixed = try
+            _effective_chunk_size(1000, 1, 999, 999, :bulk_update, "SQLite")
+            nothing
+        catch e
+            e
+        end
+        @test err_fixed isa ArgumentError
+        @test occursin("999", string(err_fixed))
+        @test occursin(r"bulk_update"i, string(err_fixed))
+    end
+end


### PR DESCRIPTION
## Summary

`bulk_insert` / `bulk_update` chunked by a **fixed row count** (`chunk_size = 1000`) that ignored column count. Each row binds one parameter per mapped field, so a flushed statement carried `chunk_rows × ncols` bind parameters — overflowing the backend's per-statement ceiling with only a raw driver error and no hint that `chunk_size` was the lever:

- **PostgreSQL**: 65535 params/statement → any table with ≥ 66 mapped columns overflows at the default `chunk_size`.
- **SQLite**: `SQLITE_MAX_VARIABLE_NUMBER` is **999** before v3.32.0 and **32766** after → a single-column table overflows the 999 build; a 33-column table overflows the 32766 build.

`bulk_copy` is unaffected (it streams CSV over `COPY`, not bind params).

## Fix

Derive an **effective chunk** from the column count and the active backend's bind-parameter limit, so wide-table / single-column bulk ops auto-chunk and succeed at default settings.

- `_sqlite_param_limit(version)` — pure 999-vs-32766 split at the 3.32.0 boundary (unit-testable without an old SQLite).
- `_backend_parameter_limit(conn)` — dispatched on the pool **marker** so core never names a concrete driver: `65535` for PostgreSQL, version-probed (via the existing `backend_sqlite_version`) for SQLite.
- `_effective_chunk_size(...)` — caps to `fld(limit − fixed, per_row)`; **fails closed** with an actionable error naming the limit/`chunk_size`/columns when a single row can't fit under the limit no matter the chunk size. A non-positive `chunk_size` is still capped, never collapsed to one un-chunked statement.
- `bulk_insert` (`fixed = 0`) and `bulk_update` (`fixed =` static-WHERE params, re-included each chunk) wire the cap into their flush condition. Silent auto-cap with a `@debug` note.

At-limit is inclusive on both backends, so there's no off-by-one.

## Tests

- **Unit** (`test/unit/test_bulk_param_limit.jl`): the cap math for both backend limits (PG 65535, SQLite 999/32766), the version boundary at 3031999/3032000, the fail-closed error (message cause-checked), and the non-positive-`chunk_size` clamp.
- **Integration** (`test_inserts.jl`, `test_updates.jl`): auto-chunk gated on **both** backends via a driver-independent `show_query=:sql` chunk-count check, plus an end-to-end execute proving the split writes the full row set. The concrete `32766` / `65535` limit constants are **pinned** so a wrong value fails loudly (every other assertion derives from `limit`, so this is the one check that catches a bad constant).

The wiring is mutation-gated: reverting the two flush lines makes both `#84` tests fail (the `show_query` gate catches it independently of the driver's true variable limit, which on modern SQLite exceeds the conservative 32766 default).

## Verification

| Suite | Result |
|-------|--------|
| Unit (`test/runtests.jl`) | 2249/2249 (incl. Aqua) |
| Full integration — PostgreSQL (`db_2`) | 1590/1590 |
| Full integration — SQLite (`db_sl`) | 1553/1553 |
| Mutation gate (revert fix) | both `#84` tests fail ✔ |

## Acceptance criteria (from #84)

- [x] Wide-table (PG) and single-column (SQLite) bulk insert succeed at default settings (auto-chunked), or raise a clear PormG error naming the limit and `chunk_size`.
- [x] Effective chunk size accounts for column count and the active backend's parameter limit.
- [x] Regression test with `chunk_size × ncols` exceeding the limit completes via auto-chunk (and the impossible single-row case raises the actionable error).

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)