### PR TITLE
fix(#75): normalize ORDER BY NULL placement across PostgreSQL and SQLite

### DIFF
--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -386,6 +386,59 @@ query.filter(Qor("constructorid" => 1, "constructorid" => 9))
 
 ---
 
+## Ordering and NULL Placement
+
+`order_by(...)` sorts the result. Prefix a field with `-` for descending; pass several fields to break ties left to right:
+
+```julia
+# By nationality (A→Z), then surname (A→Z) within each nationality
+query = M.Driver.objects
+query.values("surname", "nationality")
+query.order_by("nationality", "surname")
+```
+
+### Where NULLs land
+
+Nullable sort keys are normalized to sort **the same way on PostgreSQL and SQLite** (the two
+backends have *opposite* native defaults, which used to make `order_by(...).first()` return
+different rows on each). PormG standardizes on PostgreSQL's convention — **NULL sorts as the
+largest value** — on every backend:
+
+| Direction | NULL placement |
+|-----------|----------------|
+| `order_by("field")` (ASC)  | NULLs **last**  |
+| `order_by("-field")` (DESC) | NULLs **first** |
+
+```julia
+# nationality is nullable. Ascending → the rows with a NULL nationality come LAST,
+# identically on PostgreSQL and SQLite.
+M.Driver.objects.values("surname", "nationality").order_by("nationality").list()
+```
+
+### Overriding placement per term
+
+Pass a `SQLOrder` object with `nulls = :first` or `nulls = :last` to force placement independently
+of the sort direction:
+
+```julia
+using PormG.QueryBuilder: SQLOrder, SQLField
+
+# Ascending by nationality, but push NULL nationalities to the FRONT
+M.Driver.objects.values("surname", "nationality").order_by(
+    SQLOrder(SQLField("nationality", "nationality"); orientation = "ASC", nulls = :first)
+).list()
+```
+
+On SQLite builds older than 3.30.0 (which lack `NULLS FIRST/LAST` syntax) PormG emits the portable
+`(field IS NULL)` sort prefix, so the placement is identical there too.
+
+!!! note
+    `nulls` normalization and the `SQLOrder(...; nulls=…)` override apply to the query's top-level
+    `ORDER BY`. Ordering **inside** a window frame (`WindowOver(order_by=…)`) is not yet normalized —
+    its NULL placement still follows each backend's native default.
+
+---
+
 ## Counting
 
 `count()` is a terminal that returns a scalar `Int` for the current query (filters included). It has four forms:

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -54,6 +54,39 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
   end
 end
 
+# NULLS FIRST/LAST syntax landed in SQLite 3.30.0; older builds need the portable
+# `(expr IS NULL)` prefix instead (#75).
+const SQLITE_NULLS_ORDER_MIN_VERSION = 3030000
+
+# Resolve NULL placement for one ORDER BY term (#75). The canonical default matches PostgreSQL
+# (NULL sorts as the largest value): ASC → :last, DESC → :first — so ordering a nullable column
+# returns the same rows on both backends. An explicit SQLOrder(...; nulls=:first|:last) overrides it.
+function _nulls_placement(orientation::AbstractString, nulls::Union{Symbol,Nothing})
+  nulls === :first && return :first
+  nulls === :last  && return :last
+  nulls === nothing || throw(_argerr("Invalid nulls placement $(repr(nulls)); use :first or :last"))
+  return uppercase(strip(String(orientation))) == "DESC" ? :first : :last
+end
+
+# Render one ORDER BY term with explicit NULL placement, portable across backends (#75).
+function _order_term_sql(expr, orientation::AbstractString, placement::Symbol, conn)
+  if conn isa PormGSQLite && backend_sqlite_version(conn) < SQLITE_NULLS_ORDER_MIN_VERSION
+    # SQLite < 3.30 has no NULLS syntax → emulate placement by sorting on the null-flag first.
+    # NULLS FIRST means nulls (flag 1) come first → DESC on the flag; NULLS LAST → ASC on the flag.
+    # This references `expr` twice. A resolved ORDER BY column/alias is a bare identifier, but a
+    # function-valued order term could render a positional `?` placeholder; duplicating that would
+    # bind the value once yet reference it twice → parameter misalignment. Guard against it: only
+    # emulate when `expr` is placeholder-free. For the rare parameterized order term on this ancient
+    # SQLite, emit the plain term (native NULL placement) — normalization is skipped, never corrupted.
+    if occursin('?', string(expr))
+      return string(expr, " ", orientation)
+    end
+    flag_dir = placement === :first ? "DESC" : "ASC"
+    return string("(", expr, " IS NULL) ", flag_dir, ", ", expr, " ", orientation)
+  end
+  return string(expr, " ", orientation, " ", placement === :first ? "NULLS FIRST" : "NULLS LAST")
+end
+
 function get_order_query(object::SQLObject, instruc::SQLInstruction)
   for v in object.order
     found_in_select = false
@@ -85,7 +118,8 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     else
       v_field_copy.field = _get_select_query(v_field_copy.field, instruc)
     end
-    push!(instruc.order, string(v_field_copy.field, " ", v.orientation))
+    placement = _nulls_placement(v.orientation, v.nulls)
+    push!(instruc.order, _order_term_sql(v_field_copy.field, v.orientation, placement, instruc.connection))
     instruc.cache[v_field_copy._as] = v_field_copy
 
     if !found_in_select

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -126,9 +126,12 @@ mutable struct SQLOrder <: SQLTypeOrder
   order::Union{Integer,Nothing}
   orientation::String
   _as::OptionalString
+  # NULL placement for this term (#75): `nothing` = apply the canonical backend-aligned default
+  # (ASC → NULLS LAST, DESC → NULLS FIRST); `:first`/`:last` force the placement explicitly.
+  nulls::Union{Symbol,Nothing}
 end
-SQLOrder(field::Union{SQLTypeField,String}; order::Union{Integer,Nothing}=nothing, orientation::String="ASC", _as::OptionalString=nothing) = SQLOrder(field, order, orientation, _as)
-Base.deepcopy(x::SQLTypeOrder) = SQLOrder(x.field, x.order, x.orientation, x._as)
+SQLOrder(field::Union{SQLTypeField,String}; order::Union{Integer,Nothing}=nothing, orientation::String="ASC", _as::OptionalString=nothing, nulls::Union{Symbol,Nothing}=nothing) = SQLOrder(field, order, orientation, _as, nulls)
+Base.deepcopy(x::SQLTypeOrder) = SQLOrder(x.field, x.order, x.orientation, x._as, x.nulls)
 
 #
 # SQLObject Objects (main object to build a query)

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -287,6 +287,86 @@ end
 end
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ORDER BY NULL placement is normalized across backends (#75).
+#
+# PostgreSQL and SQLite default NULLs to OPPOSITE ends of an ORDER BY, so ordering a
+# nullable column used to return different rows on each backend — and with .first()/.page()
+# that changed WHICH row you got, not just its position. PormG now emits an explicit
+# NULLS clause matching PostgreSQL's default on both backends: ASC → NULLS LAST,
+# DESC → NULLS FIRST, overridable per term via SQLOrder(field; nulls=:first|:last).
+#
+# This test asserts the (now backend-independent) expected order on whichever backend is
+# running. Pre-fix it FAILS on SQLite (NULLs would sort first for ASC) — the cross-backend
+# mutation gate. It uses the permanent `bulk_update_payload_scratch` fixture (nullable_int
+# column) with try/finally cleanup so the F1 tables are untouched.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ORDER BY NULL placement normalized across backends (#75)" begin
+    # Scratch helpers are loaded in-suite by runtests.jl; load them for standalone runs too.
+    if !isdefined(Main, :_clear_bulk_update_scratch_rows!)
+        include("common_bulk_scratch_setup.jl")
+    end
+
+    _is_nullish(x) = x === nothing || ismissing(x)
+
+    _clear_bulk_update_scratch_rows!()
+    try
+        required_ids, _ = _seed_bulk_update_scratch_parents!(["req-nulls-75"], String[])
+        pid = required_ids["req-nulls-75"]
+
+        # Four rows: three non-NULL sort keys plus one NULL. Labels identify rows regardless
+        # of how a NULL integer renders back (nothing/missing).
+        M.Bulk_update_payload_scratch.objects.create("label" => "n75-a", "required_parent_id" => pid, "nullable_int" => 30)
+        M.Bulk_update_payload_scratch.objects.create("label" => "n75-b", "required_parent_id" => pid, "nullable_int" => 10)
+        M.Bulk_update_payload_scratch.objects.create("label" => "n75-c", "required_parent_id" => pid)  # nullable_int → NULL
+        M.Bulk_update_payload_scratch.objects.create("label" => "n75-d", "required_parent_id" => pid, "nullable_int" => 20)
+
+        our_labels = ["n75-a", "n75-b", "n75-c", "n75-d"]
+        labels_of(rows) = [r[:label] for r in rows]
+
+        # Ascending: non-NULL keys ascend, NULL sorts LAST (PostgreSQL's default, now on SQLite too).
+        asc_rows = M.Bulk_update_payload_scratch.objects.
+            filter("label__@in" => our_labels).
+            order_by("nullable_int").
+            values("label", "nullable_int").
+            list()
+        @test labels_of(asc_rows) == ["n75-b", "n75-d", "n75-a", "n75-c"]
+        @test _is_nullish(asc_rows[end][:nullable_int])          # the NULL row is last
+
+        # The concrete #75 symptom: .first() over the ascending nullable key must return the
+        # smallest non-NULL row (n75-b / 10) on BOTH backends — pre-fix SQLite returned the NULL row.
+        first_asc = M.Bulk_update_payload_scratch.objects.
+            filter("label__@in" => our_labels).
+            order_by("nullable_int").
+            first()
+        @test first_asc !== nothing
+        @test first_asc[:label] == "n75-b"
+
+        # Descending: NULL sorts FIRST (matches PostgreSQL DESC default).
+        desc_rows = M.Bulk_update_payload_scratch.objects.
+            filter("label__@in" => our_labels).
+            order_by("-nullable_int").
+            values("label", "nullable_int").
+            list()
+        @test labels_of(desc_rows) == ["n75-c", "n75-a", "n75-d", "n75-b"]
+        @test _is_nullish(desc_rows[1][:nullable_int])           # the NULL row is first
+
+        # Override: ascending order but NULLs forced to the FRONT via SQLOrder(...; nulls=:first).
+        ovr_rows = M.Bulk_update_payload_scratch.objects.
+            filter("label__@in" => our_labels).
+            order_by(PormG.QueryBuilder.SQLOrder(
+                PormG.QueryBuilder.SQLField("nullable_int", "nullable_int");
+                orientation = "ASC", nulls = :first)).
+            values("label", "nullable_int").
+            list()
+        @test labels_of(ovr_rows) == ["n75-c", "n75-b", "n75-d", "n75-a"]
+        @test _is_nullish(ovr_rows[1][:nullable_int])            # override put the NULL row first
+    finally
+        _clear_bulk_update_scratch_rows!()
+    end
+end
+
+
 @testset "Filtering" begin
     # Contains and icontains
     query = M.Result.objects.filter("raceid__circuitid__name__@contains" => "Monaco");

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,7 @@ end
     @testset "Configuration API" include("unit/test_configuration_api.jl")
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
+    @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_order_by_nulls.jl
+++ b/test/unit/test_order_by_nulls.jl
@@ -1,0 +1,134 @@
+# ============================================================
+# test/unit/test_order_by_nulls.jl
+#
+# ORDER BY NULL-placement normalization (#75).
+#
+# CONTRACT being tested:
+#   Top-level ORDER BY must emit an explicit NULL-placement clause on BOTH backends so a
+#   nullable sort key returns the same rows on PostgreSQL and SQLite. The canonical default
+#   matches PostgreSQL (NULL sorts as the largest value): ASC → NULLS LAST, DESC → NULLS FIRST.
+#   A per-term override — SQLOrder(field; nulls=:first|:last) — forces placement. On SQLite
+#   builds older than 3.30.0 (no NULLS syntax) the term degrades to the portable
+#   `(expr IS NULL)` prefix that sorts identically.
+#
+# These are deterministic SQL-shape / pure-function tests: no live database. Reverting the fix
+# (bare `expr ASC|DESC` push) drops the `NULLS …` suffix, so every default/override assertion
+# below fails — the mutation gate.
+# ============================================================
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, CharField, IntegerField
+using PormG.QueryBuilder: SQLField, SQLOrder
+
+# Internal helpers live in the QueryBuilder submodule (build_query.jl), unexported.
+const _nulls_placement = PormG.QueryBuilder._nulls_placement
+const _order_term_sql  = PormG.QueryBuilder._order_term_sql
+
+# ── Mock backends ───────────────────────────────────────────────────────────────────────────
+# A mock PostgreSQL marker for full-render tests (no DB round-trip), mirroring the pattern in
+# test_inspect_query.jl. Two mock SQLite markers pin the version-gated rendering branch: one
+# reports a modern library (native NULLS syntax), one an old one (portable fallback). We add
+# `backend_sqlite_version` methods on our own mock types so the branch is provable without an
+# actual old SQLite build.
+struct MockPG_OrderNulls <: PormG.PormGPostgres end
+struct MockNewSQLite_OrderNulls <: PormG.PormGSQLite end
+struct MockOldSQLite_OrderNulls <: PormG.PormGSQLite end
+PormG.backend_sqlite_version(::MockNewSQLite_OrderNulls) = 3039000   # 3.39.0 → native NULLS
+PormG.backend_sqlite_version(::MockOldSQLite_OrderNulls) = 3029000   # 3.29.0 → portable fallback
+
+DriverNullsModel = Model("drivers_nulls",
+  id = IDField(),
+  surname = CharField(),
+  nationality = CharField(null=true),   # nullable → the #75 divergence surface
+)
+DriverNullsModel.connect_key = "order_nulls_pg"
+PormG.config["order_nulls_pg"] = PormG.Configuration.Settings(
+  connections = MockPG_OrderNulls(),
+  change_data = true,
+)
+
+@testset "ORDER BY NULL-placement normalization (#75)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Pure placement resolution: canonical default is PostgreSQL's (ASC→last, DESC→first),
+  # and an explicit override wins regardless of orientation.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "_nulls_placement resolves the canonical default and overrides" begin
+    @test _nulls_placement("ASC",  nothing) === :last     # ASC default → NULLS LAST
+    @test _nulls_placement("DESC", nothing) === :first    # DESC default → NULLS FIRST
+    @test _nulls_placement("asc",  nothing) === :last     # case-insensitive
+    @test _nulls_placement("DESC", :last)   === :last     # override beats the DESC default
+    @test _nulls_placement("ASC",  :first)  === :first    # override beats the ASC default
+
+    # Garbage placement must fail loudly and name the valid options — not silently default.
+    err = try
+      _nulls_placement("ASC", :bogus)
+      nothing
+    catch e
+      e
+    end
+    @test err isa ArgumentError
+    @test occursin(":first", string(err))
+    @test occursin(":last", string(err))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Per-backend term rendering. PG and modern SQLite emit native NULLS syntax; the SQLite
+  # < 3.30 build emits the portable `(expr IS NULL)` prefix that sorts the same way.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "_order_term_sql renders native NULLS and the old-SQLite fallback" begin
+    pg  = MockPG_OrderNulls()
+    sln = MockNewSQLite_OrderNulls()
+    slo = MockOldSQLite_OrderNulls()
+
+    # Native NULLS syntax (PostgreSQL + SQLite ≥ 3.30).
+    @test _order_term_sql("col", "ASC",  :last,  pg)  == "col ASC NULLS LAST"
+    @test _order_term_sql("col", "DESC", :first, pg)  == "col DESC NULLS FIRST"
+    @test _order_term_sql("col", "ASC",  :last,  sln) == "col ASC NULLS LAST"
+    @test _order_term_sql("col", "DESC", :first, sln) == "col DESC NULLS FIRST"
+
+    # Portable fallback (SQLite < 3.30): NULLS LAST → non-nulls (flag 0) first → flag ASC;
+    # NULLS FIRST → nulls (flag 1) first → flag DESC. The base orientation trails.
+    @test _order_term_sql("col", "ASC",  :last,  slo) == "(col IS NULL) ASC, col ASC"
+    @test _order_term_sql("col", "DESC", :first, slo) == "(col IS NULL) DESC, col DESC"
+
+    # Bind-safety guard: the fallback references `expr` twice, so a placeholder-carrying order term
+    # must NOT be duplicated (that would bind once but reference twice → parameter misalignment).
+    # For such a term on old SQLite, emit the plain term — no null-flag prefix, no NULLS syntax.
+    @test _order_term_sql("col = ?", "ASC", :last, slo) == "col = ? ASC"
+    # The native path still appends NULLS even with a placeholder (no duplication there → safe).
+    @test _order_term_sql("col = ?", "ASC", :last, sln) == "col = ? ASC NULLS LAST"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # End-to-end SQL shape through the public order_by API on a mock PostgreSQL connection.
+  # This gates the wiring in get_order_query, not just the helpers.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "order_by() emits NULLS placement in rendered SQL" begin
+    # Default ascending → NULLS LAST.
+    q_asc = DriverNullsModel.objects
+    q_asc.order_by("nationality")
+    sql_asc = q_asc.list(show_query=:sql)
+    @test occursin("ORDER BY", sql_asc)
+    @test occursin("ASC NULLS LAST", sql_asc)
+
+    # Default descending (leading '-') → NULLS FIRST.
+    q_desc = DriverNullsModel.objects
+    q_desc.order_by("-nationality")
+    sql_desc = q_desc.list(show_query=:sql)
+    @test occursin("DESC NULLS FIRST", sql_desc)
+
+    # Override via SQLOrder object: ascending but nulls forced to the front.
+    q_ovr = DriverNullsModel.objects
+    q_ovr.order_by(SQLOrder(SQLField("nationality", "nationality"); orientation="ASC", nulls=:first))
+    sql_ovr = q_ovr.list(show_query=:sql)
+    @test occursin("ASC NULLS FIRST", sql_ovr)
+
+    # Override the other direction: descending but nulls forced to the end.
+    q_ovr2 = DriverNullsModel.objects
+    q_ovr2.order_by(SQLOrder(SQLField("nationality", "nationality"); orientation="DESC", nulls=:last))
+    sql_ovr2 = q_ovr2.list(show_query=:sql)
+    @test occursin("DESC NULLS LAST", sql_ovr2)
+  end
+end


### PR DESCRIPTION
Closes #75.

## Problem

Top-level `ORDER BY` was emitted as a bare `<expr> ASC|DESC` with **no** `NULLS FIRST`/`NULLS LAST` clause. PostgreSQL and SQLite default NULLs to **opposite** ends (PG: NULL as largest value; SQLite: NULL as smallest), so ordering a nullable column returned a **different row order on each backend** — and combined with `.first()`/`.page()` that changed *which rows you get back*, not just their display order. High-severity for an ORM that promises PG/SQLite alignment.

## Fix

Emit an explicit NULLS clause matching **PostgreSQL's default** on both backends — leaving PG output unchanged and shifting only SQLite to align:

| Direction | NULL placement |
|-----------|----------------|
| ASC  | NULLS **last**  |
| DESC | NULLS **first** |

- Overridable per term via `SQLOrder(field; nulls=:first\|:last)`.
- SQLite builds older than 3.30.0 (no `NULLS` syntax) get the portable `(expr IS NULL)` prefix; that fallback **skips** normalization for a placeholder-carrying order term so a duplicated `expr` can't cause parameter misalignment.
- **Scope:** top-level `ORDER BY`. Window `OVER(...)` ordering is a separate render path (`_resolve_window_order`) and is intentionally left for a follow-up (documented caveat added).

## Changes

- `src/querybuilder/types.jl` — add `nulls` field to `SQLOrder` (constructor + `deepcopy`).
- `src/querybuilder/build_query.jl` — `_nulls_placement` / `_order_term_sql` helpers, wired into `get_order_query`.
- `test/unit/test_order_by_nulls.jl` (new) — placement math, per-backend rendering, old-SQLite fallback + bind-safety guard.
- `test/integration/test_selection.jl` — cross-backend row order + `.first()` on a nullable key + override.
- `docs/src/read/filters_and_aggregates.md` — "Ordering and NULL Placement" section (default, override, old-SQLite note, window caveat).

## Verification

- Unit `test_order_by_nulls.jl`: 21/21 · full unit suite: 2273/2273
- Integration `test_selection.jl`: SQLite **and** PostgreSQL pass, incl. `#75` 8/8 each; existing Ordering 21/21 intact
- **Mutation gate proven**: reverting the one-line `push!` → 4 unit + 5 SQLite-integration assertions fail; restored → green

## Acceptance criteria (#75)

- [x] ORDER BY over a nullable column returns the same row order on PG and SQLite
- [x] Chosen NULL-placement default is documented and overridable (`SQLOrder(; nulls=…)`)
- [x] Regression test with NULL + non-NULL sort keys asserts identical ordering and `.first()` across both backends

## Follow-up

Window `OVER(...)` ORDER BY has the same NULL divergence on a separate render path — to be opened as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)