### PR TITLE
fix(#76): DISTINCT + ORDER BY on an unselected column raises identically on PG and SQLite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,13 @@
 > authoritative DDL/queries (#50), string FK targets (#62), ManyToMany/CTE join keys (#64) ·
 > isolated PG migration fixture (#36) · pool-exhaustion investigation (#37 → follow-ups
 > #124–#128) · `ORDER BY` NULL placement (#75) · `.copy()` state aliasing (#43 → #112) ·
-> bulk mapping contract, `columns=` as the single df→model border (#107).
+> bulk mapping contract, `columns=` as the single df→model border (#107) · non-mutating
+> zero-copy bulk pipeline, `copy=` kwarg removed (#132).
 >
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-- [#132](https://github.com/PingoLee/PormG.jl/issues/132) — Bulk ops: drop the `copy=` deepcopy default — non-mutating zero-copy pipeline
+*(none — the gating list is empty; new `pre-publish`-labeled issues appear here as they open)*
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,9 +43,59 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `distinct().order_by()` — the sort key must be in the projection (raises otherwise)
+
+- **PormG ref**: issue #76 ; `src/querybuilder/build_query.jl`
+- **Recorded**: 2026-07-13
+- **Severity**: behavior change (new `ArgumentError`)
+
+### What changed
+
+A `DISTINCT` query that orders by a column outside its projection —
+`.values("a").distinct().order_by("b")` with `b` not in `values(...)` — now raises a clear
+`ArgumentError` on **both** backends. Previously PostgreSQL rejected it with a raw DB error while
+SQLite silently ran it, returning rows in a nondeterministic `DISTINCT`/order interaction. Ordering a
+`DISTINCT` result by an unprojected column is rejected by PostgreSQL and the SQL standard (SQL Server,
+Oracle, DB2, and default-mode MySQL all reject it); PormG now makes SQLite conform too. The guard
+matches the resolved SQL *expression*, so ordering by a *function of* a projected column
+(`order_by("created_at__@date")` while only `created_at` is selected) is likewise rejected — that too
+is a PostgreSQL error.
+
+### How to find the calls to migrate
+
+Run the app or its tests: the new error reads
+`DISTINCT query cannot ORDER BY <col>: it is not in the SELECT DISTINCT projection`. Grep for
+`.distinct()` and check each one's `order_by(...)` — every ordered column (or the exact ordering
+expression) must also appear in `values(...)`. **Postgres-backed apps already errored on these; only
+SQLite-tested queries could have been running silently.**
+
+### Migrate your app
+
+```julia
+# ✗ raises: surname is ordered but not projected
+M.Driver.objects.values("nationality").distinct().order_by("surname").list()
+
+# ✓ include the sort key in values() (distinct is now over both columns) …
+M.Driver.objects.values("nationality", "surname").distinct().order_by("surname").list()
+
+# ✓ … or drop distinct() if you meant "one row per nationality, ordered by an aggregate"
+M.Driver.objects.values("nationality", "n" => Count("driverid")).order_by("n").list()
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
 ## bulk ops `copy=` kwarg removed — the pipeline never mutates (and never copies) your DataFrame
 
-- **PormG ref**: issue #132 ; `src/querybuilder/execution_bulk.jl`
+- **PormG ref**: issue #132 / PR #137 ; `src/querybuilder/execution_bulk.jl`
 - **Recorded**: 2026-07-12
 - **Severity**: breaking (kwarg removed) / behavior improvement
 
@@ -100,7 +150,7 @@ was never supported — it just happened to be masked by the default deepcopy).
 
 ## `bulk_update(match_on=)` — pairs removed; `columns=` is the single df→field mapping point
 
-- **PormG ref**: issue #107 ; `src/querybuilder/execution_bulk.jl`
+- **PormG ref**: issue #107 / PR #135 ; `src/querybuilder/execution_bulk.jl`
 - **Recorded**: 2026-07-12
 - **Severity**: breaking
 
@@ -136,6 +186,184 @@ bulk_update(query, df,
 
 Bare-name calls (`match_on = ["id"]` with an `id` DataFrame column, or relying on the
 primary-key fallback) need no change.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
+## `SQLOrder` orientation is now whitelisted — only `"ASC"`/`"DESC"` (case-insensitive) construct and render
+
+- **PormG ref**: issue #77 / PR #133 ; `src/querybuilder/types.jl`, `src/querybuilder/build_query.jl`
+- **Recorded**: 2026-07-12
+- **Severity**: behavior change (new `ArgumentError`; closes an injection seam)
+
+### What changed
+
+A directly constructed `SQLOrder` used to accept **any** string as `orientation` and interpolate
+it verbatim into the rendered `ORDER BY` — a SQL-injection seam for apps forwarding a
+user-controlled sort direction. Every construction path (and render, guarding post-construction
+mutation) now normalizes (`uppercase` + `strip`) and whitelists against `"ASC"`/`"DESC"`, raising
+`ArgumentError` for anything else. The documented string API — `.order_by("field")` /
+`.order_by("-field")` — was always safe and is unchanged.
+
+### How to find the calls to migrate
+
+Grep the app for direct `SQLOrder(` construction. Only call sites passing a *dynamic*
+(user- or data-derived) `orientation` need action; literal `"ASC"`/`"DESC"` in any case keep
+working.
+
+### Migrate your app
+
+```julia
+# ✗ before — a user-controlled direction string reached the SQL verbatim
+dir = params["dir"]   # e.g. "ASC; DROP TABLE results" used to render as-is
+query.order_by(SQLOrder(SQLField("points", "points"); orientation = dir))
+
+# ✓ after — map untrusted input onto the whitelist yourself (or handle the ArgumentError)
+query.order_by(SQLOrder(SQLField("points", "points");
+    orientation = lowercase(dir) == "desc" ? "DESC" : "ASC"))
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
+## Pool exhaustion now raises typed `PoolTimeoutError`; expansion ceiling raised to `pool_size × 10`
+
+- **PormG ref**: issue #37 / PR #129 ; `src/ConnectionPool.jl`
+- **Recorded**: 2026-07-12
+- **Severity**: behavior change (error type changed; pool sizing change)
+
+### What changed
+
+Exhausting the connection pool used to throw a **bare `String`** after a noisy busy-retry loop.
+Both the PostgreSQL and SQLite acquire paths now throw `PormG.PoolTimeoutError` (exported; fields
+`adapter` / `pool_size` / `max_size` / `attempts` / `elapsed`, with a "raise pool_size" remedy in
+`showerror`). The lazy expansion ceiling grew from `pool_size × 5` to `pool_size × 10` (default
+pool: 3 base → up to 30 on demand; idle footprint unchanged), and per-retry logging dropped to
+`@debug` — a single actionable `@warn` fires only when the pool hits its ceiling.
+
+### How to find the calls to migrate
+
+Grep the app for `catch` blocks that match the old exhaustion message as a string
+(e.g. `occursin("No available"` …). Most apps have none — then there is nothing to change; the
+new error type and quieter logs just apply.
+
+### Migrate your app
+
+```julia
+# ✗ before — the only way to detect exhaustion was string-matching a bare String throw
+catch e
+    e isa String && occursin("No available", e) && back_off()
+
+# ✓ after — catch the typed error; consider raising pool_size in connection.yml if it fires
+catch e
+    e isa PormG.PoolTimeoutError || rethrow()
+    back_off()
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
+## `order_by` on nullable columns — NULL placement normalized to PostgreSQL's convention on both backends
+
+- **PormG ref**: issue #75 / PR #120 ; `src/querybuilder/build_query.jl`
+- **Recorded**: 2026-07-12
+- **Severity**: behavior change (result order can change on SQLite)
+
+### What changed
+
+Top-level `ORDER BY` used to render a bare `expr ASC|DESC`, and PostgreSQL and SQLite default
+NULLs to **opposite ends** — so ordering a nullable column returned different rows per backend,
+and with `.first()` / `.page()` that changed *which* rows you got. PormG now emits an explicit
+NULLS clause matching PostgreSQL's default on **both** backends: ASC → `NULLS LAST`,
+DESC → `NULLS FIRST` (SQLite < 3.30.0 gets an equivalent portable `(expr IS NULL)` prefix).
+Per-term override: `SQLOrder(field; nulls = :first | :last)`. Window `OVER(...)` ordering is
+**not** yet normalized (follow-up pending).
+
+**PostgreSQL-backed apps see no change.** SQLite-backed apps: any `order_by` on a nullable key
+may now sort NULL rows to the other end.
+
+### How to find the calls to migrate
+
+No API change and nothing errors. In SQLite-backed apps, review `order_by` calls on **nullable**
+columns whose consumers depend on row order — `.first()`, pagination, "top N" reports.
+
+### Migrate your app
+
+```julia
+# Only if the app depended on SQLite's old NULLS-first-on-ASC ordering — pin it explicitly:
+using PormG.QueryBuilder: SQLOrder, SQLField
+
+M.Driver.objects.values("surname", "nationality").order_by(
+    SQLOrder(SQLField("nationality", "nationality"); orientation = "ASC", nulls = :first)
+).list()
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | |
+| app-2 | ⏳ | |
+| app-3 | ⏳ | |
+| app-4 | ⏳ | |
+
+---
+
+## `bulk_copy` — field formatters now applied; `""` and `missing` no longer collapse to NULL
+
+- **PormG ref**: issue #86 / PR #115 ; `src/querybuilder/execution_bulk.jl`
+- **Recorded**: 2026-07-12
+- **Severity**: behavior change (persisted values can differ)
+
+### What changed
+
+`bulk_copy` wrote **raw** DataFrame values (each field's formatter result was validated, then
+discarded), so datetime/bool/float values could silently diverge from what `bulk_insert` /
+`create()` store; and the COPY payload carried no NULL marker, collapsing `""` and `missing`
+into the same NULL. It now formats every cell exactly like `bulk_insert` and serializes with a
+`\N` NULL sentinel: `missing` → SQL `NULL`, `""` → empty string, and the two round-trip
+distinctly.
+
+### How to find the calls to migrate
+
+No API change. Review `bulk_copy` call sites that (a) pre-formatted datetimes/bools/floats to
+compensate for the old raw write — the workaround is now redundant (but harmless), or
+(b) relied on empty strings being stored as NULL.
+
+### Migrate your app
+
+```julia
+# The old behavior stored NULL for BOTH of these; they now persist differently:
+df = DataFrames.DataFrame(surname = ["Senna", "Prost"], code = ["", missing])
+bulk_copy(M.Driver.objects, df)   # row 1 code → '' (empty string), row 2 code → NULL
+
+# Keep the NULL semantics only where you actually want it — coerce before the call:
+df[!, :code] = map(x -> !ismissing(x) && x == "" ? missing : x, df[!, :code])
+```
 
 ### Per-app rollout
 

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -441,6 +441,14 @@ On SQLite builds older than 3.30.0 (which lack `NULLS FIRST/LAST` syntax) PormG 
     `ORDER BY`. Ordering **inside** a window frame (`WindowOver(order_by=…)`) is not yet normalized —
     its NULL placement still follows each backend's native default.
 
+!!! note "Ordering a `distinct()` query"
+    When a query uses `distinct()`, every `order_by(...)` column must be part of the
+    projection (`values(...)`). Ordering a `DISTINCT` result by an unprojected column — or by a
+    *function* of a projected column, e.g. `order_by("created_at__@date")` while only `created_at` is
+    selected — is rejected by PostgreSQL and the SQL standard, so PormG raises on both backends rather
+    than let SQLite return nondeterministic rows. Add the exact ordering expression to `values(...)`,
+    or drop `distinct()`.
+
 ---
 
 ## Counting

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -167,6 +167,22 @@ page2 = M.Driver.objects.order_by("surname").limit(20).offset(20).list()
 nationalities = M.Driver.objects.values("nationality").distinct().list()
 ```
 
+!!! warning "`distinct()` + `order_by()`: the sort key must be projected"
+    Under `distinct()`, every column you `order_by(...)` must appear in `values(...)`. Ordering a
+    `DISTINCT` query by a column outside its projection is rejected by PostgreSQL (and the SQL
+    standard), and returns rows in a nondeterministic order on SQLite — so PormG raises the same clear
+    error on both backends:
+
+    ```julia
+    # ✗ raises: surname is not in the SELECT DISTINCT projection
+    M.Driver.objects.values("nationality").distinct().order_by("surname").list()
+
+    # ✓ include the sort key in values() (distinct over both columns) …
+    M.Driver.objects.values("nationality", "surname").distinct().order_by("surname").list()
+
+    # ✓ … or drop distinct() if you meant "one row per nationality, ordered by an aggregate"
+    ```
+
 ### Copying a Query for Reuse
 
 ```julia

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -126,6 +126,37 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     instruc.cache[v_field_copy._as] = v_field_copy
 
     if !found_in_select
+      # #76: Under DISTINCT, an ORDER BY term that is not part of the projection is rejected by
+      # PostgreSQL and the SQL standard (SQL Server / Oracle / DB2 / default-mode MySQL all reject
+      # it), while SQLite silently runs it with a nondeterministic DISTINCT/order interaction. Refuse
+      # it on both backends so the two stay aligned. Match on the resolved SQL *expression*
+      # (v_field_copy.field was resolved just above), not the base column: PG rejects `ORDER BY
+      # DATE(x)` even when `x` is projected, yet accepts an aliased column (`SELECT x AS y ... ORDER
+      # BY x`) — expression membership captures both. Skip when there is no explicit projection
+      # (`SELECT DISTINCT *`) or the projection carries a `*` wildcard that already covers the column.
+      if object.distinct && !isempty(object.values) && !any(_is_wildcard_projection, object.values)
+        order_expr = string(v_field_copy.field)
+        in_projection = false
+        for i in eachindex(instruc.select)
+          isassigned(instruc.select, i) || continue
+          if string(instruc.select[i].field) == order_expr
+            in_projection = true
+            break
+          end
+        end
+        if !in_projection
+          # Keep the suggestion generic (`.values(...)`) rather than echoing v_field_copy._as: for a
+          # transform order term the alias is the internal name (e.g. "created_at__date"), which is NOT
+          # valid input syntax to paste back (the user wrote "created_at__@date"), so a specific token
+          # would mislead. The offending term is still named in the diagnosis.
+          throw(_argerr(
+            "DISTINCT query cannot ORDER BY \e[4m\e[31m$(v_field_copy._as)\e[0m: it is not in the " *
+            "SELECT DISTINCT projection. PostgreSQL (and the SQL standard) rejects this; SQLite " *
+            "would return rows in a nondeterministic order. Add the ordering column or expression " *
+            "to \e[4m\e[32m.values(...)\e[0m so it is projected, or drop " *
+            "\e[4m\e[32m.distinct()\e[0m and order by an aggregate if you meant one row per key."))
+        end
+      end
       push!(instruc.group, v_field_copy.field)
     end
 

--- a/test/integration/test_sql_functions.jl
+++ b/test/integration/test_sql_functions.jl
@@ -722,6 +722,44 @@ end
         @test all(df_ne.driverid .!= 1)
     end
 
+    @testset "DISTINCT + ORDER BY must project the sort key (#76)" begin
+        # A DISTINCT query that orders by a column outside its projection is rejected by PostgreSQL
+        # (and the SQL standard) but runs with a nondeterministic DISTINCT/order interaction on
+        # SQLite. PormG raises on both backends so the behavior is identical whichever backend this
+        # suite runs against. See issue #76.
+
+        # Misaligned: distinct driverids ordered by surname (not projected) -> raises everywhere.
+        @test_throws ArgumentError begin
+            M.Driver.objects.values("driverid").distinct().order_by("surname") |> DataFrame
+        end
+
+        # The error is actionable and discriminating (names the column + the DISTINCT context) —
+        # not a bare @test_throws that any ArgumentError would satisfy.
+        err = try
+            M.Driver.objects.values("driverid").distinct().order_by("surname") |> DataFrame
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = sprint(showerror, err)
+        @test occursin("surname", msg)
+        @test occursin("DISTINCT", msg)
+
+        # The guard does not over-fire: aligned forms still execute end to end.
+        #   - the order key IS the projected column
+        df_aligned = M.Driver.objects.values("driverid").distinct().order_by("driverid") |> DataFrame
+        @test issorted(df_aligned.driverid)
+        #   - the sort key is included in a multi-column projection. driverid is the PK, so distinct
+        #     (driverid, surname) is exactly one row per driver — the same 861 the fixture seeds.
+        #     (Row *order* is left to the backend collation — asserting it here with Julia's codepoint
+        #     `issorted` would spuriously fail on accented/mixed-case surnames; NULL/collation ordering
+        #     is covered by the #75 tests. What matters for #76 is that the guard did not over-fire.)
+        df_both = M.Driver.objects.values("driverid", "surname").distinct().order_by("surname") |> DataFrame
+        @test nrow(df_both) == 861
+        @test Set(names(df_both)) == Set(["driverid", "surname"])
+    end
+
     @testset "Range Operator (range / BETWEEN)" begin
         # Test: driverid BETWEEN 50 AND 100
         q_range = M.Driver.objects.filter("driverid__@range" => [50, 100]).order_by("driverid").values("driverid")

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -10,7 +10,7 @@ All tests use mock PostgreSQL connections (no live database required).
 
 using Test
 using PormG
-using PormG.Models: Model, CharField, IDField, IntegerField
+using PormG.Models: Model, CharField, IDField, IntegerField, DateTimeField
 using PormG.QueryBuilder: Q, Qor, F, Exists, OuterRef, inspect_query, list, update, delete, bulk_insert, bulk_update
 import DataFrames
 
@@ -328,6 +328,81 @@ PormG.config["default"] = MockSettings
     
     @test contains(res[:sql_text], "DISTINCT")
     @test res[:parameters] == ["French"]
+  end
+
+  # ===== Section 11b: DISTINCT + ORDER BY projection guard (#76) =====
+  @testset "Distinct + Order By must project the sort key (#76)" begin
+    # Under SELECT DISTINCT, an ORDER BY term that is not part of the projection is rejected by
+    # PostgreSQL and the SQL standard (SQL Server / Oracle / DB2 / default-mode MySQL all reject it)
+    # while SQLite runs it with a nondeterministic DISTINCT/order interaction. PormG raises on both
+    # backends so they stay aligned. The guard matches the resolved SQL *expression*, not the base
+    # column, so it tolerates aliased columns yet still rejects `ORDER BY f(x)` when only `x` is
+    # projected. See issue #76.
+    DistinctModel = Model("distinct_drivers",
+      id = IDField(),
+      surname = CharField(),
+      nationality = CharField(null = true),
+      created_at = DateTimeField(null = true),
+    )
+    DistinctModel.connect_key = "default"
+
+    @testset "unselected plain column raises with an actionable message" begin
+      # The reported bug: distinct nationalities ordered by a column that isn't projected.
+      err = try
+        DistinctModel.objects.values("nationality").distinct().order_by("surname").list(show_query = :sql)
+        nothing
+      catch e
+        e
+      end
+      @test err isa ArgumentError
+      msg = sprint(showerror, err)
+      # Discriminating: names the offending column, the DISTINCT context, and the .values() fix —
+      # not a bare @test_throws that any ArgumentError would satisfy.
+      @test occursin("surname", msg)
+      @test occursin("DISTINCT", msg)
+      @test occursin(".values(", msg)
+    end
+
+    @testset "ordering by a function of a selected column raises" begin
+      # PG rejects `ORDER BY DATE(created_at)` even though created_at is projected: the *expression*
+      # (not the base column) must be in the select list. A crude column-membership check would wrongly
+      # allow this; the expression-membership guard matches PG. Cause-check the message (not a bare
+      # @test_throws) so an unrelated ArgumentError — e.g. a future transform-resolution change — can't
+      # masquerade as a pass.
+      err = try
+        DistinctModel.objects.values("created_at").distinct().
+          order_by("created_at__@date").list(show_query = :sql)
+        nothing
+      catch e
+        e
+      end
+      @test err isa ArgumentError
+      msg = sprint(showerror, err)
+      @test occursin("created_at", msg)   # names the offending order term
+      @test occursin("DISTINCT", msg)
+      @test occursin("projection", msg)
+    end
+
+    @testset "valid distinct + order forms still render (no false positives)" begin
+      # aligned: the order key is the (only) projected column
+      @test DistinctModel.objects.values("nationality").distinct().
+        order_by("nationality").list(show_query = :sql) isa String
+      # no explicit projection => SELECT DISTINCT * (the sort key is covered by *)
+      sql_star = DistinctModel.objects.distinct().order_by("surname").list(show_query = :sql)
+      @test occursin("DISTINCT *", sql_star)
+      # explicit wildcard projection likewise covers the sort key
+      @test DistinctModel.objects.values("*").distinct().
+        order_by("surname").list(show_query = :sql) isa String
+      # aliased source: SELECT surname AS nm ... ORDER BY surname — surname IS the selected expression
+      @test DistinctModel.objects.values("nm" => "surname").distinct().
+        order_by("surname").list(show_query = :sql) isa String
+      # projected function: the DATE(created_at) expression is itself in the select list
+      @test DistinctModel.objects.values("created_at", "d" => "created_at__@date").distinct().
+        order_by("created_at__@date").list(show_query = :sql) isa String
+      # scope guard: the check is DISTINCT-only — a non-distinct unselected order must NOT raise
+      @test DistinctModel.objects.values("nationality").
+        order_by("surname").list(show_query = :sql) isa String
+    end
   end
 
   # ===== Section 12: Deep Copy Safety =====


### PR DESCRIPTION
## What & why

`SELECT DISTINCT a … ORDER BY b`, when the `ORDER BY` term `b` is **not** in the `SELECT DISTINCT` projection, diverged between backends:

- **PostgreSQL** rejected it (`ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list`).
- **SQLite** silently ran it, returning rows in a nondeterministic `DISTINCT`/order interaction.

So a query that "worked in dev on SQLite" failed in prod on PostgreSQL — the exact PG/SQLite divergence PormG exists to prevent. The unselected order column landed in *neither* the projection nor a `GROUP BY` (`get_order_query` pushes it to `instruc.group`, which is only emitted as `GROUP BY` when `instruction.agregate` is true, and `.distinct()` never sets that).

## Decision: raise identically on both backends

This is the SQL standard, not a PG quirk — PostgreSQL, SQL Server, Oracle, DB2, and default-mode MySQL (`ONLY_FULL_GROUP_BY`) all reject it; SQLite is the lone lenient default. The query is genuinely ambiguous (many `b` values per distinct `a`). So PormG raises a clear, actionable `ArgumentError` at build time on **both** backends, making SQLite conform to the standard PG already follows. (Django's silent auto-projection was deliberately rejected — its own docs flag it as a footgun that changes the result set.)

## Implementation

A guard in the existing `!found_in_select` branch of `get_order_query` ([`src/querybuilder/build_query.jl`](src/querybuilder/build_query.jl)):

- Fires only when `object.distinct && !isempty(object.values) && !any(_is_wildcard_projection, object.values)`.
- Matches on the **resolved SQL expression** (not the base column), comparing the order term against `instruc.select`. This tolerates aliased columns (`SELECT x AS y … ORDER BY x` — valid on PG) yet still rejects `ORDER BY f(x)` when only `x` is projected (PG rejects `ORDER BY UPPER(type)` even when `type` is selected — the SQL92/99 rule is on the whole expression).
- Skips `SELECT DISTINCT *` (no explicit projection) and wildcard projections, where `*` covers the column.
- The aggregate `GROUP BY` path is untouched. Error routed through `_argerr` so ANSI degrades off-TTY.

## Tests

- **Unit** ([`test/unit/test_inspect_query.jl`](test/unit/test_inspect_query.jl)): misaligned plain-column and function-of-selected-column both raise (message cause-checked, not bare `@test_throws`); no-raise regressions for aligned, no-`values()` `SELECT DISTINCT *`, wildcard, aliased source, projected function, and the non-distinct scope check. **Mutation-gated** — disabling the guard fails exactly the raise-assertions.
- **Integration** ([`test/integration/test_sql_functions.jl`](test/integration/test_sql_functions.jl)): the misaligned form raises on the live backend; aligned forms still execute end to end (exact distinct count). Row *order* is intentionally left to the backend collation (asserting it with Julia's codepoint `issorted` would spuriously fail on accented surnames; NULL/collation ordering is covered by #75).

## Verification

- Unit suite: **2464/2464**.
- PostgreSQL (`db_2`) integration: green (misaligned raises).
- SQLite (`db_sl`) integration: green — **the misaligned case now raises on SQLite too**, confirming the alignment.
- Docs build: green.

## Docs

`docs/src/read/index.md` and `docs/src/read/filters_and_aggregates.md` gain caveats. `UPGRADING.md` gets a consumer-rollout entry (behavior change: new `ArgumentError`).

## Bundled housekeeping (unrelated to #76)

Per the maintainer's call, this commit also carries pending rollout-log/backlog maintenance: `UPGRADING.md` backfills the already-rolled-out entries (#75/#77/#37/#86) with PR-number stamps, and `TODO.md` applies the #132 close-sync (the `pre-publish` gating index is now empty).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
