### PR TITLE
fix(#145): Model_to_str avoids deprecated sort(::Dict)

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -587,7 +587,11 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; c
   fields::String = ""
   render_failures::Vector{String} = String[]
   django_prefix::Bool = settings.django_prefix === nothing ? false : true
-  for (field_name, field) in pairs(model.fields) |> sort
+  # Iterate fields by name for deterministic output. Use `sort(collect(...))` rather than
+  # `sort(::Dict)` (via `pairs(...) |> sort`), which is deprecated and emits a Warn-level
+  # depwarn — that surfaces under CI's depwarn-enabled `Pkg.test` run and trips the #70
+  # render-failure test's "healthy model → no warn" assertion.
+  for (field_name, field) in sort(collect(model.fields); by = first)
     occursin(r"__|@|^_", field_name) && throw(ArgumentError("The field name $field_name in the model $model contains __ or @ or starts with _"))
     db_field_name::String = field_name  # real column name, before reserved-word prefixing — diagnostics must show this one
     field_name in contants_julia && (field_name = "_$field_name")


### PR DESCRIPTION
## Summary

`Model_to_str` iterated fields via `pairs(model.fields) |> sort` — i.e. `sort(::Dict)`, a **deprecated Julia API**. Under `Pkg.test()` (what CI runs), deprecation warnings are surfaced, so the call emitted a **Warn-level** `depwarn` from inside `Model_to_str`, tripping the `#70` render-failure test's "healthy model → no warn" assertion. A plain `julia --project=. test/runtests.jl` run does not surface depwarns — which is why the test passed locally but failed in CI across the last several merges.

## Fix

```julia
# was: for (field_name, field) in pairs(model.fields) |> sort
for (field_name, field) in sort(collect(model.fields); by = first)
```

Same sort-by-field-name output order, no deprecated API. It is the only occurrence of the pattern in `src/`. The existing `#70` test is the regression guard — it runs under CI's depwarn-enabled `Pkg.test`, so any future Warn-level log in `Model_to_str` fails the build again.

## Verification

`Pkg.test()` (exact CI invocation): **2485/2485 pass** after the fix (was 2484 pass / 1 fail). This clears the pre-existing `main` CI red that was unrelated to the feature the failing test actually covers.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
