### PR TITLE
Unify the model-load resolve lifecycle (#65)

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -45,6 +45,12 @@ end
   related_column::String
   inverse_accessor::String
   reverse::Bool = false
+  # #65: resolved model objects for the two sides, populated wherever a relation is built
+  # (`_relation_from_many_to_many` for the forward relation, swapped in the reverse one). This
+  # completes the "resolve every lazy reference once" guarantee for M2M — the query builder still
+  # re-resolves by binding today; consuming these slots to retire that reflection is #68/#41.
+  owner_model_resolved::Union{PormGModel, Nothing} = nothing
+  related_model_resolved::Union{PormGModel, Nothing} = nothing
 end
 function deepcopy(model::Model_Type)
   try
@@ -62,6 +68,33 @@ function deepcopy(model::Model_Type)
     @error("Failed to deepcopy Model_Type: $(e)")
     rethrow(e)
   end
+end
+
+# #65: a ManyToManyRelation now carries resolved model objects (owner/related). Those are shared,
+# derived state — `set_models` repopulates them — so deep-copying them would needlessly clone the
+# whole related-model graph (a Model_Type's `related_objects` holds these relations, and
+# `deepcopy(model)` above recurses into it). Copy the value-type String/Bool fields; SHARE the two
+# resolved-model references. Mirrors the targeted override for SQLiteParameterizedQuery.
+function Base.deepcopy_internal(r::ManyToManyRelation, stackdict::IdDict)
+  haskey(stackdict, r) && return stackdict[r]
+  new = ManyToManyRelation(
+    field_name=r.field_name,
+    through_model=r.through_model,
+    owner_model=r.owner_model,
+    owner_binding=r.owner_binding,
+    owner_pk=r.owner_pk,
+    owner_column=r.owner_column,
+    related_model=r.related_model,
+    related_binding=r.related_binding,
+    related_pk=r.related_pk,
+    related_column=r.related_column,
+    inverse_accessor=r.inverse_accessor,
+    reverse=r.reverse,
+    owner_model_resolved=r.owner_model_resolved,
+    related_model_resolved=r.related_model_resolved,
+  )
+  stackdict[r] = new
+  return new
 end
 
 #═══════════════════════════════════════════════════════════════════════════════
@@ -195,18 +228,10 @@ function set_models(_module::Module, path::String)::Nothing
     # println(model.name)
     for (field_name, field) in pairs(model.fields)
       if field isa sForeignKey || field isa sOneToOneField
-        field_to::Union{PormGModel, Nothing} = _resolve_target_model(field.to, _module)
-        field_to === nothing && throw(ArgumentError("The model $(field.to) in the field $field_name in the model $(model.name) is not defined"))
-        # #62: persist the resolved target so `fk_target_column` honors a referenced
-        # parent's db_column for string-declared FKs too. Idempotent on reload (a model
-        # `.to` resolves to itself); the rest of this loop keeps using the local `field_to`.
-        field.to = field_to
-        if field.pk_field === nothing
-          pk_sym = get_model_pk_field(field_to)
-          if pk_sym !== nothing
-            field.pk_field = string(pk_sym)
-          end
-        end
+        # #65: single-sourced FK/O2O resolution + pk_field defaulting, shared with the migration
+        # prelude via `resolve_fk_target!`. strict=true throws on an unresolvable target, so the
+        # returned value is always a resolved model here; it drives the reverse-relation wiring below.
+        field_to::PormGModel = resolve_fk_target!(field, field_name, model.name, _module; strict=true)
         if haskey(dict_tables_c, field_to.name)
           dict_tables_c[field_to.name] += 1
           push!(dict_tables_fiels[field_to.name], field_name)
@@ -448,6 +473,42 @@ function _resolve_target_model(to, mod::Module)::Union{PormGModel, Nothing}
     e isa UndefVarError ? nothing : rethrow()
   end
   return m isa PormGModel ? m : nothing
+end
+
+"""
+    resolve_fk_target!(field, field_name, model_name, lookup; strict) -> Union{PormGModel, Nothing}
+
+Single source (#65) of the FK/O2O "resolve target → write-back `field.to` → default `pk_field`" step that
+both model-load lifecycles share — the runtime path (`set_models`) and the migration prelude
+(`_load_current_models` → `_resolve_fk_targets_and_pk!`). Side-effect-free with respect to globals: it
+mutates only `field.to`/`field.pk_field`, never `REGISTERED_MODULES`, `Configuration`, or reverse relations.
+
+`strict=true` (runtime) throws `ArgumentError` on an unresolvable target; `strict=false` (migrations) is
+best-effort — it leaves `field.to` a string, emits a `@debug`, and returns `nothing`, which skips the
+`pk_field` default (so an unresolved field keeps both its string `.to` and a `nothing` `.pk_field`, matching
+the pre-#65 migration behavior). The statement order is load-bearing: the strict throw fires *before* the
+write-back so the message still names the originally-declared target string.
+
+`field` is left untyped because `sForeignKey`/`sOneToOneField` are defined later in the load order (in
+`models/fields.jl`); both call sites already guard with `field isa sForeignKey || field isa sOneToOneField`,
+so only FK/O2O fields (which carry `.to`/`.pk_field`) ever reach here.
+"""
+function resolve_fk_target!(field, field_name::AbstractString,
+                            model_name::AbstractString, lookup::Module; strict::Bool)::Union{PormGModel, Nothing}
+  resolved = _resolve_target_model(field.to, lookup)
+  if resolved === nothing
+    strict && throw(ArgumentError("The model $(field.to) in the field $field_name in the model $model_name is not defined"))
+    @debug "makemigrations: FK target $(field.to) of field $field_name in model $model_name is not a model binding in the models module; leaving as a string"
+    return nothing
+  end
+  # #62: persist the resolved target so `fk_target_column` honors a referenced parent's db_column for
+  # string-declared FKs too. Idempotent on reload (a resolved `.to` resolves to itself).
+  field.to = resolved
+  if field.pk_field === nothing
+    pk_sym = get_model_pk_field(resolved)
+    pk_sym !== nothing && (field.pk_field = string(pk_sym))
+  end
+  return resolved
 end
 
 # Resolve a field-name string to its physical column within `model` (db_column when
@@ -1254,6 +1315,10 @@ function _relation_from_many_to_many(
     related_column=related_column,
     inverse_accessor=inverse_accessor,
     reverse=false,
+    # #65: persist the already-resolved model objects (both sides arrive here resolved from either
+    # load lifecycle) so the relation is a fully-resolved reference, not just strings.
+    owner_model_resolved=owner_model,
+    related_model_resolved=related_model,
   )
 end
 
@@ -1271,6 +1336,9 @@ function _reverse_many_to_many_relation(relation::ManyToManyRelation, reverse_ac
     related_column=relation.owner_column,
     inverse_accessor=relation.field_name,
     reverse=true,
+    # #65: swap the resolved sides to match the swapped string fields above.
+    owner_model_resolved=relation.related_model_resolved,
+    related_model_resolved=relation.owner_model_resolved,
   )
 end
 

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -678,14 +678,15 @@ end
 return models
 end
 
-# #62: Shared makemigrations prelude — load the code models for a schema diff, then
+# #62/#65: Shared makemigrations prelude — load the code models for a schema diff, then
 # resolve string FK/O2O targets to model objects and default `pk_field`. The planner
 # loads models into a throwaway module via `Base.include` and never runs `set_models`
 # (deliberately, to keep diffing free of `set_models`' global side effects), so the
 # resolution `set_models` does at runtime must be reproduced here — otherwise a
 # string-declared FK, or any FK with an omitted `pk_field`, would not honor a referenced
-# parent's `db_column` in the generated DDL. Both backends call this; see Follow-up
-# (#65) for collapsing the two load lifecycles into one.
+# parent's `db_column` in the generated DDL. #65: that resolution is now single-sourced —
+# both this prelude and `set_models` call `Models.resolve_fk_target!`, so the two load
+# lifecycles can no longer drift. Both backends call this.
 function _load_current_models(path::String)::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}
   temp_module = Module(:TemporaryModels)
   Base.include(temp_module, path)
@@ -695,29 +696,21 @@ function _load_current_models(path::String)::Dict{Symbol, Dict{Symbol, Union{Boo
   return current_models
 end
 
-# Resolve each code model's FK/O2O targets against `models_module` (write-back) and
-# default a missing `pk_field` to the parent's primary key. Best-effort: an unresolvable
-# string target is left as-is (e.g. a cross-module reference whose verbatim fallback is
-# already correct) with a `@debug`, never breaking the run. The runtime path's strict
-# throw lives in `set_models`, so typos surface loudly there first.
+# Resolve each code model's FK/O2O targets against `models_module` (write-back) and default a
+# missing `pk_field`, by delegating each field to the shared `Models.resolve_fk_target!` (#65).
+# Best-effort (strict=false): an unresolvable string target is left as-is (e.g. a cross-module
+# reference whose verbatim fallback is already correct) with a `@debug`, never breaking the run.
+# The runtime path's strict throw lives in `set_models`, so typos surface loudly there first.
 function _resolve_fk_targets_and_pk!(current_models::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, models_module::Module)::Nothing
   for (_, entry) in current_models
     model = entry[:model]
     model isa PormGModel || continue
     for (field_name, field) in pairs(model.fields)
       (field isa Models.sForeignKey || field isa Models.sOneToOneField) || continue
-      if !(field.to isa PormGModel)
-        resolved = Models._resolve_target_model(field.to, models_module)
-        if resolved === nothing
-          @debug "makemigrations: FK target $(field.to) of field $field_name in model $(model.name) is not a model binding in the models module; leaving as a string"
-          continue
-        end
-        field.to = resolved
-      end
-      if field.pk_field === nothing
-        pk_sym = Models.get_model_pk_field(field.to)
-        pk_sym !== nothing && (field.pk_field = string(pk_sym))
-      end
+      # #65: delegate to the single shared resolver. Best-effort (strict=false): an unresolvable
+      # string target is left as-is with a @debug (its verbatim db-column fallback stays correct),
+      # and the pk_field default is skipped — identical to the pre-#65 migration behavior.
+      Models.resolve_fk_target!(field, string(field_name), model.name, models_module; strict=false)
     end
   end
   return nothing

--- a/test/unit/test_db_column.jl
+++ b/test/unit/test_db_column.jl
@@ -356,6 +356,53 @@ end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # #65: `resolve_fk_target!` is the SINGLE source of FK/O2O resolution + pk_field
+  # defaulting that BOTH load lifecycles (runtime `set_models`, the migration prelude)
+  # call. These assertions lock the two axes that matter: (A) on a resolvable target the
+  # strict and best-effort modes are byte-for-byte equivalent — the anti-drift guarantee;
+  # if a future edit lets the runtime and migration paths diverge, (A) breaks. (B)
+  # strictness is the ONLY behavioral difference, and only on an unresolvable target.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "resolve_fk_target! single-sources FK resolution (#65)" begin
+    rfk = PormG.Models.resolve_fk_target!
+
+    # Parent whose PK carries a db_column, plus two IDENTICAL children (string FK target,
+    # no pk_field) — one driven strict (runtime mode), one best-effort (migration mode).
+    r65_parent   = Model("r65_parent", code = IDField(db_column="parent_code"), label = CharField(null=true))
+    r65_child_s  = Model("r65_child_s", id = IDField(), parent = ForeignKey("R65Parent", db_column="pfk", null=true))
+    r65_child_b  = Model("r65_child_b", id = IDField(), parent = ForeignKey("R65Parent", db_column="pfk", null=true))
+    r65_orphan_s = Model("r65_orphan_s", id = IDField(), ref = ForeignKey("R65NoSuch", db_column="rfk", null=true))
+    r65_orphan_b = Model("r65_orphan_b", id = IDField(), ref = ForeignKey("R65NoSuch", db_column="rfk", null=true))
+    mod = Module(:r65_resolver_module)
+    Core.eval(mod, :(const R65Parent = $r65_parent))   # the only resolvable binding in `mod`
+
+    # (A) Anti-drift: strict=true (runtime) and strict=false (migration) agree on a resolvable target.
+    gs = rfk(r65_child_s.fields["parent"], "parent", "r65_child_s", mod; strict=true)
+    gb = rfk(r65_child_b.fields["parent"], "parent", "r65_child_b", mod; strict=false)
+    @test gs === r65_parent === gb                                       # same resolved model object
+    @test r65_child_s.fields["parent"].to === r65_child_b.fields["parent"].to === r65_parent
+    @test r65_child_s.fields["parent"].pk_field == r65_child_b.fields["parent"].pk_field == "code"
+    @test fk_target_column(r65_child_s.fields["parent"]) == fk_target_column(r65_child_b.fields["parent"]) == "parent_code"
+
+    # Idempotent: re-resolving an already-resolved field is a no-op (safe on set_models re-runs / reload).
+    @test rfk(r65_child_s.fields["parent"], "parent", "r65_child_s", mod; strict=true) === r65_parent
+    @test r65_child_s.fields["parent"].to === r65_parent
+    @test r65_child_s.fields["parent"].pk_field == "code"
+
+    # (B) Strictness is the only axis of difference — and only on an UNRESOLVABLE target.
+    #  best-effort: nothing returned, `.to` left a string, pk_field NOT defaulted (the continue-skip).
+    @test rfk(r65_orphan_b.fields["ref"], "ref", "r65_orphan_b", mod; strict=false) === nothing
+    @test r65_orphan_b.fields["ref"].to == "R65NoSuch"
+    @test r65_orphan_b.fields["ref"].pk_field === nothing
+    #  strict: throws ArgumentError naming the target, the field, and the model — and does NOT write back
+    #  (the message must still name the originally-declared string, so the throw precedes the write-back).
+    err = try; rfk(r65_orphan_s.fields["ref"], "ref", "r65_orphan_s", mod; strict=true); nothing; catch e; e; end
+    @test err isa ArgumentError
+    @test occursin("R65NoSuch", err.msg) && occursin("field ref", err.msg) && occursin("model r65_orphan_s", err.msg)
+    @test r65_orphan_s.fields["ref"].to == "R65NoSuch"                   # strict throw did NOT mutate the field
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Serializer: a model-instance `.to` serializes to the SAME string a user would have
   # declared (uppercasefirst(model.name)) — the write-back can't change snapshot output.
   # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -257,3 +257,40 @@ end
   # Positive control: the guard did NOT break real M2M accessor dispatch.
   @test M2M.Driver_championship.drivers isa PormG.QueryBuilder.ManyToManyDescriptor
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #65: a ManyToManyRelation now carries the two sides as resolved model objects,
+# populated wherever a relation is built (`_relation_from_many_to_many`), and swapped
+# in the reverse relation. `ManyToManyUnitModels` above already ran `set_models`, so the
+# relations are fully wired. This completes the "resolve every lazy reference once"
+# guarantee for M2M; the query builder doesn't consume the slots yet (that is #68/#41).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ManyToManyRelation carries resolved model slots (#65)" begin
+  # Forward relation (owner = Driver_championship, related = Driver), from the owner's cache.
+  fwd = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
+  @test fwd.owner_model_resolved === M2M.Driver_championship
+  @test fwd.related_model_resolved === M2M.Driver
+
+  # Reverse relation (stored on the related model under the inverse accessor) — slots swapped
+  # to match the swapped string fields, so each side still names its own model.
+  rev = Models.get_many_to_many_relation(M2M.Driver, "championships")
+  @test rev.reverse
+  @test rev.owner_model_resolved === M2M.Driver
+  @test rev.related_model_resolved === M2M.Driver_championship
+
+  # deepcopy SHARES the resolved slots (the deepcopy_internal override) instead of cloning the
+  # related-model graph. This is also REQUIRED for correctness: a resolved model carries a
+  # `_module::Module`, and Julia cannot deepcopy a Module — so without the override, deep-copying
+  # a relation (e.g. via deepcopy(model.related_objects)) would throw "deepcopy of Modules not
+  # supported". The override copies the value fields and shares the two model references.
+  fwd_copy = deepcopy(fwd)
+  @test fwd_copy.owner_model_resolved === M2M.Driver_championship  # same object (===), not a clone
+  @test fwd_copy.related_model_resolved === M2M.Driver
+  @test fwd_copy.field_name == fwd.field_name                      # value fields still deep-copied
+
+  # A relation-bearing model whose own fields are all scalar (Driver is the M2M target) still
+  # deep-copies cleanly — its related_objects reverse relation routes through the same override.
+  # Guards that adding the resolved slots did not regress model deepcopy for such models.
+  dc_driver = deepcopy(M2M.Driver)
+  @test Models.get_many_to_many_relation(dc_driver, "championships").related_model_resolved === M2M.Driver_championship
+end


### PR DESCRIPTION
## Summary

PormG resolved each model's lazy references (string FK/O2O/M2M targets → model objects, `pk_field`
defaulting) in **two independent load lifecycles**, with the resolution loop **copied** into each:

- **Runtime** — `set_models` (`src/Models.jl`).
- **Migration** — `_load_current_models` → `_resolve_fk_targets_and_pk!` (`src/migrations/planner.jl`), which
  deliberately reproduces the runtime resolution *without* `set_models`' global side effects (to keep schema
  diffing pure).

Because the driver loop was duplicated, the two copies could **drift** — the literal root of two #62-era bugs
(string FK targets resolved at runtime but not in migrations; the migration path never defaulting `pk_field`,
emitting `REFERENCES parent("id")` churn). #62 single-sourced the *leaf helpers*; this PR single-sources the
**driver loop** and closes the parallel M2M gap.

This is the internal refactor of #65's "Proposal" plus its "M2M-resolution half." It is **behavior-preserving**
and **de-risks the later hot-path reflection retirement (#68/#41)**, which stays out of scope.

## How other ORMs do this

Mature ORMs converge on one rule: **resolve every lazy reference once, at a single unmissable point, then
downstream code assumes fully-resolved models — never re-resolving per query.**

- **Django `apps.populate()`** (the issue's cited analog): one idempotent, ordered population pass; string
  model references resolve *once*, after every model registers, via `lazy_related_operation()`.
- **SQLAlchemy `configure_mappers()`** (the direct structural analog): string `relationship("Target")` targets
  resolve in one pass against the class registry — **pure metadata resolution, no session/engine side effects**,
  exactly what the migration path needs (a shared resolve core it can call without `set_models`' globals).
- **EF Core `FinalizeModel()`**: build once, then **freeze** into an immutable model that's never mutated
  per query.

## Part 1 — single-sourced FK/O2O resolution

New `Models.resolve_fk_target!(field, field_name, model_name, lookup; strict)` is the one place that does
"resolve `field.to` → write-back → default `pk_field`". Side-effect-free w.r.t. globals. Both `set_models`
(`strict=true`) and the migration prelude (`strict=false`) delegate to it, so the two lifecycles **can no
longer drift**. The `strict` flag preserves the exact prior split — runtime throws on an unresolvable target,
migrations stay best-effort (`@debug` + skip the `pk_field` default). Statement order is load-bearing: the
strict throw fires *before* the write-back, so the message still names the originally-declared target string.

## Part 2 — M2M resolved-model slot (the "M2M-resolution half")

FK/O2O `field.to` was already written back to a resolved `PormGModel`, but `ManyToManyRelation` stored only
strings — so every query-time M2M site re-resolves by reflection. This PR adds
`owner_model_resolved`/`related_model_resolved`, populated in `_relation_from_many_to_many` (which **both**
lifecycles build every relation through) and swapped in `_reverse_many_to_many_relation`.

A targeted `Base.deepcopy_internal(::ManyToManyRelation, ::IdDict)` **shares** those model references instead
of cloning the schema graph. This is **required for correctness**, not just an optimization: a resolved model
carries a `_module`, which Julia cannot deepcopy — so without the override, deep-copying any relation (e.g. via
`deepcopy(model.related_objects)`) would throw `deepcopy of Modules not supported`. With it, model-deepcopy
behavior is identical to `main`.

The query builder is **untouched** — it still re-resolves M2M by binding; consuming these slots to retire that
reflection is #68/#41. Part 2's value is completing the "single resolution point" and pre-staging that work.

## Scope / out of scope

- **Internal refactor only** — no public API, schema, or migration-format change; behavior-preserving.
- **Out of scope:** retiring the hot-path `invokelatest`/`getfield` reflection (this PR *pre-stages* it; the
  query-builder change is #68/#41); a fully-merged single `load()` entry point (the two lifecycles' load halves
  differ structurally — throwaway module + `Dict` vs. existing module + `Vector`).

## Tests (lock EQUIVALENCE — a behavior-preserving refactor)

- **Full unit suite: 2601/2601** (2579 baseline + 22 new), DB-free.
- `test/unit/test_db_column.jl` — **anti-drift equivalence** (strict ≡ best-effort resolve `.to`/`pk_field`/
  `fk_target_column` identically on a resolvable target — *this assertion is the #65 guarantee*), **strictness
  is the only difference** + locked throw message, idempotency on re-resolve, and no-mutation-on-throw.
- `test/unit/test_many_to_many.jl` — resolved-slot population (forward + swapped reverse via `===` on real
  model objects) and **deepcopy sharing** (would throw `deepcopy of Modules not supported` without the override).

Mutation lens: revert the single-sourcing and let one lifecycle drift → the `==` equivalence chains break;
remove the deepcopy override → the M2M deepcopy test errors.

## Residual observation (advisory, out of scope)

`deepcopy` of a model whose *fields* reference other models (e.g. `deepcopy(Driver_championship)`, whose
`ManyToManyField.to` is a model instance) fails on `_module` — this **predates #65** and is unrelated; the new
tests steer around it. Possible future follow-up if model-graph deepcopy is ever needed.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
