### PR TITLE
fix(#70): surface Model_to_str field-render failures as warn + marker comment

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -569,7 +569,10 @@ Converts a model object to a string representation to create the model.
 - `contants_julia::Vector{String}=reserved_words`: A vector of reserved words in Julia.
 
 # Returns
-- `String`: The string representation of the model object.
+- `String`: The string representation of the model object. A field whose rendering fails is
+  omitted from the constructor call and surfaced instead as a `# PormG: field '<name>' … could
+  not be rendered …` comment line prepended above the model definition (#70), plus a structured
+  `@warn` — never dropped silently.
 
 # Examples
 ```julia
@@ -582,11 +585,13 @@ users = Models.Model("users",
 """
 function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; contants_julia::Vector{String}=reserved_words)::String
   fields::String = ""
+  render_failures::Vector{String} = String[]
   django_prefix::Bool = settings.django_prefix === nothing ? false : true
   for (field_name, field) in pairs(model.fields) |> sort
     occursin(r"__|@|^_", field_name) && throw(ArgumentError("The field name $field_name in the model $model contains __ or @ or starts with _"))
+    db_field_name::String = field_name  # real column name, before reserved-word prefixing — diagnostics must show this one
     field_name in contants_julia && (field_name = "_$field_name")
-    struct_name::Symbol = nameof(typeof(field)) |> string |> x -> x[2:end] |> Symbol    
+    struct_name::Symbol = nameof(typeof(field)) |> string |> x -> x[2:end] |> Symbol
     sets::Vector{String} = []
     try
       fields = if struct_name in [:ForeignKey, :OneToOneField]
@@ -597,14 +602,22 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; c
         _model_to_str_general(field_name, field, struct_name, sets, fields)
       end
     catch e
-      # @pormg_debug
+      # Never drop a field silently (#70). Program-state errors surface loudly (#69 guard);
+      # anything else logs and emits a visible marker comment in the generated output —
+      # the inspectdb/schema-dump convention: the artifact itself shows the gap.
+      (e isa InterruptException || e isa StackOverflowError) && rethrow()
+      @warn "Model_to_str: field render failed — emitting marker comment" model=model.name field=db_field_name field_type=struct_name exception=e
+      push!(render_failures, "# PormG: field '$(db_field_name)' ($(struct_name)) could not be rendered: $(replace(sprint(showerror, e), "\n" => " ")) — field omitted.")
     end
   end
   model_name_abs = django_prefix ? string(settings.django_prefix, "_", model.name |> lowercase) : model.name |> lowercase
   model_var_name = uppercasefirst(model.name)
-  @info("""$(model_var_name) = Models.Model("$(model_name_abs)"$fields)""")
+  # Marker comments sit directly above the model definition in the generated file (#70).
+  marker = isempty(render_failures) ? "" : join(render_failures, "\n") * "\n"
+  result = """$(marker)$(model_var_name) = Models.Model("$(model_name_abs)"$fields)"""
+  @info(result)
 
-  return """$(model_var_name) = Models.Model("$(model_name_abs)"$fields)"""
+  return result
 end
 function _model_to_str_general(field_name, field, struct_name, sets, fields)
   stadard_field = getfield(@__MODULE__, struct_name)()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ end
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "Migration Diff Fail-Safe (#69)" include("unit/test_migration_diff_failsafe.jl")
+    @testset "Model_to_str Render Failure (#70)" include("unit/test_model_to_str_render_failure.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")

--- a/test/unit/test_model_to_str_render_failure.jl
+++ b/test/unit/test_model_to_str_render_failure.jl
@@ -1,0 +1,93 @@
+# ============================================================
+# test/unit/test_model_to_str_render_failure.jl
+#
+# Model_to_str render-failure surfacing (#70).
+#
+# CONTRACT being tested:
+#   A field whose string rendering throws must NEVER be silently dropped from the generated
+#   model string. Following the inspectdb/schema-dump convention, Model_to_str emits a
+#   structured @warn AND a visible `# PormG: field '<name>' (<Type>) could not be rendered: …`
+#   marker comment directly above the model definition, then keeps rendering the remaining
+#   fields — one bad column must not abort a multi-table import. Healthy fields render with
+#   no marker and no warning.
+#
+# Deterministic, DB-free. Mutation gate: reverting the fix (restoring the empty `catch e` in
+# Models.jl Model_to_str) drops the throwing field silently — the marker assertion and the
+# @test_logs (:warn,) assertion below both fail.
+# ============================================================
+
+using Test
+using Logging
+using PormG
+using PormG.Models: CharField
+
+# A field type whose RENDERING throws. Model_to_str derives the emitted constructor name by
+# stripping the struct name's first character (sCharField → CharField), so this type resolves
+# to `ThrowingRenderField` — which has no binding inside the Models module. The render helper
+# `_model_to_str_general` then raises UndefVarError at `getfield(@__MODULE__, struct_name)()`,
+# with no monkey-patching needed.
+struct _ThrowingRenderField <: PormG.PormGField
+  payload::Any
+end
+
+# Bare Model_Type around a fields dict — bypasses the Model() constructor (and any config/FK
+# resolution) so the test isolates the rendering loop only, mirroring test_migration_diff_failsafe.jl.
+_mk_render_model(fields::Dict{String, PormG.PormGField}) =
+  PormG.Models.Model_Type(name = "drivers_render_scratch", fields = fields)
+
+# Model_to_str only reads settings.django_prefix (nothing by default) — an all-default
+# Settings is a sufficient stand-in for a real connection config here.
+const RENDER_SETTINGS = PormG.Configuration.Settings()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Model_to_str: render-failure surfacing (#70)
+# A field whose rendering throws must produce a structured @warn plus a visible marker
+# comment in the generated model string (inspectdb convention) — never a silent drop —
+# while healthy fields keep rendering and healthy models stay marker- and warning-free.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Model_to_str render failure surfaced (#70)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Criterion (issue #70): a field that raises in _model_to_str_general is surfaced —
+  # structured warn + marker comment in the artifact — and the healthy field still renders.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "throwing field → warn + marker comment, healthy field kept" begin
+    m = _mk_render_model(Dict{String, PormG.PormGField}(
+      "surname" => CharField(),                       # healthy control field
+      "validade" => _ThrowingRenderField(nothing),    # rendering raises UndefVarError
+    ))
+
+    # The warn must fire with the render-failure message — pinning the message ensures a
+    # degraded contentless @warn can't satisfy the test (match_mode=:any tolerates the @info
+    # that prints the final string). @test_logs returns the expression value.
+    s = @test_logs (:warn, r"field render failed") match_mode=:any PormG.Models.Model_to_str(m, RENDER_SETTINGS)
+
+    # The gap is visible in the artifact itself: marker names the field and its type.
+    @test occursin("# PormG: field 'validade' (ThrowingRenderField) could not be rendered", s)
+    # The marker sits ABOVE the model definition (start of the string), keeping the code valid.
+    @test startswith(s, "# PormG:")
+    # The throwing field is omitted from the constructor call — never half-rendered.
+    @test !occursin("validade = Models.", s)
+    # The healthy field still renders normally: one bad field must not poison its neighbors.
+    @test occursin("surname = Models.CharField", s)
+    @test occursin("""Models.Model("drivers_render_scratch\"""", s)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Negative case: an all-healthy model renders with NO marker and NO warning — the guard
+  # fires only when rendering actually fails.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "healthy model → no marker, no warn" begin
+    m_ok = _mk_render_model(Dict{String, PormG.PormGField}(
+      "surname" => CharField(),
+    ))
+
+    # min_level=Warn asserts NOTHING at warn-or-above is logged (the @info passes underneath).
+    s_ok = @test_logs min_level=Logging.Warn PormG.Models.Model_to_str(m_ok, RENDER_SETTINGS)
+
+    @test !occursin("# PormG:", s_ok)
+    @test occursin("surname = Models.CharField", s_ok)
+    @test startswith(s_ok, "Drivers_render_scratch = Models.Model(")
+  end
+
+end


### PR DESCRIPTION
## Summary

`Model_to_str` wrapped each field's string rendering in a bare `try/catch` with an **empty body**,
so a field whose rendering threw was **silently dropped** from the generated model string — the
schema-import flow (`src/migrations/importers.jl`) then wrote a models file that silently disagreed
with the real database schema (#70).

## Design

Follows the **inspectdb/schema-dump convention** (Django `inspectdb` emits `# This field type is a
guess.` / `# Unable to inspect table` comments; Rails `db:schema:dump` writes `# Could not dump
table…` markers): the render loop fails **visible-but-non-fatal**, so one bad column cannot abort a
multi-table import, and the gap is visible in the artifact itself. Chosen over the abort-on-error
alternative after comparing framework precedents for this exact surface (all `Model_to_str` callers
are the import/codegen flow, not the migration-diff path).

## Fix (`src/Models.jl`)

- The catch now rethrows `InterruptException`/`StackOverflowError` (same program-state guard as the
  #69 catch), otherwise logs a structured
  `@warn "Model_to_str: field render failed" model=… field=… field_type=… exception=e` and records
  a marker line.
- Markers render as `# PormG: field '<name>' (<Type>) could not be rendered: <error> — field omitted.`
  prepended directly above the generated `X = Models.Model("name", …)` line. Error text is
  newline-flattened so each marker stays a valid single-line Julia comment.
- Diagnostics report the **real DB column name** (captured before reserved-word prefixing), not the
  `_`-prefixed emitted field name.
- Docstring `# Returns` section documents the marker behavior.

## Acceptance criteria (from #70)

- [x] A field whose rendering throws produces a logged error (or a raised error), never a silent drop.
- [x] Regression test: a field that raises in `_model_to_str_general` is surfaced, not omitted.

## Tests

New `test/unit/test_model_to_str_render_failure.jl` (10 assertions, deterministic, DB-free): a
`_ThrowingRenderField` whose struct name resolves to no `Models` binding makes
`_model_to_str_general` raise `UndefVarError` naturally (no monkey-patching); asserts the pinned
warn (`r"field render failed"`), marker content and position, healthy-neighbor-field survival, and
the negative case (healthy model → no marker, no warn).

- Unit suite: **2355/2355** pass.
- PG integration suite (`db_2`): **1602/1602** pass.
- Reviewed via the changed-code review skill at xhigh effort; 4 findings applied in this PR
  (pinned warn assertion, real-column-name diagnostics, docstring, test header), 1 deferred by
  design (shared rethrow-guard helper — below abstraction threshold at two sites), 1 spun off as
  #134 (pre-existing all-fields-failed edge: empty `Models.Model("name")` call throws at
  include-time).

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
