### PR TITLE
fix(#71): renew or discard pooled connection after failed ROLLBACK

### DIFF
--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -16,6 +16,7 @@ dev:
   pool_size: 10   # base 10 → grows to 100 under burst
 ```
 - **Thread Safety:** PormG uses `ReentrantLock` for pool management.
+- **Failed-rollback self-healing:** If a transaction's `ROLLBACK` itself fails (e.g. the connection died mid-transaction), the pool never returns that connection as-is. It is renewed in its slot (PostgreSQL: `LibPQ.reset!`; SQLite: a fresh handle, with the old one closed so it releases the database file write-lock) or — if renewal also fails — closed and its slot cleared so the next borrower opens a fresh connection.
 
 ---
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -470,6 +470,97 @@ function reconnect_db(pool::PormGSQLite, conn)
   return nothing
 end
 
+"""
+    _discard_connection!(pool, conn) -> Bool
+
+Remove `conn` from its pool slot (the slot becomes `nothing` and is marked available, so the
+next `acquire_connection` opens a fresh physical connection through the empty-slot path) and
+best-effort `close` it. Used when a connection is known-dirty — e.g. a failed ROLLBACK (#71)
+— and renewal via `reconnect_db` also failed. Returns whether the slot was found. Never
+throws (callers run it while an original error is propagating).
+"""
+function _discard_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn)::Bool
+  found = Base.lock(pool.lock) do
+    for i in 1:length(pool.connections)
+      if pool.connections[i] === conn
+        pool.connections[i] = nothing
+        pool.available[i] = true
+        return true
+      end
+    end
+    return false
+  end
+  # Close OUTSIDE the pool lock: a driver close can block on I/O. On SQLite this also
+  # releases the database file write-lock an aborted `BEGIN IMMEDIATE` may still hold.
+  try
+    close(conn)
+  catch close_error
+    @debug "Error closing discarded connection" exception=close_error
+  end
+  found || @warn "Connection to discard not found in the pool - it may already have been replaced"
+  return found
+end
+
+"""
+    _renew_or_discard_connection!(pool, conn) -> Nothing
+
+Post-failed-ROLLBACK cleanup (#71). Renews `conn` in its slot via `reconnect_db`
+(PostgreSQL: `LibPQ.reset!`, which aborts any open transaction and may return the SAME
+handle; SQLite: a fresh handle) and releases the RENEWED handle back to the pool — never
+the dirty one (`reconnect_db` swaps the slot in place and `release_connection` matches by
+identity, so releasing the stale handle would leak the slot as permanently busy). If
+renewal fails — including a `before_connect` hook abort, which `reconnect_db` surfaces as
+a throw — the slot is discarded instead so the next borrower opens a fresh connection.
+Never throws: the transaction's original error must keep propagating through the caller's
+`finally`.
+"""
+function _renew_or_discard_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn)
+  new_conn = try
+    reconnect_db(pool, conn)  # replaces the slot in place; does NOT flip `available`
+  catch renew_error
+    # reconnect_db only throws via the before_connect hook; driver renewal errors are
+    # caught inside it and returned as `nothing`.
+    @error "Connection renewal after failed rollback threw; discarding the connection" exception=renew_error
+    nothing
+  end
+  if new_conn === nothing
+    _discard_connection!(pool, conn)
+  else
+    if new_conn !== conn
+      # A brand-new handle replaced the dirty one (always on SQLite; on PG only when
+      # reset! fell back to a fresh Connection). Close the old handle now rather than
+      # waiting for GC — on SQLite it may still hold the database file write-lock.
+      try
+        close(conn)
+      catch close_error
+        @debug "Error closing replaced connection" exception=close_error
+      end
+    end
+    release_connection(pool, new_conn)
+  end
+  return nothing
+end
+
+"""
+    _is_benign_rollback_error(pool, e) -> Bool
+
+Classify a failed `ROLLBACK` as benign, meaning the connection is known-clean and may be
+released normally. SQLite-only divergence: SQLite auto-rolls-back some failures, after
+which `ROLLBACK` reports "no transaction is active"; PostgreSQL's `ROLLBACK` outside a
+transaction merely warns, it never throws. Unwraps before matching: async failures arrive
+as `TaskFailedException`, whose `string()` does not include the driver message.
+"""
+_is_benign_rollback_error(pool::Union{PormGPostgres, PormGSQLite}, e) =
+  pool isa PormGSQLite && occursin("no transaction is active", string(_unwrap_async_exception(e)))
+
+# A statement that ends the current transaction (plain ROLLBACK) — deliberately NOT
+# "ROLLBACK TO SAVEPOINT", which keeps the outer transaction alive and must never
+# trigger connection renewal.
+function _is_transaction_rollback(sql::AbstractString)
+  s = uppercase(strip(sql))
+  return startswith(s, "ROLLBACK") && !startswith(s, "ROLLBACK TO")
+end
+
 #
 # Connection Execution
 #
@@ -511,7 +602,10 @@ function _ensure_sqlite_async_worker!()
         item = take!(_sqlite_async_work_queue)
         try
           # Dispatches into the SQLite extension's backend_execute (materialized + retry).
-          result = backend_execute(item.pool, item.conn, item.sql, item.params)
+          # invokelatest: this task lives forever and Julia tasks run in the world age
+          # they were created in, so without it the worker cannot see backend_execute
+          # methods defined after it spawned (Revise hot-reloads, test mocks).
+          result = Base.invokelatest(backend_execute, item.pool, item.conn, item.sql, item.params)
           put!(item.response, SQLiteAsyncResponse(true, result))
         catch e
           put!(item.response, SQLiteAsyncResponse(false, e))
@@ -785,6 +879,7 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
   params::Union{Nothing, AbstractPormGParam} = nothing)
 
   conn_acquired = false
+  rollback_failed = false
   if conn === nothing
     if pool isa PormGSQLite
       conn = acquire_connection(pool; mode=:write)
@@ -804,17 +899,21 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
     result = Base.fetch(task)
     return result, conn
   catch e
+    # A transaction-ending ROLLBACK that itself failed may leave the connection with an
+    # open/aborted transaction — it must never return to the pool as-is (#71); both
+    # release points below renew or discard it instead.
+    rollback_failed = _is_transaction_rollback(sql) && !_is_benign_rollback_error(pool, e)
     # If we acquired the connection here and the command failed (like BEGIN),
     # and we were not asked to release it (which means the caller expected it back),
     # we MUST release it now because the caller won't receive it in the return.
     if conn_acquired && !release_conn
-      release_connection(pool, conn)
+      rollback_failed ? _renew_or_discard_connection!(pool, conn) : release_connection(pool, conn)
     end
     @error "Failed to execute SQL transaction, rolling back: $e"
     throw(e)
   finally
     if release_conn
-      release_connection(pool, conn)
+      rollback_failed ? _renew_or_discard_connection!(pool, conn) : release_connection(pool, conn)
     end
   end
 end
@@ -943,6 +1042,7 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
     acquire_connection(pool)
   end
   tx_started = false
+  rollback_failed = false
   try
     # Begin transaction
     if pool isa PormGPostgres
@@ -984,15 +1084,26 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
           Base.fetch(task)
         end
       catch rollback_error
-        # Only log if it's not a "no transaction active" error in SQLite
-        if !(pool isa PormGSQLite && occursin("no transaction is active", string(rollback_error)))
-            @error "Failed to rollback transaction: $rollback_error"
+        if _is_benign_rollback_error(pool, rollback_error)
+          # SQLite already auto-rolled-back; the connection is clean → the finally
+          # releases it normally.
+        else
+          # The connection may still hold an open/aborted transaction that the acquire
+          # liveness probe cannot detect. It must NOT return to the pool as-is (#71);
+          # the finally renews or discards it instead.
+          rollback_failed = true
+          @error "Failed to rollback transaction; connection will be renewed before returning to the pool" exception=_unwrap_async_exception(rollback_error)
         end
       end
     end
     root === e ? rethrow() : throw(root)
   finally
-    release_connection(pool, conn)
+    if rollback_failed
+      # Never releases the dirty handle; never throws (the original error keeps propagating).
+      _renew_or_discard_connection!(pool, conn)
+    else
+      release_connection(pool, conn)
+    end
   end
 end
 

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -167,8 +167,14 @@ function delete(objct::SQLObjectHandler;
         # Commit transaction
         with_transaction(settings, "COMMIT;", conn=conn, release_conn=true)
       catch e
-        # Rollback on error
-        with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=true)
+        # Rollback on error. A rollback failure must not mask the body's error — log it
+        # and rethrow the original; the pool has already renewed or discarded the
+        # connection inside with_transaction (#71).
+        try
+          with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=true)
+        catch rollback_error
+          @error "Failed to rollback delete transaction" exception=rollback_error
+        end
         rethrow(e)
       end
     end

--- a/test/integration/test_transactions.jl
+++ b/test/integration/test_transactions.jl
@@ -459,4 +459,69 @@ settings = PormG.config[PORMG_DB_FOLDER]
     @test df[1, :test_result2] === missing  # no update applied
   end
 
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Transactions (#71): failed-ROLLBACK renewal, end-to-end smoke against a real server
+  # Kill our own PostgreSQL backend mid-transaction (pg_terminate_backend on our own
+  # pid) so the transaction body error AND the subsequent ROLLBACK genuinely fail,
+  # driving the renewal path (LibPQ.reset!) against a live server: no crash, no hang,
+  # pool stays consistent, nothing commits. NOTE this is a smoke test, not the
+  # regression gate: a terminated backend leaves a DEAD socket, which the acquire-time
+  # liveness probe already replaced before the #71 fix — the true #71 hazard (an ALIVE
+  # connection stuck in aborted-transaction state) can't be forced on a healthy server
+  # and is gated by the unit mocks in test/unit/test_transaction_rollback_renewal.jl.
+  # The @test_logs gate below asserts the renewal branch actually ran: its message
+  # exists only in the #71 code path, so reverting the fix fails this testset.
+  # The terminate statement is issued DIRECTLY via backend_execute_async on the tx
+  # connection — this test is explicitly about pool internals, and going through
+  # fetch() would engage its lost-connection retry, which re-runs the statement on
+  # a fresh connection outside the transaction (a separate latent issue).
+  # PG-only: SQLite has no server-side session to terminate.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "Failed rollback renews the pooled connection (#71)" begin
+    if adapter_name == "PostgreSQL"
+      M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+      pool = settings.connections
+
+      got_error = false
+      # Log-gate: this @error is emitted only by the #71 renewal branch (the pre-fix
+      # code logged a different message), so the fix being active is what makes this
+      # assertion pass. match_mode=:any tolerates the driver's own error logs.
+      @test_logs (:error, r"connection will be renewed") match_mode=:any begin
+        try
+          PormG.run_in_transaction(settings) do
+            # A write inside the doomed transaction — it must NOT survive.
+            # test_result is a nullable FK to result(resultid); keep it NULL (see the
+            # concurrent-writers testset above).
+            M.Just_a_test_deletion.objects.create("name" => "dirty-tx", "test_result" => nothing)
+
+            conn = get_tx_connection()
+            # Our own backend dies mid-statement: the fetch below throws, and the
+            # ROLLBACK the transaction wrapper then attempts fails on the dead socket.
+            t = PormG.backend_execute_async(pool, conn, "SELECT pg_terminate_backend(pg_backend_pid());", nothing)
+            Base.fetch(t)
+            # Belt-and-braces: if the terminate somehow returned, the dead connection
+            # must throw on the next statement.
+            t2 = PormG.backend_execute_async(pool, conn, "SELECT 1;", nothing)
+            Base.fetch(t2)
+            error("unreachable: connection survived pg_terminate_backend")
+          end
+        catch
+          got_error = true
+        end
+      end
+      @test got_error
+
+      # The next borrowers must get a CLEAN connection: a read and a write both work
+      # (no leftover aborted-transaction state), and the doomed write never committed.
+      q = M.Just_a_test_deletion.objects
+      @test q.count() == 0
+      M.Just_a_test_deletion.objects.create("name" => "post-heal", "test_result" => nothing)
+      @test q.count() == 1
+
+      M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+    else
+      @test_skip "PG-only: pg_terminate_backend has no SQLite equivalent"
+    end
+  end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ end
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
+    @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_transaction_rollback_renewal.jl
+++ b/test/unit/test_transaction_rollback_renewal.jl
@@ -1,0 +1,313 @@
+# ============================================================
+# test/unit/test_transaction_rollback_renewal.jl
+#
+# Failed ROLLBACK → connection renewed or discarded, never returned dirty (#71).
+#
+# CONTRACT being tested:
+#   When a transaction body throws AND the ROLLBACK itself fails, `_run_in_transaction_impl`
+#   must NOT hand the connection back to the pool as-is (it may still hold an open/aborted
+#   transaction that `backend_is_alive` cannot detect). Instead the `finally` renews the
+#   connection in its slot via `reconnect_db` (releasing the RENEWED handle — the slot is
+#   replaced in place and `release_connection` matches by identity), or — if renewal also
+#   fails — discards the slot (`nothing` + available) so the next borrower opens a fresh
+#   physical connection. The transaction body's ORIGINAL error must keep propagating, and
+#   SQLite's benign "no transaction is active" rollback error must still release normally.
+#
+# Deterministic and DB-free: behavioral mock pools carry the exact fields the pool machinery
+# reads (acquire/release/reconnect are generic over PormGPostgres/PormGSQLite), fake driver
+# handles track `close`, and `backend_*` overrides on the mock types simulate driver failures.
+# The PG mock fails ROLLBACK *inside* the `@async` task so `Base.fetch` surfaces a
+# TaskFailedException — the wrapped form the real async paths produce; the SQLite mock fails
+# it on the real global async worker. Reverting the fix (releasing the dirty handle from the
+# `finally`) fails the slot-identity assertions — the mutation gate.
+# ============================================================
+
+using Test
+using PormG
+
+# No DB drivers needed: every backend_* call in these flows dispatches to the mock methods
+# below, so this file runs without the LibPQ/SQLite weakdep extensions.
+
+const CP = PormG.ConnectionPool
+
+# ── Fake driver handle: tracks whether the pool cleanup closed it ──
+# (structs live at file top level — Julia forbids type definitions inside @testset blocks)
+mutable struct FakeConn71
+  id::Int
+  closed::Bool
+end
+FakeConn71(id::Int) = FakeConn71(id, false)
+Base.close(c::FakeConn71) = (c.closed = true; nothing)
+
+# ── PG-shaped mock: PostgresConnectionPool's exact fields + failure knobs ──
+mutable struct MockPGPool71 <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+  fail_rollback::Bool     # ROLLBACK task throws (inside the task → TaskFailedException)
+  fail_renew::Bool        # backend_renew_connection throws → reconnect_db → nothing → discard
+  renew_in_place::Bool    # renew returns the SAME handle (LibPQ.reset! semantics)
+  next_id::Int            # id source for freshly "connected"/renewed FakeConn71s
+  executed::Vector{String}
+end
+MockPGPool71(; fail_rollback::Bool = false, fail_renew::Bool = false, renew_in_place::Bool = false) =
+  MockPGPool71(Any[FakeConn71(1)], [true], "mock://pg", 1, ReentrantLock(),
+               fail_rollback, fail_renew, renew_in_place, 1, String[])
+
+PormG.backend_is_alive(::MockPGPool71, conn) = conn isa FakeConn71 && !conn.closed
+PormG.backend_connect(pool::MockPGPool71; kwargs...) = FakeConn71(pool.next_id += 1)
+function PormG.backend_execute_async(pool::MockPGPool71, conn, sql::String, params)
+  push!(pool.executed, sql)
+  # Fail INSIDE the task (like a real async driver failure) so Base.fetch throws a
+  # TaskFailedException and the rollback catch exercises _unwrap_async_exception.
+  return @async begin
+    if pool.fail_rollback && startswith(sql, "ROLLBACK")
+      error("mock: rollback refused")
+    end
+    nothing
+  end
+end
+function PormG.backend_renew_connection(pool::MockPGPool71, conn; kwargs...)
+  pool.fail_renew && error("mock: renew refused")
+  return pool.renew_in_place ? conn : FakeConn71(pool.next_id += 1)
+end
+
+# ── SQLite-shaped mock: SQLiteConnectionPool's exact fields + a rollback-error knob.
+#    Statements funnel through the REAL global async worker → backend_execute, proving the
+#    PG/SQLite policy alignment on the actual SQLite code path. ──
+mutable struct MockSQLitePool71 <: PormG.PormGSQLite
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  split_read_write::Bool
+  writer_slot::Int
+  reader_cursor::Int
+  lock::ReentrantLock
+  write_lock::ReentrantLock
+  rollback_error_msg::Union{Nothing, String}  # nothing → ROLLBACK succeeds
+  next_id::Int
+end
+MockSQLitePool71(; rollback_error_msg::Union{Nothing, String} = nothing) =
+  MockSQLitePool71(Any[FakeConn71(1)], [true], "mock://sqlite", 1, false, 1, 0,
+                   ReentrantLock(), ReentrantLock(), rollback_error_msg, 1)
+
+PormG.backend_is_alive(::MockSQLitePool71, conn) = conn isa FakeConn71 && !conn.closed
+PormG.backend_connect(pool::MockSQLitePool71; read_only::Bool = false) = FakeConn71(pool.next_id += 1)
+PormG.backend_renew_connection(pool::MockSQLitePool71, conn; read_only::Bool = false) = FakeConn71(pool.next_id += 1)
+function PormG.backend_execute(pool::MockSQLitePool71, conn, sql::String, params)
+  # Runs on the global SQLite worker thread — keep it pure (no @test in here); the raised
+  # error travels back to the caller as the @async task's failure (→ TaskFailedException).
+  if pool.rollback_error_msg !== nothing && startswith(sql, "ROLLBACK")
+    error(pool.rollback_error_msg)
+  end
+  return NamedTuple[]
+end
+
+# Run a transaction whose body throws ErrorException("boom") and return the caught value —
+# every testset asserts the BODY error propagates (never the rollback/renewal error).
+function run_failing_tx_71(pool)
+  try
+    CP.run_in_transaction(pool) do
+      error("boom")
+    end
+    return nothing
+  catch e
+    return e
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): PG failed ROLLBACK → slot renewed, original error preserved
+# The dirty handle must be replaced in its slot (reconnect_db) and CLOSED, the slot must be
+# available again, the next borrower must get the renewed handle, and the caller must see
+# the body's "boom" — not the rollback error. Also gates the structured @error log.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG failed rollback renews the pooled connection (#71)" begin
+  pool = MockPGPool71(fail_rollback = true)
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Failed to rollback transaction") match_mode=:any begin
+    run_failing_tx_71(pool)
+  end
+
+  @test err isa ErrorException && err.msg == "boom"   # root cause wins, not "rollback refused"
+  @test pool.connections[1] !== old                   # slot renewed (identity changed)
+  @test pool.connections[1] isa FakeConn71 && pool.connections[1].id == 2
+  @test pool.available[1] === true                    # renewed handle released (not the stale one)
+  @test old.closed === true                           # dirty handle closed, not leaked to GC
+  # BEGIN and ROLLBACK were issued; COMMIT never was (the body threw before it).
+  @test any(sql -> startswith(sql, "BEGIN"), pool.executed)
+  @test any(sql -> startswith(sql, "ROLLBACK"), pool.executed)
+  @test !any(sql -> startswith(sql, "COMMIT"), pool.executed)
+  # The next borrower gets the RENEWED connection, never the dirty one.
+  c = CP.acquire_connection(pool)
+  @test c === pool.connections[1] && c !== old
+  CP.release_connection(pool, c)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): PG in-place renewal (LibPQ.reset! semantics) → same handle, NOT closed
+# backend_renew_connection may reset the connection IN PLACE and return the SAME object
+# (LibPQ.reset!). The cleanup must then release that handle without closing it — closing a
+# live, just-reset connection would kill it. Mutation gate for the `new_conn !== conn` guard.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG in-place renewal releases the reset handle unclosed (#71)" begin
+  pool = MockPGPool71(fail_rollback = true, renew_in_place = true)
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Failed to rollback transaction") match_mode=:any begin
+    run_failing_tx_71(pool)
+  end
+
+  @test err isa ErrorException && err.msg == "boom"
+  @test pool.connections[1] === old                   # reset in place: same object stays in the slot
+  @test pool.available[1] === true                    # and it was released (identity trap avoided)
+  @test old.closed === false                          # a live reset handle must NOT be closed
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): PG renewal failure → slot discarded, next acquire reconnects fresh
+# When reconnect_db cannot renew (driver renewal throws), the dirty handle must be closed and
+# its slot cleared (`nothing` + available) so the next borrower opens a brand-new physical
+# connection through the existing empty-slot acquire path.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG renewal failure discards the slot (#71)" begin
+  pool = MockPGPool71(fail_rollback = true, fail_renew = true)
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Failed to rollback transaction") match_mode=:any begin
+    run_failing_tx_71(pool)
+  end
+
+  @test err isa ErrorException && err.msg == "boom"
+  @test pool.connections[1] === nothing               # slot cleared, not left holding the dirty handle
+  @test pool.available[1] === true                    # slot reusable
+  @test old.closed === true                           # dirty handle closed
+  # Next borrower triggers backend_connect on the empty slot → a fresh connection.
+  c = CP.acquire_connection(pool)
+  @test c isa FakeConn71 && c !== old
+  @test pool.connections[1] === c                     # slot repopulated
+  CP.release_connection(pool, c)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): SQLite benign "no transaction is active" → plain release, no renewal
+# SQLite auto-rolls-back some failures; a ROLLBACK then fails with "no transaction is active"
+# and the connection is CLEAN — it must be released as-is (same object, not closed, no fresh
+# handle created). This also gates the unwrap fix: the error arrives wrapped in a
+# TaskFailedException (via the global worker task), whose string() does NOT contain the
+# driver message — without _unwrap_async_exception the benign case would be misclassified
+# as a failed rollback and pointlessly renewed, failing the identity assertion below.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "SQLite benign rollback error releases the connection as-is (#71)" begin
+  pool = MockSQLitePool71(rollback_error_msg = "cannot rollback - no transaction is active")
+  old = pool.connections[1]
+
+  err = run_failing_tx_71(pool)
+
+  @test err isa ErrorException && err.msg == "boom"
+  @test pool.connections[1] === old                   # NOT renewed: same object stays in the slot
+  @test pool.available[1] === true                    # released normally
+  @test old.closed === false                          # never closed
+  @test pool.next_id == 1                             # no fresh handle was ever created
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): SQLite non-benign rollback failure → renewal (PG/SQLite alignment)
+# Same policy as PG, proven through the REAL SQLite path: BEGIN/ROLLBACK funnel through the
+# global async worker into backend_execute, the rollback failure surfaces wrapped, and the
+# cleanup renews the slot and closes the dirty handle (releasing its file write-lock — an
+# aborted BEGIN IMMEDIATE would otherwise hold it until GC).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "SQLite non-benign rollback failure renews the connection (#71)" begin
+  pool = MockSQLitePool71(rollback_error_msg = "disk I/O error")
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Failed to rollback transaction") match_mode=:any begin
+    run_failing_tx_71(pool)
+  end
+
+  @test err isa ErrorException && err.msg == "boom"
+  @test pool.connections[1] !== old                   # slot renewed
+  @test pool.connections[1] isa FakeConn71 && pool.connections[1].id == 2
+  @test pool.available[1] === true
+  @test old.closed === true                           # dirty handle closed promptly
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): with_transaction ROLLBACK failure → renewal (sibling-path heal)
+# delete() and both migration lifecycles issue their ROLLBACK through the shared
+# with_transaction(..., release_conn=true) primitive, not run_in_transaction. A failed
+# ROLLBACK there must renew/discard the connection exactly like the tx wrapper does —
+# releasing it dirty was the same #71 defect on a sibling path.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "with_transaction failed ROLLBACK renews the connection (#71)" begin
+  pool = MockPGPool71(fail_rollback = true)
+  old = pool.connections[1]
+
+  # Mirror the runner/delete() catch pattern: the caller holds the tx connection and
+  # asks with_transaction to roll back and release it.
+  conn = CP.acquire_connection(pool)
+  @test conn === old
+  err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode=:any begin
+    try
+      CP.with_transaction(pool, "ROLLBACK;", conn = conn, release_conn = true)
+      nothing
+    catch e
+      e
+    end
+  end
+
+  @test err !== nothing                               # the rollback failure propagates
+  @test pool.connections[1] !== old                   # slot renewed, dirty handle gone
+  @test pool.available[1] === true                    # renewed handle released
+  @test old.closed === true                           # dirty handle closed
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): with_transaction benign SQLite rollback error → plain release
+# The benign "no transaction is active" classification must apply on the shared
+# primitive too: the connection is clean, so it is released as-is (same object,
+# not closed, no fresh handle created).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "with_transaction benign SQLite rollback releases as-is (#71)" begin
+  pool = MockSQLitePool71(rollback_error_msg = "cannot rollback - no transaction is active")
+  old = pool.connections[1]
+
+  conn = CP.acquire_connection(pool; mode = :write)
+  @test conn === old
+  err = try
+    CP.with_transaction(pool, "ROLLBACK;", conn = conn, release_conn = true)
+    nothing
+  catch e
+    e
+  end
+
+  @test err !== nothing                               # the driver error still propagates
+  @test pool.connections[1] === old                   # NOT renewed
+  @test pool.available[1] === true                    # released normally
+  @test old.closed === false                          # never closed
+  @test pool.next_id == 1                             # no fresh handle was ever created
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transactions (#71): _discard_connection! on an unpooled handle → false, still closed
+# The not-found path (e.g. the slot was already replaced by a concurrent reconnect) must
+# warn-and-return-false, but the handle is still best-effort closed so it never leaks.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_discard_connection! not-found path still closes the handle (#71)" begin
+  pool = MockPGPool71()
+  stray = FakeConn71(99)                              # never lived in this pool
+
+  found = @test_logs (:warn, r"not found") match_mode=:any begin
+    CP._discard_connection!(pool, stray)
+  end
+
+  @test found === false
+  @test stray.closed === true                         # closed even when unpooled
+  @test pool.connections[1] isa FakeConn71            # pool untouched
+  @test pool.available[1] === true
+end


### PR DESCRIPTION
Closes #71.

## Problem

When a transaction body throws and the `ROLLBACK` itself also fails, the connection was released back to the pool as-is. A connection left with an open/aborted transaction passes the acquire-time liveness probe (PG `CONNECTION_OK` and SQLite `SELECT 1` both succeed), so the next borrower ran inside stale transaction state — "current transaction is aborted, commands ignored until end of transaction block" on PostgreSQL, or a still-held file write-lock on SQLite.

## Fix

- `_run_in_transaction_impl`: a failed rollback now routes the connection through the new `_renew_or_discard_connection!` helper instead of `release_connection` — the connection is renewed in its slot via the existing `reconnect_db`/`backend_renew_connection` machinery (PG: `LibPQ.reset!`, which aborts any open transaction; SQLite: fresh handle, old one closed so the file write-lock is freed immediately), and the **renewed** handle is released (the slot is swapped in place and `release_connection` matches by identity). If renewal also fails, the new `_discard_connection!` clears the slot so the next borrower opens a fresh physical connection.
- The same heal is wired into `with_transaction`'s two release points, covering the sibling ROLLBACK paths used by `delete()` and both migration lifecycles. Only a transaction-ending `ROLLBACK` triggers it — never `ROLLBACK TO SAVEPOINT`.
- SQLite's benign "no transaction is active" rollback error is classified by a shared `_is_benign_rollback_error` helper that unwraps `TaskFailedException` first — the previous string match never fired on the async path (the driver message isn't in `string(::TaskFailedException)`), so the benign check was dead code.
- `delete()` no longer masks the body's original error when its rollback fails.
- The global SQLite async worker dispatches `backend_execute` via `Base.invokelatest`: the worker task lives forever and Julia 1.12 tasks run in their creation world age, so late-defined methods (Revise hot-reloads, test mocks) were invisible to it.

## Tests

- New `test/unit/test_transaction_rollback_renewal.jl` (8 testsets, DB-free): behavioral mock pools + fake driver handles covering PG renewal, in-place `reset!` semantics (renewed-same-handle must not be closed), renewal-failure discard, the benign SQLite carve-out (also gates the unwrap fix), SQLite renewal through the real global worker, the `with_transaction` heal and its benign path, and the discard not-found path.
- New PG-only integration testset: kills its own backend mid-transaction (`pg_terminate_backend`) so the rollback genuinely fails against a live server; a `@test_logs` gate on the renewal branch's message makes the testset fail if the fix is reverted (a dead socket alone would self-heal via the acquire probe). Skipped on SQLite.
- Docs: pool self-healing bullet in `docs/src/configuration/advanced.md`.

## Verification

- Unit suite: 2395/2395
- Integration db_sl (SQLite): 1563 passed, 1 expected skip
- Integration db_2 (PostgreSQL): 1606/1606 — the #71 testset genuinely terminated its backend and healed
- Docs build green

## Follow-ups filed during this work

- #138 — `fetch()`'s lost-connection retry re-runs statements outside the transaction and releases the tx connection mid-transaction (the integration test bypasses `fetch()` for this reason).
- #139 — failed COMMIT in the `with_transaction` lifecycles releases the connection before issuing ROLLBACK on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
