### PR TITLE
fix(#77): whitelist SQLOrder orientation at construction and render

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -46,6 +46,7 @@ rows = M.Result.objects
 | Consuming PormG in a downstream app — setup, queries, examples (no internals) | `.github/skills/pormg-usage/SKILL.md` |
 | Pre-push / pre-PR review | `.github/skills/pormg-changed-code-review/SKILL.md` |
 | Managing the backlog — creating/updating GitHub issues, migrating or syncing the `TODO.md` index | `.github/skills/pormg-issue-management/SKILL.md` |
+| Tests failing, flaky, or environment-dependent (pool exhaustion, PG/SQLite divergence, fixture isolation) | `.github/skills/pormg-test-troubleshooting/SKILL.md` |
 
 Cross-cutting changes: public-API skill + the most specific subsystem skill. Reviews: review skill only — **except doc-content reviews** ("review the doc/examples in …"), which read the review skill **and** the public-API skill, so the live-database example-verification recipe applies.
 

--- a/.github/skills/pormg-test-troubleshooting/SKILL.md
+++ b/.github/skills/pormg-test-troubleshooting/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: pormg-test-troubleshooting
+description: Diagnose and mitigate failing, flaky, or environment-dependent PormG tests (unit + integration, PostgreSQL + SQLite) — pool exhaustion, backend divergence, fixture isolation, aliasing bugs. Read when a test is red and the cause isn't an obvious code regression.
+---
+
+# PormG Test Troubleshooting
+
+## Purpose
+
+Use this skill when a test fails and it isn't immediately clear whether that's a real regression
+in the change you're making, or an environment/infrastructure issue the repo has hit before.
+It captures recurring failure classes and how they were diagnosed and fixed previously, so you
+don't have to rediscover them from a cold start.
+
+This skill is about **diagnosing failures**, not writing new tests — see
+[`test-writing.md`](../../instructions/test-writing.md) for `@testset` conventions. Once you've
+root-caused a failure to a specific subsystem, hand off to the matching subsystem skill
+(`pormg-querybuilder-internals`, `pormg-migrations-development`, `pormg-public-api-development`)
+for the fix itself.
+
+## Use This Skill For
+
+- A test that fails locally but the change looks unrelated to what it's testing
+- A test that only fails under `-t auto`, only against PostgreSQL, or only against SQLite
+- A test that fails intermittently (passes on rerun) rather than deterministically
+- Deciding whether a failure is a real regression before spending time on a fix
+
+## Test layout & how to run a narrow slice
+
+- `test/runtests.jl` — unit suite (`julia --project=. test/runtests.jl`). No live DB required;
+  SQLite `:memory:` only. This is what CI (`.github/workflows/CI.yml`) runs — integration tests are
+  **not** part of CI, they're local/dev-only.
+- `test/integration/runtests.jl` — phased integration suite against a live DB (migration bootstrap
+  → fixture seeding → behavioral tests → advanced features → internals/security). Run via
+  `test/runtests.jl` with `PORMG_INTEGRATION_TESTS=true`, or directly.
+- Always run the **narrowest relevant file** first (e.g.
+  `julia --project=. test/unit/test_order_by_nulls.jl`), and only broaden to the full suite once
+  it's green — this repo's other skills all specify this same narrow-first order.
+
+Environment variables that change test behavior:
+
+| Var | Effect |
+|-----|--------|
+| `PORMG_DB` | Selects the integration DB folder: `db_2` (PostgreSQL, default) or `db_sl` (SQLite) |
+| `PORMG_INTEGRATION_TESTS` | `true` makes `test/runtests.jl` also run the integration suite |
+| `PORMG_TEST_POOL_SIZE` | Pre-sizes the PostgreSQL pool for the run (default `20`); see #37 below |
+| `PORMG_INFILTRATOR` | Rewires `@pormg_debug` to a live `Infiltrator.@infiltrate` breakpoint (non-interactive runs ignore this) |
+
+Threading: PostgreSQL integration tests are meant to run under `julia -t auto`. **SQLite does not
+tolerate `-t auto` well** — run `db_sl` integration tests with `-t 1`
+(`test/integration/common_setup.jl` documents this directly above the connection setup).
+
+```powershell
+# Unit suite (CI-equivalent)
+julia --project=. test/runtests.jl
+
+# Unit suite against SQLite instead of the default backend assumptions
+$env:PORMG_DB="db_sl"; julia --project=. test/runtests.jl
+
+# Full integration suite, PostgreSQL
+julia -t auto --project=. test/integration/runtests.jl
+
+# Full integration suite, SQLite (single-threaded)
+$env:PORMG_DB="db_sl"; julia -t 1 --project=. test/integration/runtests.jl
+
+# Everything, via the unit entrypoint's opt-in integration block
+$env:PORMG_INTEGRATION_TESTS="true"; julia -t auto --project=. test/runtests.jl
+```
+
+## Known recurring failure classes
+
+### PostgreSQL connection pool exhaustion (#37)
+
+**Symptom:** integration run against PostgreSQL hangs or throws under concurrency (`-t auto`),
+especially against a remote/higher-latency DB; historically a busy-retry loop logging heavily,
+now a typed `PoolTimeoutError` (`src/ConnectionPool.jl`).
+
+**Cause:** default pool size is small; the pool lazily expands up to
+`pool_size * POOL_EXPANSION_FACTOR` (`POOL_EXPANSION_FACTOR = 10`) before acquisition gives up.
+Under high fan-out this ceiling can still be reached.
+
+**Mitigation:** `test/integration/common_setup.jl` pre-sizes the pool from
+`PORMG_TEST_POOL_SIZE` (default `20`) — raise it for a heavier run. If you hit a genuine
+`PoolTimeoutError`, that's a sizing/contention symptom, not a connection leak (every
+`fetch_async` in `src/` is awaited/released). Regression coverage:
+`test/unit/test_connection_pool_timeout.jl`.
+
+### PostgreSQL vs SQLite backend divergence
+
+**Symptom:** a test passes on one backend and fails on the other with no logic change.
+
+**Cause:** SQL rendering differences the two dialects don't (yet) normalize — e.g. `ORDER BY` NULL
+placement diverges without explicit `NULLS FIRST/LAST` handling (#75, see
+`test/unit/test_order_by_nulls.jl`), and datetime/sequence handling differ by backend
+(`test/integration/test_sqlite_datetime_normalize.jl`, `test/unit/test_sequence_sync.jl`).
+
+**Mitigation:** before assuming a logic regression, check `src/Dialect.jl` for backend-specific
+rendering of the clause involved, and run the same test against **both** `db_2` and `db_sl` to
+confirm the divergence is backend-specific rather than a general bug.
+
+### Migration fixture isolation / credential leakage (#36)
+
+**Symptom:** migration-related tests behave differently depending on who runs them, or touch a
+shared database unexpectedly.
+
+**Cause:** a migration test fixture pointed at the shared `pormg_teste` database, or a
+`connection.yml` carried real credentials.
+
+**Mitigation:** the committed fixture `test/integration/db_test_migration_pg/connection.yml` is
+credential-free (hydrated in-memory at runtime) and points at a dedicated, disposable database —
+never the shared one. `test/unit/test_migration_pg_fixture.jl` is a deterministic, DB-free guard
+that fails the build if this regresses; if you're adding a new migration fixture, follow the same
+pattern.
+
+### Intermittent failures after `.copy()` / chained query mutation (#43, #112)
+
+**Symptom:** a test fails only sometimes, or only after a preceding test in the same file mutated
+a query object — classic shared-mutable-state symptom, not a real race.
+
+**Cause:** `QueryBuilder` objects have previously leaked shared references across `.copy()` (e.g.
+custom-join state aliasing the original — #112) instead of deep-copying per-instance state.
+
+**Mitigation:** when a failure looks intermittent or order-dependent rather than deterministic,
+suspect aliasing in the object being mutated before suspecting a race. See
+`test/unit/test_shared_state_readpath.jl` and `test/unit/test_custom_join_copy.jl` for the shape
+of this failure class and how it was isolated.
+
+### False regression from two sessions/worktrees sharing one live database
+
+**Symptom:** an integration test fails with data that doesn't match what the test just seeded, or
+a `DELETE`/schema-migration step trips over rows another process put there — while working in a
+git worktree alongside another Claude Code session (or any other process) also running the
+PostgreSQL integration suite.
+
+**Cause:** both processes point at the same live `db_2` database at the same time; the suite isn't
+designed to be safe under concurrent external writers.
+
+**Mitigation:** rule this out first — rerun the failing test alone with nothing else touching the
+same database — before treating it as a real bug. If you're routinely running parallel sessions,
+point one at a separate database/schema instead of debugging phantom failures.
+
+## Diagnostic workflow
+
+1. Reproduce with the narrowest failing test file, run alone (not the full suite).
+2. Confirm whether it fails on both backends (`PORMG_DB=db_2` and `PORMG_DB=db_sl`) or only one —
+   a single-backend failure points at `Dialect.jl`, not general logic.
+3. Check thread count and pool size if it's a PostgreSQL integration failure — rerun with
+   `-t 1` and a larger `PORMG_TEST_POOL_SIZE` to see if it's contention-shaped.
+4. Check whether anything else (another session, another worktree) is running integration tests
+   against the same live database right now.
+5. Rerun the same narrow test 2-3 times — deterministic failure vs. intermittent failure points to
+   different classes above.
+6. Only once the failure survives all of the above in isolation, treat it as a real regression and
+   move to the relevant subsystem skill for the fix.
+
+## Anti-Patterns
+
+- Do not weaken an assertion or a model/field contract just to make a flaky test pass — normalize
+  the fixture/setup instead (already the rule in `test-writing.md`; it applies doubly here since a
+  weakened assertion hides the next real regression).
+- Do not add blind retries or `sleep`-based waits to paper over a suspected race — root-cause it
+  via the workflow above first; a retry that "fixes" a test without understanding why is usually
+  masking a real shared-state bug (see #43/#112 above).
+- Do not silently bump timeouts or pool sizes without noting why in a comment — future runs need
+  to know whether that number reflects real capacity planning or a guess.
+- Do not conclude "flaky test, ignore it" — every flakiness class found in this repo so far has
+  had a deterministic root cause and a regression test once actually investigated.
+
+## Verification Commands
+
+```powershell
+julia --project=. test/runtests.jl
+$env:PORMG_DB="db_sl"; julia --project=. test/runtests.jl
+julia -t auto --project=. test/integration/runtests.jl
+$env:PORMG_DB="db_sl"; julia -t 1 --project=. test/integration/runtests.jl
+```

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -429,6 +429,10 @@ M.Driver.objects.values("surname", "nationality").order_by(
 ).list()
 ```
 
+`orientation` must be `"ASC"` or `"DESC"` (case-insensitive); any other value — including a
+user-supplied sort-direction string forwarded as-is — raises an `ArgumentError` at construction
+instead of reaching the SQL.
+
 On SQLite builds older than 3.30.0 (which lack `NULLS FIRST/LAST` syntax) PormG emits the portable
 `(field IS NULL)` sort prefix, so the placement is identical there too.
 

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -617,11 +617,9 @@ function _resolve_window_expression(v, instruc::SQLInstruction)
   end
 end
 
-function _normalize_window_orientation(orientation::AbstractString)::String
-  normalized = uppercase(strip(String(orientation)))
-  normalized in ("ASC", "DESC") || throw(ArgumentError("Window ORDER BY orientation must be ASC or DESC, got $(repr(orientation))"))
-  return normalized
-end
+# Delegates to the shared whitelist (types.jl, #77) so the ORDER BY and window paths can't drift.
+_normalize_window_orientation(orientation::AbstractString)::String =
+  _normalize_order_orientation(orientation; context="Window ORDER BY")
 
 function _resolve_window_order(v::String, instruc::SQLInstruction)::String
   isempty(v) && throw(ArgumentError("Window ORDER BY fields cannot be empty"))

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -118,8 +118,11 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     else
       v_field_copy.field = _get_select_query(v_field_copy.field, instruc)
     end
-    placement = _nulls_placement(v.orientation, v.nulls)
-    push!(instruc.order, _order_term_sql(v_field_copy.field, v.orientation, placement, instruc.connection))
+    # Re-validate at render: SQLOrder is mutable, so a post-construction reassignment could
+    # bypass the constructor whitelist (#77) — same render-time guard the window path has.
+    orientation = _normalize_order_orientation(v.orientation)
+    placement = _nulls_placement(orientation, v.nulls)
+    push!(instruc.order, _order_term_sql(v_field_copy.field, orientation, placement, instruc.connection))
     instruc.cache[v_field_copy._as] = v_field_copy
 
     if !found_in_select

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -120,6 +120,15 @@ SQLField(field::FieldPart; _as::OptionalString=nothing) = SQLField(field, _as, n
 SQLField(field::FieldPart, _as::OptionalString) = SQLField(field, _as, nothing)
 Base.deepcopy(x::SQLTypeField) = SQLField(x.field, x._as, x.custom_as)
 
+# `orientation` is interpolated into rendered SQL, so it is whitelisted here (#77) and stored
+# uppercase. Single whitelist for every orientation path — the window path
+# (_normalize_window_orientation, build_helpers.jl) delegates here with its own context label.
+function _normalize_order_orientation(orientation::AbstractString; context::String="ORDER BY")::String
+  normalized = uppercase(strip(String(orientation)))
+  normalized in ("ASC", "DESC") || throw(_argerr("$(context) orientation must be ASC or DESC, got $(repr(orientation))"))
+  return normalized
+end
+
 # Return a order of field to sql query
 mutable struct SQLOrder <: SQLTypeOrder
   field::Union{SQLTypeField,String}
@@ -129,6 +138,9 @@ mutable struct SQLOrder <: SQLTypeOrder
   # NULL placement for this term (#75): `nothing` = apply the canonical backend-aligned default
   # (ASC → NULLS LAST, DESC → NULLS FIRST); `:first`/`:last` force the placement explicitly.
   nulls::Union{Symbol,Nothing}
+  # Inner constructor: every construction path (keyword, positional, deepcopy) passes the
+  # orientation whitelist (#77), so an injection-shaped direction never reaches the renderer.
+  SQLOrder(field, order, orientation, _as, nulls) = new(field, order, _normalize_order_orientation(orientation), _as, nulls)
 end
 SQLOrder(field::Union{SQLTypeField,String}; order::Union{Integer,Nothing}=nothing, orientation::String="ASC", _as::OptionalString=nothing, nulls::Union{Symbol,Nothing}=nothing) = SQLOrder(field, order, orientation, _as, nulls)
 Base.deepcopy(x::SQLTypeOrder) = SQLOrder(x.field, x.order, x.orientation, x._as, x.nulls)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
+    @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")

--- a/test/unit/test_sqlorder_orientation.jl
+++ b/test/unit/test_sqlorder_orientation.jl
@@ -1,0 +1,120 @@
+# ============================================================
+# test/unit/test_sqlorder_orientation.jl
+#
+# SQLOrder orientation whitelist (#77).
+#
+# CONTRACT being tested:
+#   `SQLOrder.orientation` is interpolated into the rendered ORDER BY clause, so every
+#   construction path (keyword constructor, positional constructor, deepcopy) must whitelist
+#   the direction to ASC/DESC — case/whitespace-insensitive, stored uppercase. An
+#   injection-shaped direction (e.g. "ASC; DROP TABLE drivers --") must raise ArgumentError
+#   at construction and never reach SQL rendering. The documented string API
+#   (.order_by("-field")) already normalizes before construction and is unaffected.
+#
+# Deterministic, DB-free constructor tests. Mutation gate: reverting the inner-constructor
+# whitelist in querybuilder/types.jl (#77) lets the payload construct successfully and flow
+# verbatim into ORDER BY, so every rejection assertion below fails.
+# ============================================================
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, CharField
+using PormG.QueryBuilder: SQLField, SQLOrder
+
+# ── Mock backend for full-render tests ──────────────────────────────────────────────────────
+# A mock PostgreSQL marker (no DB round-trip), mirroring the pattern in test_order_by_nulls.jl,
+# so the render-time guard can be exercised through the public order_by/list(show_query=:sql) path.
+struct MockPG_OrientGuard <: PormG.PormGPostgres end
+
+DriverOrientModel = Model("drivers_orientation",
+  id = IDField(),
+  surname = CharField(),
+)
+DriverOrientModel.connect_key = "orientation_guard_pg"
+PormG.config["orientation_guard_pg"] = PormG.Configuration.Settings(
+  connections = MockPG_OrientGuard(),
+  change_data = true,
+)
+
+@testset "SQLOrder orientation whitelist (#77)" begin
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Valid directions construct and are stored normalized (uppercased, trimmed), so the
+  # renderer only ever interpolates the literal tokens ASC or DESC.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "valid orientations normalize to uppercase" begin
+    @test SQLOrder(SQLField("surname", "surname"); orientation="ASC").orientation == "ASC"
+    @test SQLOrder(SQLField("surname", "surname"); orientation="DESC").orientation == "DESC"
+    @test SQLOrder(SQLField("surname", "surname"); orientation="asc").orientation == "ASC"      # case-insensitive
+    @test SQLOrder(SQLField("surname", "surname"); orientation=" Desc ").orientation == "DESC"  # whitespace-tolerant
+    # Positional path (the one deepcopy delegates to) normalizes identically.
+    @test SQLOrder(SQLField("surname", "surname"), nothing, "desc", "surname", nothing).orientation == "DESC"
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Injection-shaped directions are rejected at construction — on the keyword AND the
+  # positional path — never reaching SQL. This is the #77 acceptance criterion.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "injection-shaped orientations raise at construction" begin
+    for bad in ("ASC; DROP TABLE drivers --", "DESC --", "ASC, (SELECT 1)", "")
+      # Keyword constructor (the direct-construction path the issue flags).
+      @test_throws ArgumentError SQLOrder(SQLField("surname", "surname"); orientation=bad)
+      # Positional constructor (deepcopy's path) is guarded by the same whitelist.
+      @test_throws ArgumentError SQLOrder(SQLField("surname", "surname"), nothing, bad, "surname", nothing)
+    end
+
+    # The rejection must fail loudly and name the valid options — not silently default.
+    # ("DESC" is the discriminating check: the injected payload itself contains "ASC".)
+    err = try
+      SQLOrder(SQLField("surname", "surname"); orientation="ASC; DROP TABLE drivers --")
+      nothing
+    catch e
+      e
+    end
+    @test err isa ArgumentError
+    @test occursin("ASC", string(err))
+    @test occursin("DESC", string(err))
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # deepcopy re-runs the positional constructor; a valid order must survive the round-trip
+  # unchanged (the whitelist re-validates an already-normalized value harmlessly).
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "deepcopy of a valid SQLOrder survives re-validation" begin
+    o = SQLOrder(SQLField("surname", "surname"); orientation="desc", nulls=:first)
+    c = deepcopy(o)
+    @test c.orientation == "DESC"
+    @test c.nulls === :first
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Render-time guard: SQLOrder is mutable, so a post-construction reassignment bypasses the
+  # constructor whitelist. get_order_query re-validates before interpolation, so the payload
+  # still raises instead of reaching SQL — mirroring the window path's render-time check.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "post-construction mutation is caught at render time" begin
+    # Construct validly, then smuggle the payload past the constructor by direct mutation.
+    o = SQLOrder(SQLField("surname", "surname"); orientation="ASC")
+    o.orientation = "ASC; DROP TABLE drivers --"
+
+    q = DriverOrientModel.objects
+    q.order_by(o)
+    # Rendering must raise — never emit the payload into the SQL string.
+    err = try
+      q.list(show_query=:sql)
+      nothing
+    catch e
+      e
+    end
+    @test err isa ArgumentError
+    @test occursin("DESC", string(err))   # the whitelist error, naming the valid options
+
+    # Sanity (negative case): the same query shape with a valid order renders fine.
+    q_ok = DriverOrientModel.objects
+    q_ok.order_by(SQLOrder(SQLField("surname", "surname"); orientation="ASC"))
+    sql = q_ok.list(show_query=:sql)
+    @test occursin("ORDER BY", sql)
+    @test occursin("ASC", sql)
+  end
+
+end


### PR DESCRIPTION
## Summary

`SQLOrder.orientation` was interpolated **raw** into the rendered `ORDER BY` clause. The documented
string API (`.order_by("-field")`) normalizes direction and was safe, but a directly constructed
`SQLOrder("surname"; orientation = "ASC; DROP TABLE drivers --")` landed verbatim in the SQL — a
latent injection seam for downstream apps forwarding a user-controlled sort direction (#77).

## Fix

- **`src/querybuilder/types.jl`** — new `_normalize_order_orientation(orientation; context="ORDER BY")`:
  `uppercase(strip(…))` then whitelist against `("ASC","DESC")`, throwing `_argerr` otherwise. An
  **inner constructor** on `SQLOrder` routes every construction path (keyword, positional, `deepcopy`)
  through it; the stored value is always the normalized uppercase token.
- **`src/querybuilder/build_query.jl`** — `get_order_query` **re-validates at render time**: `SQLOrder`
  is mutable, so a post-construction reassignment could bypass the constructor whitelist. This mirrors
  the render-time guard the window path already had.
- **`src/querybuilder/build_helpers.jl`** — `_normalize_window_orientation` now delegates to the shared
  whitelist (`context="Window ORDER BY"`), so the two paths cannot drift; its error now routes through
  `_argerr` per repo convention (message text unchanged).

## Acceptance criteria (from #77)

- [x] `SQLOrder` with an `orientation` other than ASC/DESC (case-insensitive) raises, never reaches SQL.
- [x] Regression test asserting an injection-shaped `orientation` is rejected.

## Tests

New `test/unit/test_sqlorder_orientation.jl` (22 assertions, deterministic, DB-free): rejection of
injection-shaped orientations on **both** constructor paths, case/whitespace normalization, `deepcopy`
round-trip, and the mutation-bypass caught at render via a mock-PG full render (negative case included).
Wired into `test/runtests.jl`.

- Full unit suite: **2345/2345** pass.
- `test_order_by_nulls.jl` (21/21) and `test_window_functions.jl` (drivers loaded, zero failures) green.
- Reviewed via the changed-code review skill at xhigh effort; all three findings (render-time
  re-check, whitelist unification, doc note) applied in this PR.

## Docs

`docs/src/read/filters_and_aggregates.md` now states the `orientation` contract at the `SQLOrder`
example: `"ASC"`/`"DESC"` case-insensitive, anything else raises `ArgumentError`.

## Bundled

New **`pormg-test-troubleshooting`** skill (`.github/skills/pormg-test-troubleshooting/SKILL.md` +
index row in `general.instructions.md`): diagnosing failing/flaky/environment-dependent tests — pool
exhaustion (#37), PG/SQLite divergence (#75), fixture isolation (#36), copy-aliasing (#43/#112), and
parallel-session DB contention.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
