### PR TITLE
feat(#19): composite uniqueness via Models.UniqueConstraint (add-only)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,55 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Composite uniqueness (`unique_together`) via `Models.UniqueConstraint`
+
+- **PormG ref**: issue #19 ; `src/Models.jl`, `src/migrations/planner.jl`, `src/migrations/importers.jl`
+- **Recorded**: 2026-07-14
+- **Severity**: new feature — **additive, non-breaking**. No existing API changed; no forced code edit.
+
+### What changed
+
+Models can now declare multi-column uniqueness (Django's `Meta.unique_together`) with a
+model-level `constraints=` list of named `Models.UniqueConstraint` objects:
+
+```julia
+Constructor_engine = Models.Model("constructor_engines",
+  id = Models.IDField(),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="CASCADE"),
+  year = Models.IntegerField(),
+  engine_manufacturer = Models.CharField(max_length=50),
+  constraints = [
+    Models.UniqueConstraint(fields=("constructorid", "year"), name="uniq_constructor_year"),
+  ],
+)
+```
+
+At migration time each constraint becomes a `CREATE UNIQUE INDEX` (identical on PostgreSQL and
+SQLite). The Django importer now maps `Meta.unique_together` to this form automatically (resolving
+the FK `_id` suffix). See [Composite Uniqueness](docs/src/models.md).
+
+**Limitation (this release):** a constraint is materialized when its table is first created (same
+lifecycle as the automatic many-to-many index). Adding/removing a constraint on an
+already-migrated table is not yet diffed by `makemigrations` — deferred to a follow-up.
+
+### How to find the calls to migrate
+
+Nothing to grep — no API changed. This is purely additive. **Optional adoption:** if an app has a
+natural composite key currently enforced only in application code (or a Django model with
+`unique_together` that was imported before this feature), declare it with `UniqueConstraint` and
+create the table (or add the unique index by hand on the existing table).
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | optional — review models for composite keys to enforce |
+| app-2 | ⏳ | optional |
+| app-3 | ⏳ | optional |
+| app-4 | ⏳ | optional |
+
+---
+
 ## Connection errors inside `run_in_transaction` now propagate (no silent statement retry)
 
 - **PormG ref**: issue #138 ; `src/ConnectionPool.jl`

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -998,7 +998,7 @@ All field types support these common parameters:
 ### Validation Options
 - `null::Bool = false`: Allow NULL values in database
 - `blank::Bool = false`: Allow empty values in forms  
-- `unique::Bool = false`: Enforce uniqueness constraint
+- `unique::Bool = false`: Enforce uniqueness constraint on this single column. For uniqueness spanning **two or more** columns, use a model-level `UniqueConstraint` — see [Composite Uniqueness](models.md#Composite-Uniqueness-(unique_together)).
 - `default`: Set default value for new records
 
 ### Database Options

--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -152,6 +152,41 @@ Django parameters are automatically converted to PormG equivalents:
 | `on_delete=CASCADE` | `on_delete=CASCADE` | Direct mapping |
 | `choices=[]` | `choices=()` | List to tuple conversion |
 
+### Meta Options
+
+The importer reads one `class Meta:` option:
+
+| Django `Meta` option | PormG equivalent | Notes |
+|----------------------|------------------|-------|
+| `unique_together = ('a', 'b')` | `constraints=[Models.UniqueConstraint(fields=("a", "b"))]` | Composite uniqueness. A tuple-of-tuples (multiple composite keys) becomes one `UniqueConstraint` per group. |
+
+Because foreign-key fields are imported with an `_id` suffix (`item` → `item_id`), the importer
+resolves each `unique_together` member to its imported field name automatically:
+
+```python
+class Dim_item_fabricante(models.Model):
+    item = models.ForeignKey(Dim_item, on_delete=models.CASCADE)
+    fabricante = models.ForeignKey(Dim_fabricante, on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('item', 'fabricante')
+```
+
+imports as:
+
+```julia
+Dim_item_fabricante = Models.Model("dim_item_fabricante",
+  id = Models.IDField(),
+  item_id = Models.ForeignKey("Dim_item", pk_field="id", on_delete=CASCADE),
+  fabricante_id = Models.ForeignKey("Dim_fabricante", pk_field="id", on_delete=CASCADE),
+  constraints = [Models.UniqueConstraint(fields = ("item_id", "fabricante_id",))],
+)
+```
+
+See [Composite Uniqueness](models.md#Composite-Uniqueness-(unique_together)) for how the
+constraint is materialized. Django's newer `Meta.constraints = [UniqueConstraint(...)]` form is
+not parsed yet — declare it directly in PormG.
+
 ### ⚠️ Important: CharField with Choices Syntax
 
 When using `CharField` with choices, PormG requires the choices to be defined **inline** for proper parsing. External variables are not supported.

--- a/docs/src/models.md
+++ b/docs/src/models.md
@@ -127,6 +127,50 @@ end
 - Each field uses a PormG field constructor (e.g., `IDField`, `CharField`, `DateField`).
 - You can use keyword arguments to customize field options (e.g., `max_length`, `unique`, `null`).
 
+## Composite Uniqueness (`unique_together`)
+
+A single-column uniqueness rule is a field option (`unique=true`). To require a combination
+of **two or more** columns to be unique together — Django's `Meta.unique_together` — declare a
+model-level `constraints=[...]` list of `Models.UniqueConstraint` objects (the same shape as
+Django 2.2+ / SQLAlchemy named constraints):
+
+```julia
+Constructor_engine = Models.Model("constructor_engines",
+  id = Models.IDField(),
+  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="CASCADE"),
+  year = Models.IntegerField(),
+  engine_manufacturer = Models.CharField(max_length=50),
+  constraints = [
+    Models.UniqueConstraint(fields=("constructorid", "year"), name="uniq_constructor_year"),
+  ],
+)
+```
+
+Each `UniqueConstraint` takes:
+
+- `fields` — a tuple (or vector) of **field names** on this model. Foreign-key fields are
+  referenced by the field name; PormG resolves each to its physical column (honoring
+  `db_column`).
+- `name` — the index name (optional). When omitted, PormG derives `<table>_<cols>_uniq`,
+  matching the auto-generated many-to-many index convention. On tables/columns with long names
+  the derived name can exceed PostgreSQL's 63-byte identifier limit (which Postgres silently
+  truncates) — pass an explicit `name` in that case to keep it stable and unique.
+
+A model may carry several constraints (each its own tuple). At migration time each becomes a
+`CREATE UNIQUE INDEX` — identical on PostgreSQL and SQLite:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_constructor_year"
+  ON "constructor_engines" ("constructorid", "year");
+```
+
+!!! note "Materialized when the table is created"
+    In this release a `UniqueConstraint` is emitted when its table is first created (the same
+    lifecycle as the automatic many-to-many join-table index). Adding or removing a constraint
+    on a table that **already exists** is not yet detected by `makemigrations` — it requires
+    composite-index introspection that is tracked as a follow-up. Declare composite uniqueness
+    when you create the model, or add the index by hand on an existing table.
+
 ## Naming Conventions and Considerations
 
 ### Model Naming Rules

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -471,6 +471,93 @@ function model_has_db_column(model::PormGModel)::Bool
 end
 
 #═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Model-level constraints (composite uniqueness · #19)
+#═══════════════════════════════════════════════════════════════════════════════
+# A model-level UNIQUE spanning one or more columns — Django's `unique_together`,
+# spelled here as named `UniqueConstraint` objects (the Django 2.2+/SQLAlchemy form).
+# Declared via the `constraints=` kwarg on `Model(...)`; materialized by the migration
+# planner as a `CREATE UNIQUE INDEX` (portable, byte-identical on PostgreSQL and SQLite),
+# reusing the exact primitive the auto ManyToManyField join-table index already uses.
+# `name === nothing` ⇒ the planner derives `<table>_<cols>_uniq` (mirrors the M2M
+# auto-index naming convention). This is NOT a `PormGField` — it carries no column of
+# its own; it references existing fields by name.
+struct UniqueConstraint
+  fields::Vector{String}
+  name::Union{String, Nothing}
+end
+function UniqueConstraint(; fields, name::Union{AbstractString, Nothing} = nothing)
+  cols = _normalize_constraint_fields(fields)
+  isempty(cols) && throw(ArgumentError("UniqueConstraint requires at least one field"))
+  length(unique(cols)) == length(cols) ||
+    throw(ArgumentError("UniqueConstraint has duplicate fields: $(cols)"))
+  # A blank name would render as an empty (invalid) index identifier; require nothing (auto-derive)
+  # or a real name.
+  name !== nothing && isempty(strip(name)) &&
+    throw(ArgumentError("UniqueConstraint name must be non-empty (pass name=nothing to auto-derive)"))
+  return UniqueConstraint(cols, name === nothing ? nothing : String(name))
+end
+
+# Accept a single field name (Symbol/String) or an iterable of them; normalize each via
+# `format_fild_name` so declared names match the model's field-dict keys (#57 is
+# case-sensitive). A lone String must NOT be iterated char-by-char — the scalar method
+# below is more specific and wins dispatch for Symbol/AbstractString.
+_normalize_constraint_fields(f::Union{Symbol, AbstractString})::Vector{String} = String[format_fild_name(String(f))]
+function _normalize_constraint_fields(f)::Vector{String}
+  out = String[]
+  for x in f
+    (x isa Symbol || x isa AbstractString) ||
+      throw(ArgumentError("UniqueConstraint fields must be Symbol or String, got $(typeof(x))"))
+    push!(out, format_fild_name(String(x)))
+  end
+  return out
+end
+
+# Coerce the `constraints=` argument (a single UniqueConstraint, an iterable of them, or
+# nothing) into a concrete Vector. Anything that is not a UniqueConstraint is an error.
+_as_constraint_vector(::Nothing)::Vector{UniqueConstraint} = UniqueConstraint[]
+_as_constraint_vector(c::UniqueConstraint)::Vector{UniqueConstraint} = UniqueConstraint[c]
+function _as_constraint_vector(cs)::Vector{UniqueConstraint}
+  out = UniqueConstraint[]
+  for c in cs
+    c isa UniqueConstraint ||
+      throw(ArgumentError("`constraints` must contain UniqueConstraint objects, got $(typeof(c))"))
+    push!(out, c)
+  end
+  return out
+end
+
+# Validate declared UniqueConstraints against the built model and stash them in the
+# general-purpose `cache` (the same mechanism the ManyToManyField auto-index uses, so
+# `deepcopy`/`strip_many_to_many_fields` carry them for free — no new struct field, no
+# `deepcopy` positional-enumeration edit). Each referenced field must exist on the model
+# and be a concrete column (not a ManyToManyField, which has no column of its own).
+function _apply_unique_constraints!(model::Model_Type, constraints)::Model_Type
+  list = _as_constraint_vector(constraints)
+  isempty(list) && return model
+  seen_names = Set{String}()
+  for c in list
+    for fname in c.fields
+      haskey(model.fields, fname) || throw(ArgumentError(
+        "UniqueConstraint references unknown field '$(fname)' on model '$(model.name)'. " *
+        "Declared fields: $(sort(collect(keys(model.fields))))"))
+      is_many_to_many_field(model.fields[fname]) && throw(ArgumentError(
+        "UniqueConstraint field '$(fname)' on model '$(model.name)' is a ManyToManyField; " *
+        "composite uniqueness must reference concrete columns"))
+    end
+    # Two constraints sharing an explicit name collide into one index (the plan keys on the name);
+    # reject it here for a clear, early error instead of a silent drop at planning time.
+    if c.name !== nothing
+      c.name in seen_names && throw(ArgumentError(
+        "Duplicate UniqueConstraint name '$(c.name)' on model '$(model.name)'; " *
+        "constraint names must be unique within a model"))
+      push!(seen_names, c.name)
+    end
+  end
+  model.cache["unique_constraints"] = Dict{String, Any}("constraints" => list)
+  return model
+end
+
+#═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Model Constructors
 #═══════════════════════════════════════════════════════════════════════════════
 # Constructor a function that adds a field to the model the number of fields is not limited to the number of fields, the fields are added to the fields dictionary but the name of the field is the key
@@ -488,9 +575,12 @@ function Model(name::AbstractString, fields::NTuple{N, <:Pair{Symbol}}) where N
   # println(fields_dict)
   return Model_Type(name=name, fields=fields_dict, field_names=field_names)
 end
-function Model(name::AbstractString; fields...)
-  
-  return Model(name,  Tuple(pairs(fields)))
+function Model(name::AbstractString; constraints = nothing, fields...)
+  # Peel `constraints` off BEFORE the `fields...` slurp — otherwise it would flow into the
+  # `NTuple{Pair{Symbol}}` method below and trip its `isa PormGField` check (#19). Generated
+  # model files (Model_to_str) reload through this kwargs form, so this is the round-trip seam.
+  model = Model(name, Tuple(pairs(fields)))
+  return _apply_unique_constraints!(model, constraints)
 end
 function Model(name::AbstractString, dict::Dict{String, PormGField})
   field_names::Vector{String} = []
@@ -517,8 +607,12 @@ function Model(name::String)
   example_usage = "\e[32musers = Models.PormGModel(\"users\", name = Models.CharField(), age = Models.IntegerField())\e[0m"
   throw(ArgumentError(_emsg("You need to add fields to the model, example: $example_usage")))
 end
-function Model(; fields...)
-  return Model("", fields |> Tuple)
+function Model(; constraints = nothing, fields...)
+  # No-positional-name form (the idiomatic style — the table name is inferred from the binding
+  # via set_models). `constraints=` must work here too, so peel it before the `fields...` slurp
+  # exactly like the named form above.
+  model = Model("", Tuple(pairs(fields)))
+  return _apply_unique_constraints!(model, constraints)
 end
 
 """
@@ -615,6 +709,22 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; c
       (e isa InterruptException || e isa StackOverflowError) && rethrow()
       @warn "Model_to_str: field render failed — emitting marker comment" model=model.name field=db_field_name field_type=struct_name exception=e
       push!(render_failures, "# PormG: field '$(db_field_name)' ($(struct_name)) could not be rendered: $(replace(sprint(showerror, e), "\n" => " ")) — field omitted.")
+    end
+  end
+  # Composite uniqueness (#19): emit model-level UniqueConstraints so inspectdb/import output
+  # round-trips through the `constraints=` kwarg on Model(...). Only when ≥1 field rendered —
+  # an all-failed model (fields == "") stays commented-out below, constraints included.
+  if fields != "" && haskey(model.cache, "unique_constraints")
+    ucs = get(model.cache["unique_constraints"], "constraints", UniqueConstraint[])
+    if !isempty(ucs)
+      rendered = String[]
+      for c in ucs
+        cols = join(("\"$(f)\"" for f in c.fields), ", ")
+        namepart = c.name === nothing ? "" : ", name = \"$(c.name)\""
+        # Trailing comma keeps a single-field tuple valid Julia: ("a",)
+        push!(rendered, "Models.UniqueConstraint(fields = ($(cols),)$(namepart))")
+      end
+      fields *= ",\n  constraints = [$(join(rendered, ", "))]"
     end
   end
   model_name_abs = django_prefix ? string(settings.django_prefix, "_", model.name |> lowercase) : model.name |> lowercase

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -334,7 +334,17 @@ function import_models_from_django(
 
     # Collect all create instructions
     if !isempty(fields_dict)
-        push!(Instructions, Models.Model_to_str(Models.Model(class_name, fields_dict), render_settings))
+        model = Models.Model(class_name, fields_dict)
+        # Recover Django `Meta.unique_together` → composite UniqueConstraints (#19). Lenient:
+        # BOTH parsing and validation are wrapped — a malformed `unique_together` (e.g. duplicate
+        # fields) is warned and skipped, never aborting the whole multi-class import.
+        try
+          constraints = parse_meta_unique_together(class_content, fields_dict, class_name)
+          isempty(constraints) || Models._apply_unique_constraints!(model, constraints)
+        catch e
+          @warn "import: could not parse/apply unique_together; skipping" class=class_name exception=e
+        end
+        push!(Instructions, Models.Model_to_str(model, render_settings))
     end
 
   end
@@ -585,6 +595,116 @@ function split_field_options(field_options::AbstractString)
   if position(buffer) > 0
       push!(tokens, String(take!(buffer)) |> strip)
   end
-  
+
   return tokens
+end
+
+# ── Django `Meta.unique_together` → PormG `UniqueConstraint` (#19) ────────────────────────
+# The field regex above silently drops any non-`models.X(...)` line, so `class Meta:` options
+# never reached the model. These helpers recover `unique_together` and map it to PormG's
+# composite-uniqueness declaration. Django `Meta.constraints=[UniqueConstraint(...)]` (the newer
+# named form) is not parsed here yet — `unique_together` is the concrete #19 need.
+
+# Return the text inside the FIRST balanced (...) or [...] group in `s` (Django allows tuples
+# or lists), or nothing. Quote-aware so a paren inside a string literal is ignored.
+function _balanced_group(s::AbstractString)::Union{String, Nothing}
+  chars = collect(s)
+  start = findfirst(c -> c == '(' || c == '[', chars)
+  start === nothing && return nothing
+  depth = 0
+  buf = IOBuffer()
+  in_quotes = false
+  quote_char = ' '
+  for idx in start:length(chars)
+    c = chars[idx]
+    if in_quotes
+      c == quote_char && (in_quotes = false)
+      print(buf, c)
+    elseif c == '"' || c == '\''
+      in_quotes = true
+      quote_char = c
+      print(buf, c)
+    elseif c == '(' || c == '['
+      depth += 1
+      depth > 1 && print(buf, c)
+    elseif c == ')' || c == ']'
+      depth -= 1
+      depth == 0 && return String(take!(buf))
+      print(buf, c)
+    else
+      print(buf, c)
+    end
+  end
+  return nothing
+end
+
+# Strip surrounding quotes/whitespace off each token, dropping empties (e.g. trailing-comma
+# artifacts). `django_to_string` already normalizes `'`→`"` for file input; handle both anyway.
+function _clean_constraint_field_names(tokens)::Vector{String}
+  out = String[]
+  for t in tokens
+    n = strip(replace(String(t), "\"" => "", "'" => ""))
+    isempty(n) || push!(out, String(n))
+  end
+  return out
+end
+
+# Split the inner text of a `unique_together` value into column groups. Handles both a flat
+# single group `('a','b')` and a tuple/list of groups `(('a','b'),('c','d'))`.
+function _parse_unique_together_groups(inner::AbstractString)::Vector{Vector{String}}
+  tokens = split_field_options(inner)
+  isempty(tokens) && return Vector{String}[]
+  if any(t -> (st = strip(t); startswith(st, "(") || startswith(st, "[")), tokens)
+    groups = Vector{String}[]
+    for t in tokens
+      st = strip(t)
+      (startswith(st, "(") || startswith(st, "[")) || continue
+      innerg = _balanced_group(st)
+      innerg === nothing && continue
+      names = _clean_constraint_field_names(split_field_options(innerg))
+      isempty(names) || push!(groups, names)
+    end
+    return groups
+  else
+    names = _clean_constraint_field_names(tokens)
+    return isempty(names) ? Vector{String}[] : [names]
+  end
+end
+
+# Map a Django field name to the imported PormG field name: FK/OneToOne fields gain an `_id`
+# suffix at import (see process_class_fields!), so `item` in Django is `item_id` in PormG.
+function _resolve_django_constraint_field(name::AbstractString, fields_dict::Dict{Symbol, Any})::Union{String, Nothing}
+  haskey(fields_dict, Symbol(name)) && return String(name)
+  haskey(fields_dict, Symbol("$(name)_id")) && return "$(name)_id"
+  return nothing
+end
+
+# Build PormG UniqueConstraints from a class's `Meta.unique_together`, resolving each declared
+# Django field to its imported PormG field name. Unresolvable groups are warned and skipped
+# (lenient, matching the importer's philosophy) rather than aborting the whole import.
+function parse_meta_unique_together(class_content, fields_dict::Dict{Symbol, Any}, class_name::AbstractString)
+  content = join(string.(class_content), "\n")
+  occursin("unique_together", content) || return Models.UniqueConstraint[]
+  # `\b` anchors to a word boundary so a longer identifier ending in `unique_together`
+  # (e.g. `not_unique_together = ...`) is not mis-parsed as the Meta option.
+  m = match(r"\bunique_together\s*=\s*(.*)"s, content)
+  m === nothing && return Models.UniqueConstraint[]
+  inner = _balanced_group(m.captures[1])
+  inner === nothing && return Models.UniqueConstraint[]
+  constraints = Models.UniqueConstraint[]
+  for group in _parse_unique_together_groups(inner)
+    resolved = String[]
+    ok = true
+    for name in group
+      r = _resolve_django_constraint_field(name, fields_dict)
+      if r === nothing
+        @warn "import: unique_together field matches no imported field; skipping constraint" field=name class=class_name
+        ok = false
+        break
+      end
+      push!(resolved, r)
+    end
+    ok && !isempty(resolved) && push!(constraints, Models.UniqueConstraint(fields = resolved))
+  end
+  return constraints
 end

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -177,13 +177,47 @@ function _add_many_to_many_auto_constraints(conn::Union{PormGPostgres, PormGSQLi
   return nothing
 end
 
+# User-declared composite uniqueness (#19). Emits one `CREATE UNIQUE INDEX` per
+# `UniqueConstraint` in `model.cache["unique_constraints"]`, generalizing the add-only
+# ManyToManyField auto-index pipeline above. Called ONLY from `_add_new_table` (like the M2M
+# sibling), so the index is materialized when its table is first created and never re-emitted —
+# no false "pending" churn. Adding/removing a constraint on an already-migrated table (which
+# needs composite-unique introspection PormG does not have yet) is out of scope for this pass.
+function _add_unique_constraints(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, model::PormGModel)::Nothing
+  haskey(model.cache, "unique_constraints") || return nothing
+  constraints = get(model.cache["unique_constraints"], "constraints", nothing)
+  constraints === nothing && return nothing
+  table = model.name |> lowercase
+  seen = Set{String}()
+  for c in constraints
+    # Resolve declared field names to physical columns (honors db_column #50; PormG adds no
+    # `_id` suffix for FKs — the field name IS the column).
+    cols = String[Models.model_column(model, f) for f in c.fields]
+    index_name = c.name === nothing ? "$(table)_$(join(cols, "_"))_uniq" : c.name
+    # The step label (and thus the plan slot) keys on index_name; a collision — same explicit
+    # name, or two constraints deriving the same name — would silently overwrite. Fail loudly.
+    index_name in seen && throw(ArgumentError(
+      "Duplicate unique-constraint index name '$(index_name)' on table '$(table)'; " *
+      "give each UniqueConstraint a distinct name"))
+    push!(seen, index_name)
+    _configure_order_dict_migration_plan(
+      migration_plan,
+      model_name,
+      "Create unique constraint: $(index_name)",
+      Dialect.create_unique_index(conn, "\"$index_name\"", "\"$table\"", ["\"$col\"" for col in cols])
+    )
+  end
+  return nothing
+end
+
 function _add_new_table(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, model::PormGModel)::Nothing
   _configure_order_dict_migration_plan(migration_plan, model_name, "New model", Dialect.create_table(conn, model))
-  for (field_name, field) in model.fields       
-    name = _hash_field_name(model_name, field_name)      
-    _add_constrains(conn, migration_plan, model_name, model, field_name, field, name)      
+  for (field_name, field) in model.fields
+    name = _hash_field_name(model_name, field_name)
+    _add_constrains(conn, migration_plan, model_name, model, field_name, field, name)
   end
   _add_many_to_many_auto_constraints(conn, migration_plan, model_name, model)
+  _add_unique_constraints(conn, migration_plan, model_name, model)
   return nothing
 end
 

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1407,6 +1407,46 @@ end
     @test !isfile(pending_path)                                # archive retry cleared the stale file
   end
 
+  # ── Phase 17: Composite unique constraint (#19) ──────────────────────
+  # A model-level UniqueConstraint must materialize a real composite unique index when the table
+  # is created, and the database must REJECT a duplicate (season, round) pair while allowing a
+  # different pair. Uses the idiomatic no-positional-name model form (table inferred from binding).
+  @testset "Phase 17: Composite unique constraint (#19)" begin
+    write_edge_models("""
+    Uniqtest = Models.Model(
+        id = Models.IDField(),
+        season = Models.IntegerField(),
+        round = Models.IntegerField(),
+        constraints = [Models.UniqueConstraint(fields=("season", "round"), name="uniqtest_season_round_uniq")]
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    @test table_exists(pool, "uniqtest")
+    # The composite unique index exists on the freshly created table (both backends).
+    @test "uniqtest_season_round_uniq" in index_names(pool, "uniqtest")
+
+    # First (2021, 1) inserts; the duplicate must violate the composite unique index.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO uniqtest ("season", "round") VALUES (2021, 1);""")
+    dup_rejected = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO uniqtest ("season", "round") VALUES (2021, 1);""")
+      false
+    catch
+      true
+    end
+    @test dup_rejected
+
+    # A different pair is accepted — uniqueness is composite, not per-column.
+    accepted = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO uniqtest ("season", "round") VALUES (2021, 2);""")
+      true
+    catch
+      false
+    end
+    @test accepted
+  end
+
   # ── Cleanup ─────────────────────────────────────────────────────────
   PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
   delete!(PormG.config, joinpath(@__DIR__, edge_db_name))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ end
     @testset "Execution Returns (show_query)" include("unit/test_execution_show.jl")
     @testset "Complex Query Patterns" include("unit/test_complex_queries.jl")
     @testset "Many-to-Many Relationships" include("unit/test_many_to_many.jl")
+    @testset "Composite Uniqueness (unique_together #19)" include("unit/test_unique_constraints.jl")
     @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")
     @testset "custom_join Copy Isolation (#112)" include("unit/test_custom_join_copy.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")

--- a/test/unit/test_unique_constraints.jl
+++ b/test/unit/test_unique_constraints.jl
@@ -1,0 +1,261 @@
+# ==============================================================================
+# UNIT TESTS: Composite uniqueness via named UniqueConstraint (#19)
+#
+# `unique_together`, spelled as Django-2.2+/SQLAlchemy-style named `UniqueConstraint`
+# objects on a model. Verifies, WITHOUT a live database:
+#   1. UniqueConstraint construction, field normalization, and model-level validation.
+#   2. The migration planner emits a CREATE UNIQUE INDEX at table creation (add-only,
+#      mirroring the ManyToManyField auto-index), on BOTH PostgreSQL and SQLite mocks.
+#   3. Model_to_str round-trips the declaration through the `constraints=` kwarg.
+#   4. The Django importer maps `Meta.unique_together` to a UniqueConstraint.
+#
+# DB-free: mock backends subtype PormGPostgres/PormGSQLite; the planner is driven via
+# get_migration_plan and the rendered SQL text is asserted with occursin — the same
+# pattern as test_many_to_many.jl.
+# ==============================================================================
+
+using Test
+using PormG
+using PormG.Models
+using PormG.Migrations
+
+import PormG: PormGModel
+
+# ── DB-free mock backends ─────────────────────────────────────────────────────
+struct UCMockPostgres <: PormG.PormGPostgres end
+struct UCMockSQLite   <: PormG.PormGSQLite end
+
+PormG.config["uc_mock_pg"] = PormG.Configuration.Settings(
+  connections = UCMockPostgres(), change_data = true, db_def_folder = "uc_mock_pg")
+PormG.config["uc_mock_sl"] = PormG.Configuration.Settings(
+  connections = UCMockSQLite(), change_data = true, db_def_folder = "uc_mock_sl")
+
+# ── Models carrying composite-uniqueness declarations ─────────────────────────
+module UniqueConstraintUnitModels
+import PormG
+import PormG.Models
+
+# Two plain columns, auto-derived index name (<table>_<cols>_uniq).
+Season_entry = Models.Model("season_entries",
+  id = Models.IDField(),
+  season = Models.IntegerField(),
+  round  = Models.IntegerField(),
+  constraints = [Models.UniqueConstraint(fields = ("season", "round"))],
+)
+
+# Explicit index name + a db_column-mapped field: the index must target the PHYSICAL
+# column (race_ref), not the field name (race) — proves #50 resolution.
+Grid_slot = Models.Model("grid_slots",
+  id = Models.IDField(),
+  race = Models.IntegerField(db_column = "race_ref"),
+  position = Models.IntegerField(),
+  constraints = [Models.UniqueConstraint(fields = ("race", "position"), name = "grid_slot_unique")],
+)
+
+PormG.Models.set_models(@__MODULE__, "uc_mock_pg")
+end
+const UM = UniqueConstraintUnitModels
+
+# Helper: build a fresh-schema plan (every model :exist => false) for a backend mock.
+function _uc_plan(conn)
+  settings = PormG.Configuration.Settings(connections = conn, change_data = true)
+  current_schema = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(
+    :season_entry => Dict{Symbol, Union{Bool, PormGModel}}(:model => UM.Season_entry, :exist => false),
+    :grid_slot    => Dict{Symbol, Union{Bool, PormGModel}}(:model => UM.Grid_slot,    :exist => false),
+  )
+  return Migrations.get_migration_plan(PormGModel[], current_schema, conn, settings, interactive = false)
+end
+
+@testset "UniqueConstraint construction & validation" begin
+  # Field normalization: Symbol/String/Tuple/Vector all accepted; name optional.
+  @test Models.UniqueConstraint(fields = ("a", "b")).fields == ["a", "b"]
+  @test Models.UniqueConstraint(fields = [:x, :y], name = "my_uniq").fields == ["x", "y"]
+  @test Models.UniqueConstraint(fields = [:x, :y], name = "my_uniq").name == "my_uniq"
+  @test Models.UniqueConstraint(fields = ("a", "b")).name === nothing
+  # A single field name (not wrapped) is accepted and NOT iterated char-by-char.
+  @test Models.UniqueConstraint(fields = "solo").fields == ["solo"]
+  @test Models.UniqueConstraint(fields = :solo).fields == ["solo"]
+
+  # Duplicate fields are rejected.
+  @test_throws ArgumentError Models.UniqueConstraint(fields = ("a", "a"))
+
+  # A blank name would render as an empty (invalid) index identifier — rejected.
+  @test_throws ArgumentError Models.UniqueConstraint(fields = ("a", "b"), name = "")
+  @test_throws ArgumentError Models.UniqueConstraint(fields = ("a", "b"), name = "   ")
+
+  # Applied to a model → validated + stashed in cache (the M2M metadata mechanism).
+  m = Models.Model("widgets",
+    id = Models.IDField(),
+    a = Models.IntegerField(),
+    b = Models.IntegerField(),
+    constraints = [Models.UniqueConstraint(fields = ("a", "b"))],
+  )
+  @test haskey(m.cache, "unique_constraints")
+  @test length(m.cache["unique_constraints"]["constraints"]) == 1
+  @test m.cache["unique_constraints"]["constraints"][1].fields == ["a", "b"]
+
+  # A model with no constraints has no cache entry (no churn on the common path).
+  plain = Models.Model("plain", id = Models.IDField(), a = Models.IntegerField())
+  @test !haskey(plain.cache, "unique_constraints")
+
+  # The idiomatic NO-positional-name form (table inferred from the binding via set_models) must
+  # also accept constraints= — it uses a distinct Model(; ...) method.
+  noname = Models.Model(
+    id = Models.IDField(),
+    a = Models.IntegerField(),
+    b = Models.IntegerField(),
+    constraints = [Models.UniqueConstraint(fields = ("a", "b"))],
+  )
+  @test haskey(noname.cache, "unique_constraints")
+  @test noname.cache["unique_constraints"]["constraints"][1].fields == ["a", "b"]
+
+  # Referencing an unknown field is rejected, naming the offender.
+  @test_throws ArgumentError Models.Model("bad_unknown",
+    id = Models.IDField(),
+    a = Models.IntegerField(),
+    constraints = [Models.UniqueConstraint(fields = ("a", "nope"))],
+  )
+
+  # Referencing a ManyToManyField (no concrete column) is rejected.
+  Tag = Models.Model("uc_tags", id = Models.IDField(), label = Models.CharField())
+  @test_throws ArgumentError Models.Model("bad_m2m",
+    id = Models.IDField(),
+    tags = Models.ManyToManyField(Tag),
+    constraints = [Models.UniqueConstraint(fields = ("tags",))],
+  )
+
+  # Two constraints sharing an explicit name collide into one index — rejected at construction.
+  @test_throws ArgumentError Models.Model("bad_dupname",
+    id = Models.IDField(),
+    a = Models.IntegerField(),
+    b = Models.IntegerField(),
+    c = Models.IntegerField(),
+    constraints = [
+      Models.UniqueConstraint(fields = ("a", "b"), name = "dup"),
+      Models.UniqueConstraint(fields = ("a", "c"), name = "dup"),
+    ],
+  )
+end
+
+@testset "Planner rejects colliding derived index names" begin
+  # Two constraints over the same columns derive the same auto name; the planner must fail
+  # loudly rather than silently overwrite one in the plan OrderedDict.
+  module_collide = Models.Model("collide_tbl",
+    id = Models.IDField(),
+    a = Models.IntegerField(),
+    b = Models.IntegerField(),
+    constraints = [
+      Models.UniqueConstraint(fields = ("a", "b")),
+      Models.UniqueConstraint(fields = ("a", "b")),
+    ],
+  )
+  settings = PormG.Configuration.Settings(connections = UCMockPostgres(), change_data = true)
+  current_schema = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(
+    :collide => Dict{Symbol, Union{Bool, PormGModel}}(:model => module_collide, :exist => false),
+  )
+  @test_throws ArgumentError Migrations.get_migration_plan(
+    PormGModel[], current_schema, UCMockPostgres(), settings, interactive = false)
+end
+
+@testset "Planner emits CREATE UNIQUE INDEX at table creation (PostgreSQL)" begin
+  plan = _uc_plan(UCMockPostgres())
+
+  # Auto-named composite index over the two declared columns.
+  sql = join(values(plan[:season_entry]), "\n")
+  @test occursin("CREATE TABLE", sql)
+  @test occursin("CREATE UNIQUE INDEX", sql)
+  @test occursin("season_entries_season_round_uniq", sql)  # <table>_<cols>_uniq
+  @test occursin("\"season\"", sql)
+  @test occursin("\"round\"", sql)
+
+  # Explicit name honored verbatim; db_column-mapped field targets the PHYSICAL column.
+  sql2 = join(values(plan[:grid_slot]), "\n")
+  @test occursin("CREATE UNIQUE INDEX", sql2)
+  @test occursin("grid_slot_unique", sql2)   # explicit name, not derived
+  @test occursin("\"race_ref\"", sql2)        # physical column (#50), not "race"
+  @test occursin("\"position\"", sql2)
+end
+
+@testset "Planner emits CREATE UNIQUE INDEX at table creation (SQLite)" begin
+  # PG/SQLite alignment: create_unique_index renders identically on both backends.
+  plan = _uc_plan(UCMockSQLite())
+  sql = join(values(plan[:season_entry]), "\n")
+  @test occursin("CREATE UNIQUE INDEX", sql)
+  @test occursin("season_entries_season_round_uniq", sql)
+  @test occursin("\"season\"", sql)
+  @test occursin("\"round\"", sql)
+end
+
+@testset "Model_to_str round-trips constraints through the constraints= kwarg" begin
+  rt_settings = PormG.Configuration.Settings(db_def_folder = "uc_rt", django_prefix = nothing)
+  m = Models.Model("standings",
+    id = Models.IDField(),
+    season = Models.IntegerField(),
+    round  = Models.IntegerField(),
+    constraints = [Models.UniqueConstraint(fields = ("season", "round"), name = "standings_uniq")],
+  )
+  str = Models.Model_to_str(m, rt_settings)
+  @test occursin("constraints = [Models.UniqueConstraint(fields = (\"season\", \"round\",)", str)
+  @test occursin("name = \"standings_uniq\"", str)
+
+  # Evaluate the generated declaration and confirm it reconstructs the constraint —
+  # this guards the "sync Model_to_str when kwargs are added" round-trip rule.
+  rt_mod = Module()
+  Core.eval(rt_mod, :(import PormG.Models))
+  reconstructed = Core.eval(rt_mod, Meta.parse(str))
+  @test haskey(reconstructed.cache, "unique_constraints")
+  rc = reconstructed.cache["unique_constraints"]["constraints"][1]
+  @test rc.fields == ["season", "round"]
+  @test rc.name == "standings_uniq"
+end
+
+@testset "Django importer maps Meta.unique_together" begin
+  # FK fields gain an `_id` suffix at import, so Django `item`/`fabricante` become
+  # PormG `item_id`/`fabricante_id`; the importer must resolve the declared names.
+  django = """
+  class Dim_item_fab(models.Model):
+      item = models.ForeignKey(Dim_item, on_delete=models.CASCADE)
+      fabricante = models.ForeignKey(Dim_fab, on_delete=models.CASCADE)
+      validade = models.IntegerField(null=True, blank=True)
+
+      class Meta:
+          unique_together = ('item', 'fabricante')
+  """
+
+  config_key = mktempdir()
+  PormG.config[config_key] = PormG.Configuration.Settings(
+    db_def_folder = config_key, django_prefix = nothing)
+  try
+    import_models_from_django(django; db = config_key, file = "uc_import_unit.jl", force_replace = true)
+    generated = read(joinpath(config_key, "uc_import_unit.jl"), String)
+    @test occursin("constraints = [Models.UniqueConstraint(fields = (\"item_id\", \"fabricante_id\",))", generated)
+  finally
+    delete!(PormG.config, config_key)
+    isdir(config_key) && rm(config_key; recursive = true)
+  end
+end
+
+@testset "Django importer is lenient with a malformed unique_together" begin
+  # A duplicate-field unique_together makes the UniqueConstraint constructor throw; the importer
+  # must warn and skip it, still generating the model (never aborting the whole import).
+  django = """
+  class Widget(models.Model):
+      color = models.CharField(max_length=20)
+      size = models.IntegerField()
+
+      class Meta:
+          unique_together = ('color', 'color')
+  """
+  config_key = mktempdir()
+  PormG.config[config_key] = PormG.Configuration.Settings(
+    db_def_folder = config_key, django_prefix = nothing)
+  try
+    import_models_from_django(django; db = config_key, file = "uc_bad_unit.jl", force_replace = true)
+    generated = read(joinpath(config_key, "uc_bad_unit.jl"), String)
+    @test occursin("Widget = Models.Model(\"widget\"", generated)   # model still generated
+    @test !occursin("UniqueConstraint", generated)                   # bad constraint skipped
+  finally
+    delete!(PormG.config, config_key)
+    isdir(config_key) && rm(config_key; recursive = true)
+  end
+end


### PR DESCRIPTION
## Summary

Implements Django-style composite/multi-column uniqueness (`unique_together`) for regular models — issue #19. Single-column `unique=true` was already supported; this adds uniqueness spanning **two or more** columns.

Spelled as named **`Models.UniqueConstraint`** objects (the Django 2.2+ / SQLAlchemy form) declared via a model-level `constraints=` kwarg:

```julia
Constructor_engine = Models.Model("constructor_engines",
  id = Models.IDField(),
  constructorid = Models.ForeignKey(Constructor, pk_field="constructorid", on_delete="CASCADE"),
  year = Models.IntegerField(),
  engine_manufacturer = Models.CharField(max_length=50),
  constraints = [
    Models.UniqueConstraint(fields=("constructorid", "year"), name="uniq_constructor_year"),
  ],
)
```

At migration time each constraint becomes a `CREATE UNIQUE INDEX` — byte-identical on PostgreSQL and SQLite:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS "uniq_constructor_year"
  ON "constructor_engines" ("constructorid", "year");
```

### Design

- **Named-constraint API** (not the legacy tuple) — custom index names now, room for conditional/partial uniqueness later. Fits the pre-publish "get the API right" ethos.
- **Reuses the proven `ManyToManyField` pipeline** — `model.cache[…]` → planner → `Dialect.create_unique_index` — instead of new machinery. No new SQL rendering.
- **Add-only (this PR):** a constraint is materialized when its table is first created (same lifecycle as the automatic M2M join-table index), so it never pollutes later migration plans. Diffing add/drop/change on an already-migrated table is deferred — it needs composite-unique introspection that does not exist yet on either backend (a tracked follow-up).

This PR **references** #19 but does not fully close it — the migration-diff requirement (#3 in the issue) is the deferred follow-up.

## What changed

- **`src/Models.jl`** — `UniqueConstraint` type + validation (fields must exist and be concrete columns, not `ManyToManyField`; no duplicate or blank names); `constraints=` on both the named `Model("t"; …)` and the idiomatic no-positional-name `Model(; …)` forms; round-trip emission in `Model_to_str`.
- **`src/migrations/planner.jl`** — `_add_unique_constraints` (sibling of `_add_many_to_many_auto_constraints`), called from `_add_new_table`; resolves field names to physical columns via `model_column` (honors `db_column`); guards against colliding index names.
- **`src/migrations/importers.jl`** — the Django importer maps `Meta.unique_together` to `UniqueConstraint` (resolving the FK `_id` suffix), leniently warning and skipping a malformed declaration rather than aborting the import.
- **Docs** — `models.md` (with the 63-char identifier-limit note), `import_django.md`, `fields.md`, `UPGRADING.md`.

## Testing

- **Unit** (`test/unit/test_unique_constraints.jl`, DB-free): construction/validation, planner rendering on **both** backends, `Model_to_str` round-trip, importer mapping + leniency. Full unit suite **2619/2619**.
- **Integration** (new Phase 17 in `test_migration_bootstrap.jl`, isolated temp DB): declare a `UniqueConstraint` → migrate → assert the composite index exists → assert a duplicate insert is rejected and a different pair is accepted. Runs on both backends.
  - PostgreSQL (db_2): **1656 pass**, exit 0 — log shows `UniqueViolation: duplicate key value violates unique constraint "uniqtest_season_round_uniq"`.
  - SQLite (db_sl): **1619 pass + 1 known broken**, exit 0 — duplicate rejected with `UNIQUE constraint failed: uniqtest.season, uniqtest.round`.
- Docs build clean.

## Follow-up (deferred)

Full add/drop/change diff across migrations (Django's `AlterUniqueTogether`): needs a new composite-unique introspection query returning `(index_name, columns, is_unique)` for **both** PostgreSQL and SQLite (today PG discards composite-unique column sets and the SQLite diff doesn't read indexes at all), plus a table-level diff pass and the SQLite table-rebuild interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
