### PR TITLE
chore: auto-provision worktrees (.worktreeinclude + setup script)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,6 @@
 # and the trailing CR breaks the `$`-anchored line scan (and would desync a byte-frozen
 # fixture). Pin LF so the working tree matches the index (already LF) on every platform.
 *.jl text eol=lf
+# Shell scripts must stay LF: a CRLF `#!/usr/bin/env bash\r` shebang / `set -euo\r` breaks
+# under bash on a Windows checkout (autocrlf=true would otherwise rewrite LF -> CRLF).
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ test/integration/db_test_migration_pg/migrations/
 # *connection.yml rule (top of this file) would otherwise exclude it; this negation re-includes
 # it (git last-match-wins). host/username/password are blank and hydrated in-memory at runtime.
 !test/integration/db_test_migration_pg/connection.yml
+
+# Claude Code parallel-session worktrees live here; keep their contents out of the main
+# checkout's status (they are provisioned per-worktree, see .worktreeinclude).
+.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,18 @@
+# .worktreeinclude — gitignored local state auto-copied into each new worktree at creation
+# (Claude Code feature; .gitignore syntax; only files that match a pattern AND are gitignored
+# are copied, so tracked files are never duplicated). This gives a fresh worktree the untracked
+# state it needs to load PormG and run the unit suite without any manual copying.
+#
+# NOT listed on purpose:
+#   - test/integration/db_2/migrations  — TRACKED (already present in every worktree).
+#   - test/integration/db_sl/f1.sqlite  — 42 MB + torn-WAL risk on unconditional copy; copied
+#                                          on demand (guarded) by scripts/worktree_setup.sh,
+#                                          needed only for db_sl integration runs.
+#
+# Still run after creation: `julia --project=. -e 'import Pkg; Pkg.instantiate()'`
+# (instantiate is not a file copy, so .worktreeinclude cannot do it). See scripts/worktree_setup.sh.
+
+Manifest.toml
+test/integration/db_sl/connection.yml
+test/integration/db_2/connection.yml
+test/integration/db_sl/migrations/

--- a/scripts/worktree_setup.sh
+++ b/scripts/worktree_setup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Provision a fresh PormG worktree with the untracked local state it needs to run tests:
+# the resolved Manifest (holds the LibPQ/SQLite weakdeps) and the gitignored integration
+# fixtures (connection.yml, db_sl/migrations/, and optionally f1.sqlite). Safe to re-run.
+#
+# If the repo has a `.worktreeinclude`, EnterWorktree already copies the small gitignored
+# files at creation time — then this script is only needed for `Pkg.instantiate()` and the
+# guarded `f1.sqlite` copy. It also works standalone (re-copies everything) if you created
+# the worktree with plain `git worktree add`, which does NOT process `.worktreeinclude`.
+#
+# Usage:
+#   bash scripts/worktree_setup.sh [<worktree-path>]     # defaults to $(pwd)
+#
+# The f1.sqlite copy is GUARDED: if the main checkout's fixture looks like it is being
+# written right now (recent mtime, or a non-empty -wal from a parallel session's suite), it
+# is skipped with a warning so you never copy a torn WAL — copy it by hand once idle.
+
+set -euo pipefail
+
+WT="${1:-$(pwd)}"
+WT="$(cd "$WT" && pwd)"
+
+# The main working tree is the first entry of `git worktree list`.
+MAIN="$(git -C "$WT" worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+if [[ -z "${MAIN:-}" || "$MAIN" == "$WT" ]]; then
+  echo "!! could not resolve the main checkout for worktree: $WT" >&2
+  echo "   (are you inside a worktree created from the main repo?)" >&2
+  exit 1
+fi
+echo "main checkout : $MAIN"
+echo "worktree      : $WT"
+
+copy() {  # copy SRC -> DST if SRC exists; create parent dirs
+  local src="$1" dst="$2"
+  if [[ -e "$src" ]]; then
+    mkdir -p "$(dirname "$dst")"
+    cp -r "$src" "$dst"
+    echo "  + ${src#$MAIN/}"
+  fi
+}
+
+echo "provisioning gitignored local state (idempotent; .worktreeinclude may have done these):"
+# 1) Resolved Manifest — WITHOUT this, `Pkg.instantiate` drops the LibPQ/SQLite weakdeps
+#    that test/load_drivers.jl loads by UUID.
+copy "$MAIN/Manifest.toml" "$WT/Manifest.toml"
+# 2) Always-safe, tiny fixtures. (db_2/migrations is TRACKED — already present, not copied.)
+for f in test/integration/db_sl/connection.yml \
+         test/integration/db_2/connection.yml \
+         test/integration/db_sl/migrations; do
+  copy "$MAIN/$f" "$WT/$f"
+done
+
+# 3) f1.sqlite — guarded. Skip if the source was written in the last 30s (likely an active
+#    parallel run), or if a non-empty -wal is present (an unpumped in-progress transaction).
+sl="$MAIN/test/integration/db_sl/f1.sqlite"
+if [[ -f "$sl" ]]; then
+  now=$(date +%s); busy=0
+  for s in "$sl" "$sl-wal" "$sl-shm"; do
+    [[ -e "$s" ]] || continue
+    (( now - $(stat -c %Y "$s") < 30 )) && busy=1
+  done
+  [[ -s "$sl-wal" ]] && busy=1
+  if (( busy )); then
+    echo "  ! f1.sqlite looks busy (recent write / non-empty -wal) — SKIPPED."
+    echo "    copy it manually once the other integration run is idle:"
+    echo "      cp '$sl'* '$WT/test/integration/db_sl/'"
+  else
+    for s in "$sl" "$sl-wal" "$sl-shm"; do
+      [[ -e "$s" ]] && copy "$s" "$WT/test/integration/db_sl/$(basename "$s")"
+    done
+  fi
+fi
+
+# 4) Instantiate against the copied Manifest so the weakdeps resolve.
+echo "instantiating (julia --project=.) ..."
+julia --project="$WT" -e 'import Pkg; Pkg.instantiate()'
+
+echo "done — worktree ready for unit + SQLite(db_sl) tests."
+echo "  (docs only) julia --project=docs -e 'import Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'"


### PR DESCRIPTION
## What

Auto-provision fresh worktrees so a new parallel session can load PormG and run the unit suite without the manual Manifest/fixture copying we've been doing by hand every time.

## Changes

- **`.worktreeinclude`** (repo root) — Claude Code copies these gitignored files into every new worktree at creation: `Manifest.toml`, `test/integration/db_sl/connection.yml`, `test/integration/db_2/connection.yml`, `test/integration/db_sl/migrations/`.
  - `db_2/migrations` is **tracked** (already present in every worktree) — not listed.
  - `f1.sqlite` (42 MB, gitignored) is intentionally **excluded** — an unconditional copy on every worktree is wasteful and risks a torn WAL; the setup script copies it on demand, guarded.
- **`scripts/worktree_setup.sh`** — the two things `.worktreeinclude` can't do: `Pkg.instantiate()` (not a file copy) and a **guarded** `f1.sqlite` copy (skips a fixture that a parallel session is mid-writing — recent mtime or non-empty `-wal`). Also a standalone fallback that re-copies everything for a `git worktree add` worktree (which does **not** process `.worktreeinclude`). Run with `bash scripts/worktree_setup.sh`.
- **`.gitignore`** — ignore `.claude/worktrees/` (the worktrees docs' own tip) so worktree dirs don't appear as untracked in the main checkout.

## Verification

- **Setup script, end-to-end:** ran it in a fresh worktree — it detected the main checkout, copied Manifest + both `connection.yml` + `db_sl/migrations` (218 files) + `f1.sqlite` (guard let it through since the fixture wasn't mid-write), and `Pkg.instantiate()` succeeded. Exit 0.
- **`.worktreeinclude`, static:** all four targets confirmed gitignored (so they'll be copied) and none tracked (so nothing is duplicated); the identical copy logic is what the script exercised above.
- **Live auto-copy:** activates on the first worktree created **after** this merges — new worktrees branch from `origin/main` and `.worktreeinclude` is read from the main checkout, so a pre-merge test would be a false negative (the base lacks the file). Confirm post-merge by creating a worktree and checking `ls Manifest.toml test/integration/db_sl/migrations/` in it.

No source or behavior changes; no Julia test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
