### PR TITLE
fix(#116): rebuild table to drop an FK field on SQLite (DROP COLUMN can't)

### DIFF
--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -68,13 +68,15 @@ The exact on-disk file layout, checksum algorithm, and tracking-table columns ar
 ## Database-Specific Behavior
 
 ### SQLite: Table Recreation
-SQLite has limited `ALTER TABLE` support (it cannot change types or modify nullability/unique constraints directly on existing tables). 
+SQLite has limited `ALTER TABLE` support. It can rename tables/columns and add or drop plain columns, but it **cannot** change a column's type, modify nullability/`UNIQUE`/`CHECK` constraints in place, remove a foreign key (there is no `ALTER TABLE ... DROP CONSTRAINT`), or `DROP COLUMN` on a column that participates in a `FOREIGN KEY`.
 
-To handle these types of changes, PormG automatically:
-- Creates a new temporary table with the desired schema.
-- Migrates existing data from the old table to the new one.
-- Re-creates indexes and foreign keys.
-- Drops the old table and renames the new one.
+To handle any of those changes, PormG automatically rebuilds the table from your model:
+- Creates a new table with the desired schema.
+- Copies existing data from the old table into it (surviving columns only).
+- Re-creates the surviving indexes and foreign keys — an index on a *dropped* column is **not** re-created.
+- Drops the old table, renames the new one, and runs `PRAGMA foreign_key_check` to catch orphaned rows.
+
+The rebuild is emitted as plain DDL that composes with the migration's transaction, so no data is lost and the remaining indexes and constraints are preserved. This is what makes **removing a foreign-key field or constraint** work on SQLite even though `DROP COLUMN`/`DROP CONSTRAINT` alone cannot express it. Changes SQLite *can* do in place — adding a column, or dropping a column that is not part of a foreign key — use `ALTER TABLE` directly, without a rebuild.
 
 This process is transparent to the user but may take longer on very large tables.
 

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -455,15 +455,36 @@ Return the `CREATE INDEX` DDL for every *user-created* secondary index on `table
 they are recreated automatically by the rebuilt `CREATE TABLE`. Used by the SQLite table-rebuild path to
 re-create the indexes that the rebuild's `DROP TABLE` would otherwise silently lose (#82).
 """
-function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Symbol})::Vector{String}
+function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Symbol};
+                                  surviving_columns::Union{Nothing,Set{String}} = nothing)::Vector{String}
   tname = replace(string(table_name), "'" => "''")
-  rows = fetch(conn, "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '$(tname)' AND sql IS NOT NULL") |> DataFrame
+  # `name` is fetched alongside `sql` so we can probe each index's columns via pragma_index_info
+  # when filtering (#116). Auto-created indexes (UNIQUE/PK) carry a NULL `sql` and are excluded here,
+  # exactly as before — they belong to the CREATE TABLE the rebuild already re-emits.
+  rows = fetch(conn, "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '$(tname)' AND sql IS NOT NULL") |> DataFrame
   isempty(rows) && return String[]
   ddls = String[]
-  for s in rows.sql
+  for r in eachrow(rows)
+    s = r.sql
     s === missing && continue
     stmt = strip(string(s))
     isempty(stmt) && continue
+    # #116: when the caller is rebuilding a table with columns removed (FK-field deletion), an index on a
+    # dropped column must NOT be re-created — SQLite would raise "no such column". `pragma_index_info`
+    # gives the index's exact indexed-column membership (robust vs. substring-matching the DDL text); drop
+    # the index if any of its columns is no longer present in the rebuilt table. No filtering when the
+    # kwarg is `nothing`, so every existing rebuild call site keeps its current behavior.
+    #
+    # Known limitation: `pragma_index_info` reports NULL for an *expression* column and does not list a
+    # *partial* index's WHERE-clause columns, so a user-created expression/partial index over a dropped
+    # column would slip through and fail the rebuild. Accepted for #116: PormG only ever emits plain
+    # single/multi-column indexes (create_index in Dialect.jl), which pragma_index_info covers exactly.
+    if surviving_columns !== nothing
+      idxname = replace(string(r.name), "'" => "''")
+      cols = fetch(conn, "SELECT name FROM pragma_index_info('$(idxname)')") |> DataFrame
+      referenced = String[string(c) for c in cols.name if c !== missing]
+      any(c -> !(c in surviving_columns), referenced) && continue
+    end
     push!(ddls, endswith(stmt, ";") ? stmt : stmt * ";")
   end
   return ddls

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -45,12 +45,23 @@ end
 # same way. The check is SCOPED to the rebuilt table (not the whole DB) so an unrelated pre-existing orphan
 # elsewhere can't fail this migration; the rename preserves the table name + PKs, so children of this table
 # stay valid and need no check.
-function _sqlite_rebuild_preserving_indexes(conn, table_name::String, rebuild_sql::AbstractString)::String
+function _sqlite_rebuild_preserving_indexes(conn, table_name::String, rebuild_sql::AbstractString;
+                                            surviving_columns::Union{Nothing,Set{String}} = nothing)::String
   (!(conn isa PormGSQLite) || isempty(rebuild_sql)) && return String(rebuild_sql)
-  idx_ddls = get_secondary_index_ddls(conn, table_name)
+  # #116: when the rebuild removes columns (FK-field deletion), pass the rebuilt table's columns so an
+  # index on a just-dropped column isn't re-created ("no such column"). `nothing` (the default) preserves
+  # every live index, i.e. the pre-#116 behavior for pure alterations where no column disappears.
+  idx_ddls = get_secondary_index_ddls(conn, table_name; surviving_columns = surviving_columns)
   safe_tbl = replace(table_name, "\"" => "\"\"")
   return join(String[String(rebuild_sql); idx_ddls; "PRAGMA foreign_key_check(\"$(safe_tbl)\");"], "\n")
 end
+
+# Physical column names (db_column when set, else field name) of a model's rebuilt table — the exact set
+# `alter_field(::PormGSQLite, model, …)` writes into the new CREATE TABLE / INSERT (see Dialect.jl). Passed
+# as `surviving_columns` to `_sqlite_rebuild_preserving_indexes` so index preservation stays column-aware
+# across a rebuild that drops a column (#116).
+_model_physical_columns(model::PormGModel)::Set{String} =
+  Set(Models.field_db_column(f, string(k)) for (k, f) in model.fields)
 
 function _drop_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, field_name::String, new_field::Union{PormGField, Nothing}, old_field::PormGField)::Nothing
   if hasfield(old_field |> typeof, :to) && old_field.db_constraint && (new_field === nothing || !hasfield(new_field |> typeof, :to) || !new_field.db_constraint)
@@ -197,7 +208,8 @@ function _add_new_field(conn::Union{PormGPostgres, PormGSQLite}, migration_plan:
     # existing secondary indexes too (no-op on PostgreSQL).
     _configure_order_dict_migration_plan(migration_plan, model_name, alter_key,
       _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
-        Dialect.alter_field(conn, model, field_name, field, nothing, [:default])))
+        Dialect.alter_field(conn, model, field_name, field, nothing, [:default]);
+        surviving_columns = _model_physical_columns(model)))
   end
   return nothing
 end
@@ -299,7 +311,8 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
         # #82: on SQLite this preserves the table's secondary indexes across the rebuild and gates on
         # foreign_key_check (no-op on PostgreSQL). See _sqlite_rebuild_preserving_indexes.
         alter_sql = _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
-          Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal))
+          Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal);
+          surviving_columns = _model_physical_columns(current_schema[model_name][:model]))
         _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, alter_sql)
 
         # Check if the field is a foreign key
@@ -389,14 +402,49 @@ function _resolve_table_fields(
     filter!(x -> x != field_name_sym, colect_addition)
   end
   if !isempty(colect_deletion)
-    for field_name_sym in colect_deletion
-      field_name = field_name_sym |> string
-      _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name, nothing, model.fields[model_fields_map[field_name]])
-      _drop_index(conn, migration_plan, model_name, field_name)
-      _configure_order_dict_migration_plan(migration_plan, model_name, "Remove field: $field_name", 
-      Dialect.drop_field(conn, model_name, field_name))
+    # #116: On SQLite an FK column can't be removed with `ALTER TABLE DROP COLUMN` (SQLite forbids it and
+    # has no `ALTER TABLE DROP CONSTRAINT`), so deleting an FK field needs a full table rebuild. The rebuild
+    # is generated from `current_model`, which already omits EVERY deleted field, so ONE rebuild drops all of
+    # this table's deleted columns (and their FKs/indexes) at once. Therefore if ANY deleted field forces a
+    # rebuild, route the WHOLE table's deletions through it and skip the per-column DROP COLUMNs — emitting
+    # both would race: the rebuild removes the column, then a separate `DROP COLUMN "<other>"` for a
+    # sibling deletion fails "no such column" (order-dependent on the deletion set's iteration).
+    fk_delete_idx = nothing
+    if conn isa PormGSQLite
+      fk_delete_idx = findfirst(colect_deletion) do fsym
+        f = model.fields[model_fields_map[string(fsym)]]
+        hasfield(typeof(f), :to) && f.db_constraint
+      end
+    end
+    if fk_delete_idx !== nothing
+      # `alter_field(::PormGSQLite, model, …)` rebuilds the table purely from `model.fields`; its
+      # field_name/new_field/old_field/colect_not_equal arguments are unused for the SQLite recreation, so a
+      # representative deleted field is passed only to satisfy the shared signature. `surviving_columns` keeps
+      # the dropped columns' indexes off the preserved set (see _sqlite_rebuild_preserving_indexes). The
+      # stable "Alter table:" key means a co-occurring alteration/add-default collapses into this one
+      # idempotent recreation from the same desired model.
+      rebuild_field = model.fields[model_fields_map[string(colect_deletion[fk_delete_idx])]]
+      _configure_order_dict_migration_plan(migration_plan, model_name, "Alter table: $model_name",
+        _sqlite_rebuild_preserving_indexes(conn, current_model.name |> lowercase,
+          Dialect.alter_field(conn, current_model, string(colect_deletion[fk_delete_idx]), rebuild_field, rebuild_field, Symbol[]);
+          surviving_columns = _model_physical_columns(current_model)))
+    else
+      # PostgreSQL, or SQLite with no FK-column deletions: plain DROP COLUMN works (the FK drop runs first on
+      # PostgreSQL; the index is pre-dropped so SQLite can drop an ordinary column).
+      for field_name_sym in colect_deletion
+        field_name = field_name_sym |> string
+        old_field = model.fields[model_fields_map[field_name]]
+        _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name, nothing, old_field)
+        _drop_index(conn, migration_plan, model_name, field_name)
+        _configure_order_dict_migration_plan(migration_plan, model_name, "Remove field: $field_name",
+        Dialect.drop_field(conn, model_name, field_name))
+      end
     end
   end
+  # `_configure_order_dict_migration_plan` returns the created OrderedDict when it makes a fresh table
+  # entry; the FK-rebuild branch above ends on that call, so return `nothing` explicitly to satisfy this
+  # function's `::Nothing` contract (otherwise Julia tries to `convert(Nothing, OrderedDict)` and errors).
+  return nothing
 end
 
 function _colect_numbered_fields(colect::Vector{Symbol})

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -402,6 +402,159 @@ end
     PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 900;""")
   end
 
+  # ── Phase 4c: Delete a live FK field (#116) ───────────────────────
+  # Sibling of #83: #83 dropped an FK *constraint* via field alteration; this deletes the whole FK
+  # *field*. On SQLite `ALTER TABLE DROP COLUMN` refuses a column bound by a FOREIGN KEY, so the
+  # deletion path must route through the same model-based table rebuild the alteration path uses —
+  # which omits the deleted column + its FK clause and preserves the survivors. It also exercises the
+  # column-aware index filter: an FK field is db_index=true by default, so a naïve rebuild would try to
+  # re-create the dropped column's index and fail "no such column" (the Django #33899 crash).
+  #
+  # Uses a DEDICATED child table with TWO FKs defined in CREATE TABLE (guaranteed-live, indexed FKs) plus
+  # a plain `doomed` column. The deletion removes BOTH the `drop_id` FK field AND the non-FK `doomed`
+  # column in one migration — exercising that a single table rebuild drops every removed column at once (a
+  # per-column DROP COLUMN for `doomed` after the rebuild would race with "no such column"). `keep_id`
+  # (sibling FK) and `label` survive. Placed after 4b so it can't disturb 4b's baseline; the leftover table
+  # is swept away by Phase 5's model redefinition. Runs on both backends (PostgreSQL takes the plain
+  # DROP CONSTRAINT + DROP COLUMN path; SQLite takes the rebuild).
+  @testset "Phase 4c: Delete Foreign Key Field (#116)" begin
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        keep_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true),
+        drop_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true),
+        doomed = Models.CharField(null=true),
+        label = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # Baseline: the new table has TWO live FKs (both created via CREATE TABLE) and the doomed column.
+    @assert foreign_key_count(pool, "childfktable") == 2 "Phase 4c requires two live FKs on childfktable"
+    @test "drop_id" in column_names(pool, "childfktable")
+    @test "doomed" in column_names(pool, "childfktable")
+
+    # Seed a parent + child; keep_id/label carry data that must survive the rebuild.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "migrationtest" ("id", "name") VALUES (920, 'fk-parent-116');""")
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "childfktable" ("id", "keep_id", "drop_id", "doomed", "label") VALUES (921, 920, 920, 'gone-116', 'child-116');""")
+
+    # Desired model: delete BOTH the `drop_id` FK field and the plain `doomed` column (keep keep_id + label).
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        keep_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true),
+        label = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+
+    # AC2: the generated plan must not embed its own transaction control (composes with the runner tx).
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    # AC1: this must NOT raise (pre-fix, SQLite `DROP COLUMN "drop_id"` aborts because drop_id is an FK
+    # column; a naïve rebuild would instead fail re-creating drop_id's index — both are the #116 bug).
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # Both deleted columns are gone (drop_id via the FK-forced rebuild, doomed swept up in the same rebuild);
+    # the sibling FK column, its FK, and the remaining columns survive.
+    cols = column_names(pool, "childfktable")
+    @test !("drop_id" in cols)
+    @test !("doomed" in cols)
+    @test "keep_id" in cols
+    @test "label" in cols
+    @test foreign_key_count(pool, "childfktable") == 1   # drop_id's FK removed; keep_id's preserved
+
+    # Data fidelity: the child row survived the rebuild with its surviving values intact.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "keep_id", "label" FROM "childfktable" WHERE "id" = 921;""") |> DataFrame
+    @test nrow(surviving) == 1
+    # `isequal` (not `==`) so a would-be NULL never propagates `missing` into `@test` (house convention).
+    @test isequal(surviving[1, :keep_id], 920)
+    @test isequal(surviving[1, :label], "child-116")
+
+    # Cleanup child-then-parent so the DELETE never depends on ON DELETE CASCADE (childfktable itself is
+    # dropped later by Phase 5's model redefinition).
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "childfktable" WHERE "id" = 921;""")
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 920;""")
+  end
+
+  # ── Phase 4d: Alter a field AND delete an FK field together (#116) ─
+  # Gates the COMBINED path on one SQLite table in a single migration: the FK deletion forces a table
+  # rebuild, and the field alteration ALSO rebuilds under the same "Alter table:" key. Both must feed
+  # `surviving_columns` so the deleted FK column's index is dropped from the preserved set — if the
+  # ALTERATION-site rebuild re-created keep_id's index, `migrate` would fail "no such column: keep_id".
+  # After Phase 4c, childfktable = {id, keep_id (FK, nullable), label (nullable)}. Runs on both backends
+  # (PostgreSQL: DROP CONSTRAINT/COLUMN for keep_id + ALTER COLUMN label SET NOT NULL; SQLite: one rebuild).
+  @testset "Phase 4d: Alter Field + Delete FK Field Together (#116)" begin
+    @assert foreign_key_count(pool, "childfktable") == 1 "Phase 4d requires childfktable's keep_id FK from 4c"
+    @assert column_nullable(pool, "childfktable", "label") "Phase 4d requires label to start nullable"
+
+    # Seed a parent + child; label carries data that must survive, and must be non-NULL for SET NOT NULL.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "migrationtest" ("id", "name") VALUES (930, 'fk-parent-116d');""")
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "childfktable" ("id", "keep_id", "label") VALUES (931, 930, 'child-116d');""")
+
+    # Desired model: delete keep_id (FK) AND alter label (null=true -> null=false) in the SAME migration.
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        label = Models.CharField(null=false)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    # Must NOT raise: on SQLite the FK-delete rebuild and the label alteration collapse into one recreation
+    # whose preserved indexes exclude keep_id's (a broken alteration-site filter → "no such column: keep_id").
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    cols = column_names(pool, "childfktable")
+    @test !("keep_id" in cols)                            # FK field deleted
+    @test "label" in cols
+    @test foreign_key_count(pool, "childfktable") == 0    # keep_id's FK gone
+    @test !column_nullable(pool, "childfktable", "label") # the alteration applied: label is now NOT NULL
+
+    # Data fidelity: the row survived the combined rebuild.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "label" FROM "childfktable" WHERE "id" = 931;""") |> DataFrame
+    @test nrow(surviving) == 1
+    @test isequal(surviving[1, :label], "child-116d")
+
+    # Cleanup (childfktable is dropped by Phase 5's model redefinition).
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "childfktable" WHERE "id" = 931;""")
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 930;""")
+  end
+
   # ── Phase 5: Indexes and unique constraints ───────────────────────
   @testset "Phase 5: Indexes and Unique Constraints" begin
     write_edge_models("""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,6 +68,7 @@ end
     @testset "Positive Integer Fields CHECK" include("unit/test_positive_small_integer_check.jl")
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
+    @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")
     @testset "Migration Diff Fail-Safe (#69)" include("unit/test_migration_diff_failsafe.jl")
     @testset "Model_to_str Render Failure (#70)" include("unit/test_model_to_str_render_failure.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")

--- a/test/unit/test_sqlite_index_filter.jl
+++ b/test/unit/test_sqlite_index_filter.jl
@@ -1,0 +1,65 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Column-aware secondary-index preservation for the SQLite table rebuild (#116)
+#
+# Deleting a ForeignKey field on SQLite can't use `ALTER TABLE DROP COLUMN` (SQLite
+# refuses a column bound by a FOREIGN KEY), so PormG rebuilds the table from the
+# desired model — create new / INSERT…SELECT / drop / rename — and re-creates the
+# table's secondary indexes afterward. `get_secondary_index_ddls` snapshots those
+# index DDLs from the LIVE schema at planning time; if the rebuild dropped a column,
+# re-creating an index that references it would raise SQLite "no such column" (the
+# exact crash Django hit — ticket #33899).
+#
+# The `surviving_columns` kwarg fixes that: an index is preserved only when every one
+# of its columns still exists in the rebuilt table. It probes each index's exact
+# column membership via `pragma_index_info` (robust vs. substring-matching the DDL).
+# `nothing` (the default) disables filtering — the pre-#116 "copy every live index"
+# behavior every pure-alteration rebuild still relies on.
+#
+# Hermetic temp SQLite DB (same pattern as test_ignore_tables_registry.jl); no live
+# integration DB. Mutation gate: dropping the filter makes the `Set(["a","c"])` case
+# below return all three indexes instead of just the one on the surviving column.
+# ─────────────────────────────────────────────────────────────────────────────
+using Test
+using PormG
+using DataFrames
+import PormG.ConnectionPool: SQLiteConnectionPool, fetch, close_pool!
+import PormG.Migrations: get_secondary_index_ddls
+
+@testset "get_secondary_index_ddls column filter (#116)" begin
+  mktempdir() do dir
+    pool = SQLiteConnectionPool(joinpath(dir, "idxfilter.sqlite"); pool_size = 1)
+    try
+      fetch(pool, "CREATE TABLE t (a INTEGER, b INTEGER, c INTEGER);")
+      fetch(pool, "CREATE INDEX ia ON t(a);")          # single column a
+      fetch(pool, "CREATE INDEX ib ON t(b);")          # single column b
+      fetch(pool, "CREATE INDEX iab ON t(a, b);")      # multi-column: a AND b
+
+      # Baseline — no kwarg → every live secondary index is preserved (pre-#116 behavior).
+      all_ddls = get_secondary_index_ddls(pool, "t")
+      @test length(all_ddls) == 3
+      @test any(occursin("ia", d) for d in all_ddls)
+      @test any(occursin("ib", d) for d in all_ddls)
+      @test any(occursin("iab", d) for d in all_ddls)
+
+      # The #116 fix — column `b` was removed by the rebuild (surviving = {a, c}). Any index
+      # touching `b` must be filtered so it isn't re-created against a now-missing column:
+      #   ia(a)     → kept   (a survives)
+      #   ib(b)     → dropped (b gone)
+      #   iab(a, b) → dropped (b gone, even though a survives)
+      kept = get_secondary_index_ddls(pool, "t"; surviving_columns = Set(["a", "c"]))
+      @test length(kept) == 1
+      @test occursin("ia", kept[1])
+      @test !any(occursin("ib", d) for d in kept)      # single-column index on dropped col
+      @test !any(occursin("iab", d) for d in kept)     # multi-column index touching dropped col
+
+      # Passing the kwarg but dropping nothing (surviving ⊇ every column) filters nothing —
+      # proves the filter removes indexes ONLY for genuinely-absent columns (no false drops on
+      # the pure-alteration path, where existing rebuild tests must stay green).
+      kept_all = get_secondary_index_ddls(pool, "t"; surviving_columns = Set(["a", "b", "c"]))
+      @test length(kept_all) == 3
+    finally
+      # Release the SQLite handle so mktempdir can delete the temp DB on Windows (WAL keeps it open).
+      close_pool!(pool)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Deleting a `ForeignKey` field through a migration emitted `ALTER TABLE … DROP COLUMN` on SQLite, which
SQLite **refuses for a column bound by a `FOREIGN KEY`** — so `migrate` aborted at apply time. This is
the deletion-path sibling of #83 (which fixed the FK-constraint *alteration* path and made the SQLite
FK-drop a planning-time no-op; the deletion path then failed at `migrate` time instead).

## Fix

Route SQLite FK-field deletion through the same **model-based table rebuild** the alteration path already
uses. The desired model already omits the deleted field, so one rebuild drops the column + its `FOREIGN
KEY` clause and copies the survivors (`CREATE` new → `INSERT … SELECT` → `DROP` old → `RENAME`).

- **`src/migrations/planner.jl`** — in the deletion loop, if any deleted field is an FK-with-constraint on
  SQLite, emit **one** rebuild (under the stable `"Alter table:"` key) that drops *all* of that table's
  deleted columns, and skip the per-column `DROP COLUMN`s. Emitting both would race — the rebuild removes
  the column, then a sibling `DROP COLUMN` fails `"no such column"`, order-dependent on the deletion set's
  iteration. PostgreSQL keeps its existing `DROP CONSTRAINT` + `DROP COLUMN` path unchanged.
- **`src/migrations/introspection.jl`** — FK fields default to `db_index=true`, so the deleted column
  usually has a secondary index. The rebuild snapshots live index DDLs and re-creates them; make that
  snapshot **column-aware** (`surviving_columns`, resolved via `pragma_index_info`) so an index on a
  dropped column isn't re-created. This is the exact *"error in index after drop column: no such column"*
  crash Django hit ([ticket #33899](https://code.djangoproject.com/ticket/33899)). Default `nothing`
  preserves the pre-existing behavior for pure alterations.

The rebuild is pure DDL (no embedded `BEGIN`/`COMMIT`) so it composes with the migration runner's
transaction, ending with `PRAGMA foreign_key_check`.

## Framework precedent

Every mature migration engine rebuilds the table here, because SQLite has no `ALTER TABLE DROP
CONSTRAINT` and its `DROP COLUMN` is restricted to columns that aren't a PK / `UNIQUE` / FK / indexed:
Django's `_remake_table` (and its #33899 guard for indexed fields), Rails' "move and copy" `alter_table`,
and Alembic's SQLite batch mode. PormG doesn't need the `defer_foreign_keys`/`legacy_alter_table` dance
Rails/Django use because it runs SQLite with `foreign_keys` **OFF**, so the `DROP`/`RENAME` can't trip
enforcement — the trailing `PRAGMA foreign_key_check` validates orphans and rolls back if any.

## Acceptance criteria (from #116)

- [x] A SQLite migration that deletes an FK field succeeds (no `DROP COLUMN` failure), preserving the
      remaining columns + data + indexes.
- [x] The generated statement block contains no embedded `BEGIN`/`COMMIT`.
- [x] Regression test exercising FK-field deletion on SQLite end-to-end (analogous to #83's Phase 4b).

## Tests

- **`test/integration/test_migration_bootstrap.jl`** — two new both-backend phases on a dedicated child
  table with live FKs:
  - **Phase 4c** deletes an FK field **and** a plain column in one migration (asserts migrate succeeds,
    both columns gone, sibling FK + data survive, no `BEGIN TRANSACTION`).
  - **Phase 4d** alters a field **and** deletes an FK field on the same table (gates the alteration-site
    filter — a broken filter would fail `no such column: keep_id`).
- **`test/unit/test_sqlite_index_filter.jl`** *(new)* — direct gate for the column-aware index filter
  (single- and multi-column indexes; the no-filter default preserved).

**Results:** unit **2470/2470**, PostgreSQL (`db_2`) **1630/1630**, SQLite (`db_sl`) **1587 pass + 1
PG-only skip** — all green. Reviewed via the `pormg-changed-code-review` skill (mutation-test lens); the
two real defects found during review (a `MethodError`, an order-dependent `DROP COLUMN` race) and one
integration-caught `::Nothing`-return bug were fixed before commit.

## Docs

`docs/src/migrations/index.md` — the "SQLite: Table Recreation" section now documents that removing a
foreign-key field/constraint triggers the rebuild, that a dropped column's index is not re-created, and
that plain add/drop use `ALTER TABLE` directly.

## Out of scope (follow-up)

- Renaming an FK field whose FK constraint **also** changes on SQLite (the rename path doesn't rebuild).
- Deleting a `unique`/PK **non-FK** column on SQLite (Django rebuilds those too; PormG's non-FK path
  pre-drops a plain index, so ordinary indexed deletes work, but unique/PK is a latent sibling).
- Adding an indexed field **and** triggering any rebuild in the same migration loses the just-queued
  index (pre-existing: `get_secondary_index_ddls` snapshots only *live* indexes).

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
