### PR TITLE
fix(migrations): rebuild SQLite table when deleting a unique or PK non-FK column (#151)

### DIFF
--- a/docs/src/migrations/index.md
+++ b/docs/src/migrations/index.md
@@ -68,7 +68,7 @@ The exact on-disk file layout, checksum algorithm, and tracking-table columns ar
 ## Database-Specific Behavior
 
 ### SQLite: Table Recreation
-SQLite has limited `ALTER TABLE` support. It can rename tables/columns and add or drop plain columns, but it **cannot** change a column's type, modify nullability/`UNIQUE`/`CHECK` constraints in place, remove a foreign key (there is no `ALTER TABLE ... DROP CONSTRAINT`), or `DROP COLUMN` on a column that participates in a `FOREIGN KEY`.
+SQLite has limited `ALTER TABLE` support. It can rename tables/columns and add or drop plain columns, but it **cannot** change a column's type, modify nullability/`UNIQUE`/`CHECK` constraints in place, remove a foreign key (there is no `ALTER TABLE ... DROP CONSTRAINT`), or `DROP COLUMN` on a column that participates in a `FOREIGN KEY`, a `UNIQUE` constraint, or the `PRIMARY KEY`.
 
 To handle any of those changes, PormG automatically rebuilds the table from your model:
 - Creates a new table with the desired schema.
@@ -76,9 +76,12 @@ To handle any of those changes, PormG automatically rebuilds the table from your
 - Re-creates the surviving indexes and foreign keys — an index on a *dropped* column is **not** re-created.
 - Drops the old table, renames the new one, and runs `PRAGMA foreign_key_check` to catch orphaned rows.
 
-The rebuild is emitted as plain DDL that composes with the migration's transaction, so no data is lost and the remaining indexes and constraints are preserved. This is what makes **removing a foreign-key field or constraint** work on SQLite even though `DROP COLUMN`/`DROP CONSTRAINT` alone cannot express it. Changes SQLite *can* do in place — adding a column, or dropping a column that is not part of a foreign key — use `ALTER TABLE` directly, without a rebuild.
+The rebuild is emitted as plain DDL that composes with the migration's transaction, so no data is lost and the remaining indexes and constraints are preserved. This is what makes **removing a foreign-key field or constraint, a `UNIQUE` column, or a `PRIMARY KEY` column** work on SQLite even though `DROP COLUMN`/`DROP CONSTRAINT` alone cannot express it. Changes SQLite *can* do in place — adding a column, or dropping an *ordinary* column (not part of a `FOREIGN KEY`, `UNIQUE`, or `PRIMARY KEY`) — use `ALTER TABLE` directly, without a rebuild.
 
 This process is transparent to the user but may take longer on very large tables.
+
+!!! warning "Dropping a primary key: PostgreSQL vs SQLite"
+    Removing a column that is the table's **only** primary key diverges by backend. PostgreSQL's `DROP COLUMN` drops the column and its `PRIMARY KEY` constraint natively, leaving a table with no primary key. SQLite cannot express that without silently degrading the table to a rowid table, so PormG **fails `makemigrations` loudly** instead — declare a replacement primary key, or make the change manually. Dropping a primary-key column while the model still declares a primary key (the key moved to another column) rebuilds normally on both backends.
 
 !!! note "SQLite Limitation"
     Advisory locking is not available for SQLite. Migration safety is single-instance only.

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -447,6 +447,22 @@ function get_constraints_index(conn::PormGSQLite, table_name::Symbol, field_name
   return nothing
 end
 
+# #151: SQLite introspection does not populate `field.unique` (see convertSQLToModel(::PormGSQLite)), so the
+# deletion path can't trust the old field's attribute — probe the live schema for a UNIQUE index covering
+# `field_name`. That covers the column-level UNIQUE auto-index (`sqlite_autoindex_…`, which `DROP INDEX`
+# can't remove) as well as any `CREATE UNIQUE INDEX`. Such a column is refused by `ALTER TABLE DROP COLUMN`,
+# so its deletion must route through a table rebuild (same remedy #116 uses for FK columns).
+function _sqlite_column_is_unique(conn::PormGSQLite, table_name, field_name::String)::Bool
+  idx_list = fetch(conn, "PRAGMA index_list(\"$(string(table_name))\")") |> DataFrame
+  isempty(idx_list) && return false
+  for row in eachrow(idx_list)
+    row.unique == 1 || continue
+    idx_info = fetch(conn, "PRAGMA index_info(\"$(row.name)\")") |> DataFrame
+    (!isempty(idx_info) && field_name in idx_info.name) && return true
+  end
+  return false
+end
+
 """
     get_secondary_index_ddls(conn::PormGSQLite, table_name) -> Vector{String}
 

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -446,6 +446,31 @@ function _resolve_table_fields(
     end      
     filter!(x -> x != field_name_sym, colect_addition)
   end
+  # #151: the PK loud-fail guard runs for ANY SQLite deletion on this table, and BEFORE the rename-rebuild
+  # skip below — otherwise a #150 rename-rebuild co-scheduled in the same migration would skip the deletion
+  # block and silently rebuild a PK-less rowid table from `current_model`. Deleting a primary-key column
+  # that would leave the desired table with NO primary key is not auto-migratable on SQLite; fail loudly
+  # rather than produce a rowid table (or a raw DROP COLUMN error). When the desired model still declares a
+  # PK (the primary key moved to another column), the rebuild handles it normally.
+  #
+  # INTENTIONAL PG/SQLite DIVERGENCE: PostgreSQL's `ALTER TABLE DROP COLUMN` drops a primary-key column and
+  # its constraint natively, so removing the sole PK succeeds there; SQLite has no such path, and this guard
+  # makes it fail loudly instead of silently degrading the table to rowid. Removing the only primary key is
+  # therefore rejected on SQLite but allowed on PostgreSQL — a deliberate, backend-capability-driven
+  # difference (see the #151 Phase 4g test, which gates this case to SQLite).
+  if conn isa PormGSQLite && !isempty(colect_deletion)
+    desired_has_pk = any(f -> hasfield(typeof(f), :primary_key) && f.primary_key, values(current_model.fields))
+    if !desired_has_pk
+      for fsym in colect_deletion
+        f = model.fields[model_fields_map[string(fsym)]]
+        if hasfield(typeof(f), :primary_key) && f.primary_key
+          error("Cannot auto-migrate on SQLite: deleting primary-key column \"$(fsym)\" from table " *
+                "\"$(model_name)\" would leave it with no primary key. Declare a replacement primary key, " *
+                "or make this change manually.")
+        end
+      end
+    end
+  end
   # #150: a rename-with-FK-change may already have scheduled a full SQLite rebuild for this model (keyed
   # "Alter table: $model_name"). That rebuild is generated from `current_model`, which omits EVERY deleted
   # field, so it already drops this table's remaining deletions. Running the per-column deletion handling
@@ -454,31 +479,36 @@ function _resolve_table_fields(
   sqlite_rename_rebuild = conn isa PormGSQLite && haskey(migration_plan, model_name) &&
     haskey(migration_plan[model_name], "Alter table: $model_name")
   if !isempty(colect_deletion) && !sqlite_rename_rebuild
-    # #116: On SQLite an FK column can't be removed with `ALTER TABLE DROP COLUMN` (SQLite forbids it and
-    # has no `ALTER TABLE DROP CONSTRAINT`), so deleting an FK field needs a full table rebuild. The rebuild
-    # is generated from `current_model`, which already omits EVERY deleted field, so ONE rebuild drops all of
-    # this table's deleted columns (and their FKs/indexes) at once. Therefore if ANY deleted field forces a
-    # rebuild, route the WHOLE table's deletions through it and skip the per-column DROP COLUMNs — emitting
-    # both would race: the rebuild removes the column, then a separate `DROP COLUMN "<other>"` for a
-    # sibling deletion fails "no such column" (order-dependent on the deletion set's iteration).
-    fk_delete_idx = nothing
+    # #116/#151: SQLite refuses `ALTER TABLE DROP COLUMN` for an FK-with-constraint, a UNIQUE, or a PRIMARY
+    # KEY column (and a UNIQUE column's `sqlite_autoindex_…` can't be pre-dropped), so deleting any of those
+    # needs a full table rebuild. The rebuild is generated from `current_model` (which omits EVERY deleted
+    # field), so ONE rebuild drops all of this table's deleted columns + their indexes at once — hence if ANY
+    # deleted field forces a rebuild, route the WHOLE table's deletions through it and skip the per-column
+    # DROP COLUMNs (emitting both would race: the rebuild removes the column, then a stray `DROP COLUMN` for a
+    # sibling deletion fails "no such column"). Ordinary indexed columns still take the cheap DROP COLUMN path
+    # below (their plain index is pre-dropped). `unique` is probed live — SQLite introspection doesn't set
+    # `old_field.unique` (see _sqlite_column_is_unique) — while `primary_key` IS populated by introspection.
+    rebuild_delete_idx = nothing
     if conn isa PormGSQLite
-      fk_delete_idx = findfirst(colect_deletion) do fsym
-        f = model.fields[model_fields_map[string(fsym)]]
-        hasfield(typeof(f), :to) && f.db_constraint
+      rebuild_delete_idx = findfirst(colect_deletion) do fsym
+        fname = string(fsym)
+        f = model.fields[model_fields_map[fname]]
+        (hasfield(typeof(f), :to) && f.db_constraint) ||
+          (hasfield(typeof(f), :primary_key) && f.primary_key) ||
+          _sqlite_column_is_unique(conn, model_name, fname)
       end
     end
-    if fk_delete_idx !== nothing
+    if rebuild_delete_idx !== nothing
       # `alter_field(::PormGSQLite, model, …)` rebuilds the table purely from `model.fields`; its
       # field_name/new_field/old_field/colect_not_equal arguments are unused for the SQLite recreation, so a
       # representative deleted field is passed only to satisfy the shared signature. `surviving_columns` keeps
       # the dropped columns' indexes off the preserved set (see _sqlite_rebuild_preserving_indexes). The
       # stable "Alter table:" key means a co-occurring alteration/add-default collapses into this one
       # idempotent recreation from the same desired model.
-      rebuild_field = model.fields[model_fields_map[string(colect_deletion[fk_delete_idx])]]
+      rebuild_field = model.fields[model_fields_map[string(colect_deletion[rebuild_delete_idx])]]
       _configure_order_dict_migration_plan(migration_plan, model_name, "Alter table: $model_name",
         _sqlite_rebuild_preserving_indexes(conn, current_model.name |> lowercase,
-          Dialect.alter_field(conn, current_model, string(colect_deletion[fk_delete_idx]), rebuild_field, rebuild_field, Symbol[]);
+          Dialect.alter_field(conn, current_model, string(colect_deletion[rebuild_delete_idx]), rebuild_field, rebuild_field, Symbol[]);
           surviving_columns = _model_physical_columns(current_model)))
     else
       # PostgreSQL, or SQLite with no FK-column deletions: plain DROP COLUMN works (the FK drop runs first on

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -763,6 +763,132 @@ end
     PormG.ConnectionPool.fetch(pool, """DELETE FROM "migrationtest" WHERE "id" = 950;""")
   end
 
+  # ── Phase 4g: Delete a UNIQUE (and, guarded, a PK) non-FK column (#151) ─
+  # #116 routed FK-column deletion through a table rebuild; a non-FK UNIQUE column still fell to plain
+  # `ALTER TABLE DROP COLUMN`, which SQLite refuses (its `sqlite_autoindex_…` can't be pre-dropped). #151
+  # widens the SQLite rebuild trigger to UNIQUE/PK columns too. Carries the prior phases' tables forward so
+  # adding the test tables is a pure table-ADD. Runs on BOTH backends for the UNIQUE case (PostgreSQL takes
+  # the plain DROP COLUMN path — it drops a unique column natively; SQLite takes the rebuild). The PK
+  # loud-fail case is SQLite-only (PostgreSQL drops a PK column natively, no guard needed).
+  @testset "Phase 4g: Delete Unique/PK Non-FK Column (#151)" begin
+    base5 = """
+    MigrationTest = Models.Model(
+        id = Models.IDField(),
+        name = Models.CharField()
+    )
+    SecondTable = Models.Model(
+        id = Models.IDField(),
+        test_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, db_constraint=false),
+        description = Models.CharField(null=true)
+    )
+    ChildFKTable = Models.Model(
+        id = Models.IDField(),
+        label = Models.CharField(null=false)
+    )
+    RenameFKChild = Models.Model(
+        id = Models.IDField(),
+        new_parent_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_index=true, db_constraint=false),
+        note = Models.CharField(null=true)
+    )
+    RenameDelChild = Models.Model(
+        id = Models.IDField(),
+        link_ref_id = Models.ForeignKey("MigrationTest", on_delete=Models.CASCADE, null=true, db_constraint=false),
+        note = Models.CharField(null=true)
+    )
+    """
+
+    # ── Unique-column deletion (both backends) ──
+    # Setup: a table with a UNIQUE non-FK `code` column and a plain `keeper`.
+    write_edge_models(base5 * """
+    UniqueDelChild = Models.Model(
+        id = Models.IDField(),
+        code = Models.CharField(unique=true, null=true),
+        keeper = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    @assert "code" in column_names(pool, "uniquedelchild") "Phase 4g requires the unique column to exist"
+
+    # The UNIQUE constraint is live: seed one row, then a duplicate `code` INSERT must raise (behavioral
+    # verification, per the #82 technique — introspection can't confirm uniqueness on SQLite).
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO "uniquedelchild" ("id", "code", "keeper") VALUES (960, 'code-X', 'keep-960');""")
+    dup_err = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO "uniquedelchild" ("id", "code", "keeper") VALUES (961, 'code-X', 'dup');""")
+      nothing
+    catch e; e; end
+    @test dup_err !== nothing
+    @test any(tok -> occursin(tok, lowercase(string(dup_err))), ["unique", "constraint", "duplicate"])
+
+    # Desired: remove the UNIQUE `code` column.
+    write_edge_models(base5 * """
+    UniqueDelChild = Models.Model(
+        id = Models.IDField(),
+        keeper = Models.CharField(null=true)
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    pending = read(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"), String)
+    @test !occursin("BEGIN TRANSACTION", pending)
+
+    # Must NOT raise. Pre-fix on SQLite, deleting `code` took the plain path — `DROP INDEX` on its
+    # `sqlite_autoindex` (or the `DROP COLUMN` itself) is refused. #151 routes it through the rebuild.
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    cols = column_names(pool, "uniquedelchild")
+    @test !("code" in cols)          # the unique column is gone
+    @test "keeper" in cols           # the plain column survives
+    # Data fidelity: the surviving row kept its non-unique value.
+    surviving = PormG.ConnectionPool.fetch(pool,
+      """SELECT "keeper" FROM "uniquedelchild" WHERE "id" = 960;""") |> DataFrame
+    @test nrow(surviving) == 1
+    @test isequal(surviving[1, :keeper], "keep-960")
+    # (The migrate above NOT raising is itself the #151 proof: pre-fix, deleting a UNIQUE column aborts on
+    # the `DROP INDEX` of its `sqlite_autoindex`. `code` being absent proves its UNIQUE index is gone too —
+    # SQLite can't keep an index on a dropped column. No separate auto-index count is asserted because the
+    # surviving `id` column keeps its own UNIQUE auto-index, so "no auto-index at all" would be wrong.)
+    PormG.ConnectionPool.fetch(pool, """DELETE FROM "uniquedelchild" WHERE "id" = 960;""")
+
+    # ── PK loud-fail (SQLite only) ──
+    # Deleting a PK column that would leave the table with NO primary key must fail loudly at
+    # makemigrations rather than emit a raw DROP COLUMN. (PormG permits PK-less models, so this is
+    # reachable.) PostgreSQL drops a PK column natively, so this guard is SQLite-specific.
+    if adapter_name == "SQLite"
+      uniquedelchild_now = """
+    UniqueDelChild = Models.Model(
+        id = Models.IDField(),
+        keeper = Models.CharField(null=true)
+    )
+    """
+      write_edge_models(base5 * uniquedelchild_now * """
+    PkGuardChild = Models.Model(
+        pk_code = Models.CharField(primary_key=true, null=false),
+        payload = Models.CharField(null=true)
+    )
+    """)
+      makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+      migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+      @assert "pk_code" in column_names(pool, "pkguardchild") "Phase 4g requires the PK column to exist"
+
+      # Desired: drop pk_code, leaving `payload` only → NO primary key. makemigrations must throw.
+      write_edge_models(base5 * uniquedelchild_now * """
+    PkGuardChild = Models.Model(
+        payload = Models.CharField(null=true)
+    )
+    """)
+      pk_err = try
+        makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+        nothing
+      catch e; e; end
+      @test pk_err !== nothing
+      # Assert the SPECIFIC guard message, so an unrelated error can't masquerade as a pass.
+      @test occursin("no primary key", lowercase(string(pk_err)))
+      # The live schema is untouched — the failed makemigrations wrote/applied nothing.
+      @test "pk_code" in column_names(pool, "pkguardchild")
+    end
+  end
+
   # ── Phase 5: Indexes and unique constraints ───────────────────────
   @testset "Phase 5: Indexes and Unique Constraints" begin
     write_edge_models("""

--- a/test/unit/test_sqlite_index_filter.jl
+++ b/test/unit/test_sqlite_index_filter.jl
@@ -23,7 +23,7 @@ using Test
 using PormG
 using DataFrames
 import PormG.ConnectionPool: SQLiteConnectionPool, fetch, close_pool!
-import PormG.Migrations: get_secondary_index_ddls
+import PormG.Migrations: get_secondary_index_ddls, _sqlite_column_is_unique
 
 @testset "get_secondary_index_ddls column filter (#116)" begin
   mktempdir() do dir
@@ -112,6 +112,39 @@ end
       # `!occursin("\"old_col\"")` checks fail. Drop the filter mapping and `kept` goes empty.
     finally
       # Release the SQLite handle so mktempdir can delete the temp DB on Windows (WAL keeps it open).
+      close_pool!(pool)
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #151: `_sqlite_column_is_unique` — the live-schema probe that decides whether deleting a non-FK column
+# needs a table rebuild.
+#
+# SQLite refuses `ALTER TABLE DROP COLUMN` for a UNIQUE column, and its backing `sqlite_autoindex_…` can't
+# be pre-dropped with `DROP INDEX` — so such a deletion must route through a rebuild. SQLite introspection
+# does NOT populate `field.unique`, so the deletion path can't trust the old field's attribute; it probes
+# the live schema instead. This probe must fire for a column-level `UNIQUE` (auto-index) but NOT for an
+# ordinary secondary index (whose column CAN take DROP COLUMN once the plain index is pre-dropped).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_sqlite_column_is_unique (#151)" begin
+  mktempdir() do dir
+    pool = SQLiteConnectionPool(joinpath(dir, "uniqueprobe.sqlite"); pool_size = 1)
+    try
+      # `uc` has a column-level UNIQUE (→ sqlite_autoindex); `ic` has a plain CREATE INDEX; `plain` has none.
+      fetch(pool, "CREATE TABLE t (uc TEXT UNIQUE, ic INTEGER, plain TEXT);")
+      fetch(pool, "CREATE INDEX ix_ic ON t(ic);")
+
+      @test _sqlite_column_is_unique(pool, :t, "uc") == true      # UNIQUE column → rebuild required
+      @test _sqlite_column_is_unique(pool, :t, "ic") == false     # plain index → cheap DROP COLUMN is fine
+      @test _sqlite_column_is_unique(pool, :t, "plain") == false  # no index → cheap DROP COLUMN is fine
+      @test _sqlite_column_is_unique(pool, :t, "absent") == false # unknown column → false, never throws
+
+      # Also true for an explicit CREATE UNIQUE INDEX (still a UNIQUE index covering the column).
+      fetch(pool, "CREATE UNIQUE INDEX ux_plain ON t(plain);")
+      @test _sqlite_column_is_unique(pool, :t, "plain") == true
+      # Mutation gate: without the `row.unique == 1` filter, `ic` (plain index) would return true.
+    finally
       close_pool!(pool)
     end
   end


### PR DESCRIPTION
## Summary

SQLite refuses `ALTER TABLE DROP COLUMN` for a column that is a `PRIMARY KEY`, has a `UNIQUE` constraint, or is indexed. #116 routed **FK-with-constraint** column deletion through a model-based table rebuild, but a non-FK **unique**/**PK** column still took the plain `DROP COLUMN` path — so the migration aborted at `migrate` time (a `UNIQUE` column's `sqlite_autoindex_…` can't be pre-dropped, and a PK column can't be dropped at all). Sibling of #150; discovered while implementing #116.

## Fix

Widen the SQLite deletion-branch rebuild trigger (was FK-with-constraint only) to also rebuild for `UNIQUE` and `PRIMARY KEY` columns, reusing the #116 `_sqlite_rebuild_preserving_indexes` + `alter_field(current_model)` machinery (which already omits the deleted column and preserves survivors' `UNIQUE`/`PRIMARY KEY`).

Two backend-specific details:
- **`unique` is probed live.** SQLite introspection does **not** populate `field.unique`, so the old-field attribute can't be trusted — a new `_sqlite_column_is_unique` helper probes `PRAGMA index_list`/`index_info` for a `UNIQUE` index covering the column. `primary_key` **is** populated by introspection, so it's read directly.
- Ordinary indexed columns still take the cheap `DROP COLUMN` path (their plain index is pre-dropped).

**PK-deletion policy:** rebuild when the desired model still declares a primary key (the key moved to another column); if removing the column would leave the table with **no** primary key, **fail loudly** at `makemigrations` rather than silently degrade it to a rowid table. The guard runs for any SQLite deletion, *before* the #150 rename-rebuild skip, so a co-scheduled rename-rebuild can't bypass it.

**Prior art:** Django's SQLite schema editor (ticket #33899) rebuilds for PK/unique/indexed/FK columns; PormG keeps `DROP COLUMN` for plain-indexed and rebuilds for unique/PK/FK-with-constraint.

## Intentional PG/SQLite divergence

Removing the **sole** primary key succeeds on PostgreSQL (`DROP COLUMN` drops the column + constraint natively) but **fails loudly on SQLite** (no native path; the alternative is a silent rowid-table degradation). Documented in code, the Phase 4g test, and `docs/src/migrations/index.md`.

## Tests

- **Unit:** `_sqlite_column_is_unique` — column-level `UNIQUE` ⇒ true; plain index / no index / unknown column ⇒ false; explicit `CREATE UNIQUE INDEX` ⇒ true (`test/unit/test_sqlite_index_filter.jl`).
- **Integration Phase 4g (both backends):** delete a `unique` non-FK column — succeeds, column gone, remaining data preserved (uniqueness verified live beforehand via a duplicate-insert). PK loud-fail is SQLite-gated (PostgreSQL drops a PK column natively).

**Verification:** unit **2696/2696**; SQLite edge cases **155/155**; PostgreSQL edge cases **146/146**; docs build passes.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
