### PR TITLE
fix(#36): isolate PostgreSQL migration fixture with credential-free in-memory hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ test/unit/db_r/
 test/integration/db_test_migration/
 test/integration/db_test_migration_pg/models.jl
 test/integration/db_test_migration_pg/migrations/
+
+# ...but DO commit the credential-free isolated fixture config (issue #36). The blanket
+# *connection.yml rule (top of this file) would otherwise exclude it; this negation re-includes
+# it (git last-match-wins). host/username/password are blank and hydrated in-memory at runtime.
+!test/integration/db_test_migration_pg/connection.yml

--- a/test/integration/common_migration_setup.jl
+++ b/test/integration/common_migration_setup.jl
@@ -72,37 +72,111 @@ function ensure_postgres_test_config!(edge_db_path::String)::Bool
 end
 
 """
-    hydrate_postgres_test_config!(edge_db_path::String, source_settings::PormG.SQLConn)
+    hydrate_postgres_settings!(edge_settings, source_settings, folder::String)
 
-Populate blank PostgreSQL connection.yml values in the edge-case migration DB folder
-using the currently selected integration database settings.
+Fill blank connection values (host/username/password/etc.) on an already-loaded edge-case
+`Settings` from the currently selected integration DB — entirely IN-MEMORY, then rebuild the
+connection pool. The committed `connection.yml` is never rewritten, so no credentials ever land
+in git (issue #36).
 
-This keeps committed test fixtures credential-free while still allowing the
-PostgreSQL migration edge-case suite to run against the active integration DB.
+Why rebuild the pool: `Configuration.load` builds the pool eagerly, freezing host/user/pass into
+`pool.connection_string`, so mutating `db_config_settings` after load has no effect until the pool
+is rebuilt via `_build_connection_pool!`.
+
+`database` is preserved (non-blank in the committed fixture → the loop below skips it), which is
+exactly what keeps the edge DB isolated from the selected integration DB.
 """
-function hydrate_postgres_test_config!(edge_db_path::String, source_settings::PormG.SQLConn)
-  config_path = joinpath(edge_db_path, "connection.yml")
-  raw = YAML.load_file(config_path)
-  env_name = get(raw, "env", source_settings.app_env)
-  env_key = String(env_name)
-  haskey(raw, env_key) || error("Missing '$env_key' section in $(config_path)")
-
-  edge_cfg = raw[env_key]
+function hydrate_postgres_settings!(edge_settings::PormG.SQLConn,
+                                    source_settings::PormG.SQLConn, folder::String)
+  edge_cfg = edge_settings.db_config_settings
   source_cfg = source_settings.db_config_settings
 
+  changed = false
   for key in ("database", "host", "username", "password", "port", "url")
     current_value = get(edge_cfg, key, nothing)
     source_value = get(source_cfg, key, nothing)
     if (current_value === nothing || isempty(strip(string(current_value)))) &&
        !(source_value === nothing || isempty(strip(string(source_value))))
       edge_cfg[key] = source_value
+      changed = true
     end
   end
 
-  open(config_path, "w") do io
-    YAML.write(io, raw)
+  if changed
+    # The pool built at load time used the blank credentials but was never dialed (connections
+    # open lazily on first fetch); close it and rebuild from the hydrated dict.
+    try; PormG.Configuration.close_pool!(folder); catch; end
+    PormG.Configuration._build_connection_pool!(edge_settings, folder)
   end
 
+  return nothing
+end
+
+# ── Auto-provisioning of the disposable PostgreSQL DB (Django/Rails/Prisma style) ──────────────
+# The edge-case suite creates its dedicated throwaway DB if absent and drops it at teardown, so
+# there is no manual pre-create step. The connecting role needs the CREATEDB privilege.
+
+# The disposable DB name must be a validated, hardcoded identifier: DDL cannot bind identifiers,
+# so CREATE/DROP DATABASE must interpolate it — this allowlist makes that injection-safe. (Same
+# principle as _reset_postgres! interpolating pg_tables names into `DROP TABLE "$tbl"` above.)
+_is_safe_pg_ident(name::AbstractString) = occursin(r"^[A-Za-z_][A-Za-z0-9_]*$", name)
+
+# Build an ad-hoc pool to the `postgres` maintenance DB using the (already-hydrated) host/port/
+# user/password from the edge settings, so we can CREATE/DROP the disposable DB from outside it.
+function _maintenance_pool(edge_settings::PormG.SQLConn)
+  cfg = copy(edge_settings.db_config_settings)
+  cfg["database"] = "postgres"     # connect to the always-present maintenance DB
+  delete!(cfg, "url")              # force param-based DNS so the `database` override takes effect
+  maint = PormG.Configuration.Settings(app_env = edge_settings.app_env,
+                                       db_config_settings = cfg)
+  PormG.Configuration._build_connection_pool!(maint, "db_test_migration_pg::maint")
+  return maint
+end
+
+"""
+    ensure_postgres_database!(edge_settings, dbname::String)
+
+Create the disposable `dbname` database if it does not already exist, connecting to the `postgres`
+maintenance DB with the hydrated edge credentials. No-op when the DB is already present.
+"""
+function ensure_postgres_database!(edge_settings::PormG.SQLConn, dbname::String)
+  _is_safe_pg_ident(dbname) || error("Refusing unsafe database identifier: $(repr(dbname))")
+  maint = _maintenance_pool(edge_settings)
+  try
+    # The lookup VALUE is bindable, so parameterize it ($1). Only the CREATE identifier below must
+    # be interpolated (validated + quoted) — DDL cannot bind identifiers.
+    lookup = PormG.QueryBuilder.PgParameterizedQuery("", Any[], 0)
+    placeholder = PormG.QueryBuilder.add_parameter!(lookup, dbname)
+    rows = PormG.ConnectionPool.fetch(maint.connections,
+      "SELECT 1 AS present FROM pg_database WHERE datname = $(placeholder);"; params=lookup)
+    if nrow(DataFrame(rows)) == 0
+      PormG.ConnectionPool.fetch(maint.connections, "CREATE DATABASE \"$(dbname)\";")  # not txn-able
+    end
+  finally
+    try; PormG.Configuration.close_pool!(maint.connections); catch; end
+  end
+  return nothing
+end
+
+"""
+    drop_postgres_database!(edge_settings, dbname::String)
+
+Best-effort drop of the disposable `dbname` database at teardown (`WITH (FORCE)` terminates any
+straggler connections; requires PostgreSQL 13+). Failure only warns — the next run re-creates it.
+Close the edge pool for `dbname` before calling this.
+"""
+function drop_postgres_database!(edge_settings::PormG.SQLConn, dbname::String)
+  _is_safe_pg_ident(dbname) || return nothing
+  maint = _maintenance_pool(edge_settings)
+  try
+    PormG.ConnectionPool.fetch(maint.connections, "DROP DATABASE IF EXISTS \"$(dbname)\" WITH (FORCE);")
+  catch e
+    # Log a scrubbed message only — attaching the raw exception could echo the maintenance DSN
+    # (which carries the password) if the failure happens at connection time.
+    @warn "best-effort drop of disposable migration DB failed" db=dbname reason=sprint(showerror, e)
+  finally
+    try; PormG.Configuration.close_pool!(maint.connections); catch; end
+  end
   return nothing
 end
 

--- a/test/integration/db_test_migration_pg/connection.yml
+++ b/test/integration/db_test_migration_pg/connection.yml
@@ -1,0 +1,46 @@
+# Isolated PostgreSQL fixture for the migration edge-case suite (issue #36).
+#
+# Credential-free by design: host/username/password are left blank and hydrated
+# IN-MEMORY at runtime from the selected integration DB (see hydrate_postgres_settings!
+# in test/integration/common_migration_setup.jl). The tracked file is NEVER rewritten,
+# so no secrets ever land in git. NEVER commit real credentials here.
+#
+# `database` is a DEDICATED disposable DB — the edge-case suite DROPs every table in it
+# and auto-creates/drops it — so it must NOT be the shared pormg_teste.
+env: dev
+
+dev:
+  adapter: "PostgreSQL"
+  database: "pormg_migration_test"
+  host: ~
+  username: ~
+  password: ~
+  port: 5432
+  config:
+    time_zone: "UTC"
+    change_db: true
+    change_data: true
+
+test:
+  adapter: "PostgreSQL"
+  database: "pormg_migration_test"
+  host: ~
+  username: ~
+  password: ~
+  port: 5432
+  config:
+    time_zone: "UTC"
+    change_db: true
+    change_data: true
+
+prod:
+  adapter: "PostgreSQL"
+  database: "pormg_migration_test"
+  host: ~
+  username: ~
+  password: ~
+  port: 5432
+  config:
+    time_zone: "UTC"
+    change_db: true
+    change_data: true

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -228,29 +228,37 @@ end
     yml_content = replace(yml_content, "database: database.sqlite" => "database: migration_test.sqlite")
     open(yml_path, "w") do f; write(f, yml_content); end
   else
-    # PostgreSQL: use the committed connection.yml when available, otherwise
-    # generate a blank fixture and hydrate it from the selected DB settings.
+    # PostgreSQL: load the committed credential-free fixture (issue #36) and hydrate
+    # host/username/password IN-MEMORY from the selected DB — the tracked connection.yml is
+    # never rewritten. ensure_postgres_test_config! only regenerates a blank fixture if the
+    # committed file was deleted.
     selected_settings = PormG.Configuration.get_settings(PORMG_DB_FOLDER)
     edge_db_fixture_generated[] = ensure_postgres_test_config!(joinpath(@__DIR__, edge_db_name))
-    hydrate_postgres_test_config!(joinpath(@__DIR__, edge_db_name), selected_settings)
 
-    # Detect whether the edge-case database actually points at the same
-    # PostgreSQL instance/database as the selected integration environment.
-    # That is not ideal, but the final reactivation block below will rebuild
-    # the selected schema from its real models as a fallback.
     PormG.Configuration.load(joinpath(@__DIR__, edge_db_name))
     pg_edge_settings = PormG.Configuration.get_settings(joinpath(@__DIR__, edge_db_name))
+    hydrate_postgres_settings!(pg_edge_settings, selected_settings, joinpath(@__DIR__, edge_db_name))
+
+    # Detect whether the edge-case database resolves to the SAME PostgreSQL database as the
+    # selected integration environment. With the committed fixture (distinct `database`) this is
+    # false; it can only be true in the degraded case where the fixture was removed and
+    # regenerated blank, in which case the final reactivation block rebuilds the selected schema.
     edge_db_reuses_selected_db[] = postgres_connection_identity(selected_settings) == postgres_connection_identity(pg_edge_settings)
+    # #36 acceptance: with the committed fixture the edge DB MUST resolve to a database distinct
+    # from the selected one. Guards runtime isolation — if hydration ever overwrote `database`,
+    # this fails (a silent @warn + fallback would otherwise keep the suite green). Skipped only in
+    # the degraded case where the committed fixture was deleted and regenerated blank.
+    !edge_db_fixture_generated[] && @test !edge_db_reuses_selected_db[]
     if edge_db_reuses_selected_db[]
-      @warn "db_test_migration_pg/connection.yml points to the same PostgreSQL database as the selected integration DB; the final bootstrap step will rebuild $(PORMG_DB_FOLDER) as a fallback." db=PORMG_DB_FOLDER edge_db=edge_db_name
+      @warn "db_test_migration_pg/connection.yml resolves to the same PostgreSQL database as the selected integration DB; the final bootstrap step will rebuild $(PORMG_DB_FOLDER) as a fallback." db=PORMG_DB_FOLDER edge_db=edge_db_name
+    else
+      # Auto-create the dedicated disposable DB if absent (Django/Rails/Prisma style), so there is
+      # no manual pre-create step; the connecting role just needs CREATEDB. The name is read from
+      # the loaded fixture (not hardcoded) so it always matches what the edge pool connects to.
+      ensure_postgres_database!(pg_edge_settings, string(pg_edge_settings.db_config_settings["database"]))
     end
 
-    # Reset the public schema to start clean
-    try; PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name)); catch; end
-    delete!(PormG.config, joinpath(@__DIR__, edge_db_name))
-
-    PormG.Configuration.load(joinpath(@__DIR__, edge_db_name))
-    pg_edge_settings = PormG.Configuration.get_settings(joinpath(@__DIR__, edge_db_name))
+    # Reset the public schema to start clean.
     _reset_postgres!(pg_edge_settings.connections)
     PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
     delete!(PormG.config, joinpath(@__DIR__, edge_db_name))
@@ -262,6 +270,12 @@ end
 
   PormG.Configuration.load(joinpath(@__DIR__, edge_db_name))
   edge_settings = PormG.Configuration.get_settings(joinpath(@__DIR__, edge_db_name))
+  if adapter_name != "SQLite"
+    # This reload re-read the credential-free fixture, so re-hydrate in-memory (PG only). The
+    # edge-case tests below reuse this pool and never reload the fixture, so one hydrate suffices.
+    hydrate_postgres_settings!(edge_settings,
+      PormG.Configuration.get_settings(PORMG_DB_FOLDER), joinpath(@__DIR__, edge_db_name))
+  end
   pool = edge_settings.connections
 
   # ── Phase 1: Initial table creation ───────────────────────────────
@@ -1247,6 +1261,11 @@ end
     # SQLite: remove the entire disposable folder
     ispath(joinpath(@__DIR__, edge_db_name)) && rm(joinpath(@__DIR__, edge_db_name), recursive=true)
   else
+    # Best-effort drop of the disposable DB (the edge pool was just closed above). Guarded: never
+    # drop when the edge DB resolved to the shared selected DB (degraded regenerated-fixture case).
+    if !edge_db_reuses_selected_db[]
+      drop_postgres_database!(edge_settings, string(edge_settings.db_config_settings["database"]))
+    end
     if edge_db_fixture_generated[]
       # Remove the entire temporary fixture if this test had to create it.
       ispath(joinpath(@__DIR__, edge_db_name)) && rm(joinpath(@__DIR__, edge_db_name), recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ end
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
+    @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_migration_pg_fixture.jl
+++ b/test/unit/test_migration_pg_fixture.jl
@@ -1,0 +1,62 @@
+# ============================================================
+# test/unit/test_migration_pg_fixture.jl
+#
+# Committed PostgreSQL migration fixture contract (#36).
+#
+# CONTRACT being tested:
+#   `test/integration/db_test_migration_pg/connection.yml` is committed (so the migration
+#   edge-case suite runs against a DEDICATED disposable DB, never the shared pormg_teste) AND
+#   is credential-free (host/username/password blank, hydrated in-memory at runtime — no secrets
+#   in git). This is a deterministic, DB-free guard: it parses the tracked YAML and fails if
+#   anyone commits credentials or points the fixture back at the shared integration database.
+#
+# Mutation gate: point `database` at pormg_teste, or fill in any credential, and an assertion
+# below fails. The blanket `*connection.yml` .gitignore rule plus its #36 negation exception are
+# what make this file exist in a clean checkout for the test to read.
+# ============================================================
+
+using Test
+import YAML
+
+# The fixture lives beside the integration suite; resolve it relative to this unit test file.
+const PG_FIXTURE_PATH = normpath(joinpath(@__DIR__, "..", "integration",
+                                          "db_test_migration_pg", "connection.yml"))
+
+# A value is "blank" when it is YAML null (`~` → nothing) or an empty/whitespace string.
+_fixture_blank(v) = v === nothing || isempty(strip(string(v)))
+
+@testset "Committed PostgreSQL migration fixture is isolated + credential-free (#36)" begin
+  # ───────────────────────────────────────────────────────────────────────────
+  # The file must be present in the checkout (the .gitignore negation makes it committable).
+  # If this fails, the negation rule regressed and the fixture is being ignored again.
+  # ───────────────────────────────────────────────────────────────────────────
+  @test isfile(PG_FIXTURE_PATH)
+
+  raw = YAML.load_file(PG_FIXTURE_PATH)
+
+  # The active env section is what the loader actually reads, but we assert the invariant on
+  # EVERY PostgreSQL section present (dev/test/prod) so no section can smuggle in credentials or
+  # a shared-DB name.
+  env_sections = [k for (k, v) in raw if v isa AbstractDict && get(v, "adapter", nothing) == "PostgreSQL"]
+  @test !isempty(env_sections)   # at least one PostgreSQL section to validate
+
+  for key in env_sections
+    section = raw[key]
+
+    # Adapter is PostgreSQL (this is the PG fixture).
+    @test section["adapter"] == "PostgreSQL"
+
+    # Isolation: a dedicated disposable DB, explicitly NOT the shared integration database.
+    db = get(section, "database", nothing)
+    @test !_fixture_blank(db)
+    @test db == "pormg_migration_test"
+    @test db != "pormg_teste"
+
+    # Credential-free: no host/username/password committed — these are hydrated in-memory at
+    # runtime (hydrate_postgres_settings! in common_migration_setup.jl). Guards against secrets
+    # ever landing in git.
+    @test _fixture_blank(get(section, "host", nothing))
+    @test _fixture_blank(get(section, "username", nothing))
+    @test _fixture_blank(get(section, "password", nothing))
+  end
+end


### PR DESCRIPTION
Closes #36.

## Problem
The migration edge-case suite (`test/integration/test_migration_bootstrap.jl`, Phase C) DROPs and rebuilds a throwaway PostgreSQL schema. Its `db_test_migration_pg/connection.yml` was gitignored (blanket `*connection.yml`) and pointed at the **same** `pormg_teste` as the shared `db_2`, so the suite tripped the `edge_db_reuses_selected_db` fallback and would wipe the shared integration DB.

## Change
Commit a **credential-free** `db_test_migration_pg/connection.yml` pinned to a **dedicated disposable** database (`pormg_migration_test`), isolated from `db_2`/`pormg_teste` by its distinct `database` name.

- **Credential-free + in-memory hydration** — `host`/`username`/`password` are blank and filled at runtime from the selected DB via `hydrate_postgres_settings!`, which rebuilds the pool in-memory. The tracked file is **never rewritten**, so no secrets land in git (verified clean after a live run).
- **Auto-provisioning (Django/Rails/Prisma style)** — the suite auto-creates the disposable DB if absent (through the `postgres` maintenance DB) and best-effort drops it at teardown (`WITH (FORCE)`). Only prerequisite: `CREATEDB` on the connecting role.
- **.gitignore** — a negation re-includes the fixture past the blanket `*connection.yml` rule; its runtime `models.jl`/`migrations/` stay ignored.

## Review follow-ups (all fixed in this branch)
- Disposable DB name is **derived from the loaded settings** (not hardcoded) so create/drop always match what the edge pool connects to.
- The `datname` existence lookup is **parameterized** (`$1`); only the unavoidable `CREATE`/`DROP` identifier is interpolated (allowlist-validated + quoted).
- The best-effort drop logs a **scrubbed** message (`reason=sprint(showerror, e)`) instead of the raw exception, so a connect-time failure can't echo the maintenance DSN.
- A **runtime-isolation assertion** (`@test !edge_db_reuses_selected_db[]`) fails if hydration ever overwrites `database` — the silent-fallback gap the review flagged.

## Tests
- New `test/unit/test_migration_pg_fixture.jl` (DB-free): asserts the committed fixture is PostgreSQL, isolated (`database != pormg_teste`), and credential-free.

## Verification
- Unit guard: **23/23**
- SQLite bootstrap: **8/8, 5/5, 2/2, 108/108, 2/2, 11/11**
- Live PostgreSQL: Preflight 8/8, Backfill 5/5, Bootstrap 2/2, **Edge Cases 104/104**, Reactivation 2/2 (`fallback=false`, no reuse warning)
- Fixture remains credential-free on disk after the live run

## Out of scope
CI (`.github/workflows/CI.yml`) does not provision PostgreSQL; the PG edge-case suite runs in the dev environment. Wiring a GitHub-Actions PG service is a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)