### PR TITLE
fix(#112): isolate custom_join state in query copies (per-entry dict copy, share field refs)

### DIFF
--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -185,6 +185,32 @@ function _copy_ctes(ctes::Dict{String,CTEDict})::Dict{String,CTEDict}
   return out
 end
 
+# #112: custom_join is the build-time sibling of the #43 CTE aliasing. A shallow
+# `copy(custom_join)` shares the inner per-join Dicts, and on() mutates those in place
+# ("filters" / "join_type") — so extending a join path on a copy rewrote the original's
+# join definition. Rebuild a fresh inner dict per path: copy the "filters" vector into a
+# new Vector (its FilterType elements are shared — on() replaces the whole vector, it
+# never mutates elements in place), share the "field" PormGField by reference (it holds
+# a Model_Type → Module that deepcopy cannot traverse — the very reason this copy was
+# shallow), and carry scalar entries ("join_type") as-is.
+function _copy_custom_join(custom_join::Dict{String,Any})::Dict{String,Any}
+  out = Dict{String,Any}()
+  for (path, config) in custom_join
+    if config isa AbstractDict
+      # AbstractDict (not just Dict{String,Any}) so a future writer storing a differently
+      # typed inner dict still gets an independent copy instead of silently re-aliasing.
+      fresh = Dict{String,Any}()
+      for (k, v) in config
+        fresh[k] = v isa Vector ? copy(v) : v
+      end
+      out[path] = fresh
+    else
+      out[path] = config  # non-dict config: nothing produces one today (cjoin/on store Dicts)
+    end
+  end
+  return out
+end
+
 function Base.deepcopy(obj::SQLObjectQuery)
   try
     return SQLObjectQuery(
@@ -202,7 +228,7 @@ function Base.deepcopy(obj::SQLObjectQuery)
       row_join=deepcopy(obj.row_join),
       distinct=obj.distinct,
       ctes=_copy_ctes(obj.ctes),  # #43: independent CTE state (deep sub-query, drop transient "model")
-      custom_join=copy(obj.custom_join)  # shallow copy: PormGField refs contain Model_Type → Module that deepcopy can't handle
+      custom_join=_copy_custom_join(obj.custom_join)  # #112: fresh per-join dicts; "field" shared by ref (Module — deepcopy can't traverse)
     )
   catch e
     @pormg_debug false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
     @testset "Complex Query Patterns" include("unit/test_complex_queries.jl")
     @testset "Many-to-Many Relationships" include("unit/test_many_to_many.jl")
     @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")
+    @testset "custom_join Copy Isolation (#112)" include("unit/test_custom_join_copy.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")
     @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")

--- a/test/unit/test_custom_join_copy.jl
+++ b/test/unit/test_custom_join_copy.jl
@@ -1,0 +1,137 @@
+"""
+Unit coverage for custom_join copy isolation (#112) — the build-time sibling of #43.
+
+`deepcopy(::SQLObjectQuery)` shallow-copied `custom_join` (`copy(obj.custom_join)`), so a
+query and its `.copy()` shared the inner per-join `Dict` objects by reference. `on()`
+mutates that inner dict in place (`existing["filters"] = …`, `existing["join_type"] = …`),
+so extending an existing join path on a copy rewrote the ORIGINAL's join definition.
+
+The fix (`_copy_custom_join` in src/querybuilder/types.jl, mirroring #43's `_copy_ctes`)
+rebuilds a fresh inner dict per join path and copies the "filters" vector, while the
+"field" `PormGField` stays shared by reference — it holds a Model_Type → Module that
+`deepcopy` cannot traverse (the very reason the original copy was shallow).
+
+Deterministic and DB-free: a mock PostgreSQL connection + inline F1-flavored models; SQL
+is rendered via `show_query = :sql`, which short-circuits before any fetch.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+# Mock connection under a dedicated key so this file cannot contaminate (or be
+# contaminated by) other unit files sharing Main in runtests.jl.
+struct CustomJoinCopyMockPostgres <: PormG.PormGPostgres end
+
+PormG.config["cjc_mock"] = PormG.Configuration.Settings(
+  connections = CustomJoinCopyMockPostgres(),
+  change_data = true,
+  db_def_folder = "cjc_mock",
+)
+
+# Inline F1-flavored models (NOT a re-include of db_sl/models.jl — a second include would
+# redefine module `models` in the shared Main scope). Result.driverid is a real FK so
+# `on("driverid", …)` resolves its join target without a prior cjoin. Bindings match the
+# table names modulo case (Cjc_driver ↔ "cjc_driver") because cjoin validates the join
+# target BOTH against the FK's model name (case-insensitive) and as a module binding.
+module CustomJoinCopyModels
+import PormG
+import PormG.Models
+
+Cjc_driver = Models.Model("cjc_driver",
+  driverid = Models.IDField(),
+  surname = Models.CharField(),
+  nationality = Models.CharField(),
+)
+
+Cjc_results = Models.Model("cjc_results",
+  id = Models.IDField(),
+  driverid = Models.ForeignKey(Cjc_driver, pk_field = "driverid", on_delete = "RESTRICT"),
+  points = Models.IntegerField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "cjc_mock")
+end
+
+const CJC = CustomJoinCopyModels
+
+@testset "custom_join copy isolation (#112)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Copy independence: on()-seeded path (the issue's reproduction)
+  # A copy must own fresh inner per-join dicts; extending the SAME join path via on()
+  # on the copy must not alter the original's filters or join_type, and the two
+  # queries must render different SQL while the original's SQL stays stable.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "on() on a copy does not mutate the original" begin
+    q = CJC.Cjc_results.objects
+    # Select through the join path — a custom join only renders its JOIN/ON clause when
+    # the path is actually traversed, and AC3 needs the ON predicates visible in SQL.
+    q.values("id", "driverid__surname")
+    q.on("driverid", "driverid__nationality" => "British")
+    q2 = q.copy()
+
+    # AC1: distinct outer AND inner dicts — the aliasing signal. Pre-fix, the outer
+    # dict was fresh but the inner dict was the SAME object on both queries.
+    @test q2.object.custom_join !== q.object.custom_join
+    @test q2.object.custom_join["driverid"] !== q.object.custom_join["driverid"]
+
+    # Snapshot the original before touching the copy: rendered SQL, the filters
+    # vector OBJECT (to prove on() never wrote through it), and its length.
+    sql_before   = q.list(show_query = :sql)
+    orig_filters = q.object.custom_join["driverid"]["filters"]
+    orig_n       = length(orig_filters)
+
+    # AC2: extend the SAME path on the copy — with a different predicate AND an
+    # explicit join_type override, so both in-place writes of on() are exercised.
+    q2.on("driverid", "driverid__nationality" => "Brazilian", join_type = "INNER")
+
+    # Original untouched: same vector object, same length, join_type still the
+    # default "LEFT" set by the first on(); the copy carries the extension alone.
+    @test q.object.custom_join["driverid"]["filters"] === orig_filters
+    @test length(q.object.custom_join["driverid"]["filters"]) == orig_n
+    @test q.object.custom_join["driverid"]["join_type"] == "LEFT"
+    @test length(q2.object.custom_join["driverid"]["filters"]) == orig_n + 1
+    @test q2.object.custom_join["driverid"]["join_type"] == "INNER"
+
+    # AC3: the copy renders its own SQL, and neither building nor rendering the copy
+    # changed what the original renders.
+    sql_copy  = q2.list(show_query = :sql)
+    sql_after = q.list(show_query = :sql)
+    @test sql_copy != sql_before   # copy diverged (extra ON predicate, INNER join)
+    @test sql_after == sql_before  # original unchanged by the copy's build
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Copy independence: cjoin()-seeded path (the "field" sharing contract)
+  # cjoin() seeds the inner dict with "filters" AND a "field" PormGField. The copy
+  # must own a fresh inner dict and a fresh filters vector, but the "field" is
+  # DELIBERATELY shared by reference (it holds a Module deepcopy can't traverse) —
+  # this pins that contract so a future over-eager deep copy fails loudly here.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "cjoin-seeded copy: fresh dicts, shared field ref" begin
+    q = CJC.Cjc_results.objects
+    # warn=false: driverid is a real FK, so cjoin would otherwise warn about the
+    # auto-discovered pk link (same suppression as test_alignment_sqlite.jl).
+    q.cjoin("driverid" => "Cjc_driver", filters = ["nationality" => "British"], warn = false)
+    q2 = q.copy()
+
+    # Fresh containers: inner dict and filters vector are distinct objects…
+    @test q2.object.custom_join["driverid"] !== q.object.custom_join["driverid"]
+    @test q2.object.custom_join["driverid"]["filters"] !== q.object.custom_join["driverid"]["filters"]
+    # …while the un-deepcopy-able field metadata is intentionally the same reference.
+    @test q2.object.custom_join["driverid"]["field"] === q.object.custom_join["driverid"]["field"]
+
+    orig_n = length(q.object.custom_join["driverid"]["filters"])
+
+    # Extend the cjoin-seeded path on the copy via on(): adds a predicate and writes
+    # "join_type" — a key cjoin never sets, so any leak into the original is visible
+    # as a brand-new key, not just a changed value.
+    q2.on("driverid", "driverid__surname" => "Senna", join_type = "INNER")
+
+    @test length(q.object.custom_join["driverid"]["filters"]) == orig_n
+    @test !haskey(q.object.custom_join["driverid"], "join_type")
+    @test length(q2.object.custom_join["driverid"]["filters"]) == orig_n + 1
+    @test q2.object.custom_join["driverid"]["join_type"] == "INNER"
+  end
+end


### PR DESCRIPTION
Closes #112.

## Problem

`q.copy()` → `deepcopy(::SQLObjectQuery)` copied every field independently **except** `custom_join`, which was shallow (`copy(obj.custom_join)`): the outer dict was fresh, but each inner per-join `Dict` (`"filters"` / `"join_type"` / `"field"`) was shared by reference between the original and the copy. `on()` mutates that inner dict in place, so extending an existing join path on a copy rewrote the **original's** join filters and join type — the build-time sibling of the #43 CTE aliasing:

```julia
q = M.Result.objects
q.values("id", "driverid__surname")
q.on("driverid", "driverid__nationality" => "British")

q2 = q.copy()
q2.on("driverid", "driverid__nationality" => "Brazilian", join_type = "INNER")
# pre-fix: q now ALSO carries the "Brazilian" predicate and renders INNER JOIN
```

## Fix

`_copy_custom_join` in `src/querybuilder/types.jl`, mirroring #43's `_copy_ctes` — the clone-boundary rule mature ORMs converged on (Django `Query.clone()`, SQLAlchemy `_clone()`): **depth follows mutability**.

- fresh inner dict per join path (the object `on()` mutates in place);
- fresh `"filters"` vector (elements shared — `on()` replaces the vector, never mutates elements);
- `"field"` `PormGField` shared by reference — it holds a `Model_Type → Module` that `deepcopy` cannot traverse (the reason the original copy was shallow);
- scalar entries (`"join_type"`) carried as-is.

Review hardening: the copy branch matches `AbstractDict` (not exactly `Dict{String,Any}`) so a future differently-typed inner dict still gets an independent copy instead of silently re-aliasing. A writer audit confirmed `cjoin()`/`on()` are the only `custom_join` writers in `src/`, so no build-path back-channel is severed. Bonus: CTE sub-queries carrying `custom_join` state are now isolated too, via `_copy_ctes`'s recursive handler deepcopy.

## Tests

New `test/unit/test_custom_join_copy.jl` (DB-free: mock PostgreSQL + inline F1-flavored models with a real FK; SQL via `show_query = :sql`), registered beside the #43 sibling in `test/runtests.jl`:

- **on()-seeded path (the issue's repro, AC1–AC3):** copy owns distinct outer *and* inner dicts; extending the same path on the copy leaves the original's filters vector (same object, same length) and `join_type` untouched; the copy renders different SQL while the original's SQL stays byte-identical.
- **cjoin()-seeded path:** fresh inner dict and `"filters"` vector, `"field"` intentionally shared (pinned by `===` so a future over-eager deep copy fails loudly); the original never gains the `"join_type"` key the copy's `on()` writes.

**Mutation gate (executed, not assumed):** reverting the fix to the shallow copy fails 9 assertions with the exact bug signatures (original's filters grew 1→2, `join_type` flipped LEFT→INNER, phantom `"join_type"` key appeared).

## Verification

| Suite | Result |
|---|---|
| `test/unit/test_custom_join_copy.jl` standalone | 16/16 |
| Full unit suite (`-t auto`) | 2323/2323 |
| PG integration `db_2` (live, `-t auto`) — AC4 | 1602/1602 |
| SQLite integration `db_sl` — AC4 | 1563/1563 |

No docs change: no new API or export — the fix makes `.copy()` match its existing independent-copy contract (same rationale as #43). Backend-agnostic (`deepcopy` renders no SQL), so PG/SQLite cannot diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
