### PR TITLE
fix(#37): raise pool ceiling to 10x, typed PoolTimeoutError, quiet retry noise

### DIFF
--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -6,6 +6,15 @@ PormG is designed for Julia's asynchronous task scheduling. This section covers 
 
 - **Async-First API:** The synchronous `fetch()` API is a wrapper around the asynchronous `fetch_async()` core. This wrapper yields to the Julia scheduler while waiting for the database, ensuring compatibility with async frameworks.
 - **Pooling Strategy:** The default strategy is `:poll`, which retries at configured intervals. Use `:block` for PostgreSQL to let the server-side manage the wait, often combined with a `statement_timeout`.
+- **Sizing & capacity:** A pool starts at `pool_size` connections (default `3`) and grows **lazily, on demand,** up to `pool_size × 10` under concurrent load — so the idle footprint stays small while async fan-out still gets headroom. If every connection is busy and none frees within the retry/timeout budget, `acquire_connection` raises a catchable `PoolTimeoutError` (exported by PormG). Raise `pool_size` in your `connection.yml` to add capacity for genuinely high-concurrency workloads:
+
+```yaml
+dev:
+  adapter: PostgreSQL
+  database: 'formula1'
+  # ...
+  pool_size: 10   # base 10 → grows to 100 under burst
+```
 - **Thread Safety:** PormG uses `ReentrantLock` for pool management.
 
 ---

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -14,6 +14,7 @@ import PormG: backend_connect, backend_renew_connection, backend_is_alive, backe
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, with_savepoint
 export acquire_connection, release_connection
+export PoolTimeoutError
 # NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
 # `close_pool!` (it dispatches on a pool OR a db-name String and delegates the pool case to
 # this module's `close_pool!`). Exporting it from both modules made `PormG.close_pool!`
@@ -28,6 +29,32 @@ const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
 # must be opened. The before_connect hook then runs OUTSIDE the lock and the
 # block is re-entered. Keeps long hooks (VPN, tunnels) off the pool lock.
 const _BEFORE_CONNECT_PENDING = :__pormg_before_connect_pending__
+
+# A pool starts at `pool_size` connections and may grow lazily (on demand) up to
+# `pool_size * POOL_EXPANSION_FACTOR` before acquisition fails with a PoolTimeoutError (#37).
+# The base stays small (idle footprint) while the ceiling gives async fan-out real headroom.
+const POOL_EXPANSION_FACTOR = 10
+
+"""
+    PoolTimeoutError <: Exception
+
+Thrown by `acquire_connection` when no connection becomes available within the retry/timeout budget —
+i.e. the pool is saturated at its ceiling (`pool_size * POOL_EXPANSION_FACTOR`). It is a catchable
+`Exception` (apps can e.g. translate it to a 503 / back off and retry). Remedy: raise `pool_size` in
+`connection.yml`.
+"""
+struct PoolTimeoutError <: Exception
+  adapter::String        # "PostgreSQL" | "SQLite"
+  pool_size::Int
+  max_size::Int
+  attempts::Int
+  elapsed_seconds::Float64
+end
+
+Base.showerror(io::IO, e::PoolTimeoutError) = print(io,
+  "PoolTimeoutError: no available ", e.adapter, " connection after ", e.attempts, " attempts / ",
+  round(e.elapsed_seconds, digits=1), "s (pool_size=", e.pool_size, ", max=", e.max_size,
+  "). Raise pool_size (connection.yml `pool_size:`) to add capacity.")
 
 function _run_before_connect!(pool::Union{PormGPostgres, PormGSQLite})
   if !ensure_before_connect!(pool)
@@ -219,15 +246,23 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
         end
       end
 
-      # If we reach here, no available connections found
-      # Try to expand the pool if we haven't reached the limit
-      if length(pool.connections) < (pool.pool_size * 5)
+      # If we reach here, no available connections found.
+      # Try to expand the pool if we haven't reached the ceiling. This runs inside the pool lock
+      # and `pool.connections` is append-only (dead slots are replaced in-place, never removed), so
+      # the `== ceiling` check below is race-free even under `-t auto`: exactly one locked push
+      # transitions length to the ceiling → the @warn fires exactly once (#37).
+      if length(pool.connections) < (pool.pool_size * POOL_EXPANSION_FACTOR)
         before_connect_done || return _BEFORE_CONNECT_PENDING
         try
           new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
-          @warn "PG pool expanded beyond initial size" current_size=length(pool.connections) initial_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+          new_size = length(pool.connections)
+          if new_size == pool.pool_size * POOL_EXPANSION_FACTOR
+            @warn "PG pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+          else
+            @debug "PG pool expanded beyond initial size" current_size=new_size initial_size=pool.pool_size
+          end
           return new_conn
         catch e
           @error "Failed to expand PG pool: $e"
@@ -250,20 +285,23 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
       return connection
     end
 
-    # No connection available, wait and retry
+    # No connection available, wait and retry. @debug (not @info): under saturation this fires every
+    # 100ms across many concurrent acquires; the actionable signals are the once-at-ceiling @warn above
+    # and the PoolTimeoutError below (#37).
     retry_count += 1
-    @info "No available PG connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
+    @debug "No available PG connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
     sleep(0.1)  # Wait 100ms before retrying
   end
 
-  # If we've exhausted all retries
+  # Exhausted the retry/timeout budget → genuine starvation. This is a recoverable, caller-handleable
+  # condition (the typed error lets apps back off / return 503), so log at @warn, not @error — an app
+  # that catches PoolTimeoutError shouldn't see a scary error on every gracefully-handled timeout.
   if retry_count >= max_retries
-    @error "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
-    throw("No available PG connections in the pool after $max_retries attempts")
+    @warn "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
   else
-    @error "Timeout after $(timeout_seconds) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
-    throw("No available PG connections in the pool after $(timeout_seconds) seconds")
+    @warn "Timeout after $(timeout_seconds) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
   end
+  throw(PoolTimeoutError("PostgreSQL", pool.pool_size, pool.pool_size * POOL_EXPANSION_FACTOR, retry_count, time() - start_time))
 end
 
 function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_retries::Int = 300, mode::Symbol = :any)
@@ -305,15 +343,21 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
         end
       end
 
-      # Expand pool logic
-      can_expand = !pool.split_read_write && length(pool.connections) < (pool.pool_size * 5)
+      # Expand pool logic (append-only + under the lock → the `== ceiling` warn below is race-free; see
+      # the PostgreSQL twin for the full rationale, #37).
+      can_expand = !pool.split_read_write && length(pool.connections) < (pool.pool_size * POOL_EXPANSION_FACTOR)
       if can_expand
         before_connect_done || return _BEFORE_CONNECT_PENDING
         try
           new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
-          @warn "SQLite pool expanded beyond initial size" current_size=length(pool.connections) initial_size=pool.pool_size connection_string=pool.connection_string
+          new_size = length(pool.connections)
+          if new_size == pool.pool_size * POOL_EXPANSION_FACTOR
+            @warn "SQLite pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=pool.connection_string
+          else
+            @debug "SQLite pool expanded beyond initial size" current_size=new_size initial_size=pool.pool_size
+          end
           return new_conn
         catch e
           @error "Failed to expand SQLite pool: $e"
@@ -333,17 +377,18 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
       return connection
     end
 
+    # @debug (not @info): see the PostgreSQL twin — avoids per-retry spam under saturation (#37).
     retry_count += 1
-    @info "No available SQLite connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
+    @debug "No available SQLite connections, retrying ($retry_count/$max_retries) in 100ms..." pool_size=pool.pool_size
     sleep(0.1)
   end
 
-  error_msg = retry_count >= max_retries ?
-    "No available SQLite connections in the pool after $max_retries attempts" :
-    "Timeout after $(timeout_seconds) seconds waiting for available SQLite connection"
-
-  @error error_msg pool_size=pool.pool_size connection_string=pool.connection_string
-  throw(error_msg)
+  # Exhausted the retry/timeout budget → genuine starvation. Recoverable + caller-handleable, so
+  # @warn not @error (see the PostgreSQL twin).
+  @warn (retry_count >= max_retries ?
+    "Exceeded maximum retry attempts ($max_retries) to acquire SQLite connection" :
+    "Timeout after $(timeout_seconds) seconds waiting for available SQLite connection") pool_size=pool.pool_size connection_string=pool.connection_string
+  throw(PoolTimeoutError("SQLite", pool.pool_size, pool.pool_size * POOL_EXPANSION_FACTOR, retry_count, time() - start_time))
 end
 
 function release_connection(pool::PormGPostgres, conn)

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -152,6 +152,7 @@ end
 export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, with_savepoint  # Async-first API
+export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)
 export with_tx_context, in_transaction_context  # Transaction context helpers
 export setup, install_ai_skills
 

--- a/test/integration/common_setup.jl
+++ b/test/integration/common_setup.jl
@@ -50,6 +50,24 @@ const PORMG_DB_FOLDER = get(ENV, "PORMG_DB", "db_2")
 # Load configurations once
 PormG.Configuration.load(PORMG_DB_FOLDER)
 
+# #37: the async integration suite (`-t auto`, heavy fan-out) saturates a small PostgreSQL pool
+# against a possibly-remote DB. Size the pool to the run's concurrency for this run only
+# (env-overridable) and rebuild so the initial slots are pre-sized instead of grown via the
+# expansion path. We cannot use `db_2/connection.yml` (git-ignored), so this is the code-level
+# equivalent of bumping the pool in the test environment. Keep PORMG_TEST_POOL_SIZE modest:
+# with the ×10 ceiling a value of 20 means a max of 200 connections — far above the suite's real
+# peak (~20-30) but a high value could exhaust the PostgreSQL server's max_connections.
+let s = PormG.config[PORMG_DB_FOLDER]
+    if s.connections isa PormG.PormGPostgres
+        pool_n = parse(Int, get(ENV, "PORMG_TEST_POOL_SIZE", "20"))
+        if pool_n != s.connections.pool_size
+            s.db_config_settings["pool_size"] = pool_n
+            PormG.Configuration.close_pool!(s.connections)   # close the size-3 pool; config[key] still → s
+            PormG.Configuration._build_connection_pool!(s, PORMG_DB_FOLDER)
+        end
+    end
+end
+
 # Load the models and expose the alias `M`
 # Using the new @import_models macro which handles registration automatically
 if PORMG_DB_FOLDER == "db_sl"

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -48,6 +48,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Custom Joins (cjoin)"         begin include("test_cjoin.jl")              end    
     @testset "Cached Joins"                 begin include("test_cache_join.jl")         end
     @testset "Transactions"                 begin include("test_transactions.jl")       end
+    @testset "Connection Pool (#37)"        begin include("test_connection_pool.jl")    end
     @testset "Advisory Locks"               begin include("test_advisorylock.jl")       end
     @testset "Having (Aggregates)"          begin include("test_having.jl")             end
     @testset "Field Validation DB Tests"    begin include("test_field_validation_db_roundtrip.jl") end

--- a/test/integration/test_connection_pool.jl
+++ b/test/integration/test_connection_pool.jl
@@ -1,0 +1,45 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Connection pool: no connection leak under concurrent async fan-out (#37)
+# Fires N un-awaited fetch_async calls (each acquires its connection *synchronously* before it
+# returns) so N connections are held at once, then awaits all and asserts the pool's busy-count
+# returns to its baseline. Proves both real concurrency (N held simultaneously) and full release.
+# ─────────────────────────────────────────────────────────────────────────────
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+using Test
+
+@testset "Connection pool: no leak under concurrent async (#37)" begin
+    settings = PormG.config[PORMG_DB_FOLDER]
+    pool = settings.connections
+
+    # Baseline count of *busy* (not-available) slots — should be 0 between tests, but we compare
+    # against whatever it is now so the leak check is robust to any pre-existing checkouts.
+    base_in_use = count(!, pool.available)
+
+    # Cap N to the pool's pre-sized capacity so we never exhaust it (a misconfigured
+    # PORMG_TEST_POOL_SIZE below N would otherwise make fetch_async block+throw mid-setup).
+    N = min(15, pool.pool_size)
+    # `fetch_async` acquires its connection SYNCHRONOUSLY before returning the task handle (only the
+    # query body runs async), so each started task holds a connection until awaited. Build inside the
+    # try so the finally releases whatever was started even if one fails partway.
+    tasks = Any[]
+    try
+        for _ in 1:N
+            push!(tasks, fetch_async(settings, "SELECT 1"))
+        end
+        # (1) Real concurrency + no premature release: N connections held SIMULTANEOUSLY.
+        # Guarded to PostgreSQL — SQLite serializes work through a shared async worker/queue, so N
+        # concurrent fetches may not check out N distinct slots there (the check would fail spuriously
+        # with no leak). The baseline invariant (2) below still runs on both backends.
+        if pool isa PormG.PormGPostgres
+            @test count(!, pool.available) >= N
+        end
+    finally
+        foreach(await_result, tasks)   # await → each task's finally releases its connection
+    end
+
+    # (2) No leak: every one of the N connections was returned → busy-count back to baseline.
+    @test count(!, pool.available) == base_in_use
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
+    @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_connection_pool_timeout.jl
+++ b/test/unit/test_connection_pool_timeout.jl
@@ -1,0 +1,68 @@
+# ============================================================
+# test/unit/test_connection_pool_timeout.jl
+#
+# Connection-pool exhaustion → typed PoolTimeoutError (#37).
+#
+# CONTRACT being tested:
+#   When a pool is saturated at its ceiling (pool_size * POOL_EXPANSION_FACTOR) and no connection
+#   frees up within the retry/timeout budget, `acquire_connection` throws a typed, catchable
+#   `PoolTimeoutError` (NOT a bare String) carrying pool_size / max_size / attempts / elapsed and a
+#   "raise pool_size" remedy.
+#
+# Deterministic and DB-free: a local temp-FILE SQLite pool (not :memory: — that has shared-cache
+# semantics that could short-circuit the acquire/expand path) with pool_size=1 has a ceiling of
+# 1 * POOL_EXPANSION_FACTOR = 10; acquiring all 10 and requesting an 11th on a short budget exhausts
+# it. This is ALSO the proof of PG/SQLite symmetry — the SQLite acquire twin must reach the same
+# typed throw. Reverting the throw to a String (or dropping the type) fails the `isa PoolTimeoutError`
+# assertion — the mutation gate.
+# ============================================================
+
+using Test
+using PormG
+
+# SQLite is a weakdep since #34 — load the driver extension so `backend_connect` works when this file
+# runs standalone (runtests.jl loads it too; re-loading is idempotent). See test/load_drivers.jl.
+include(joinpath(@__DIR__, "..", "load_drivers.jl"))
+
+const CP = PormG.ConnectionPool
+
+@testset "Pool exhaustion throws typed PoolTimeoutError (#37)" begin
+  # The ceiling this test depends on: pool_size(1) * POOL_EXPANSION_FACTOR(10) = 10.
+  @test CP.POOL_EXPANSION_FACTOR == 10
+
+  tmp = tempname() * ".sqlite"
+  # pool_size=1, split_read_write=false → a simple shared pool that expands to the ceiling on demand.
+  pool = CP.SQLiteConnectionPool(tmp; pool_size = 1, split_read_write = false)
+
+  held = Any[]
+  try
+    # Fill the pool to its ceiling (10) and hold every connection — none are released.
+    for _ in 1:(1 * CP.POOL_EXPANSION_FACTOR)
+      push!(held, CP.acquire_connection(pool))
+    end
+    @test length(held) == 10
+
+    # The 11th acquire cannot succeed → genuine starvation. Capture the thrown value (cause-check,
+    # not a bare `@test_throws`) so we can assert its TYPE, its FIELDS, and its message text.
+    err = try
+      CP.acquire_connection(pool; timeout_seconds = 1, max_retries = 3)
+      nothing
+    catch e
+      e
+    end
+
+    @test err isa PormG.PoolTimeoutError            # a real, catchable Exception — not a String
+    @test err.adapter == "SQLite"
+    @test err.pool_size == 1
+    @test err.max_size == 10                        # pool_size * POOL_EXPANSION_FACTOR
+    @test err.attempts >= 1
+    @test err.elapsed_seconds >= 0.0
+    @test occursin(r"raise pool_size"i, sprint(showerror, err))   # remediation text really present
+  finally
+    for c in held
+      try; CP.release_connection(pool, c); catch; end
+    end
+    try; CP.close_pool!(pool); catch; end
+    isfile(tmp) && rm(tmp; force = true)
+  end
+end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -19,7 +19,7 @@ const EXPECTED_TOPLEVEL = Set([
     # Query builder
     :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :show_query, :inspect_query,
     # Rows & exceptions
-    :PormGRow, :DoesNotExist, :MultipleObjectsReturned,
+    :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API


### PR DESCRIPTION
Closes #37.

## Problem
Running the async-first integration suite (`julia -t auto`) against a remote PostgreSQL DB saturated the connection pool: the default `pool_size=3` gave a hard ceiling of `pool_size*5 = 15`, after which `acquire_connection` spun in a 100 ms busy-retry loop logging ~300 `@info` lines per stuck acquire, then threw a **bare `String`** at the ceiling. Audit confirmed **no leak** — every `fetch_async` in `src/` is awaited/released — so this is sizing/contention.

## Change
**Core (`src/ConnectionPool.jl`, `src/PormG.jl`)**
- `POOL_EXPANSION_FACTOR = 10`: the lazy expansion ceiling moves from `pool_size*5` to `pool_size*10` (default pool now grows **3 → 30 on demand**). Base/idle footprint stays **3**; expansion is lazy so idle cost is unchanged. For PormG's scientific/interactive niche this keeps the small idle footprint while giving async fan-out real headroom.
- **`PoolTimeoutError <: Exception`** (`adapter`/`pool_size`/`max_size`/`attempts`/`elapsed_seconds` + `showerror` with a "raise `pool_size`" remedy), exported from PormG — replaces the bare-`String` throw on **both** the PostgreSQL and SQLite acquire paths. Mirrors the existing `exceptions.jl` convention.
- **Quieter logs**: per-retry `@info` → `@debug`; per-expansion `@warn` → `@debug` with a single actionable `@warn` only when the pool reaches its ceiling (redacted conn string). Throw-site logs are `@warn` (recoverable, caller-handleable), not `@error`. The `== ceiling` check is race-safe under `-t auto` (under the pool lock + append-only connections vector).

**Test env (`test/integration/common_setup.jl`)**
- Pre-size the PG pool to the run's concurrency via `PORMG_TEST_POOL_SIZE` (default 20), rebuilt after load — the code-level equivalent of bumping the pool in the test env (can't use the git-ignored `db_2/connection.yml`).

**Docs** — `configuration/advanced.md`: the `pool_size × 10` ceiling + the catchable `PoolTimeoutError`.

## Tests
- `unit/test_connection_pool_timeout.jl` — temp-file SQLite pool driven to its ceiling; **cause-checks** the typed error (type + fields + `showerror`), not a bare `@test_throws`. Also the proof of PG/SQLite throw symmetry.
- `integration/test_connection_pool.jl` — **discriminating** leak guard: N un-awaited `fetch_async` hold N connections simultaneously (PG-scoped, since SQLite serializes via a shared worker) → all release back to baseline.
- `:PoolTimeoutError` added to the frozen export-surface test (#35).

## Verification
- Unit: **2307/2307**
- Live PostgreSQL parallel suite (`-t auto`): **1602/1602**, with **zero** `No available PG connections` retry spam and **no** `PoolTimeoutError` (answers #37 item 1: recovers cleanly at the larger pool, never reaches the ceiling)
- SQLite leak guard: green
- Docs build: not run here (pre-existing `docs/` `Manifest.toml` mismatch — `DocumenterMermaid`; unrelated to this content)

## Follow-ups filed (all `priority:low`, none release-gating)
#124 (busy-poll → condition-variable wait), #125 (idle reaping / max-lifetime), #126 (configurable acquire timeout), #127 (pool metrics + leak detection), #128 (SQLite leak soak + `reconnect_db` audit).

## Out of scope
Base default stays 3; the busy-poll retry mechanism is unchanged (only its log level) — see #124. No idle reaping (see #125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
