### PR TITLE
fix(migrations): rebuild SQLite table when a renamed FK field's constraint changes (#150)

### DIFF
--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -454,9 +454,16 @@ Return the `CREATE INDEX` DDL for every *user-created* secondary index on `table
 `sqlite_master`. Auto-indexes backing column-level `UNIQUE` constraints have a NULL `sql` and are excluded —
 they are recreated automatically by the rebuilt `CREATE TABLE`. Used by the SQLite table-rebuild path to
 re-create the indexes that the rebuild's `DROP TABLE` would otherwise silently lose (#82).
+
+`column_renames` (old ⇒ new physical name) supports the rename-with-FK-change rebuild (#150): the DDL is
+snapshotted from the LIVE schema at planning time (old column name), but the rebuilt table carries the new
+name, so each renamed column is mapped through this dict both when testing `surviving_columns` membership
+(else the renamed column's index would be wrongly filtered out and lost) and when rewriting the emitted DDL.
+Default empty ⇒ no rewriting, so every existing #82/#116 call site is unaffected.
 """
 function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Symbol};
-                                  surviving_columns::Union{Nothing,Set{String}} = nothing)::Vector{String}
+                                  surviving_columns::Union{Nothing,Set{String}} = nothing,
+                                  column_renames::Dict{String,String} = Dict{String,String}())::Vector{String}
   tname = replace(string(table_name), "'" => "''")
   # `name` is fetched alongside `sql` so we can probe each index's columns via pragma_index_info
   # when filtering (#116). Auto-created indexes (UNIQUE/PK) carry a NULL `sql` and are excluded here,
@@ -482,8 +489,16 @@ function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Sy
     if surviving_columns !== nothing
       idxname = replace(string(r.name), "'" => "''")
       cols = fetch(conn, "SELECT name FROM pragma_index_info('$(idxname)')") |> DataFrame
-      referenced = String[string(c) for c in cols.name if c !== missing]
+      # #150: the live index references the OLD column name; map it to the rebuilt table's new name
+      # before the membership test so a renamed-but-surviving column keeps its index.
+      referenced = String[get(column_renames, string(c), string(c)) for c in cols.name if c !== missing]
       any(c -> !(c in surviving_columns), referenced) && continue
+    end
+    # #150: rewrite renamed columns in the snapshotted DDL. PormG emits quoted identifiers
+    # (create_index in Dialect.jl), so replacing the quoted `"old"` token is precise — it can't
+    # touch the index name or table name. Empty dict ⇒ no-op for the #82/#116 call sites.
+    for (oldc, newc) in column_renames
+      stmt = replace(stmt, "\"$oldc\"" => "\"$newc\"")
     end
     push!(ddls, endswith(stmt, ";") ? stmt : stmt * ";")
   end

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -46,12 +46,15 @@ end
 # elsewhere can't fail this migration; the rename preserves the table name + PKs, so children of this table
 # stay valid and need no check.
 function _sqlite_rebuild_preserving_indexes(conn, table_name::String, rebuild_sql::AbstractString;
-                                            surviving_columns::Union{Nothing,Set{String}} = nothing)::String
+                                            surviving_columns::Union{Nothing,Set{String}} = nothing,
+                                            column_renames::Dict{String,String} = Dict{String,String}())::String
   (!(conn isa PormGSQLite) || isempty(rebuild_sql)) && return String(rebuild_sql)
   # #116: when the rebuild removes columns (FK-field deletion), pass the rebuilt table's columns so an
   # index on a just-dropped column isn't re-created ("no such column"). `nothing` (the default) preserves
   # every live index, i.e. the pre-#116 behavior for pure alterations where no column disappears.
-  idx_ddls = get_secondary_index_ddls(conn, table_name; surviving_columns = surviving_columns)
+  # #150: `column_renames` (old ⇒ new physical name) maps a renamed column so its live index survives the
+  # filter and is re-created under the new name; empty (the default) for every non-rename rebuild.
+  idx_ddls = get_secondary_index_ddls(conn, table_name; surviving_columns = surviving_columns, column_renames = column_renames)
   safe_tbl = replace(table_name, "\"" => "\"\"")
   return join(String[String(rebuild_sql); idx_ddls; "PRAGMA foreign_key_check(\"$(safe_tbl)\");"], "\n")
 end
@@ -62,6 +65,22 @@ end
 # across a rebuild that drops a column (#116).
 _model_physical_columns(model::PormGModel)::Set{String} =
   Set(Models.field_db_column(f, string(k)) for (k, f) in model.fields)
+
+# #150: true when the FK definition differs between the old and the desired field — the signal that a
+# renamed FK field also needs a SQLite table rebuild (RENAME COLUMN alone keeps the old FK clause). Covers
+# an FK being added/removed by the rename (incl. a db_constraint true⇄false flip) and, when both sides are
+# live FKs, a change of target model, target column, or on_delete. Reuses the same FK comparison the
+# alteration path uses (`Models._compare_field_foreign_key` / `Models.fk_target_column`).
+function _fk_definition_changed(new_field::PormGField, old_field::PormGField)::Bool
+  new_fk = hasfield(typeof(new_field), :to) && new_field.db_constraint
+  old_fk = hasfield(typeof(old_field), :to) && old_field.db_constraint
+  new_fk != old_fk && return true
+  (new_fk && old_fk) || return false
+  return !Models._compare_field_foreign_key(new_field, old_field) ||
+         Models.fk_target_column(new_field) != Models.fk_target_column(old_field) ||
+         (hasfield(typeof(new_field), :on_delete) && hasfield(typeof(old_field), :on_delete) &&
+          new_field.on_delete != old_field.on_delete)
+end
 
 function _drop_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, field_name::String, new_field::Union{PormGField, Nothing}, old_field::PormGField)::Nothing
   if hasfield(old_field |> typeof, :to) && old_field.db_constraint && (new_field === nothing || !hasfield(new_field |> typeof, :to) || !new_field.db_constraint)
@@ -388,11 +407,37 @@ function _resolve_table_fields(
           return
         end
         old_field_name = old_field_sym |> string
-        _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, old_field_name, current_model.fields[current_fields_map[field_name]], model.fields[model_fields_map[old_field_name]])
-        !current_model.fields[current_fields_map[field_name]].primary_key && _drop_index(conn, migration_plan, model_name, old_field_name)
-        _configure_order_dict_migration_plan(migration_plan, model_name, "Rename field: $field_name", 
-        Dialect.rename_field(conn, model_name, old_field_name, field_name))
-        _add_constrains(conn, migration_plan, model_name, current_model, field_name, current_model.fields[current_fields_map[field_name]], _hash_field_name(model_name, field_name))
+        new_field = current_model.fields[current_fields_map[field_name]]
+        old_field = model.fields[model_fields_map[old_field_name]]
+        if conn isa PormGSQLite && _fk_definition_changed(new_field, old_field)
+          # #150: on SQLite the FK clause lives inside CREATE TABLE and `RENAME COLUMN` keeps the OLD clause,
+          # so a rename whose FK definition ALSO changes needs the same model-based table rebuild the
+          # alteration (#83) and deletion (#116) paths use. RENAME COLUMN is emitted FIRST so the rebuild's
+          # INSERT..SELECT — which copies by the NEW physical name — finds the column; the rebuild then
+          # re-creates the table from `current_model` with the new FK clause, preserving the secondary
+          # indexes (renamed via `column_renames`) under the stable "Alter table:" key. A plain FK rename
+          # (no FK change) takes the cheap path below — SQLite updates the FK's local column reference
+          # natively. Co-occurring field DELETIONS on this table are handled: the deletion loop below defers
+          # to this rebuild (which already drops every removed column). Residual limitation: a co-occurring
+          # field ALTERATION re-emits "Alter table:" WITHOUT column_renames (the renamed column's index may
+          # be dropped), and a second rename/addition on the same table is unsupported (the rebuild copies by
+          # `current_model`'s names, which the other change hasn't applied to the old table yet) — both rare,
+          # and both fail safely (the runner transaction rolls back). Tracked as a #150 follow-up.
+          old_phys = Models.field_db_column(old_field, old_field_name)
+          _configure_order_dict_migration_plan(migration_plan, model_name, "Rename field: $field_name",
+          Dialect.rename_field(conn, model_name, old_field_name, field_name))
+          _configure_order_dict_migration_plan(migration_plan, model_name, "Alter table: $model_name",
+          _sqlite_rebuild_preserving_indexes(conn, current_model.name |> lowercase,
+            Dialect.alter_field(conn, current_model, field_name, new_field, old_field, Symbol[]);
+            surviving_columns = _model_physical_columns(current_model),
+            column_renames = Dict(old_phys => field_name)))
+        else
+          _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, old_field_name, new_field, old_field)
+          !new_field.primary_key && _drop_index(conn, migration_plan, model_name, old_field_name)
+          _configure_order_dict_migration_plan(migration_plan, model_name, "Rename field: $field_name",
+          Dialect.rename_field(conn, model_name, old_field_name, field_name))
+          _add_constrains(conn, migration_plan, model_name, current_model, field_name, new_field, _hash_field_name(model_name, field_name))
+        end
         # Update model.fields to reflect rename to avoid double processing if needed
         model.fields[model_fields_map[old_field_name]] = model.fields[model_fields_map[old_field_name]] # effectively stays same but we can update key if we want to sync
         # remove the old field from colect_deletion
@@ -401,7 +446,14 @@ function _resolve_table_fields(
     end      
     filter!(x -> x != field_name_sym, colect_addition)
   end
-  if !isempty(colect_deletion)
+  # #150: a rename-with-FK-change may already have scheduled a full SQLite rebuild for this model (keyed
+  # "Alter table: $model_name"). That rebuild is generated from `current_model`, which omits EVERY deleted
+  # field, so it already drops this table's remaining deletions. Running the per-column deletion handling
+  # below as well would emit `DROP COLUMN "<other>"` for a column the rebuild already removed ("no such
+  # column"), so defer to the rebuild when it is present (SQLite only; PostgreSQL uses plain DROP COLUMN).
+  sqlite_rename_rebuild = conn isa PormGSQLite && haskey(migration_plan, model_name) &&
+    haskey(migration_plan[model_name], "Alter table: $model_name")
+  if !isempty(colect_deletion) && !sqlite_rename_rebuild
     # #116: On SQLite an FK column can't be removed with `ALTER TABLE DROP COLUMN` (SQLite forbids it and
     # has no `ALTER TABLE DROP CONSTRAINT`), so deleting an FK field needs a full table rebuild. The rebuild
     # is generated from `current_model`, which already omits EVERY deleted field, so ONE rebuild drops all of
@@ -448,11 +500,15 @@ function _resolve_table_fields(
 end
 
 function _colect_numbered_fields(colect::Vector{Symbol})
+  # Number the rename candidates in a deterministic (name-sorted) order so the prompt — and the index the
+  # user answers with — is stable across runs regardless of the underlying set-iteration order. Sorting a
+  # copy leaves the caller's `colect_deletion` untouched (it's still needed for the later `filter!`).
+  colect = sort(colect, by = string)
   colect_numbered = Dict{Int64, Symbol}()
   for (index, field_name) in enumerate(colect)
     colect_numbered[index] = field_name
   end
-  return colect_numbered, join([string(index, " - ", colect[index]) for index in keys(colect_numbered)], ", ")
+  return colect_numbered, join([string(index, " - ", colect_numbered[index]) for index in sort(collect(keys(colect_numbered)))], ", ")
 end
 function _get_temporary_default_value(field::PormGField, settings::SQLConn)
   if field |> typeof == Models.sDateTimeField

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -555,6 +555,214 @@ end
     PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 930;""")
   end
 
+  # ── Phase 4e: Rename an FK field whose FK constraint also changes (#150) ─
+  # The rename-path sibling of #83/#116. On SQLite the FK clause lives inside CREATE TABLE, so a plain
+  # `RENAME COLUMN` keeps the OLD constraint; renaming an FK field while ALSO changing its FK — here
+  # flipping db_constraint true→false, i.e. dropping the constraint — must route through the same
+  # model-based table rebuild. Before the fix, SQLite renamed the column but silently KEPT the FK
+  # (foreign_key_count stays 1); after, the rebuild drops it (→ 0) with data + the field's secondary index
+  # preserved (the index is re-created against the RENAMED column via `column_renames`, so a broken rewrite
+  # would fail "no such column"). PostgreSQL is clean either way (DROP CONSTRAINT + RENAME COLUMN). Field-
+  # rename detection is INTERACTIVE (readline), so the rename step feeds the confirmation number via a
+  # redirected stdin. Uses a dedicated child table; carries childfktable through unchanged so the setup is
+  # a pure table-ADD (no add/remove pairing ⇒ no table-rename prompt to consume the fed answer).
+  @testset "Phase 4e: Rename FK Field + Change FK Constraint (#150)" begin
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        label = Models.CharField(null=false)
+    )
+    RenameFKChild = Models.Model(
+        id = Models.IDField(),
+        old_parent_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_index=true),
+        note = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # Baseline: one live FK on the indexed old_parent_id column, plus the field's secondary index (db_index).
+    @assert foreign_key_count(pool, "renamefkchild") == 1 "Phase 4e requires a live FK on renamefkchild"
+    @test "old_parent_id" in column_names(pool, "renamefkchild")
+    idx_before = index_names(pool, "renamefkchild")
+    @assert !isempty(idx_before) "Phase 4e requires the db_index secondary index on the FK field"
+
+    # Seed a parent + child row whose FK value must survive the rebuild.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "migrationtest" ("id", "name") VALUES (940, 'fk-parent-150');""")
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "renamefkchild" ("id", "old_parent_id", "note") VALUES (941, 940, 'child-150');""")
+
+    # Desired: RENAME old_parent_id → new_parent_id AND flip db_constraint true→false (drop the FK) in the
+    # same migration. Everything else is identical so the only interactive decision is this one field rename.
+    write_edge_models("""
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        label = Models.CharField(null=false)
+    )
+    RenameFKChild = Models.Model(
+        id = Models.IDField(),
+        new_parent_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_index=true, db_constraint=false),
+        note = Models.CharField(null=true)
+    )
+    """)
+
+    # Field-rename detection is interactive: feed "1" (old_parent_id is the sole rename candidate) to the
+    # readline prompt via a redirected stdin. EOF would yield "no" ⇒ a loud failure below, never a hang.
+    mktemp() do _path, io
+      write(io, "1\n"); flush(io); seekstart(io)
+      redirect_stdin(io) do
+        makemigrations(joinpath(@__DIR__, edge_db_name), interactive=true)
+      end
+    end
+
+    # AC2: the generated block carries no embedded transaction control (composes with the runner tx).
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    # Must NOT raise. Pre-fix on SQLite the rename emitted only RENAME COLUMN (no rebuild); the rebuild here
+    # re-creates the field's secondary index against the RENAMED column, so a broken column_renames rewrite
+    # would abort with "no such column: old_parent_id".
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # The column is renamed and the FK constraint change took effect on BOTH backends.
+    cols = column_names(pool, "renamefkchild")
+    @test !("old_parent_id" in cols)
+    @test "new_parent_id" in cols
+    @test foreign_key_count(pool, "renamefkchild") == 0   # #150: FK actually dropped (was silently kept on SQLite)
+    # The field's secondary index survived the rebuild (count preserved, not lost to the DROP TABLE)…
+    @test length(index_names(pool, "renamefkchild")) == length(idx_before)
+    # …and on SQLite it now references the RENAMED column — direct proof the `column_renames` rewrite ran
+    # (a naïve rebuild would have re-created it against old_parent_id and aborted "no such column").
+    if adapter_name == "SQLite"
+      idxcols = String[]
+      for idx in index_names(pool, "renamefkchild")
+        info = PormG.ConnectionPool.fetch(pool, """PRAGMA index_info("$(idx)");""") |> DataFrame
+        append!(idxcols, string.(info.name))
+      end
+      @test "new_parent_id" in idxcols
+      @test !("old_parent_id" in idxcols)
+    end
+
+    # Data fidelity: the child row survived with its (renamed) FK value intact.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "new_parent_id", "note" FROM "renamefkchild" WHERE "id" = 941;""") |> DataFrame
+    @test nrow(surviving) == 1
+    # `isequal` (not `==`) so a would-be NULL never propagates `missing` into `@test` (house convention).
+    @test isequal(surviving[1, :new_parent_id], 940)
+    @test isequal(surviving[1, :note], "child-150")
+
+    # Cleanup child-then-parent (renamefkchild is dropped by Phase 5's model redefinition).
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "renamefkchild" WHERE "id" = 941;""")
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 940;""")
+  end
+
+  # ── Phase 4f: Rename FK field (constraint change) + delete another field, same migration (#150) ─
+  # Regression for the co-occurrence the rename-rebuild must handle: renaming an FK field whose constraint
+  # changes AND deleting a DIFFERENT field on the SAME table in one migration. The rebuild is generated from
+  # `current_model` (which already omits the deleted field), so the deletion loop must DEFER to it — emitting
+  # a separate `DROP COLUMN` for the already-removed column would abort "no such column" on SQLite (the bug
+  # this phase guards). Carries the prior phases' tables forward unchanged so adding RenameDelChild is a pure
+  # table-ADD (no table-rename prompt). PostgreSQL takes RENAME COLUMN + DROP CONSTRAINT + DROP COLUMN.
+  @testset "Phase 4f: Rename FK Field + Delete Field Together (#150)" begin
+    base_models = """
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        label = Models.CharField(null=false)
+    )
+    RenameFKChild = Models.Model(
+        id = Models.IDField(),
+        new_parent_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_index=true, db_constraint=false),
+        note = Models.CharField(null=true)
+    )
+    """
+    # Setup: add RenameDelChild with a live FK (link_id) plus a doomed non-FK column.
+    write_edge_models(base_models * """
+    RenameDelChild = Models.Model(
+        id = Models.IDField(),
+        link_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true),
+        zztombstone = Models.CharField(null=true),
+        note = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    @assert foreign_key_count(pool, "renamedelchild") == 1 "Phase 4f requires a live FK on renamedelchild"
+    @assert "zztombstone" in column_names(pool, "renamedelchild") "Phase 4f requires the doomed column"
+
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "migrationtest" ("id", "name") VALUES (950, 'fk-parent-150f');""")
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "renamedelchild" ("id", "link_id", "zztombstone", "note") VALUES (951, 950, 'gone', 'child-150f');""")
+
+    # Desired: rename link_id → link_ref_id (flip db_constraint true→false) AND delete zztombstone.
+    write_edge_models(base_models * """
+    RenameDelChild = Models.Model(
+        id = Models.IDField(),
+        link_ref_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_constraint=false),
+        note = Models.CharField(null=true)
+    )
+    """)
+
+    # Interactive: the sole addition (link_ref_id) prompts once with the name-sorted deletion candidates
+    # "1 - link_id, 2 - zztombstone" (sorting is now deterministic, see _colect_numbered_fields); feed "1"
+    # to map it onto link_id, leaving zztombstone as a pure deletion on the same table.
+    mktemp() do _path, io
+      write(io, "1\n"); flush(io); seekstart(io)
+      redirect_stdin(io) do
+        makemigrations(joinpath(@__DIR__, edge_db_name), interactive=true)
+      end
+    end
+
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    # Must NOT raise: pre-fix on SQLite the deletion loop emitted `DROP COLUMN "zztombstone"` AFTER the
+    # rename-rebuild already dropped it → "no such column". The deletion-loop skip defers to the rebuild.
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    cols = column_names(pool, "renamedelchild")
+    @test !("link_id" in cols)        # renamed away
+    @test "link_ref_id" in cols       # renamed to
+    @test !("zztombstone" in cols)    # deleted in the SAME migration (handled by the rebuild, not a DROP COLUMN)
+    @test foreign_key_count(pool, "renamedelchild") == 0   # FK dropped by the db_constraint flip
+
+    # Data fidelity: the row survived the combined rebuild with its renamed FK value intact.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "link_ref_id", "note" FROM "renamedelchild" WHERE "id" = 951;""") |> DataFrame
+    @test nrow(surviving) == 1
+    @test isequal(surviving[1, :link_ref_id], 950)
+    @test isequal(surviving[1, :note], "child-150f")
+
+    # Cleanup child-then-parent (renamedelchild is dropped by Phase 5's model redefinition).
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "renamedelchild" WHERE "id" = 951;""")
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 950;""")
+  end
+
   # ── Phase 5: Indexes and unique constraints ───────────────────────
   @testset "Phase 5: Indexes and Unique Constraints" begin
     write_edge_models("""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,7 @@ end
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")
+    @testset "FK Rename Rebuild Gate (#150)" include("unit/test_fk_rename_rebuild.jl")
     @testset "Migration Diff Fail-Safe (#69)" include("unit/test_migration_diff_failsafe.jl")
     @testset "Model_to_str Render Failure (#70/#134)" include("unit/test_model_to_str_render_failure.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")

--- a/test/unit/test_fk_rename_rebuild.jl
+++ b/test/unit/test_fk_rename_rebuild.jl
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# #150: `_fk_definition_changed` — the gate that decides whether a *renamed* FK field also needs a SQLite
+# table rebuild.
+#
+# On SQLite a foreign-key clause lives inside `CREATE TABLE`, and a plain `ALTER TABLE … RENAME COLUMN`
+# keeps the OLD clause. So renaming an FK field whose FK *definition* also changes has to route through a
+# full table rebuild (like the #83 alteration and #116 deletion paths), while a plain FK rename must keep
+# the cheap RENAME COLUMN path — SQLite updates the FK's local-column reference natively. This predicate is
+# what distinguishes the two: it must fire for every kind of FK-definition change and stay quiet otherwise.
+#
+# Pure logic over two field structs — no DB, no dispatch — so every branch is covered deterministically
+# here; the end-to-end rebuild is exercised by test/integration Phase 4e/4f.
+# ─────────────────────────────────────────────────────────────────────────────
+using Test
+using PormG
+const _M = PormG.Models
+import PormG.Migrations: _fk_definition_changed
+
+@testset "_fk_definition_changed (#150)" begin
+    fk       = _M.ForeignKey("MigrationTest", on_delete=_M.CASCADE, null=true)
+    fk_same  = _M.ForeignKey("MigrationTest", on_delete=_M.CASCADE, null=true)                 # identical FK
+    fk_nocon = _M.ForeignKey("MigrationTest", on_delete=_M.CASCADE, null=true, db_constraint=false)
+    fk_retgt = _M.ForeignKey("SecondTable",   on_delete=_M.CASCADE, null=true)                 # different parent
+    fk_ondel = _M.ForeignKey("MigrationTest", on_delete=_M.SET_NULL, null=true)                # different on_delete
+    ch       = _M.CharField(null=true)
+
+    # No change ⇒ false, so a plain FK rename keeps the cheap RENAME COLUMN path (no needless rebuild).
+    @test _fk_definition_changed(fk_same, fk) == false
+    # A non-FK-to-non-FK rename is never a rebuild trigger.
+    @test _fk_definition_changed(ch, _M.CharField()) == false
+
+    # Every genuine FK-definition change ⇒ true (each would otherwise silently keep the old clause on SQLite).
+    @test _fk_definition_changed(fk_nocon, fk) == true    # db_constraint flip true→false (drop the constraint)
+    @test _fk_definition_changed(fk, ch)       == true    # FK added by the rename   (old non-FK → new FK)
+    @test _fk_definition_changed(ch, fk)       == true    # FK removed by the rename (old FK → new non-FK)
+    @test _fk_definition_changed(fk_retgt, fk) == true    # repoint to a different parent (the issue's headline case)
+    @test _fk_definition_changed(fk_ondel, fk) == true    # on_delete change, both sides still live FKs
+end

--- a/test/unit/test_sqlite_index_filter.jl
+++ b/test/unit/test_sqlite_index_filter.jl
@@ -63,3 +63,56 @@ import PormG.Migrations: get_secondary_index_ddls
     end
   end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #150: rename-aware index preservation via the `column_renames` kwarg.
+#
+# When a rename-with-FK-change rebuilds the table, `get_secondary_index_ddls` still
+# snapshots the LIVE (pre-rename) index DDL — with the OLD column name — but the
+# rebuilt table carries the NEW name. `column_renames` (old ⇒ new) maps each renamed
+# column so its index (a) survives the `surviving_columns` filter (keyed on the NEW
+# names) and (b) is re-created with the new column name. PormG emits quoted
+# identifiers (create_index in Dialect.jl), so the rewrite targets the quoted `"old"`
+# token — precise enough to leave an index NAME that merely contains the column
+# substring untouched.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "get_secondary_index_ddls column_renames (#150)" begin
+  mktempdir() do dir
+    pool = SQLiteConnectionPool(joinpath(dir, "idxrename.sqlite"); pool_size = 1)
+    try
+      fetch(pool, "CREATE TABLE t (old_col INTEGER, keep INTEGER);")
+      # Index name deliberately CONTAINS the column substring, to prove the quoted-token
+      # rewrite touches only the parenthesised column reference, never the name.
+      fetch(pool, "CREATE INDEX \"old_col_ix\" ON \"t\" (\"old_col\");")
+      fetch(pool, "CREATE INDEX \"multi_ix\" ON \"t\" (\"old_col\", \"keep\");")
+
+      renames = Dict("old_col" => "new_col")
+      surviving = Set(["new_col", "keep"])   # the rebuilt table's physical columns (post-rename)
+
+      # Without the map, `surviving` is keyed on the NEW names while the live index still
+      # references `old_col`, so BOTH indexes are filtered out — i.e. the renamed column's
+      # index would be silently lost. This is exactly what column_renames must prevent.
+      lost = get_secondary_index_ddls(pool, "t"; surviving_columns = surviving)
+      @test isempty(lost)
+
+      # With the map: both indexes survive (old_col maps onto the surviving new_col) and the
+      # emitted DDL references the NEW column name.
+      kept = get_secondary_index_ddls(pool, "t"; surviving_columns = surviving, column_renames = renames)
+      @test length(kept) == 2
+      for ddl in kept
+        @test occursin("\"new_col\"", ddl)      # column rewritten to the new name
+        @test !occursin("\"old_col\"", ddl)     # no bare old-column ref remains (name is not a match)
+      end
+      # The index NAME "old_col_ix" (contains the substring) is preserved verbatim — the
+      # quoted-token rewrite matched only the column, never the name.
+      @test any(occursin("\"old_col_ix\"", d) for d in kept)
+      @test any(occursin("\"keep\"", d) for d in kept)   # untouched column in the multi-col index
+
+      # Mutation gate: drop the DDL rewrite and `"old_col"` stays in the output → the
+      # `!occursin("\"old_col\"")` checks fail. Drop the filter mapping and `kept` goes empty.
+    finally
+      # Release the SQLite handle so mktempdir can delete the temp DB on Windows (WAL keeps it open).
+      close_pool!(pool)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

On SQLite a foreign-key clause lives inside `CREATE TABLE`, so a plain `ALTER TABLE … RENAME COLUMN` keeps the **old** clause. Renaming a `ForeignKey` field whose FK definition **also changes** (repoint `to`, change `on_delete`, or flip `db_constraint`) therefore renamed the column but silently dropped the constraint change — the rename branch called `_add_constrains`, whose FK sub-branch is PostgreSQL-only, so on SQLite nothing rebuilt the table (and, contrary to the issue text, it didn't even warn). This is the rename-path sibling of #83 (FK-constraint alteration) and #116 (FK-field deletion). PostgreSQL was unaffected — a real PG/SQLite divergence.

## Fix

The SQLite rename branch now detects an FK-definition change (`_fk_definition_changed`) and routes it through the **same model-based table rebuild** #83/#116 already use:

- `RENAME COLUMN` is emitted **first** so the rebuild's `INSERT … SELECT` (which copies by the new physical name) finds the column;
- then a rebuild from `current_model` carries the new FK clause and preserves the table's secondary indexes, renamed via a new `column_renames` kwarg on `get_secondary_index_ddls` / `_sqlite_rebuild_preserving_indexes`;
- a **plain** FK rename (no FK change) keeps the cheap `RENAME COLUMN` path — SQLite updates the FK's local-column reference natively.

PostgreSQL behaviour is unchanged (the non-SQLite path is byte-for-byte the prior code).

**Why this shape:** SQLite has no in-place way to alter a column's constraints, so every mature ORM does a "move-and-copy" rebuild for this — Django (`_remake_table`), Alembic/SQLAlchemy ("batch mode"), Rails (`SQLite3Adapter#alter_table`). PormG's existing rebuild helper *is* that mechanism; this just wires the rename path into it.

## Review-driven robustness (same PR)

- **Deletion co-occurrence:** the deletion loop now defers to a scheduled rename-rebuild, so renaming an FK field *and* deleting another field on the same table in one migration no longer emits a `DROP COLUMN` for an already-removed column (`no such column`) — the rebuild reconciles all deletions.
- **Deterministic rename prompts:** interactive rename candidates are now numbered in a stable (name-sorted) order (better UX + testable).

## Tests

- **Unit:** `_fk_definition_changed` across every branch (`test/unit/test_fk_rename_rebuild.jl`); `column_renames` DDL-rewrite + filter mapping (`test/unit/test_sqlite_index_filter.jl`).
- **Integration (both backends):** Phase 4e — rename an FK field + flip `db_constraint` (FK dropped, column renamed, data + index preserved, no embedded `BEGIN`/`COMMIT`); Phase 4f — rename + co-deletion in one migration.

**Verification:** unit **2594/2594**; SQLite edge cases **145/145**; PostgreSQL edge cases **139/139**.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
