### PR TITLE
fix(#147): skip non-pool mocks in close_pool! (concrete-type dispatch)

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -175,7 +175,7 @@ function _sqlite_candidate_slots!(pool::PormGSQLite, mode::Symbol)::Vector{Int}
   return ordered
 end
 
-function close_pool!(pool::PormGPostgres)
+function close_pool!(pool::PostgresConnectionPool)
   Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       conn = pool.connections[i]
@@ -193,7 +193,7 @@ function close_pool!(pool::PormGPostgres)
   end
 end
 
-function close_pool!(pool::PormGSQLite)
+function close_pool!(pool::SQLiteConnectionPool)
   Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       conn = pool.connections[i]
@@ -210,6 +210,14 @@ function close_pool!(pool::PormGSQLite)
     end
   end
 end
+
+# The two methods above dispatch on the CONCRETE pool structs so they only ever touch real
+# pool fields (`lock`/`connections`/`available`). Any other `PormGPostgres`/`PormGSQLite`
+# value is not a real connection pool — e.g. a lightweight mock that SQL-inspection unit
+# tests register in `config` to satisfy dialect dispatch — so cleanup must SKIP it rather
+# than trip on its missing fields. Without this fallback, `__cleanup__` (which closes every
+# `config` entry) aborts with a `FieldError` the first time it reaches a leaked test mock (#147).
+close_pool!(::Union{PormGPostgres, PormGSQLite}) = nothing
 
 function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_retries::Int = 300)
   start_time = time()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
+    @testset "close_pool! Skips Non-pool Mocks (#147)" include("unit/test_close_pool_mock_skip.jl")
     @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")

--- a/test/unit/test_close_pool_mock_skip.jl
+++ b/test/unit/test_close_pool_mock_skip.jl
@@ -1,0 +1,50 @@
+"""
+Regression: `close_pool!` (and therefore `Configuration.__cleanup__`) must SKIP any
+`PormGPostgres`/`PormGSQLite` value that is not a real connection pool.
+
+Background: SQL-inspection unit tests install lightweight *mock* pools into the global
+`PormG.config` (empty structs that subtype `PormGPostgres`/`PormGSQLite` only to satisfy
+dialect dispatch — they have none of a real pool's fields). When the combined
+`PORMG_INTEGRATION_TESTS=true julia test/runtests.jl` run reaches integration teardown,
+`__cleanup__()` walks every `config` entry and calls `close_pool!` on it. Previously
+`close_pool!` dispatched on the ABSTRACT `PormGPostgres`/`PormGSQLite` and immediately
+touched `pool.lock`, so a leaked mock raised
+`FieldError: type <Mock> has no field lock`, aborting cleanup with a spurious error on an
+otherwise-green run (and masking any genuine cleanup failure).
+
+Fix: the field-accessing `close_pool!` bodies dispatch on the CONCRETE pool structs
+(`PostgresConnectionPool` / `SQLiteConnectionPool`); a no-op fallback covers every other
+`PormGPostgres`/`PormGSQLite` (mocks / non-pool markers). This test is DB-free.
+"""
+
+using Test
+using PormG
+
+const CP = PormG.ConnectionPool
+
+# Mocks like the SQL-inspection suites register in `config`: subtype the pool marker but
+# carry none of a real pool's fields.
+struct _MockPGNoPool <: PormG.PormGPostgres end
+struct _MockSQLiteNoPool <: PormG.PormGSQLite end
+
+@testset "close_pool! skips non-pool mocks; still closes real pools (#147)" begin
+  # 1. Non-pool mocks must be skipped (no field access, no throw).
+  @test CP.close_pool!(_MockPGNoPool()) === nothing
+  @test CP.close_pool!(_MockSQLiteNoPool()) === nothing
+
+  # 2. The Configuration-level wrapper (what __cleanup__ calls) must also tolerate them.
+  @test PormG.Configuration.close_pool!(_MockPGNoPool()) === nothing
+  @test PormG.Configuration.close_pool!(_MockSQLiteNoPool()) === nothing
+
+  # 3. Real pools are still closed by the concrete-typed methods. A freshly-constructed
+  #    pool holds no live handles (all slots `nothing`), so this needs no live database.
+  pg = CP.PostgresConnectionPool("dummy-connection-string"; pool_size = 2)
+  @test CP.close_pool!(pg) === nothing
+  @test all(pg.available)                       # slots reset to available
+  @test all(c -> c === nothing, pg.connections) # no live handles left
+
+  sl = CP.SQLiteConnectionPool(":memory:"; pool_size = 2)
+  @test CP.close_pool!(sl) === nothing
+  @test all(sl.available)
+  @test all(c -> c === nothing, sl.connections)
+end


### PR DESCRIPTION
Closes #147.

## Problem

The **combined** `PORMG_INTEGRATION_TESTS=true julia -t auto --project=. test/runtests.jl` run (unit phase → integration phase in one process) exited with **one spurious error at the very end**, during integration teardown, even when every test passed:

```
FieldError: type MockPG_OrderNulls has no field `lock`; MockPG_OrderNulls has no fields at all.
  close_pool!(pool::MockPG_OrderNulls)  @ PormG.ConnectionPool  src/ConnectionPool.jl:178
  close_pool!(pool::MockPG_OrderNulls)  @ PormG.Configuration   src/Configuration.jl:638
  __cleanup__()                         @ PormG.Configuration   src/Configuration.jl:794
```

SQL-inspection unit tests register lightweight **mock pools** in the global `PormG.config` (empty structs that subtype `PormGPostgres`/`PormGSQLite` only to satisfy dialect dispatch — no real pool fields). `Configuration.__cleanup__()` closes every `config` entry whose `connections isa SQLConn` — and mocks satisfy that — so `close_pool!` was called on a mock. Because `close_pool!` dispatched on the **abstract** `PormGPostgres`/`PormGSQLite` and immediately touched `pool.lock`, the first leaked mock raised `FieldError` and **aborted the whole cleanup**. That's a false red on a green run, and it **masks any genuine cleanup failure** (cleanup aborts before reaching the real pools). The canonical `julia test/integration/runtests.jl` entrypoint never runs the unit phase, so it was always clean — only the combined form was affected.

## Fix

Make `close_pool!` robust at its own layer: the two field-accessing bodies now dispatch on the **concrete** pool structs (`PostgresConnectionPool` / `SQLiteConnectionPool`, both defined in core `ConnectionPool.jl`), and a no-op fallback covers every other `PormGPostgres`/`PormGSQLite` value so cleanup skips non-pool markers:

```julia
close_pool!(::Union{PormGPostgres, PormGSQLite}) = nothing
```

Real pools still dispatch to the concrete methods (more specific) and close normally; mocks hit the fallback and are skipped.

## Verification

- New DB-free regression test `test/unit/test_close_pool_mock_skip.jl`: **red before** (4 `FieldError`s), **10/10 green** after — covers `close_pool!` and the `Configuration.close_pool!` wrapper on both PG and SQLite mocks, and confirms real pools are still closed.
- Full unit suite: **2522/2522** (no regression from the dispatch change).
- End-to-end (DB-free): registered a leaked mock **and** a real pool in `config`, then called `__cleanup__()` — it no longer throws and still closes the real pool (verified the mock **is** `isa SQLConn`, so the buggy path is genuinely exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
