### PR TITLE
fix(#107): match_on takes model fields only — columns= is the single df→model mapping

### DIFF
--- a/.github/skills/pormg-usage/writing.md
+++ b/.github/skills/pormg-usage/writing.md
@@ -93,12 +93,14 @@ bulk_copy(M.Driver.objects, df, columns=[
 
 # Batch update from DataFrame
 bulk_update(M.Result.objects, df,
-    columns  = ["points"],     # fields to SET
-    match_on = ["resultid"]    # per-row keys to match on (WHERE)
+    columns  = ["points"],     # participating fields (+ any "df_col" => "field" mappings)
+    match_on = ["resultid"]    # per-row merge keys, bare model field names (WHERE)
 )
-# `filters=` is reserved for *constant* predicates AND'd onto every row
-# (e.g. filters = ["constructorid" => 131]). Putting a per-row DataFrame
-# column in filters= now raises a migration error — use match_on= for keys.
+# `columns=` is the ONLY place a df column is mapped to a model field; a field
+# selected by match_on= is used for matching, never SET. `filters=` is reserved
+# for *constant* predicates AND'd onto every row (e.g. filters =
+# ["constructorid" => 131]). Putting a per-row DataFrame column in filters=,
+# or a "df_col" => "field" pair in match_on=, raises a migration error.
 ```
 
 **Pre-process CSV nulls before bulk operations:**

--- a/TODO.md
+++ b/TODO.md
@@ -19,16 +19,15 @@
 > **Settled & merged:** Tier 1 (migration-format / tracking-table contract, frozen schema
 > conventions) · Tier 2 (#34 adapter decoupling → #35 export curation) · field-name case
 > preservation (#57) + lowercase convention (#58) · the full `db_column` authority family —
-> authoritative DDL/queries (#50), string FK targets (#62), ManyToMany/CTE join keys (#64).
+> authoritative DDL/queries (#50), string FK targets (#62), ManyToMany/CTE join keys (#64) ·
+> isolated PG migration fixture (#36) · pool-exhaustion investigation (#37 → follow-ups
+> #124–#128) · `ORDER BY` NULL placement (#75) · `.copy()` state aliasing (#43 → #112).
 >
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-- [#36](https://github.com/PingoLee/PormG.jl/issues/36) — Isolated PostgreSQL migration fixture (`db_test_migration_pg/`)
-- [#37](https://github.com/PingoLee/PormG.jl/issues/37) — Investigate PG pool exhaustion under remote-latency integration runs
-- [#75](https://github.com/PingoLee/PormG.jl/issues/75) — `ORDER BY` NULL placement diverges PG vs SQLite (no `NULLS FIRST/LAST` normalization)
-- [#107](https://github.com/PingoLee/PormG.jl/issues/107) — Reconsider `=>` direction/semantics across the query API (predicate vs projection vs mapping)
-- [#112](https://github.com/PingoLee/PormG.jl/issues/112) — `.copy()` aliases custom_join state: extending `on()`/`cjoin()` on a copy mutates the original (build-time residual of #43)
+- [#107](https://github.com/PingoLee/PormG.jl/issues/107) — Bulk mapping contract (decided): `columns=` is the single df→model border; `match_on=` takes model fields only
+- [#132](https://github.com/PingoLee/PormG.jl/issues/132) — Bulk ops: drop the `copy=` deepcopy default — non-mutating zero-copy pipeline
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,7 +43,53 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
-*No pending entries — all recorded changes have been rolled out to the consuming apps.*
+## `bulk_update(match_on=)` — pairs removed; `columns=` is the single df→field mapping point
+
+- **PormG ref**: issue #107 ; `src/querybuilder/execution_bulk.jl`
+- **Recorded**: 2026-07-12
+- **Severity**: breaking
+
+### What changed
+
+`match_on=` no longer accepts `"df_col" => "model_field"` pairs. It takes **bare model
+field names** only; `columns=` is now the **single place** a DataFrame column is mapped
+to a model field ("one border crossing"). A field listed in both `columns=` and
+`match_on=` is used for **matching only — it is never SET** (this was already true).
+A bare `match_on` name resolves its source column **mapping-first**: the `columns=`
+mapping when declared (authoritative — a same-named DataFrame column is ignored with a
+warning), otherwise a DataFrame column with the field's own name.
+
+### How to find the calls to migrate
+
+Run the app or its tests: every old pair raises
+`bulk_update: match_on= no longer accepts "df_col" => "model_field" pairs (DEPRECATED API)`
+with the exact rewrite. Or grep for `match_on` and inspect any entry containing `=>`.
+
+### Migrate your app
+
+```julia
+# ✗ before
+bulk_update(query, df,
+    columns  = ["new_score" => "points"],
+    match_on = ["record_id" => "id"])
+
+# ✓ after — the pair moves to columns=; match_on keeps the bare field name
+bulk_update(query, df,
+    columns  = ["new_score" => "points", "record_id" => "id"],
+    match_on = ["id"])
+```
+
+Bare-name calls (`match_on = ["id"]` with an `id` DataFrame column, or relying on the
+primary-key fallback) need no change.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
 
 ---
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -396,10 +396,11 @@ bulk_update(M.Result.objects, df_with_changes, columns=["points"], match_on=["re
 
 Key contracts:
 
-- `columns=` sets fields; `match_on=` gives the per-row keys that identify each row; `filters=` are constant predicates applied to every row.
-- DataFrame columns are matched **case-sensitively** for both `columns` and `match_on`. A column that differs only in case from the model field (e.g. `RaceId` vs `raceid`) raises an error naming the candidate; normalize headers with `rename!(df, lowercase.(names(df)))` or map explicitly with `"DF_COL" => "field"`.
+- `columns=` names the participating fields and is the **single place** a DataFrame column is mapped to a model field (`"df_col" => "field"`); `match_on=` selects the per-row merge keys by **bare model field name** (a field in both is matched, never SET); `filters=` are constant predicates applied to every row.
+- A `match_on` field's source column is its `columns=` mapping when declared — the mapping is authoritative even if a same-named DataFrame column also exists (that case warns) — otherwise a DataFrame column with the field's own name.
+- DataFrame columns are matched **case-sensitively** for both `columns` and `match_on`. A column that differs only in case from the model field (e.g. `RaceId` vs `raceid`) raises an error naming the candidate; normalize headers with `rename!(df, lowercase.(names(df)))` or map explicitly with `"DF_COL" => "field"` in `columns=`.
 - If `match_on` is omitted, PormG infers the model primary key columns and uses those to identify rows.
-- A per-row match key passed in `filters=` (a bare string or `"df_col" => "field"` pair) raises a migration error directing you to `match_on=`; there is no silent fallback. This migration error is a temporary deprecation aid and will be removed in a future release.
+- A per-row match key passed in `filters=` (a bare string or `"df_col" => "field"` pair) raises a migration error directing you to `match_on=`; there is no silent fallback. Likewise, the pre-#107 pair grammar in `match_on=` (`["record_id" => "id"]`) raises a migration error showing the rewrite (`columns=[..., "record_id" => "id"], match_on=["id"]`). Both migration errors are temporary deprecation aids and will be removed in a future release.
 - `bulk_update()` rebuilds the `WHERE` clause from `match_on=` and `filters=` and does not preserve filters that were already attached to the handler.
 - Constant lookup filters on base-table columns are supported, but relation traversals that would require JOINs are rejected.
 - Foreign-key columns accept scalar primary-key values, including `0` when that referenced row exists; use `nothing` or `missing` to write SQL `NULL` on nullable FK columns.

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -306,9 +306,11 @@ bulk_copy(M.Result.objects, results_df, chunk_size=10000)
 
 `bulk_update()` updates multiple rows from a `DataFrame`. It separates three concerns:
 
-- **`columns=`** — the fields to **SET** (`"df_col" => "model_field"`, or a bare string when the names match).
-- **`match_on=`** — the **per-row match keys** that identify which row each DataFrame row updates (the merge condition `Tb.field = source.df_col`). Same grammar as `columns=`. If omitted, the model primary key(s) are used.
+- **`columns=`** — the **participating fields and their mappings**. This is the **single place** a DataFrame column is mapped to a model field (`"df_col" => "model_field"`, or a bare string when the names match). Fields selected by `match_on=` are used for matching only — they are **not** SET.
+- **`match_on=`** — the **per-row match keys** that identify which row each DataFrame row updates (the merge condition `Tb.field = source.field`). Bare **model field names** only; the source column is the `columns=` mapping for that field when declared, otherwise a DataFrame column with the field's own name. If omitted, the model primary key(s) are used.
 - **`filters=`** — **constant** predicates AND'd onto every row's `WHERE` (`"model_field" => value`), e.g. `"category_id" => 172100` or `"points__@in" => [18, 25]`.
+
+**One border crossing.** `columns=` is the only argument where DataFrame names appear; `match_on=` and `filters=` always speak the model's field language. That keeps every `=>` in the bulk API meaning the same thing — "df column *to* model field" — and it appears exactly once.
 
 PormG validates every row up front, then emits a multi-row `UPDATE` using a `VALUES` source (PostgreSQL) or `WITH source(...) AS (VALUES ...)` form (SQLite).
 
@@ -316,6 +318,9 @@ PormG validates every row up front, then emits a multi-row `UPDATE` using a `VAL
     Earlier versions packed both row-matching keys and constant predicates into `filters=`. Row matching now lives in `match_on=`. Passing a per-row match key in `filters=` (a bare string, or a `"df_col" => "model_field"` pair) raises an error telling you to move it to `match_on=` — there is no silent fallback.
 
     This migration error is a **temporary deprecation aid** and will be removed in a future release; once your call sites use `match_on=`, you will not see it again.
+
+!!! note "Migrated from the `match_on=` pair grammar (#107)"
+    Earlier versions also accepted `"df_col" => "model_field"` pairs in `match_on=`, so the same mapping could be declared in two places. Pairs in `match_on=` now raise a migration error showing the rewrite: move the pair into `columns=` and keep the bare field name in `match_on=` — e.g. `match_on=["record_id" => "id"]` becomes `columns=[..., "record_id" => "id"], match_on=["id"]`. Like the `filters=` shim above, this error is temporary.
 
 ### Basic Usage
 
@@ -359,8 +364,9 @@ custom_df = DataFrame(
 )
 
 bulk_update(query, custom_df,
-    columns=["new_score" => "points"],      # SET: map 'new_score' to field 'points'
-    match_on=["record_id" => "id"]          # match key: map 'record_id' to field 'id'
+    columns=["new_score" => "points",       # SET: map 'new_score' to field 'points'
+             "record_id" => "id"],          # mapping for the match key (not SET)
+    match_on=["id"]                         # merge key, by model field name
 )
 ```
 
@@ -378,9 +384,10 @@ WHERE "Tb"."id" = source."id"::bigint
 
 ### Matching and Execution Rules
 
-- **Case-sensitive DataFrame matching**: PormG resolves `columns` and `match_on` against `DataFrame` column names **exactly**. A name that differs only in case from the model field (e.g. `ID` vs `id`) is rejected with an error that names the candidate column and suggests the fix — either `rename!(df, lowercase.(names(df)))` or an explicit `"DF_COL" => "field"` mapping. (An explicit `columns=` mapping is always honored, even when its source column differs in case from the field name.)
-- **Primary key fallback**: If you omit `match_on=`, `bulk_update()` infers the model primary key column(s) and expects those columns to be present in the `DataFrame`.
-- **Missing column errors**: A `match_on` column absent from the `DataFrame` raises an `ArgumentError` rather than silently degrading to a constant filter. An explicit `columns=` mapping (`"df_col" => "field"`) whose source column is absent likewise raises — it is never silently bound to a non-existent column.
+- **Case-sensitive DataFrame matching**: PormG resolves `columns` and `match_on` against `DataFrame` column names **exactly**. A name that differs only in case from the model field (e.g. `ID` vs `id`) is rejected with an error that names the candidate column and suggests the fix — either `rename!(df, lowercase.(names(df)))` or an explicit `"DF_COL" => "field"` mapping in `columns=`. (An explicit `columns=` mapping is always honored, even when its source column differs in case from the field name.)
+- **Mapping-first match keys**: A `match_on` field with a `columns=` mapping always uses that mapping as its source. If the `DataFrame` *also* carries a column with the field's own name, the mapping still wins and the same-named column is ignored — with a warning, so the ambiguity is visible.
+- **Primary key fallback**: If you omit `match_on=`, `bulk_update()` infers the model primary key column(s) and expects those columns to be present in the `DataFrame` (or mapped in `columns=`).
+- **Missing column errors**: A `match_on` field with no source — no `columns=` mapping and no same-named `DataFrame` column — raises an `ArgumentError` rather than silently degrading to a constant filter. An explicit `columns=` mapping (`"df_col" => "field"`) whose source column is absent likewise raises — it is never silently bound to a non-existent column.
 - **Handler filters are rebuilt**: `bulk_update()` clears any filters already attached to the query handler and rebuilds the `WHERE` clause from `match_on=` and `filters=`. Pass every predicate you need through those arguments rather than relying on prior `query.filter(...)` state.
 - **Dry-run support**: `show_query=:dict` and `show_query=:inspection` return metadata, `:sql` returns SQL text, `:params` returns the bound parameter list, and `:none` builds the statement and returns `nothing` without executing.
 - **Empty input is a no-op**: An empty `DataFrame` returns `nothing` after logging a warning.
@@ -395,15 +402,17 @@ each call by splitting `filters=` into **`match_on=`** (row-matching keys) and
 | Old call | New call |
 |----------|----------|
 | `filters=["id"]` | `match_on=["id"]` |
-| `filters=["record_id" => "id"]` | `match_on=["record_id" => "id"]` |
+| `filters=["record_id" => "id"]` | `columns=[..., "record_id" => "id"], match_on=["id"]` |
+| `match_on=["record_id" => "id"]` *(pre-#107 pair)* | `columns=[..., "record_id" => "id"], match_on=["id"]` |
 | `filters=["id", "category_id" => 172100]` | `match_on=["id"], filters=["category_id" => 172100]` |
 | `filters=["category_id" => 172100]` *(constant only)* | unchanged — stays in `filters=` |
 | `filters=[]` or `filters` omitted | unchanged — the primary key is inferred |
 
 **Rule of thumb:**
 
-- If an entry references a **DataFrame column** — a bare string (`"id"`) or a
-  `"df_col" => "field"` pair — it is a per-row key → move it to `match_on=`.
+- If an entry references a **DataFrame column** it is a per-row key: the bare field name
+  goes to `match_on=`, and any `"df_col" => "field"` mapping goes to `columns=` (a field
+  listed in both is used for matching only — it is never SET).
 - If an entry is `"field" => value` with a **literal value** (number, string, bool,
   array, `__@` lookup) → it is a constant predicate → leave it in `filters=`.
 
@@ -458,14 +467,15 @@ end
 
 `bulk_update()` combines **per-row match keys** (`match_on=`, driven by DataFrame values) with **constant filters** (`filters=`, the same value for every row).
 
-- **`match_on=`**: `["id"]` or `["record_id" => "id"]`. Always resolved against the DataFrame; identifies which row each DataFrame row updates.
+- **`match_on=`**: bare model field names, e.g. `["id"]`. Each key's per-row values come from the DataFrame — through the `columns=` mapping when one is declared, otherwise from the same-named DataFrame column; the keys identify which row each DataFrame row updates.
 - **`filters=`**: `["status" => "active"]`. Always a constant predicate AND'd onto the `WHERE` clause for every row.
 
 ```julia
 # Per-row match key + constant scope guard
 bulk_update(query, df,
-    columns=["new_points" => "points"],
-    match_on=["record_id" => "id"],   # match DB 'id' against DF 'record_id'
+    columns=["new_points" => "points",
+             "record_id" => "id"],    # mapping for the match key (not SET)
+    match_on=["id"],                  # match DB 'id' against DF 'record_id'
     filters=["category_id" => 172100] # constant: only rows where category_id is 172100
 )
 ```

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -29,6 +29,61 @@ function _normalize_bulk_columns(columns)
   return _columns
 end
 
+# #107 "one border crossing": `columns=` is the ONLY place a DataFrame column is mapped
+# to a model field. `match_on=` selects merge keys by bare model-field name; its old
+# `"df_col" => "model_field"` pair form is rejected with a migration error below.
+function _normalize_bulk_match_on(match_on)::Vector{String}
+  _match_on = String[]
+  if match_on === nothing
+  elseif match_on isa AbstractString
+    push!(_match_on, match_on)
+  elseif match_on isa Pair
+    throw(ArgumentError(_match_on_pair_migration_msg(match_on)))
+  elseif match_on isa Vector
+    for key in match_on
+      if key isa AbstractString
+        push!(_match_on, key)
+      elseif key isa Pair
+        throw(ArgumentError(_match_on_pair_migration_msg(key)))
+      else
+        throw(ArgumentError("Invalid match_on specification: $key"))
+      end
+    end
+  else
+    throw(ArgumentError("Invalid match_on argument: $match_on"))
+  end
+  return _match_on
+end
+
+# ============================================================================
+# DEPRECATION SHIM — TEMPORARY (remove once the pre-#107 pair grammar is retired)
+#
+# Before #107, `match_on=` accepted the same `"df_col" => "model_field"` grammar as
+# `columns=`, so the df→field mapping could be declared in two places. The PERMANENT
+# contract is: mappings live in `columns=` only; `match_on=` is bare model-field names.
+# This helper only turns the removed pair form into an actionable migration error.
+#
+# TO REMOVE after the deprecation window: delete this helper and let the pair fall
+# through to `_normalize_bulk_match_on`'s generic "Invalid match_on specification" error.
+# ============================================================================
+function _match_on_pair_migration_msg(pair::Pair)
+  shown = "\"$(pair.first)\" => \"$(pair.second)\""
+  return """
+  bulk_update: `match_on=` no longer accepts `"df_col" => "model_field"` pairs (DEPRECATED API).
+  `columns=` is the single place a DataFrame column is mapped to a model field; `match_on=`
+  selects the merge keys by model field name. A field listed in both is used only for
+  matching — match keys are never SET.
+
+    Change:  match_on = [$(shown)]
+    To:      columns  = [..., $(shown)], match_on = ["$(pair.second)"]
+
+  This migration error is temporary and will be removed in a future release.
+  """
+end
+# ============================================================================
+# end deprecation shim
+# ============================================================================
+
 function _normalize_bulk_filters(filters)
   _filters::Vector{Union{String, Pair{String, <:Any}}} = []
   if filters === nothing
@@ -503,35 +558,39 @@ function _ensure_unique_bulk_update_keys!(df::DataFrames.DataFrame,
   return nothing
 end
 
-# Map one match key into mapping / fields_df / dynamic_filters. Unlike the legacy
-# `filters=` path, a missing DataFrame column is a hard error rather than a silent
-# fall-through to a static predicate.
+# Map one match key (a bare MODEL FIELD name — #107) into mapping / fields_df /
+# dynamic_filters. Unlike the legacy `filters=` path, a missing source column is a hard
+# error rather than a silent fall-through to a static predicate.
 #
-# `allow_reuse` lets a bare key (and the PK fallback) fall back to a mapping already
-# established by `columns=` when `df_col` is not a DataFrame column on its own. It MUST
-# stay `false` for an explicit `"df_col" => "field"` pair, otherwise a typoed source
-# column would be silently swallowed by the existing `columns=` mapping instead of
-# raising the documented hard error.
+# Source resolution is MAPPING-FIRST: a mapping declared in `columns=` is authoritative
+# for its field. Only when no mapping exists does a DataFrame column with the field's own
+# name serve as the source. (Pre-#107 the order was reversed — an exact df column won over
+# the mapping — which made a same-named column silently override the declared mapping.)
 function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
   mapping::Dict{String, String}, fields_df::Vector{String},
-  dynamic_filters::Vector{String}, field::String, df_col::String;
-  kind::String="match_on", allow_reuse::Bool=true)
+  dynamic_filters::Vector{String}, field::String;
+  kind::String="match_on")
 
   field in model.field_names ||
     throw(_argerr("bulk_update: $(kind) field \e[4m\e[31m$(field)\e[0m is not a field of model $(model.name)"))
 
-  resolved = if df_col in names(df)
-    df_col                                # exact (case-sensitive) match wins
-  elseif allow_reuse && haskey(mapping, field)
-    mapping[field]                        # bare key / PK fallback: reuse the columns= mapping
+  resolved = if haskey(mapping, field)
+    # `columns=` mapping wins. If the df ALSO carries a column named exactly like the
+    # field, it is ignored in favor of the declared mapping — surface that loudly.
+    if mapping[field] != field && field in names(df)
+      @warn "bulk_update: $(kind) resolved through the columns= mapping; the same-named DataFrame column is ignored" field=field mapped_source=mapping[field] ignored_column=field
+    end
+    mapping[field]
+  elseif field in names(df)
+    field                                 # identity: df column named like the field
   else
-    # No exact match and nothing to reuse. A column differing only in case is a loud
-    # error, not a silent fold (see the case-sensitive matching contract above).
-    candidates = _case_fold_candidates(df_col, names(df))
+    # No mapping and no exact same-named column. A column differing only in case is a
+    # loud error, not a silent fold (see the case-sensitive matching contract above).
+    candidates = _case_fold_candidates(field, names(df))
     isempty(candidates) ||
-      throw(_argerr(_bulk_case_mismatch_msg(:update, df_col, candidates,
-        "\"$(candidates[1])\" => \"$(field)\"")))
-    throw(_argerr("bulk_update: $(kind) column \e[4m\e[31m$(df_col)\e[0m not found in the DataFrame (columns: $(names(df)))"))
+      throw(_argerr(_bulk_case_mismatch_msg(:update, field, candidates,
+        "columns = [..., \"$(candidates[1])\" => \"$(field)\"]")))
+    throw(_argerr("bulk_update: $(kind) column \e[4m\e[31m$(field)\e[0m not found in the DataFrame (columns: $(names(df))) and no columns= mapping targets that field"))
   end
 
   mapping[field] = resolved
@@ -565,13 +624,20 @@ end
 
 function _bulk_update_migration_msg(f)
   shown = f isa Pair ? "\"$(f.first)\" => \"$(f.second)\"" : "\"$(f)\""
+  # #107: match_on= takes bare field names only, so a pair's rewrite is two-part —
+  # the mapping moves to columns=, the bare field name goes to match_on=. Advising
+  # `match_on = [pair]` here would send the caller straight into the pair error.
+  to = f isa Pair ?
+    "columns  = [..., $(shown)], match_on = [\"$(f.second)\"]" :
+    "match_on = [$(shown)]"
   return """
   bulk_update: `filters=` no longer accepts per-row match keys (DEPRECATED API).
-  $(shown) references a DataFrame column, so it is a match key — move it to `match_on=`.
-  `filters=` is now for constant predicates only.
+  $(shown) references a DataFrame column, so it is a match key — match keys live in
+  `match_on=` (bare model field names), with any `"df_col" => "field"` mapping declared
+  in `columns=`. `filters=` is now for constant predicates only.
 
     Change:  filters  = [$(shown)]
-    To:      match_on = [$(shown)]
+    To:      $(to)
 
   Use `filters=` only for constant predicates, e.g. filters = ["category_id" => 172100].
   This migration error is temporary and will be removed in a future release.
@@ -588,14 +654,16 @@ _bulk_update_static_only_msg(f) =
 # Classify `match_on` into per-row merge keys (dynamic_filters) and `filters` into
 # constant predicates (static_filters). Returns (dynamic_filters, static_filters).
 #
-# - `match_on` resolves to per-row merge keys; explicit pairs must exist in the df.
+# - `match_on` entries are bare model-field names (#107); each resolves to a per-row
+#   merge key whose source column comes from the `columns=` mapping or, failing that,
+#   a DataFrame column with the field's own name.
 # - `filters` entries are constant `field => value` predicates.
 # - When `match_on` is omitted and no key is produced, the model primary key(s) are used.
 # - TEMPORARY: when `match_on` is absent, the old dynamic-in-`filters` usage raises a
 #   migration error (see the deprecation-shim banner above).
 function _resolve_bulk_update_keys!(df::DataFrames.DataFrame, model::PormGModel,
   mapping::Dict{String, String}, fields_df::Vector{String},
-  match_on::Vector{Union{String, Pair{String, String}}},
+  match_on::Vector{String},
   filters::Vector{Union{String, Pair{String, <:Any}}},
   pks::Vector{String})
 
@@ -603,15 +671,9 @@ function _resolve_bulk_update_keys!(df::DataFrames.DataFrame, model::PormGModel,
   static_filters = Pair{String, Any}[]
   match_on_given = !isempty(match_on)
 
-  # match_on: always per-row merge keys ("df_col" => "model_field")
+  # match_on: per-row merge keys, selected by model field name
   for key in match_on
-    if key isa Pair
-      # Explicit column: it must exist in the DataFrame — no reuse of a columns= mapping.
-      _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, key.second, key.first; allow_reuse=false)
-    else
-      # Bare key: match on this field using whatever column already maps to it.
-      _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, key, key; allow_reuse=true)
-    end
+    _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, key)
   end
 
   # filters: permanent contract is constant `field => value` predicates.
@@ -633,7 +695,7 @@ function _resolve_bulk_update_keys!(df::DataFrames.DataFrame, model::PormGModel,
     isempty(pks) && throw(ArgumentError(
       "bulk_update: no match_on= given and model $(model.name) has no primary key to match on"))
     for pk in pks
-      _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, pk, pk; kind="primary key")
+      _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, pk; kind="primary key")
     end
   end
 
@@ -720,7 +782,8 @@ Inserts multiple rows into the database in bulk from a DataFrame.
   # Map DataFrame column "author_name" to model field "author"
   # Exclude "ignore_me" by not including it in the columns argument
   bulk_insert(query, df, columns=["title", "year", "author_name" => "author"])
-  # the df will be modified to only include the columns "title", "year", and "author_name" (renamed to "author").
+  # Only "title", "year", and "author_name" (as field "author") participate in the INSERT;
+  # the DataFrame's columns are never renamed or removed — the mapping is internal.
 
   # If you want to copy the DataFrame before processing, set `copy=true`:
   bulk_insert(query, df, columns=["title", "year", "author_name" => "author"], copy=true)
@@ -1030,8 +1093,8 @@ Performs a bulk update operation on a database table using the provided `DataFra
 # Arguments
 - `objct::SQLObjectHandler`: The database handler object.
 - `df::DataFrames.DataFrame`: The DataFrame containing the data to be used for the update.
-- `columns`: (Optional) Which columns to **SET**. Each entry is a `String` (DataFrame column == model field) or a `Pair{String, String}` of `"df_col" => "model_field"`. A `Vector` of these is accepted. If `nothing`, columns are auto-detected from the DataFrame.
-- `match_on`: (Optional) The **per-row match keys** that identify which row each DataFrame row updates (the SQL merge condition `Tb.field = source.df_col`). Same grammar as `columns`: a `String` or `"df_col" => "model_field"`. If omitted, the model primary key(s) are used and must be present in the DataFrame.
+- `columns`: (Optional) The **participating fields and their mappings** — the single place a DataFrame column is mapped to a model field. Each entry is a `String` (DataFrame column == model field) or a `Pair{String, String}` of `"df_col" => "model_field"`. A `Vector` of these is accepted. If `nothing`, columns are auto-detected from the DataFrame. Fields selected by `match_on` are used for matching only and are **not** SET.
+- `match_on`: (Optional) The **per-row match keys** that identify which row each DataFrame row updates (the SQL merge condition `Tb.field = source.col`). Bare **model field names** only — the source column is the `columns=` mapping for that field when declared, otherwise a DataFrame column with the field's own name. If omitted, the model primary key(s) are used and must be present in the DataFrame.
 - `filters`: (Optional) **Constant** predicates AND'd onto the `WHERE` clause, applied to every row. Each entry is a `Pair{String, T}` of `"model_field" => value` (e.g. `"category_id" => 172100`, `"points__@in" => [18, 25]`). When `match_on` is provided, every `filters` entry must be such a constant predicate. A per-row match key in `filters` is rejected with a migration error — move it to `match_on`.
 - `show_query::Bool`: (Optional) If `true`, prints the generated SQL query. Defaults to `false`.
 - `chunk_size::Integer`: (Optional) Number of rows to process per chunk. Defaults to `1000`.
@@ -1045,10 +1108,13 @@ bulk_update(objct, df)
 # Set name/dof, matching rows on security_id
 bulk_update(objct, df, columns=["name", "dof"], match_on=["security_id"])
 
-# Map differing DataFrame names and add a constant scope guard
+# Map differing DataFrame names and add a constant scope guard. ALL df→field
+# mappings live in columns=; match_on selects merge keys by model field name
+# (a field listed in both is used only for matching — it is not SET).
 bulk_update(objct, df,
-    columns  = ["new_score" => "points"],   # df "new_score" → field "points"
-    match_on = ["record_id" => "id"],        # match Tb.id = source.record_id
+    columns  = ["new_score" => "points",     # df "new_score" → field "points" (SET)
+                "record_id" => "id"],        # df "record_id" → field "id" (match key)
+    match_on = ["id"],                       # match Tb.id = source.id
     filters  = ["category_id" => 172100])    # constant: only this category
 ```
 """
@@ -1061,7 +1127,7 @@ function bulk_update(objct::SQLObjectHandler, df::DataFrames.DataFrame;
     copy::Bool=true)
 
   _columns  = _normalize_bulk_columns(columns)
-  _match_on = _normalize_bulk_columns(match_on)   # same grammar as columns: "df_col" => "model_field"
+  _match_on = _normalize_bulk_match_on(match_on)  # bare model-field names only (#107)
   _filters  = _normalize_bulk_filters(filters)
 
   _bulk_update(objct, df, _columns, _match_on, _filters, show_query, chunk_size, copy)
@@ -1073,7 +1139,7 @@ bulk_update(objct::SQLObjectHandler; kwargs...) = (df) -> bulk_update(objct, df;
 
 function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
   columns::Vector{Union{String, Pair{String, String}}},
-  match_on::Vector{Union{String, Pair{String, String}}},
+  match_on::Vector{String},
   filters::Vector{Union{String, Pair{String, <:Any}}},
   show_query::Symbol,
   chunk_size::Integer=1000,

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -686,10 +686,12 @@ end
                 "new_val" => [100, 200, 300]
             )
             
-            # Update points for specific IDs BUT only if category is Cat1
+            # Update points for specific IDs BUT only if category is Cat1.
+            # #107: all df→field mappings live in columns=; match_on selects the
+            # merge key by field name (a field in both is matched, never SET).
             bulk_update(query, df,
-                columns=["new_val" => "test_result"],
-                match_on=["df_id" => "id"],   # Dynamic (Mapping)
+                columns=["new_val" => "test_result", "df_id" => "id"],
+                match_on=["id"],              # Dynamic (merge key)
                 filters=["name" => "Cat1"]    # Static (Query criteria)
             )
             

--- a/test/unit/test_bulk_update_column_scope.jl
+++ b/test/unit/test_bulk_update_column_scope.jl
@@ -345,26 +345,32 @@ end
 end
 
 # ------------------------------------------------------------------
-# match_on / filters separation contract.
+# match_on / filters separation contract (#107 "one border crossing").
 #
-#   match_on = per-row merge keys (df_col => model_field), always dynamic.
+#   columns  = participating fields + the ONLY place a df column is
+#              mapped to a model field ("df_col" => "model_field").
+#   match_on = per-row merge keys, bare MODEL FIELD names, always
+#              dynamic; a field listed in both is matched, never SET.
 #   filters  = constant predicates (model_field => value), always static.
 #
-# The legacy single-`filters` dynamic usage is rejected with a migration
-# error so call sites move loudly rather than silently misbehaving.
+# The legacy single-`filters` dynamic usage and the pre-#107
+# `match_on` pair grammar are rejected with migration errors so call
+# sites move loudly rather than silently misbehaving.
 # ------------------------------------------------------------------
 @testset "bulk_update: match_on / filters separation" begin
 
-    # match_on accepts a "df_col" => "model_field" mapping just like columns.
-    @testset "match_on supports df_col => model_field mapping" begin
+    # The #107 motivating golden: every df→field mapping is declared in columns=;
+    # match_on selects the merge key by field name. The match key ("id", sourced from
+    # df "record_id") appears in the source list and WHERE, but never in SET.
+    @testset "columns= carries the mapping; bare match_on selects the merge key" begin
         custom_df = DataFrames.DataFrame(
             record_id = [4606],
             new_w     = [9],
         )
         res = bulk_update(
             Metric.objects, custom_df,
-            columns    = ["new_w" => "weight"],
-            match_on   = ["record_id" => "id"],
+            columns    = ["new_w" => "weight", "record_id" => "id"],
+            match_on   = ["id"],
             show_query = :dict
         )
         sql = res[:sql_text]
@@ -373,7 +379,51 @@ end
         @test occursin("\"Tb\".\"id\" = source.\"id\"", sql)
         set_text = match(r"SET(.*?)FROM"s, sql).captures[1]
         @test occursin("\"weight\"", set_text)
+        @test !occursin("\"id\" =", set_text)   # match key is not SET
         # Source order: update column first, then the match key.
+        @test res[:parameters] == Any[9, 4606]
+    end
+
+    # The pre-#107 pair grammar must fail loudly with the rewrite, not silently
+    # remap — the migration error is the deprecation shim's whole point.
+    @testset "match_on pair form raises the migration error" begin
+        custom_df = DataFrames.DataFrame(record_id = [4606], new_w = [9])
+        err = try
+            bulk_update(
+                Metric.objects, custom_df,
+                columns    = ["new_w" => "weight"],
+                match_on   = ["record_id" => "id"],
+                show_query = :dict
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        # The message must show the exact rewrite: mapping moves to columns=,
+        # match_on keeps the bare field name.
+        @test occursin("no longer accepts", msg)
+        @test occursin("columns  = [..., \"record_id\" => \"id\"]", msg)
+        @test occursin("match_on = [\"id\"]", msg)
+    end
+
+    # Mapping-first resolution: when columns= maps a field AND the df also carries a
+    # column with the field's own name, the declared mapping is authoritative and the
+    # same-named column is ignored — loudly (@warn), so the ambiguity is visible.
+    @testset "columns= mapping wins over a same-named df column (with @warn)" begin
+        conflict_df = DataFrames.DataFrame(
+            record_id = [4606],   # the declared source for field id
+            id        = [999],    # same-named column that must be IGNORED
+            new_w     = [9],
+        )
+        res = @test_logs (:warn, r"same-named DataFrame column is ignored") bulk_update(
+            Metric.objects, conflict_df,
+            columns    = ["new_w" => "weight", "record_id" => "id"],
+            match_on   = ["id"],
+            show_query = :dict
+        )
+        # Params prove the mapping won: 4606 (df.record_id), not 999 (df.id).
         @test res[:parameters] == Any[9, 4606]
     end
 
@@ -419,38 +469,51 @@ end
         @test occursin("match_on", sprint(showerror, err))
     end
 
+    # The advice for a PAIR must be the #107 two-part rewrite (mapping → columns=,
+    # bare field → match_on=) — recommending `match_on = [pair]` would send the
+    # caller straight into the match_on pair error.
     @testset "legacy df_col => field filter raises migration error" begin
         custom_df = DataFrames.DataFrame(record_id = [4606], weight = [1])
-        @test_throws ArgumentError bulk_update(
-            Metric.objects, custom_df,
-            columns    = ["weight"],
-            filters    = ["record_id" => "id"],
-            show_query = :dict
-        )
+        err = try
+            bulk_update(
+                Metric.objects, custom_df,
+                columns    = ["weight"],
+                filters    = ["record_id" => "id"],
+                show_query = :dict
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        @test occursin("columns  = [..., \"record_id\" => \"id\"]", msg)
+        @test occursin("match_on = [\"id\"]", msg)
+        @test !occursin("match_on = [\"record_id\" => \"id\"]", msg)   # the stale advice
     end
 
-    # A match_on column absent from the DataFrame is a hard error, never a
-    # silent fall-through.
-    @testset "missing match_on column raises" begin
-        @test_throws ArgumentError bulk_update(
-            Metric.objects, df_upd,
-            columns    = ["weight"],
-            match_on   = ["does_not_exist" => "id"],
-            show_query = :dict
-        )
-    end
-
-    # An explicit match_on pair with a typoed source column must raise even when
-    # the target field is already mapped by columns= — the typo must not be
-    # silently swallowed by reusing the columns= mapping.
-    @testset "explicit match_on typo raises even when field is mapped by columns" begin
+    # A match key with no source — no columns= mapping for the field and no df column
+    # with the field's own name — is a hard error, never a silent fall-through.
+    @testset "match_on field without any source column raises" begin
         custom_df = DataFrames.DataFrame(record_id = [4606], new_w = [9])
-        @test_throws ArgumentError bulk_update(
-            Metric.objects, custom_df,
-            columns    = ["new_w" => "weight", "record_id" => "id"],
-            match_on   = ["typo_id" => "id"],
-            show_query = :dict
-        )
+        err = try
+            bulk_update(
+                Metric.objects, custom_df,
+                columns    = ["new_w" => "weight"],
+                match_on   = ["id"],   # field id: unmapped, and no "id" df column
+                show_query = :dict
+            )
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        # Assert the error CLASS and SUBJECT, not just substrings: a bare
+        # occursin("id", msg) also matches "record_id" in the column dump, so it
+        # cannot discriminate. The \S* tolerates ANSI codes around the field name.
+        @test occursin(r"match_on column \S*id\S* not found", msg)
+        @test occursin("no columns= mapping targets that field", msg)
     end
 
     # No match_on and no filters => fall back to the model primary key.
@@ -515,8 +578,7 @@ end
         @test res isa Dict || res isa Vector
     end
 
-    # A match_on key that is not a model field is a hard error (covers both the
-    # bare-key and the explicit-pair target-field validation branch).
+    # A match_on key that is not a model field is a hard error.
     @testset "match_on referencing a non-field raises" begin
         @test_throws ArgumentError bulk_update(
             Metric.objects, df_upd,
@@ -524,29 +586,23 @@ end
             match_on   = ["not_a_field"],
             show_query = :dict
         )
-        @test_throws ArgumentError bulk_update(
-            Metric.objects, df_upd,
-            columns    = ["weight"],
-            match_on   = ["id" => "not_a_field"],
-            show_query = :dict
-        )
     end
 
     # ─────────────────────────────────────────────────────────────────────────────
-    # Case-sensitive matching: match_on= explicit pair (Site C)
-    # Bulk column matching is exact/case-sensitive. An explicit match_on source column
-    # that differs only in case from a real DataFrame column must FAIL LOUDLY — naming
-    # the candidate and the fix — rather than silently case-fold (the pre-9958a16 risk
-    # of mapping the wrong mixed-case column). This is the inverse of the old contract.
+    # Case-sensitive matching: bare match_on key (Site C)
+    # Bulk column matching is exact/case-sensitive. A bare match key whose identity
+    # source column exists only in a different case must FAIL LOUDLY — naming the
+    # candidate and the columns= mapping fix — rather than silently case-fold (the
+    # pre-9958a16 risk of mapping the wrong mixed-case column).
     # ─────────────────────────────────────────────────────────────────────────────
-    @testset "explicit match_on pair with case-only mismatch raises" begin
-        # df column is "record_id"; match_on asks for "RECORD_ID" — same name, wrong case.
-        ci_df = DataFrames.DataFrame(record_id = [4606], new_w = [9])
+    @testset "bare match_on with case-only source mismatch raises" begin
+        # field "id" is unmapped; the df only carries "ID" — same name, wrong case.
+        ci_df = DataFrames.DataFrame(ID = [4606], new_w = [9])
         err = try
             bulk_update(
                 Metric.objects, ci_df,
                 columns    = ["new_w" => "weight"],
-                match_on   = ["RECORD_ID" => "id"],   # differs only in case from "record_id"
+                match_on   = ["id"],
                 show_query = :dict
             )
             nothing
@@ -555,9 +611,11 @@ end
         end
         @test err isa ArgumentError
         msg = sprint(showerror, err)
-        # The error must name the case-only candidate and point at the case-sensitivity.
-        @test occursin("record_id", msg)
+        # The error must name the case-only candidate and point at the case-sensitivity,
+        # and the suggested fix is a columns= mapping (the single border crossing).
+        @test occursin("ID", msg)
         @test occursin("case", msg)
+        @test occursin("columns = [..., \"ID\" => \"id\"]", msg)
     end
 
     # ─────────────────────────────────────────────────────────────────────────────
@@ -614,13 +672,13 @@ end
     end
 
     # ─────────────────────────────────────────────────────────────────────────────
-    # Case-sensitive matching: an EXPLICIT columns= mapping still wins (allow_reuse)
-    # A bare match_on key reuses the column mapping established by columns=, even when
-    # the mapped DataFrame column differs in case from the field name. The user already
-    # spelled out the mapping, so no case error fires — this guards the reorder that put
-    # the columns= reuse ahead of the case-mismatch check.
+    # Case-sensitive matching: an EXPLICIT columns= mapping is authoritative (#107)
+    # A bare match_on key resolves through the mapping established by columns=, even
+    # when the mapped DataFrame column differs in case from the field name. The user
+    # already spelled out the mapping, so no case error fires — mapping-first
+    # resolution checks columns= before looking for a same-named df column.
     # ─────────────────────────────────────────────────────────────────────────────
-    @testset "bare match_on reuses an explicit columns= mapping across case" begin
+    @testset "bare match_on resolves through an explicit columns= mapping across case" begin
         # "ID" => "id" explicitly maps the mixed-case DataFrame column to field id.
         df_reuse = DataFrames.DataFrame(ID = [4606], weight = [9])
         res = bulk_update(


### PR DESCRIPTION
Closes #107.

## Problem

The `=>` pair carried mirror-image meanings across the query API: `values` reads `"alias" => source` (right→left) while `columns`/`match_on` read `"df_col" => "field"` (left→right) — identical syntax, opposite data flow. Worse, the mapping could be declared in **two places** (`columns=` and `match_on=`), and a bare `match_on` key resolved against **two namespaces** (df column first, then the `columns=` mapping). It was confusing enough that a tooled review of a consuming app flagged *correct* code as a runtime bug; the dangerous failure mode is silent wrong SQL, not a crash.

## Decision (settled in #107): "one border crossing"

- **No arrow-direction flips anywhere** — `values` and `filter` are untouched.
- **`columns=` is the single df→model mapping point.** It was already a *participation* list, not a SET list (match keys are excluded from SET via `deny_fields`), so it naturally hosts match-key mappings too.
- **`match_on=` takes bare model field names only.** The pre-#107 pair form raises a migration error with the exact rewrite (temporary shim, mirroring the legacy `filters=` one):
  ```
  Change:  match_on = ["record_id" => "id"]
  To:      columns  = [..., "record_id" => "id"], match_on = ["id"]
  ```
- **Mapping-first resolution.** A `columns=` mapping is authoritative for its field; a same-named df column is ignored **with a warning** (pre-#107 it silently won). No mapping → the field's own column; neither → hard error naming the missing mapping (case-hint machinery preserved, now suggesting the `columns=` fix).

Cross-framework grounding: no mainstream ORM (Django, SQLAlchemy, Rails, Ecto) ships a source→target mapping in its bulk API — single namespace is the norm. PormG keeps the mapping deliberately (useful for legacy-named sources) but confines it to one home so a bare name can only ever mean a model field.

## Also in this PR

- The legacy `filters=` migration error's advice for pair entries was updated — it pointed at the now-removed `match_on` pair grammar (review finding, pinned by a negative assertion).
- Fixed the stale `bulk_insert` docstring claiming the df is trimmed/renamed (it never was — the mapping is internal).
- New `UPGRADING.md` rollout entry (breaking, 4-app checklist); docs contract rewrite in `bulk.md`/`api.md` incl. the migration table, plus the usage-skill note.

## Tests

`test/unit/test_bulk_update_column_scope.jl` (mock backend, `show_query=:dict`, DB-free): pair subtests rewritten to the new contract with golden params preserved (`Any[9, 4606]`); new subtests for the migration-error text (exact rewrite lines), the mapping-first conflict (`@test_logs (:warn, …)` + params proving `record_id`'s 4606 won over the same-named column's 999), no-source hard error (class + subject + unique-phrase assertions), and the bare-name case-hint. Integration `test_updates.jl` pair call migrated; its assertions unchanged.

**Mutation gates (executed, not assumed):** reverting to df-column-first resolution fails the conflict test on both signatures (no warn, wrong param); silently accepting pairs fails the migration-error test 3/3.

## Verification

| Suite | Result |
|---|---|
| `test_bulk_update_column_scope.jl` standalone | 55/55 (match_on testset) |
| Full unit suite (`-t auto`) | 2334/2334 |
| PG integration `db_2` (live, `-t auto`) | 1602/1602 |
| SQLite integration `db_sl` (`-t 1`) | 1563/1563 |
| Docs build (`--project=docs`) | OK |

Backend-agnostic (shared build path — the rendered SQL for equivalent calls is byte-identical to pre-#107, proven by the unchanged golden assertions), so PG/SQLite cannot diverge. `TODO.md` rides along: gating-index sync for the #107 decision + new #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
