### PR TITLE
fix(models): comment out fieldless model instead of throwing at include time (#134)

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -572,7 +572,10 @@ Converts a model object to a string representation to create the model.
 - `String`: The string representation of the model object. A field whose rendering fails is
   omitted from the constructor call and surfaced instead as a `# PormG: field '<name>' … could
   not be rendered …` comment line prepended above the model definition (#70), plus a structured
-  `@warn` — never dropped silently.
+  `@warn` — never dropped silently. If *every* field fails to render (so the constructor call
+  would be fieldless), the whole model definition is emitted **commented out** with a
+  `# PormG: model '<name>' had no renderable fields …` marker instead of a throwing
+  `Models.Model("<name>")` call, so the generated file still `include`s cleanly (#134).
 
 # Examples
 ```julia
@@ -618,7 +621,17 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; c
   model_var_name = uppercasefirst(model.name)
   # Marker comments sit directly above the model definition in the generated file (#70).
   marker = isempty(render_failures) ? "" : join(render_failures, "\n") * "\n"
-  result = """$(marker)$(model_var_name) = Models.Model("$(model_name_abs)"$fields)"""
+  if fields == ""
+    # Every field failed to render (or the model has none): a bare `Models.Model("name")` call throws
+    # ArgumentError at include time (the single-arg constructor requires ≥1 field), which would abort
+    # loading the ENTIRE generated module (#134). Comment the definition out — with an explanatory
+    # marker — so the file still loads and the user sees exactly which model to fix by hand. Mirrors
+    # Rails' SchemaDumper, which comments out a table it can't dump so schema.rb stays loadable.
+    note = "# PormG: model '$(model_name_abs)' had no renderable fields — definition commented out."
+    result = """$(marker)$(note)\n# $(model_var_name) = Models.Model("$(model_name_abs)")"""
+  else
+    result = """$(marker)$(model_var_name) = Models.Model("$(model_name_abs)"$fields)"""
+  end
   @info(result)
 
   return result

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,7 +73,7 @@ end
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")
     @testset "Migration Diff Fail-Safe (#69)" include("unit/test_migration_diff_failsafe.jl")
-    @testset "Model_to_str Render Failure (#70)" include("unit/test_model_to_str_render_failure.jl")
+    @testset "Model_to_str Render Failure (#70/#134)" include("unit/test_model_to_str_render_failure.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")

--- a/test/unit/test_model_to_str_render_failure.jl
+++ b/test/unit/test_model_to_str_render_failure.jl
@@ -91,3 +91,60 @@ const RENDER_SETTINGS = PormG.Configuration.Settings()
   end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# All-fields-failed guard (#134). When EVERY field fails to render, `fields == ""` and the old
+# code still emitted a bare `Var = Models.Model("name")` line. The single-arg constructor
+# `Model(name::String)` throws ArgumentError unconditionally, so `include`-ing the generated file
+# aborted loading the ENTIRE module — every healthy model died with the one bad one. Model_to_str
+# must instead comment the definition out (with an explanatory marker), keeping the file loadable —
+# the load-time sibling of the #70 field-level fix, matching Rails' SchemaDumper per-table rescue.
+#
+# Mutation gate: reverting the `fields == ""` branch in Models.jl restores the bare throwing
+# `Model(...)` line — the `include_string` load below then throws (loaded == false) and the
+# "no bare Model call" assertion fails.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Model_to_str all-fields-failed guard (#134)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Every field raises during rendering → `fields == ""`. The model definition must be emitted
+  # commented out (with per-field markers AND a model-level note), never as a throwing call, so
+  # the generated file still loads.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "all fields fail → definition commented out, file still loads (#134)" begin
+    m = _mk_render_model(Dict{String, PormG.PormGField}(
+      "alpha" => _ThrowingRenderField(nothing),   # rendering raises UndefVarError
+      "beta"  => _ThrowingRenderField(nothing),   # rendering raises UndefVarError
+    ))
+
+    # Both fields fail, so both must still warn + surface their own marker (match_mode=:any tolerates
+    # the trailing @info that prints the final string).
+    s = @test_logs (:warn, r"field render failed") match_mode=:any PormG.Models.Model_to_str(m, RENDER_SETTINGS)
+
+    # Every failed field is still surfaced individually (the #70 per-field markers).
+    @test occursin("# PormG: field 'alpha' (ThrowingRenderField) could not be rendered", s)
+    @test occursin("# PormG: field 'beta' (ThrowingRenderField) could not be rendered", s)
+    # A model-level note explains why the whole definition is commented out.
+    @test occursin("# PormG: model 'drivers_render_scratch' had no renderable fields", s)
+    # CRUCIAL (#134): no bare, top-level `Var = Models.Model(...)` call — that line would throw at
+    # include time. The (?m) anchors ^ to line starts so the commented `# Drivers... ` doesn't match.
+    @test !occursin(r"(?m)^Drivers_render_scratch = Models\.Model\("m, s)
+    # The definition survives, commented out, for the user to fix by hand.
+    @test occursin("# Drivers_render_scratch = Models.Model(\"drivers_render_scratch\")", s)
+
+    # End-to-end load gate: the real #134 failure is at include time. Evaluate the generated string
+    # in a fresh module exactly as @import_models `include`s the generated file, and assert it does
+    # NOT throw. With the fix reverted, `s` carries the bare `Model(...)` call → include_string
+    # throws → loaded == false → this test fails.
+    mod = Module(:PormG134Test)
+    Core.eval(mod, :(import PormG.Models))
+    loaded = try
+      include_string(mod, s)
+      true
+    catch
+      false
+    end
+    @test loaded
+  end
+
+end


### PR DESCRIPTION
## Summary

When *every* field of a model failed to render in `Models.Model_to_str`, the rendered `fields` string
was empty and the function still emitted a bare `X = Models.Model("name")` line. The single-arg
constructor `Model(name::String)` throws `ArgumentError` **unconditionally**, so when the user later
`include`s the generated models file (via `@import_models`), that one throwing top-level line **aborts
loading the entire generated module** — every healthy model dies with the one bad one. This is the
load-time sibling of #70 (which surfaced *per-field* render failures as marker comments but left the
all-fields-failed case emitting a throwing call).

## Fix

`Model_to_str` now guards on `fields == ""` (the exact condition that yields a fieldless — and therefore
throwing — constructor call): it emits the model definition **commented out**, prefixed with a
`# PormG: model '<name>' had no renderable fields — definition commented out.` note (alongside the
existing per-field `# PormG: field …` markers). The generated file then loads cleanly and the user sees
exactly which model needs manual attention.

Generated output for an all-failed model:
```
# PormG: field 'alpha' (SomeField) could not be rendered: … — field omitted.
# PormG: field 'beta'  (SomeField) could not be rendered: … — field omitted.
# PormG: model 'weird_table' had no renderable fields — definition commented out.
# Weird_table = Models.Model("weird_table")
```

- **`src/Models.jl`** — `Model_to_str`: the unconditional result build gains a `fields == ""` branch;
  docstring updated. Healthy and partially-failed models are **unchanged** (they keep the existing
  constructor call via the `else` path).
- The `Model(name::String)` constructor throw is **left untouched** — it remains the correct, helpful
  error for interactive model building. This PR is strictly about *generated-file output*.

## Framework precedent

Every mature schema-introspection / model-generation tool converges on the same rule — *the generated
artifact must always load; gaps are surfaced as comments (or a non-failing variant), never as code that
throws at load time*:

- **Rails `ActiveRecord::SchemaDumper`** (the direct precedent) wraps each table dump in a `rescue` that
  writes `# Could not dump table "x" because of following <ErrorClass>` comments, so `schema.rb` stays
  valid Ruby and still loads.
- **Django `inspectdb`** degrades an unmappable column to `TextField` + `# This field type is a guess.`,
  and emits `# Unable to inspect table 'x'` for a table it can't introspect — `models.py` stays
  importable.
- **sqlacodegen** emits a non-failing `Table(...)` variant instead of a class that would blow up at
  import.

PormG already owned the field-level machinery (#70's marker + `@warn`); this PR mirrors Rails' per-table
rescue at the model level, keeping the house `# PormG:` marker convention.

## Acceptance criteria (from #134)

- [x] A model whose every field fails to render produces a generated file that still loads
      (`include` succeeds); the model definition is commented out with an explanatory marker.
- [x] Regression test: all-throwing-fields model → returned string contains the commented-out
      definition marker and no bare `= Models.Model("name")` line; healthy models unaffected.

## Tests

- **`test/unit/test_model_to_str_render_failure.jl`** — new `Model_to_str all-fields-failed guard (#134)`
  testset (DB-free), reusing the file's existing `_ThrowingRenderField` scaffolding. Asserts the
  per-field markers, the model-level note, the **absence** of a bare top-level `Model(...)` call, and —
  as an end-to-end mutation gate — `include_string`s the generated string in a fresh module and asserts
  it loads without throwing (revert the fix → the bare `Model(...)` call returns → `include_string`
  throws → the test fails). The existing #70 "healthy model → no marker, no warn" testset gates the
  negative side (healthy/partial models stay uncommented), so the guard is proven to fire only when it
  should.

**Results:** unit **2579/2579**. Integration not required — this is a DB-independent generator-output
change; the importer→generator path always injects an `IDField`, hitting the unchanged `else` branch.
Reviewed via the `pormg-changed-code-review` skill (mutation-test lens) — no blocking findings.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
