### PR TITLE
fix(#78): Unicode-aware case folding for SQLite i* lookups

### DIFF
--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -115,7 +115,11 @@ count = query.count()
 ```
 
 > [!NOTE]
-> `@icontains` uses `ILIKE` on PostgreSQL. On SQLite (which is case-insensitive for ASCII by default), it uses `LIKE`.
+> `@icontains` uses `ILIKE` on PostgreSQL. On SQLite it renders `pormg_lower(col) LIKE pormg_lower(val)`,
+> where `pormg_lower` is a Unicode-aware case-folding function PormG registers on every SQLite
+> connection — so accented text folds case on SQLite as it does on PostgreSQL
+> (`"surname__@icontains" => "RÄIKKÖNEN"` finds `"Räikkönen"` on both backends). It folds case but
+> preserves accents; for accent-insensitive matching use the PostgreSQL-only `@iunaccent_*` lookups below.
 
 ### Prefix / Suffix (`@startswith`, `@endswith`)
 

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -40,8 +40,20 @@ function _sqlite_with_retry(op::Function)
   end
 end
 
+# Unicode-aware LOWER for SQLite case-insensitive lookups (#78). SQLite's built-in LOWER()
+# folds ASCII only, so `icontains` missed accented uppercase (e.g. "RÄIKKÖNEN" vs "Räikkönen")
+# while PostgreSQL's ILIKE matched. Julia `lowercase` is Unicode-aware. Registered per-connection
+# (below) as the SQL function `pormg_lower`, which src/Dialect.jl emits in the SQLite i* renderers.
+# A SQL NULL arrives as `missing` and must round-trip to SQL NULL, not throw; non-text values are
+# coerced to text (mirroring SQLite's built-in LOWER).
+_pormg_lower(x::AbstractString) = lowercase(x)
+_pormg_lower(::Missing) = missing
+_pormg_lower(x) = lowercase(string(x))
+
 function _create_sqlite_connection(connection_string::String; read_only::Bool = false)
   new_conn = SQLite.DB(connection_string)
+  # Unicode-aware case folding for the i* lookups (#78). Deterministic so it stays index-eligible.
+  SQLite.register(new_conn, _pormg_lower; nargs = 1, name = "pormg_lower", isdeterm = true)
   SQLite.execute(new_conn, "PRAGMA journal_mode = WAL;")
   SQLite.execute(new_conn, "PRAGMA synchronous = NORMAL;")
   SQLite.execute(new_conn, "PRAGMA busy_timeout = 30000;")

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -1026,7 +1026,9 @@ function icontains(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ILIKE $(value)$(_like_escape_clause())"
 end
 function icontains(conn::PormGSQLite, column::String, value::String)::String
-  return "LOWER($(column)) LIKE LOWER($(value))$(_like_escape_clause())"
+  # pormg_lower = Unicode-aware LOWER UDF registered per-connection in PormGSQLiteExt (#78), so case
+  # folding matches PostgreSQL ILIKE; case_sensitive_like=ON makes LIKE exact on the folded text.
+  return "pormg_lower($(column)) LIKE pormg_lower($(value))$(_like_escape_clause())"
 end
 function icontains(conn::PormGAbstractType, column::String, value)
   throw(ArgumentError("The value must be a String"))
@@ -1077,7 +1079,8 @@ function istartswith(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ILIKE $(value)$(_like_escape_clause())"
 end
 function istartswith(conn::PormGSQLite, column::String, value::String)::String
-  return "LOWER($(column)) LIKE LOWER($(value))$(_like_escape_clause())"
+  # Unicode-aware case folding via the pormg_lower UDF (#78) — see icontains above.
+  return "pormg_lower($(column)) LIKE pormg_lower($(value))$(_like_escape_clause())"
 end
 function istartswith(conn::PormGAbstractType, column::String, value)
   throw(ArgumentError("The value must be a String"))
@@ -1099,7 +1102,8 @@ function iendswith(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ILIKE $(value)$(_like_escape_clause())"
 end
 function iendswith(conn::PormGSQLite, column::String, value::String)::String
-  return "LOWER($(column)) LIKE LOWER($(value))$(_like_escape_clause())"
+  # Unicode-aware case folding via the pormg_lower UDF (#78) — see icontains above.
+  return "pormg_lower($(column)) LIKE pormg_lower($(value))$(_like_escape_clause())"
 end
 function iendswith(conn::PormGAbstractType, column::String, value)
   throw(ArgumentError("The value must be a String"))

--- a/test/integration/test_unaccent_extension.jl
+++ b/test/integration/test_unaccent_extension.jl
@@ -128,3 +128,46 @@ elseif _UNACCENT_ADAPTER == "SQLite"
 else
     @warn "Skipping unaccent extension tests for unknown adapter" adapter = _UNACCENT_ADAPTER
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# icontains is Unicode-case-insensitive on BOTH backends (#78)
+# PostgreSQL ILIKE folds Unicode case; SQLite historically used ASCII-only LOWER(),
+# so an all-caps accented query ("RÄIKKÖNEN") matched on PG but returned 0 rows on
+# SQLite. With the per-connection pormg_lower UDF, SQLite folds Unicode too, so both
+# backends return the SAME row for any casing. Runs unconditionally (outside the
+# adapter branch above) so the alignment is asserted on whichever backend is under test.
+# Mutation gate: reverting the SQLite renderer to bare LOWER makes the all-caps/mixed
+# assertions return no rows on SQLite, failing this testset.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "icontains Unicode case-insensitivity aligns PG and SQLite (#78)" begin
+    # Stored surname is "Räikkönen" (ä/ö). Every casing of the accented spelling must
+    # match it — this is the bug: "RÄIKKÖNEN" returned 0 rows on SQLite before the fix.
+    for term in ("RÄIKKÖNEN", "räikkönen", "RäiKkönen")  # upper / lower / mixed
+        q = M.Driver.objects
+        q.filter("surname__@icontains" => term)
+        df = q |> DataFrame
+        @test "Räikkönen" in df.surname
+    end
+
+    # A second accented surname with a different diacritic (ü/Ü) — guards that the fix
+    # is general Unicode case folding, not a one-off for ä/ö.
+    q_h = M.Driver.objects
+    q_h.filter("surname__@icontains" => "HÜLKENBERG")
+    df_h = q_h |> DataFrame
+    @test "Hülkenberg" in df_h.surname
+
+    # The alignment contract: upper- and lower-case accented queries return the SAME rows.
+    up = M.Driver.objects
+    up.filter("surname__@icontains" => "RÄIKKÖNEN")
+    lo = M.Driver.objects
+    lo.filter("surname__@icontains" => "räikkönen")
+    @test Set((up |> DataFrame).surname) == Set((lo |> DataFrame).surname)
+
+    # Negative / accent sensitivity: pormg_lower folds CASE, not ACCENTS. The ASCII
+    # spelling "raikkonen" must NOT match the accented "Räikkönen" — accent-insensitive
+    # matching remains the job of the PG-only iunaccent_* lookups (see ~line 59-64 above).
+    q_ascii = M.Driver.objects
+    q_ascii.filter("surname__@icontains" => "raikkonen")
+    df_ascii = q_ascii |> DataFrame
+    @test !("Räikkönen" in (nrow(df_ascii) > 0 ? df_ascii.surname : String[]))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ end
     @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")
     @testset "custom_join Copy Isolation (#112)" include("unit/test_custom_join_copy.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")
+    @testset "pormg_lower UDF (#78)" include("unit/test_pormg_lower_udf.jl")
     @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")
     @testset "Deep FK Traversal (3 hops)" include("unit/test_deep_fk_traversal.jl")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -105,7 +105,7 @@ end
     @test contains(sql, "EXISTS (SELECT 1")
     @test contains(sql, "FROM \"just_a_test_deletion\" as \"R1\"")
     @test contains(sql, "\"R1\".\"test_result\" = \"Tb\".\"resultid\"")
-    @test contains(sql, "LOWER(\"R1\".\"name\") LIKE LOWER(?)")
+    @test contains(sql, "pormg_lower(\"R1\".\"name\") LIKE pormg_lower(?)")
     @test contains(sql, "LIMIT 1)")
     @test !contains(sql, "\"R1\".\"id\" as id")
 

--- a/test/unit/test_operators.jl
+++ b/test/unit/test_operators.jl
@@ -166,13 +166,16 @@ const _E = _OperTestEvent
     @test contains(r_c[:sql_text], "ESCAPE")
     @test r_c[:parameters] == ["%lew%"]
 
-    # icontains → ILIKE '%val%' (Postgres) or LIKE with LOWER (SQLite)
-    # The bound value must be lowercased so the wildcard match is case-insensitive.
+    # icontains → ILIKE '%val%' (PostgreSQL) or pormg_lower(col) LIKE pormg_lower('%val%') (SQLite, #78).
+    # NOTE: these _OperTest models render through a PostgreSQL mock (_MockPostgresOper), so this checks
+    # the operator SHAPE only — it is NOT a SQLite gate. The SQLite pormg_lower rendering is gated in
+    # test_alignment_sqlite.jl and the UDF's folding behavior in test_pormg_lower_udf.jl. The bound
+    # value is passed as-is; case folding happens in SQL.
     q_ic = _D.objects.filter("forename__@icontains" => "LEW")
     r_ic = q_ic.list(show_query=:dict)
-    @test contains(r_ic[:sql_text], "ILIKE") || contains(r_ic[:sql_text], "LIKE")
+    @test contains(r_ic[:sql_text], "ILIKE") || contains(r_ic[:sql_text], "pormg_lower")
     @test contains(r_ic[:sql_text], "ESCAPE")
-    @test r_ic[:parameters] == ["%LEW%"] 
+    @test r_ic[:parameters] == ["%LEW%"]
 
     # iunaccent_contains → public.immutable_unaccent(column) ILIKE public.immutable_unaccent('%val%')
     q_iua = _D.objects.filter("forename__@iunaccent_contains" => "sao jose")

--- a/test/unit/test_pormg_lower_udf.jl
+++ b/test/unit/test_pormg_lower_udf.jl
@@ -1,0 +1,41 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# pormg_lower UDF: Unicode-aware case folding for SQLite i* lookups (#78)
+# The SQLite icontains/istartswith/iendswith renderers emit `pormg_lower(...)`, a
+# scalar UDF registered per-connection in PormGSQLiteExt and backed by Julia's
+# Unicode-aware `lowercase`. SQLite marshals a TEXT argument to Julia as a String,
+# a SQL NULL as `missing`, and numeric/other values as Int64/Float64/bytes. The UDF
+# must: fold text case for the FULL Unicode range (not ASCII-only, as SQLite's
+# built-in LOWER did), pass NULL through as `missing` (→ SQL NULL, never throw), and
+# coerce non-text to text (mirroring SQLite LOWER's text affinity).
+#
+# This gates all three `_pormg_lower` methods directly. It matters because the query
+# unit tests only inspect rendered SQL (`show_query`), never execute it, and the F1
+# integration schema has no nullable text column — so the `missing`/non-text branches
+# are otherwise never exercised. Mutation gate: dropping the `::Missing` method (or
+# reverting the text method to an ASCII fold) fails the corresponding assertion here.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "pormg_lower UDF (#78)" begin
+    # The SQLite weakdep is activated by test/load_drivers.jl, so the extension module
+    # (and its non-exported _pormg_lower) is reachable via Base.get_extension.
+    ext = Base.get_extension(PormG, :PormGSQLiteExt)
+    @test ext !== nothing
+    pl = ext._pormg_lower
+
+    # Unicode case folding — the fix. Accented uppercase folds to accented lowercase,
+    # which ASCII-only SQLite LOWER() could not do (this is exactly the #78 bug).
+    @test pl("RÄIKKÖNEN") == "räikkönen"
+    @test pl("HÜLKENBERG") == "hülkenberg"
+    @test pl("PÉREZ")      == "pérez"
+    # ASCII text still folds (unchanged from the old behavior).
+    @test pl("HAMILTON")   == "hamilton"
+    # Folds CASE but preserves ACCENTS — accent-insensitive matching stays the job of
+    # the PostgreSQL-only iunaccent_* lookups, so the ASCII spelling must NOT be produced.
+    @test pl("RÄIKKÖNEN") != "raikkonen"
+
+    # SQL NULL arrives as `missing` and must round-trip to `missing` (→ SQL NULL), never throw.
+    @test pl(missing) === missing
+
+    # Non-text values are coerced to text (mirrors SQLite's built-in LOWER text affinity),
+    # so an i* lookup accidentally applied to a numeric column can't crash the query.
+    @test pl(42) == "42"
+end


### PR DESCRIPTION
## Summary

The case-insensitive lookups (`icontains`/`istartswith`/`iendswith`) returned **different rows** on
PostgreSQL vs SQLite for accented/non-Latin text. PostgreSQL renders `ILIKE` (Unicode-aware case
folding); SQLite rendered `LOWER(col) LIKE LOWER(val)`, and SQLite's built-in `LOWER()` folds **ASCII
only**. So `surname__@icontains => "RÄIKKÖNEN"` matched `"Räikkönen"` on PG but returned **0 rows** on
SQLite — a silent, data-dependent divergence over exactly the accented names the F1 dataset is full of
(Räikkönen, Pérez, Hülkenberg, Häkkinen).

## Fix

Register a Unicode-aware `pormg_lower` scalar UDF (backed by Julia's `lowercase`) on every SQLite
connection, and render the SQLite `i*` lookups with `pormg_lower(...)` instead of `LOWER(...)`.

- **`ext/PormGSQLiteExt.jl`** — `_pormg_lower` (text→fold, `missing`→`missing`, non-text→text) is
  registered in `_create_sqlite_connection` (the single chokepoint both `backend_connect` and
  `backend_renew_connection` route through), so every new *and renewed* connection has it.
  `isdeterm=true` keeps it index-eligible.
- **`src/Dialect.jl`** — SQLite `icontains`/`istartswith`/`iendswith` now emit
  `pormg_lower(col) LIKE pormg_lower(val)`. PG methods (`ILIKE`) and the case-sensitive non-`i`
  lookups are untouched.

## Design

This is the `sqlite3_create_function` route that **SQLite** and **SQLAlchemy** document for real
Unicode case folding (SQLite's built-in `LOWER`/`LIKE` are ASCII-only by design). Django and
SQLAlchemy default to only *documenting* the gap because they can't robustly assume ownership of
connection setup; PormG owns `_create_sqlite_connection` (it already sets PRAGMAs there) and has
Unicode-aware `lowercase` in the stdlib, so it can close the divergence — matching PormG's
"keep PostgreSQL and SQLite aligned" rule. Folds **case** but preserves **accents** (accent-insensitive
matching remains the PostgreSQL-only `iunaccent_*` lookups). No index regression: the old code already
wrapped the column in `LOWER()`.

## Acceptance criteria (from #78)

- [x] `surname__@icontains => "RÄIKKÖNEN"` returns the same row(s) on PostgreSQL and SQLite.
- [x] Regression test: case-insensitive match on an accented value seeded in both backends returns
      identical rows for upper/lower/mixed-case query terms.

## Tests

- **`test/integration/test_unaccent_extension.jl`** — a new both-backend `@testset`: upper/lower/mixed
  accented queries all match the stored surname; upper == lower result sets; and a negative case
  proving the fold is case-only (ASCII `"raikkonen"` must **not** match `"Räikkönen"` — that stays the
  job of `iunaccent_*`).
- **`test/unit/test_pormg_lower_udf.jl`** *(new)* — direct gate of all three `_pormg_lower` methods
  (Unicode fold / `missing` round-trip / non-text coercion), since the query unit tests never execute
  SQL and the F1 schema has no nullable text column to drive the `missing` branch end to end.
- **`test/unit/test_alignment_sqlite.jl`** — updated the literal SQLite expectation to `pormg_lower`.
- **`test/unit/test_operators.jl`** — corrected a comment (that file renders via a PostgreSQL mock, so
  it is not a SQLite gate; the real gates are `test_alignment_sqlite.jl` and `test_pormg_lower_udf.jl`).

**Results:** unit **2461/2461**, PostgreSQL (`db_2`) **1608/1608**, SQLite (`db_sl`) **1569 pass + 1
PG-only skip** — all green. Reviewed via the changed-code review flow (3 finder angles → verify);
no correctness bugs in the fix; two findings applied (honest test comment, the new UDF unit gate).

## Docs

`docs/src/read/filters_and_aggregates.md` — corrected the `@icontains` note to describe the SQLite
`pormg_lower` rendering and the case-folds-not-accents contract.

## Out of scope (follow-up)

The SQLite `istartswith`/`iendswith` renderers are updated for consistency but are pre-existing dead
code — unreachable via the `__@` filter path (absent from `PormGsuffix` and the dispatch list); there
is no `iexact` renderer. Worth a separate issue to wire them up.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
