### PR TITLE
fix(#139): don't release the transaction connection before ROLLBACK

### DIFF
--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -441,14 +441,19 @@ If you need finer control (e.g., manual `SAVEPOINT` or multi-statement blocks), 
 - **`with_tx_context(conn_pool, conn::LibPQ.Connection, block)`**: Install a connection in thread-local storage so child tasks inherit it.
 - **`with_transaction(settings, sql, conn=nothing, release_conn=false)`**: Execute raw SQL inside a transaction context.
 - **`get_tx_connection()`**: Check if a transaction context is active and return the connection.
+- **`finalize_transaction_connection!(settings, conn; rollback_error=nothing)`**: Return `conn` to the pool exactly once from a terminal `finally`. Pass `rollback_error=nothing` when the COMMIT succeeded or the cleanup ROLLBACK ran cleanly; pass the caught error when the cleanup ROLLBACK itself threw, and a non-benign one causes the connection to be renewed or discarded instead of released.
 
 ### Example: Manual Savepoint
 
 ```julia
-import PormG.Configuration: with_tx_context, with_transaction, get_tx_connection
+import PormG.Configuration: with_tx_context, get_tx_connection
+import PormG.ConnectionPool: with_transaction, finalize_transaction_connection!
 
 settings = PormG.Configuration.get_settings("db_2")
 result, conn = with_transaction(settings, "BEGIN;")
+# Return the connection to the pool exactly once, in a single terminal `finally`, so a failed
+# COMMIT never hands it back before your cleanup ROLLBACK runs on it (#139).
+rollback_error = nothing
 try
   with_tx_context(settings.connections, conn) do
     # Insert first batch
@@ -464,21 +469,29 @@ try
       (M.Result.objects).create("raceid" => i, "driverid" => 2, ...)
     end
     
-    # If this fails, we can rollback just the second batch
+    # If this fails, we can roll back just the second batch
     if some_validation_error
       with_transaction(settings, "ROLLBACK TO sp1;", conn=conn)
     end
   end
   
-  # Commit
-  with_transaction(settings, "COMMIT;", conn=conn, release_conn=true)
+  # Commit — release_conn=false: the finally owns the single release.
+  with_transaction(settings, "COMMIT;", conn=conn, release_conn=false)
 catch e
-  with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=true)
+  # Roll back on the still-leased connection; capture a rollback failure so the finally
+  # renews/discards the connection instead of releasing it, then rethrow the original error.
+  try
+    with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=false)
+  catch rollback_err
+    rollback_error = rollback_err
+  end
   rethrow(e)
+finally
+  finalize_transaction_connection!(settings, conn; rollback_error=rollback_error)
 end
 ```
 
-**Important:** When manually managing connections, always pair `get_tx_connection()` calls with `release_conn=true` so the pool recovers the connection.
+**Important:** When you hand-roll a `BEGIN`/`COMMIT`/`ROLLBACK` lifecycle, do the cleanup ROLLBACK on the *still-leased* connection and return it to the pool exactly once from a single `finally` via `finalize_transaction_connection!`, as above. Running `COMMIT`/`ROLLBACK` with `release_conn=true` releases the connection *even when the statement fails*, which can hand it back to the pool before your ROLLBACK runs on it — a use-after-release race (#139). Prefer `run_in_transaction`, which does all of this for you.
 
 ---
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -13,7 +13,7 @@ import PormG: backend_connect, backend_renew_connection, backend_is_alive, backe
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, with_savepoint
-export acquire_connection, release_connection
+export acquire_connection, release_connection, finalize_transaction_connection!
 export PoolTimeoutError
 # NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
 # `close_pool!` (it dispatches on a pool OR a db-name String and delegates the pool case to
@@ -561,6 +561,32 @@ as `TaskFailedException`, whose `string()` does not include the driver message.
 _is_benign_rollback_error(pool::Union{PormGPostgres, PormGSQLite}, e) =
   pool isa PormGSQLite && occursin("no transaction is active", string(_unwrap_async_exception(e)))
 
+"""
+    finalize_transaction_connection!(pool, conn; rollback_error=nothing) -> Nothing
+
+Terminal step of a manually-driven `BEGIN`/`COMMIT`/`ROLLBACK` lifecycle: return `conn` to the
+pool exactly once. Pass `rollback_error=nothing` when the COMMIT succeeded or the cleanup ROLLBACK
+ran cleanly. If `rollback_error` is supplied — the cleanup ROLLBACK threw — and it is not a benign
+"no transaction is active" error, `conn` may still hold an open/aborted transaction that the acquire
+liveness probe cannot detect, so it is renewed or discarded instead of released (#71).
+
+Call this from a single terminal `finally`, exactly as `run_in_transaction` does, so a lifecycle
+never releases its connection to the pool before its ROLLBACK has run on it — the release-then-
+rollback use-after-release race of #139. Never throws: it runs while the transaction's original
+error is propagating.
+"""
+function finalize_transaction_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn; rollback_error = nothing)
+  if rollback_error !== nothing && !_is_benign_rollback_error(pool, rollback_error)
+    _renew_or_discard_connection!(pool, conn)
+  else
+    release_connection(pool, conn)
+  end
+  return nothing
+end
+# SQLConn overload — delegates to the underlying pool, mirroring with_transaction(::SQLConn).
+finalize_transaction_connection!(pool::SQLConn, conn; rollback_error = nothing) =
+  finalize_transaction_connection!(pool.connections, conn; rollback_error = rollback_error)
+
 # A statement that ends the current transaction (plain ROLLBACK) — deliberately NOT
 # "ROLLBACK TO SAVEPOINT", which keeps the outer transaction alive and must never
 # trigger connection renewal.
@@ -1058,7 +1084,7 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
     acquire_connection(pool)
   end
   tx_started = false
-  rollback_failed = false
+  local rollback_error = nothing
   try
     # Begin transaction
     if pool isa PormGPostgres
@@ -1099,27 +1125,27 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
           task = sqlite_execute_async(pool, conn, "ROLLBACK;", nothing)
           Base.fetch(task)
         end
-      catch rollback_error
-        if _is_benign_rollback_error(pool, rollback_error)
-          # SQLite already auto-rolled-back; the connection is clean → the finally
-          # releases it normally.
-        else
-          # The connection may still hold an open/aborted transaction that the acquire
-          # liveness probe cannot detect. It must NOT return to the pool as-is (#71);
-          # the finally renews or discards it instead.
-          rollback_failed = true
-          @error "Failed to rollback transaction; connection will be renewed before returning to the pool" exception=_unwrap_async_exception(rollback_error)
+      catch rb
+        # Capture the rollback error so the finally can decide release-vs-renew (a benign
+        # SQLite "no transaction is active" is clean → released; anything else may leave the
+        # connection with an open/aborted transaction → renewed or discarded, #71).
+        rollback_error = rb
+        # This re-classifies the error that `finalize_transaction_connection!` also classifies in
+        # the finally — intentional, not a leftover: the "will be renewed" log must fire here in the
+        # catch, while the actual release/renew decision lives in the terminal finally. The cost is
+        # one extra cheap string check on the (rare) rollback-failure path. Alternatives (a bool
+        # passed to the helper, or logging inside it) either force `_is_benign_rollback_error` into
+        # the migration/delete submodules or perturb the log the #71 tests assert — both worse.
+        if !_is_benign_rollback_error(pool, rb)
+          @error "Failed to rollback transaction; connection will be renewed before returning to the pool" exception=_unwrap_async_exception(rb)
         end
       end
     end
     root === e ? rethrow() : throw(root)
   finally
-    if rollback_failed
-      # Never releases the dirty handle; never throws (the original error keeps propagating).
-      _renew_or_discard_connection!(pool, conn)
-    else
-      release_connection(pool, conn)
-    end
+    # Single terminal release/renew, shared with the migration/delete lifecycles (#139).
+    # Never releases a dirty handle; never throws (the original error keeps propagating).
+    finalize_transaction_connection!(pool, conn; rollback_error = rollback_error)
   end
 end
 

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -14,7 +14,7 @@ using JSON
 import OrderedCollections: OrderedDict
 import Random: randstring
 import SHA
-import PormG.ConnectionPool: fetch, with_transaction, with_sqlite_write_lock
+import PormG.ConnectionPool: fetch, with_transaction, with_sqlite_write_lock, finalize_transaction_connection!
 import PormG.Configuration
 import PormG.Configuration: get_settings
 using Logging

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -11,7 +11,7 @@ import PormG: PormGsuffix, PormGtransform, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
-import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task
+import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task, finalize_transaction_connection!
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,
 	get_sqlite_reserved_primary_key_max, register_sqlite_reserved_primary_key_max!,
 	get_settings as get_configuration_settings

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -854,37 +854,50 @@ function _execute_migration_lifecycle(connection::PormGPostgres, settings::SQLCo
   end
 
   # Begin transaction
-  result, conn = with_transaction(connection, "BEGIN;")
-  
+  _, conn = with_transaction(connection, "BEGIN;")
+  # Release/renew the transaction connection exactly once, in a single terminal finally, so a
+  # failed COMMIT never returns it to the pool before the cleanup ROLLBACK has run on it (#139).
+  local rollback_error = nothing
+
   try
     # Execute all SQL statements
     _execute_statements_pg(connection, ordered_statements; conn=conn)
-    
+
     # Record in history table (within same transaction)
     _record_migration(connection, version, name, checksum, all_sql, "applied", has_destructive; conn=conn)
-    
-    # Commit
-    with_transaction(connection, "COMMIT;", conn=conn, release_conn=true)
+
+    # Commit — release_conn=false: the finally owns the single release.
+    with_transaction(connection, "COMMIT;", conn=conn, release_conn=false)
     @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
   catch e
-    # Rollback and record failure
+    # Roll back on the still-leased connection. A rollback failure must not mask the body's
+    # error — capture it so the finally renews/discards the (now-dirty) connection instead of
+    # releasing it (#71), then rethrow the original.
     try
-      with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=true)
+      with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=false)
     catch rollback_err
+      rollback_error = rollback_err
       @error "Failed to rollback transaction" exception=rollback_err
     end
-    
-    # Record failed status outside the rolled-back transaction
+
+    # Record failed status outside the (now rolled-back) transaction. Reuse the transaction's
+    # own connection (conn=conn) rather than acquiring a fresh one: it is still leased until the
+    # finally, and SQLite's single writer slot would otherwise deadlock this write. Trade-off: if
+    # the ROLLBACK above ALSO failed, `conn` is dirty/aborted and this INSERT fails too (logged and
+    # skipped, then the finally renews the connection) — so in that rare double-failure the `failed`
+    # row is not recorded; the error is still logged and rethrown.
     try
-      _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive)
+      _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive; conn=conn)
     catch record_err
       @error "Failed to record migration failure in history table" exception=record_err
     end
-    
+
     @error "Error applying migrations" exception=e
     rethrow(e)
+  finally
+    finalize_transaction_connection!(connection, conn; rollback_error=rollback_error)
   end
-  
+
   # Archive files (post-commit, best-effort)
   try
     _archive_migration_files(settings, date_str)
@@ -920,7 +933,10 @@ function _execute_migration_lifecycle(connection::PormGSQLite, settings::SQLConn
   # PostgreSQL. See ConnectionPool.with_sqlite_write_lock.
   with_sqlite_write_lock(connection) do
     # Begin transaction (IMMEDIATE for SQLite)
-    result, conn = with_transaction(connection, "BEGIN IMMEDIATE TRANSACTION;")
+    _, conn = with_transaction(connection, "BEGIN IMMEDIATE TRANSACTION;")
+    # Single terminal finally releases/renews the connection exactly once, so a failed COMMIT
+    # never returns it to the pool before the cleanup ROLLBACK has run on it (#139).
+    local rollback_error = nothing
 
     try
       # Execute all SQL statements
@@ -929,25 +945,34 @@ function _execute_migration_lifecycle(connection::PormGSQLite, settings::SQLConn
       # Record in history table (within same transaction)
       _record_migration(connection, version, name, checksum, all_sql, "applied", has_destructive; conn=conn)
 
-      # Commit
-      with_transaction(connection, "COMMIT;", conn=conn, release_conn=true)
+      # Commit — release_conn=false: the finally owns the single release.
+      with_transaction(connection, "COMMIT;", conn=conn, release_conn=false)
       @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
     catch e
+      # Roll back on the still-leased connection; capture a rollback failure so the finally
+      # renews/discards the dirty connection instead of releasing it (#71), then rethrow.
       try
-        with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=true)
+        with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=false)
       catch rollback_err
+        rollback_error = rollback_err
         @error "Failed to rollback transaction" exception=rollback_err
       end
 
-      # Record failed status outside the rolled-back transaction
+      # Record failed status outside the (now rolled-back) transaction, reusing the transaction's
+      # own connection (conn=conn): it is still leased until the finally, and acquiring a fresh
+      # writer would deadlock on SQLite's single writer slot. Trade-off: if the ROLLBACK above also
+      # failed, `conn` is dirty and this INSERT fails too (logged and skipped, then the finally
+      # renews it) — so the `failed` row is not recorded in that rare double-failure.
       try
-        _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive)
+        _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive; conn=conn)
       catch record_err
         @error "Failed to record migration failure in history table" exception=record_err
       end
 
       @error "Error applying migrations" exception=e
       rethrow(e)
+    finally
+      finalize_transaction_connection!(connection, conn; rollback_error=rollback_error)
     end
   end
   

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -160,22 +160,28 @@ function delete(objct::SQLObjectHandler;
     # PostgreSQL. See ConnectionPool.with_sqlite_write_lock.
     with_sqlite_write_lock(settings) do
       _, conn = with_transaction(settings, begin_sql)
+      # Release/renew the connection exactly once in a single terminal finally, so a failed
+      # COMMIT never returns it to the pool before the cleanup ROLLBACK has run on it (#139).
+      local rollback_error = nothing
       try
         with_tx_context(settings.connections, conn) do
           run_deletions(conn)
         end
-        # Commit transaction
-        with_transaction(settings, "COMMIT;", conn=conn, release_conn=true)
+        # Commit — release_conn=false: the finally owns the single release.
+        with_transaction(settings, "COMMIT;", conn=conn, release_conn=false)
       catch e
-        # Rollback on error. A rollback failure must not mask the body's error — log it
-        # and rethrow the original; the pool has already renewed or discarded the
-        # connection inside with_transaction (#71).
+        # Roll back on the still-leased connection. A rollback failure must not mask the body's
+        # error — capture it so the finally renews/discards the dirty connection instead of
+        # releasing it (#71), then rethrow the original.
         try
-          with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=true)
-        catch rollback_error
-          @error "Failed to rollback delete transaction" exception=rollback_error
+          with_transaction(settings, "ROLLBACK;", conn=conn, release_conn=false)
+        catch rollback_err
+          rollback_error = rollback_err
+          @error "Failed to rollback delete transaction" exception=rollback_err
         end
         rethrow(e)
+      finally
+        finalize_transaction_connection!(settings, conn; rollback_error=rollback_error)
       end
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,7 @@ end
     @testset "close_pool! Skips Non-pool Mocks (#147)" include("unit/test_close_pool_mock_skip.jl")
     @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "No Lost-Connection Retry Inside Transactions (#138)" include("unit/test_fetch_retry_transaction.jl")
+    @testset "Failed COMMIT Holds Conn Until Rollback (#139)" include("unit/test_commit_failure_release.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_commit_failure_release.jl
+++ b/test/unit/test_commit_failure_release.jl
@@ -1,0 +1,392 @@
+# ============================================================
+# test/unit/test_commit_failure_release.jl
+#
+# Failed COMMIT holds the connection until ROLLBACK runs; released/healed exactly once (#139).
+#
+# CONTRACT being tested:
+#   The manual BEGIN/COMMIT/ROLLBACK lifecycles (both migration lifecycles and delete()) must
+#   NOT return the transaction's connection to the pool on a FAILED COMMIT and then issue ROLLBACK
+#   on the already-released connection (a use-after-release + double-release race). The connection
+#   must stay leased through the cleanup ROLLBACK and be released — or renewed/discarded if that
+#   ROLLBACK left it dirty (#71) — exactly once, in a single terminal `finally`.
+#
+#   The fix routes every such lifecycle through one shared, exported helper,
+#   `finalize_transaction_connection!(pool, conn; rollback_error)`: COMMIT and ROLLBACK both run
+#   with `release_conn=false` (they never release), and the `finally` calls the helper, which
+#   releases the connection, or renews/discards it when a non-benign `rollback_error` is supplied.
+#   This mirrors `run_in_transaction`'s single-`finally` release (the one lifecycle that was never
+#   subject to #139), so all four finalize identically.
+#
+# Deterministic and DB-free: behavioral mock pools carry the exact fields the pool machinery reads
+# (acquire/release/reconnect are generic over PormGPostgres/PormGSQLite), fake driver handles track
+# `close`, and `backend_*` overrides simulate a failing COMMIT and/or ROLLBACK. A `fail_commit`
+# task throws INSIDE the `@async`/worker so `Base.fetch` surfaces a TaskFailedException — the wrapped
+# form the real async paths produce. Each mock snapshots `available[slot]` at the instant ROLLBACK
+# is issued (`available_at_rollback`): the fixed pattern keeps it `false` (still leased); the
+# pre-fix pattern (COMMIT with `release_conn=true`) flips it `true` before ROLLBACK — the mutation
+# gate, contrasted directly below.
+#
+# NOTE: the real migration/delete callers are not DB-free (they drive the ORM history table, the
+# query builder, and filesystem archiving), so this file locks the shared helper and the exact
+# lifecycle CALL SEQUENCE the callers now use, through the real `with_transaction` primitive. The
+# refactored `_run_in_transaction_impl` gets its own real-code coverage from the #71 suite
+# (test/unit/test_transaction_rollback_renewal.jl); the real callers' success paths are covered by
+# the integration transaction/migration tests.
+# ============================================================
+
+using Test
+using PormG
+
+# No DB drivers needed: every backend_* call in these flows dispatches to the mock methods below.
+const CP = PormG.ConnectionPool
+
+# ── Fake driver handle: tracks whether the pool cleanup closed it ──
+# (structs live at file top level — Julia forbids type definitions inside @testset blocks)
+mutable struct FakeConn139
+  id::Int
+  closed::Bool
+end
+FakeConn139(id::Int) = FakeConn139(id, false)
+Base.close(c::FakeConn139) = (c.closed = true; nothing)
+
+# ── PG-shaped mock: PostgresConnectionPool's exact fields + failure knobs + rollback snapshot ──
+mutable struct MockPGPool139 <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+  fail_commit::Bool      # COMMIT task throws (inside the task → TaskFailedException)
+  fail_rollback::Bool    # ROLLBACK task throws (non-benign → renewal)
+  fail_renew::Bool       # backend_renew_connection throws → reconnect_db → nothing → discard
+  next_id::Int
+  executed::Vector{String}
+  available_at_rollback::Union{Nothing, Bool}  # available[slot] snapshot when ROLLBACK is issued
+  conn_at_rollback::Any                        # the conn ROLLBACK ran on
+end
+MockPGPool139(; fail_commit::Bool = false, fail_rollback::Bool = false, fail_renew::Bool = false) =
+  MockPGPool139(Any[FakeConn139(1)], [true], "mock://pg", 1, ReentrantLock(),
+                fail_commit, fail_rollback, fail_renew, 1, String[], nothing, nothing)
+
+PormG.backend_is_alive(::MockPGPool139, conn) = conn isa FakeConn139 && !conn.closed
+PormG.backend_connect(pool::MockPGPool139; kwargs...) = FakeConn139(pool.next_id += 1)
+function PormG.backend_execute_async(pool::MockPGPool139, conn, sql::String, params)
+  push!(pool.executed, sql)
+  if startswith(sql, "ROLLBACK")
+    # Snapshot on the CALLER's task, the instant the ROLLBACK statement is issued.
+    pool.available_at_rollback = pool.available[1]
+    pool.conn_at_rollback = conn
+  end
+  return @async begin
+    pool.fail_commit   && startswith(sql, "COMMIT")   && error("mock: commit refused")
+    pool.fail_rollback && startswith(sql, "ROLLBACK") && error("mock: rollback refused")
+    NamedTuple[]   # empty result table: DataFrame(...) → 0 rows, so migration reads see an empty DB
+  end
+end
+function PormG.backend_renew_connection(pool::MockPGPool139, conn; kwargs...)
+  pool.fail_renew && error("mock: renew refused")
+  return FakeConn139(pool.next_id += 1)
+end
+
+# ── SQLite-shaped mock: SQLiteConnectionPool's exact fields; statements funnel through the REAL
+#    global async worker → backend_execute, proving the policy on the actual SQLite code path. ──
+mutable struct MockSQLitePool139 <: PormG.PormGSQLite
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  split_read_write::Bool
+  writer_slot::Int
+  reader_cursor::Int
+  lock::ReentrantLock
+  write_lock::ReentrantLock
+  fail_commit::Bool
+  rollback_error_msg::Union{Nothing, String}   # nothing → ROLLBACK succeeds
+  next_id::Int
+  executed::Vector{String}
+  available_at_rollback::Union{Nothing, Bool}
+  conn_at_rollback::Any
+end
+MockSQLitePool139(; fail_commit::Bool = false, rollback_error_msg::Union{Nothing, String} = nothing) =
+  MockSQLitePool139(Any[FakeConn139(1)], [true], "mock://sqlite", 1, false, 1, 0,
+                    ReentrantLock(), ReentrantLock(), fail_commit, rollback_error_msg, 1,
+                    String[], nothing, nothing)
+
+PormG.backend_is_alive(::MockSQLitePool139, conn) = conn isa FakeConn139 && !conn.closed
+PormG.backend_connect(pool::MockSQLitePool139; read_only::Bool = false) = FakeConn139(pool.next_id += 1)
+PormG.backend_renew_connection(pool::MockSQLitePool139, conn; read_only::Bool = false) = FakeConn139(pool.next_id += 1)
+function PormG.backend_execute(pool::MockSQLitePool139, conn, sql::String, params)
+  # Runs on the global SQLite worker; sequential vs. the caller via Base.fetch. Keep it pure.
+  push!(pool.executed, sql)
+  if startswith(sql, "ROLLBACK")
+    pool.available_at_rollback = pool.available[1]
+    pool.conn_at_rollback = conn
+  end
+  pool.fail_commit && startswith(sql, "COMMIT") && error("mock: commit refused")
+  if pool.rollback_error_msg !== nothing && startswith(sql, "ROLLBACK")
+    error(pool.rollback_error_msg)
+  end
+  return NamedTuple[]
+end
+
+# ── Minimal concrete SQLConn wrapper (like Configuration.Settings): <: SQLConn but NOT a
+#    PormGPostgres/PormGSQLite, so finalize_transaction_connection!(::SQLConn, ...) dispatches to
+#    the delegating overload that delete() relies on (settings is a Settings, not a raw pool). ──
+mutable struct MockSettings139 <: PormG.SQLConn
+  connections::Any
+end
+
+# ── The FIXED lifecycle call sequence the migration/delete callers now use (single terminal
+#    finally). Mirrors runner.jl / deletion.jl: BEGIN self-acquires, COMMIT and ROLLBACK never
+#    release, one finally finalizes. Returns (conn, caught_error_or_nothing). ──
+function run_fixed_lifecycle_139(pool, begin_sql)
+  _, conn = CP.with_transaction(pool, begin_sql)
+  local rollback_error = nothing
+  try
+    # (body succeeded) → COMMIT (which fails in these tests)
+    CP.with_transaction(pool, "COMMIT;", conn = conn, release_conn = false)
+    return conn, nothing
+  catch e
+    try
+      CP.with_transaction(pool, "ROLLBACK;", conn = conn, release_conn = false)
+    catch rb
+      rollback_error = rb
+    end
+    return conn, e
+  finally
+    CP.finalize_transaction_connection!(pool, conn; rollback_error = rollback_error)
+  end
+end
+
+# ── The PRE-FIX (buggy) sequence: COMMIT/ROLLBACK with release_conn=true. Reproduced only to
+#    show it releases the connection BEFORE ROLLBACK (available_at_rollback === true) — the exact
+#    #139 hazard the fixed sequence avoids. Characterizes with_transaction's unchanged behavior. ──
+function run_buggy_lifecycle_139(pool, begin_sql)
+  _, conn = CP.with_transaction(pool, begin_sql)
+  try
+    CP.with_transaction(pool, "COMMIT;", conn = conn, release_conn = true)
+    return conn, nothing
+  catch e
+    try
+      CP.with_transaction(pool, "ROLLBACK;", conn = conn, release_conn = true)
+    catch _
+    end
+    return conn, e
+  end
+end
+
+# ── Drive the REAL PormG.Migrations._execute_migration_lifecycle (not a reproduction) against the
+#    mock, so a future revert of the caller's `release_conn` is caught by CI. The mock returns empty
+#    result tables (so the migration reads the DB as empty → no idempotency skip), no-ops the DDL and
+#    the history INSERTs, and throws on COMMIT. `SQLConn` is abstract and the mocks are subtypes, so
+#    the same pool doubles as `connection` and `settings`; `settings` is only touched by archiving,
+#    which the COMMIT-failure rethrow never reaches. Returns the caught error (or nothing). ──
+function run_real_migration_lifecycle_139(pool)
+  try
+    PormG.Migrations._execute_migration_lifecycle(
+      pool, pool,
+      String["CREATE TABLE _pormg_t139 (id integer);"],
+      "CREATE TABLE _pormg_t139 (id integer);",
+      "v139", "commit_fail_mig", "chk139", false)
+    return nothing
+  catch e
+    return e
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# finalize_transaction_connection! — the shared terminal release/heal helper
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "finalize_transaction_connection! releases a clean connection (#139)" begin
+  pool = MockPGPool139()
+  conn = CP.acquire_connection(pool)
+  @test pool.available[1] === false                     # leased
+
+  @test CP.finalize_transaction_connection!(pool, conn) === nothing   # rollback_error defaults to nothing
+  @test pool.connections[1] === conn                    # same handle, not renewed
+  @test pool.available[1] === true                      # released
+  @test conn.closed === false                           # a clean connection is never closed
+end
+
+@testset "finalize_transaction_connection! renews on a non-benign rollback error (#139/#71)" begin
+  pool = MockPGPool139()
+  conn = CP.acquire_connection(pool)
+
+  CP.finalize_transaction_connection!(pool, conn; rollback_error = ErrorException("disk I/O error"))
+  @test pool.connections[1] !== conn                    # slot renewed
+  @test pool.connections[1] isa FakeConn139 && pool.connections[1].id == 2
+  @test pool.available[1] === true                      # renewed handle released
+  @test conn.closed === true                            # dirty handle closed
+end
+
+@testset "finalize_transaction_connection! discards when renewal also fails (#139/#71)" begin
+  pool = MockPGPool139(fail_renew = true)
+  conn = CP.acquire_connection(pool)
+
+  CP.finalize_transaction_connection!(pool, conn; rollback_error = ErrorException("disk I/O error"))
+  @test pool.connections[1] === nothing                 # slot cleared
+  @test pool.available[1] === true
+  @test conn.closed === true
+end
+
+@testset "finalize_transaction_connection! treats benign SQLite rollback errors as clean (#139/#71)" begin
+  pool = MockSQLitePool139()
+  conn = CP.acquire_connection(pool; mode = :write)
+
+  CP.finalize_transaction_connection!(pool, conn; rollback_error = ErrorException("cannot rollback - no transaction is active"))
+  @test pool.connections[1] === conn                    # NOT renewed: clean, released as-is
+  @test pool.available[1] === true
+  @test conn.closed === false
+  @test pool.next_id == 1                               # no fresh handle created
+end
+
+@testset "finalize_transaction_connection! SQLConn overload delegates to the pool (#139)" begin
+  # delete() passes a Settings (a SQLConn wrapper), not a raw pool, so it dispatches here.
+  pool = MockPGPool139()
+  conn = CP.acquire_connection(pool)
+  settings = MockSettings139(pool)
+
+  @test CP.finalize_transaction_connection!(settings, conn) === nothing   # <: SQLConn, not a pool
+  @test pool.connections[1] === conn                    # delegated to pool.connections and released
+  @test pool.available[1] === true
+  # And the renew path still routes through the delegation.
+  conn2 = CP.acquire_connection(pool)
+  CP.finalize_transaction_connection!(settings, conn2; rollback_error = ErrorException("disk I/O error"))
+  @test pool.connections[1] !== conn2                   # renewed via the wrapped pool
+  @test pool.available[1] === true
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixed lifecycle: a failed COMMIT keeps the connection leased through ROLLBACK
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG failed COMMIT holds the connection until ROLLBACK, releases once (#139)" begin
+  pool = MockPGPool139(fail_commit = true)
+  old = pool.connections[1]
+
+  conn, err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode = :any begin
+    run_fixed_lifecycle_139(pool, "BEGIN;")
+  end
+
+  @test err !== nothing && occursin("commit refused", string(CP._unwrap_async_exception(err)))   # the COMMIT failure propagates
+  @test pool.available_at_rollback === false            # STILL LEASED when ROLLBACK is issued (the #139 fix)
+  @test pool.conn_at_rollback === conn                  # ROLLBACK ran on the transaction's own connection
+  @test pool.executed == ["BEGIN;", "COMMIT;", "ROLLBACK;"]
+  # ROLLBACK succeeded → clean release, exactly once.
+  @test conn === old
+  @test pool.connections[1] === conn                    # not renewed
+  @test pool.available[1] === true                      # released
+  @test conn.closed === false
+end
+
+@testset "SQLite failed COMMIT holds the connection until ROLLBACK, releases once (#139)" begin
+  pool = MockSQLitePool139(fail_commit = true)
+  old = pool.connections[1]
+
+  conn, err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode = :any begin
+    run_fixed_lifecycle_139(pool, "BEGIN IMMEDIATE TRANSACTION;")
+  end
+
+  @test err !== nothing && occursin("commit refused", string(CP._unwrap_async_exception(err)))
+  @test pool.available_at_rollback === false            # still leased at ROLLBACK time
+  @test pool.conn_at_rollback === conn
+  @test pool.executed == ["BEGIN IMMEDIATE TRANSACTION;", "COMMIT;", "ROLLBACK;"]
+  @test conn === old
+  @test pool.connections[1] === conn
+  @test pool.available[1] === true
+  @test conn.closed === false
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Contrast: the PRE-FIX sequence releases the connection BEFORE ROLLBACK (the #139 bug)
+# This runs green on today's code (with_transaction's COMMIT-release-on-failure is unchanged);
+# it proves the `available_at_rollback === false` assertion above genuinely discriminates the fix.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG pre-fix sequence (COMMIT release_conn=true) releases before ROLLBACK — the #139 hazard" begin
+  pool = MockPGPool139(fail_commit = true)
+
+  _conn, err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode = :any begin
+    run_buggy_lifecycle_139(pool, "BEGIN;")
+  end
+
+  @test err !== nothing
+  @test pool.available_at_rollback === true             # connection already returned to the pool → use-after-release
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Failed COMMIT AND failed ROLLBACK → renew/discard exactly once, never released dirty (#139+#71)
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PG failed COMMIT then failed ROLLBACK renews the connection once (#139/#71)" begin
+  pool = MockPGPool139(fail_commit = true, fail_rollback = true)
+  old = pool.connections[1]
+
+  conn, err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode = :any begin
+    run_fixed_lifecycle_139(pool, "BEGIN;")
+  end
+
+  @test err !== nothing && occursin("commit refused", string(CP._unwrap_async_exception(err)))   # root cause wins, not "rollback refused"
+  @test pool.available_at_rollback === false            # leased through the (failing) ROLLBACK
+  @test conn === old
+  @test pool.connections[1] !== old                     # slot renewed (dirty handle never returned)
+  @test pool.connections[1] isa FakeConn139 && pool.connections[1].id == 2
+  @test pool.available[1] === true                      # renewed handle released, exactly once
+  @test old.closed === true                             # dirty handle closed
+end
+
+@testset "SQLite failed COMMIT then failed ROLLBACK renews the connection once (#139/#71)" begin
+  pool = MockSQLitePool139(fail_commit = true, rollback_error_msg = "disk I/O error")
+  old = pool.connections[1]
+
+  conn, err = @test_logs (:error, r"Failed to execute SQL transaction") match_mode = :any begin
+    run_fixed_lifecycle_139(pool, "BEGIN IMMEDIATE TRANSACTION;")
+  end
+
+  @test err !== nothing && occursin("commit refused", string(CP._unwrap_async_exception(err)))
+  @test pool.available_at_rollback === false
+  @test conn === old
+  @test pool.connections[1] !== old                     # renewed
+  @test pool.connections[1] isa FakeConn139 && pool.connections[1].id == 2
+  @test pool.available[1] === true
+  @test old.closed === true
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Real callers: drive the actual migration lifecycle through a failed COMMIT (#139)
+# These invoke PormG.Migrations._execute_migration_lifecycle directly, so they catch a future
+# revert of the caller's `release_conn=false` back to `true` (the pre-fix bug) — which the
+# reproduction-based testsets above cannot. Under the pre-fix code the failed COMMIT releases the
+# connection, flipping available_at_rollback to `true`, so these assertions would fail.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Real PG migration lifecycle: failed COMMIT holds the connection until ROLLBACK (#139)" begin
+  pool = MockPGPool139(fail_commit = true)
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Error applying migrations") match_mode = :any begin
+    run_real_migration_lifecycle_139(pool)
+  end
+
+  @test err !== nothing                                 # the COMMIT failure propagates out of the real lifecycle
+  @test pool.available_at_rollback === false            # conn still leased when the lifecycle's ROLLBACK runs
+  @test pool.conn_at_rollback === old                   # ROLLBACK ran on the transaction's own connection
+  @test any(s -> startswith(s, "COMMIT"),   pool.executed)
+  @test any(s -> startswith(s, "ROLLBACK"), pool.executed)
+  @test pool.available[1] === true                      # released exactly once by the terminal finally
+  @test pool.connections[1] === old                     # clean release (the lifecycle's ROLLBACK succeeded)
+  @test old.closed === false
+end
+
+@testset "Real SQLite migration lifecycle: failed COMMIT holds the connection until ROLLBACK (#139)" begin
+  pool = MockSQLitePool139(fail_commit = true)
+  old = pool.connections[1]
+
+  err = @test_logs (:error, r"Error applying migrations") match_mode = :any begin
+    run_real_migration_lifecycle_139(pool)
+  end
+
+  @test err !== nothing
+  @test pool.available_at_rollback === false
+  @test pool.conn_at_rollback === old
+  @test any(s -> startswith(s, "COMMIT"),   pool.executed)
+  @test any(s -> startswith(s, "ROLLBACK"), pool.executed)
+  @test pool.available[1] === true
+  @test pool.connections[1] === old
+end


### PR DESCRIPTION
Closes #139.

## Problem

The manual `BEGIN`/`COMMIT`/`ROLLBACK` lifecycles — both migration lifecycles and `delete()` — issued
`COMMIT` with `release_conn=true`, so `with_transaction`'s `finally` returned the connection to the pool
**even when the COMMIT threw**. The `catch` then ran `ROLLBACK` on that already-released connection: a
use-after-release + double-release race under concurrency (a concurrent task could acquire the same
connection between the release and the ROLLBACK, and the second `release_conn=true` marked the slot free
while another borrower still held it).

`run_in_transaction` was never subject to this — it already releases exactly once in a single `finally`.

## Fix

Route every manual lifecycle through **one terminal `finally`** that releases/renews the connection
exactly once, mirroring `run_in_transaction`:

- **`src/ConnectionPool.jl`** — new exported `finalize_transaction_connection!(pool, conn; rollback_error)`
  (+ `SQLConn` overload). It releases the connection, or renews/discards it when a non-benign
  `rollback_error` is supplied (the #71 heal). `_run_in_transaction_impl` now uses it too, so there is a
  single copy of the terminal release/renew decision.
- **`src/migrations/runner.jl`** (PG + SQLite) and **`src/querybuilder/deletion.jl`** — `COMMIT`/`ROLLBACK`
  now run with `release_conn=false`; a single `finally` calls the helper. The migration "failed"-status
  record reuses `conn=conn` (like the "applied" record) so it doesn't contend for SQLite's single writer
  slot while the tx connection is still leased.
- **`src/Migrations.jl` / `src/QueryBuilder.jl`** — import `finalize_transaction_connection!`. These
  submodules use explicit import lists (not `using`), so exporting the helper from `ConnectionPool` alone
  was not enough — omitting the import would `UndefVarError` at runtime on every `delete()` and every
  migration commit/rollback failure. **This was caught by a real-caller regression test (see below).**

Keeping the `ROLLBACK` matches Django / Rails / SQLAlchemy / Go: it's a harmless no-op on a PostgreSQL
failed `COMMIT` (the server already rolled back), but genuinely required on SQLite, where a `SQLITE_BUSY`
commit leaves the transaction open. Wrapped so a rollback failure never masks the body's error.

## Tests

New DB-free `test/unit/test_commit_failure_release.jl` (75 assertions, PG + SQLite), registered in
`test/runtests.jl`:

- `finalize_transaction_connection!` — release / renew-on-dirty / discard-on-renew-failure / benign-SQLite / `SQLConn`-overload delegation.
- The fixed lifecycle call sequence through `with_transaction`, plus a **buggy-pattern contrast** proving the invariant (`available_at_rollback === false`) discriminates the fix.
- The **real** `PormG.Migrations._execute_migration_lifecycle` driven through a COMMIT failure (`SQLConn` is abstract, so the mock doubles as `connection` and `settings`) — this is what surfaced the submodule-import bug above.

Verification: unit suite **2654 pass, 0 fail**; docs build exit 0. Integration (`db_2`/`db_sl`) not run
here — a forced COMMIT failure isn't cheaply fault-injectable against a real DB; the success paths remain
covered by the existing integration transaction tests.

## Review

A `/code-review` pass (xhigh) produced four low-severity findings:

1. Migration "failed"-status row is not recorded if the cleanup ROLLBACK *also* fails (the record reuses
   the then-dirty connection). Rare double-failure; error still logged + rethrown. **Documented the
   trade-off** in the lifecycle comments (keeping `conn=conn` preserves the backtrace on the common
   failure and avoids the SQLite writer-slot deadlock).
2. Real callers' COMMIT-failure path had no test. **Fixed** — the added real-lifecycle test caught the
   submodule-import bug.
3. `result` binding unused in the migration lifecycles. **Fixed** → `_, conn`.
4. `_run_in_transaction_impl` classifies the rollback error twice (once for the log, once in the helper).
   Negligible (cheap check, rare path); the alternatives are worse (private helper into submodules, or
   perturbing the log the #71 tests assert). **Left as-is with an explanatory comment.**

## Docs

`docs/src/write/transaction.md` — the manual `with_tx_context` + `with_transaction` recipe updated to the
race-free single-`finally` pattern, and the misleading "always pair with `release_conn=true`" note
replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
