### PR TITLE
fix(migrations): keep an index added in the same migration as a table rebuild (#152)

### DIFF
--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -441,6 +441,7 @@ function _order_statements(migration_plan)
   second_execution::Vector{String} = []
   third_execution::Vector{String} = []
   last_execution::Vector{String} = []
+  index_execution::Vector{String} = []   # #152: field CREATE INDEX runs AFTER same-table rebuilds
 
   for dict_instructs in migration_plan
     for (key, value) in dict_instructs
@@ -450,13 +451,22 @@ function _order_statements(migration_plan)
         push!(second_execution, value)
       elseif contains(key, "Rename field")
         push!(third_execution, value)
+      elseif startswith(key, "Create index")
+        # #152: a newly-added db_index field's CREATE INDEX must run AFTER any same-table rebuild. An
+        # SQLite "Alter table:" rebuild DROP TABLEs the table (dropping every secondary index) and only
+        # re-creates indexes snapshotted from the LIVE schema at planning time — which excludes an index
+        # queued in the SAME migration, so a fresh index would be dropped and never re-created. Deferring
+        # every field CREATE INDEX to the end lands it on the rebuilt table. Safe: a CREATE INDEX only
+        # needs its table to exist. Matches only "Create index on <field>"; "Remove index …" (different
+        # prefix) and the m2m "Create many-to-many unique index" (separate join table) are excluded.
+        push!(index_execution, value)
       else
         push!(last_execution, value)
       end
     end
   end
 
-  ordered = vcat(first_execution, second_execution, third_execution, last_execution)
+  ordered = vcat(first_execution, second_execution, third_execution, last_execution, index_execution)
   all_sql = join(ordered, "\n")
   return ordered, all_sql
 end

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1982,3 +1982,84 @@ if adapter_name == "SQLite"
   end
 end
 
+# ── SQLite table-rebuild: keep an index ADDED in the SAME migration (#152) ──
+#
+# Logic: adding a db_index field queues a "Create index on X" statement; if the SAME migration also rebuilds
+#        the table (here: altering an unrelated field), the rebuild's DROP TABLE drops that fresh index —
+#        and the rebuild only re-creates indexes snapshotted from the LIVE schema at planning time, which
+#        never included it. #152 defers every field CREATE INDEX (in the runner's `_order_statements`) to run
+#        AFTER the rebuild, so the new index lands on the rebuilt table and survives.
+# Why: before the fix the newly-added index was silently lost — no error (issue #152). PostgreSQL uses real
+#      ALTER COLUMN (no rebuild), so this is SQLite-specific. Sibling of #82 (which covered PRE-EXISTING
+#      indexes surviving a rebuild; this covers an index BORN in the rebuilding migration).
+if adapter_name == "SQLite"
+  @testset "SQLite rebuild keeps a newly-added index (#152)" begin
+    db152 = "db_test_migration_152"
+    db152_path = joinpath(@__DIR__, db152)
+    write152(content::String) = open(joinpath(db152_path, "models.jl"), "w") do f
+      write(f, "module models\nimport PormG.Models\n", content, "\nend")
+    end
+    user_idx(names) = sort([n for n in names if occursin("idx", lowercase(n))])
+
+    try
+      # ── setup: fresh isolated SQLite DB (mirrors the #82 scaffolding) ──
+      try; PormG.Configuration.close_pool!(db152_path); catch; end
+      try; ispath(db152_path) && rm(db152_path, recursive=true); catch; end
+      PormG.Generator.create_db_folder_and_yml(path=db152_path, adapter="SQLite")
+      yml = joinpath(db152_path, "connection.yml")
+      yml_content = replace(read(yml, String), "database: database.sqlite" => "database: migration_152.sqlite")
+      open(yml, "w") do f; write(f, yml_content); end   # read BEFORE opening "w" (which truncates)
+      PormG.Configuration.load(db152_path)
+      pool152 = PormG.Configuration.get_settings(db152_path).connections
+
+      # ── create a table with one alterable field, and seed a row so the rebuild has data to copy ──
+      write152("""
+      IndexAdd152 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField()
+      )
+      """)
+      makemigrations(db152_path, interactive=false)
+      migrate(db152_path, interactive=false, destructive=true)
+      PormG.ConnectionPool.fetch(pool152, """INSERT INTO "indexadd152" ("name") VALUES ('row1')""")
+      @test isempty(user_idx(index_names(pool152, "indexadd152")))   # no user index yet
+
+      # ── ONE migration: ADD a db_index field (`tag`) AND alter `name` (NOT NULL → nullable), which forces a
+      #    rebuild of the same table. Insertion order is "Add field: tag" → "Create index on tag" →
+      #    "Alter table:", so pre-fix the fresh index ran before the rebuild's DROP TABLE and was lost. ──
+      write152("""
+      IndexAdd152 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField(null=true),
+          tag = Models.CharField(db_index=true, null=true)
+      )
+      """)
+      makemigrations(db152_path, interactive=false)
+      pending = read(joinpath(db152_path, "migrations", "pending_migrations.jl"), String)
+      @test !occursin("BEGIN TRANSACTION", pending)
+      migrate(db152_path, interactive=false, destructive=true)
+
+      # the new column exists, and its index SURVIVED the co-occurring rebuild — the #152 fix.
+      @test "tag" in column_names(pool152, "indexadd152")
+      @test !isempty(user_idx(index_names(pool152, "indexadd152")))   # pre-fix: empty (index silently lost)
+      # column-bound proof (Phase 4e idiom): some surviving index covers the NEW column `tag`.
+      idxcols = String[]
+      for idx in index_names(pool152, "indexadd152")
+        info = PormG.ConnectionPool.fetch(pool152, """PRAGMA index_info("$(idx)");""") |> DataFrame
+        append!(idxcols, string.(info.name))
+      end
+      @test "tag" in idxcols
+
+      # data fidelity: the seeded row survived the rebuild (and the NOT NULL→nullable alter applied).
+      survivors = PormG.ConnectionPool.fetch(pool152,
+        """SELECT "name" FROM "indexadd152" WHERE "id" = 1""") |> DataFrame
+      @test DataFrames.nrow(survivors) == 1
+      @test isequal(survivors[1, :name], "row1")
+    finally
+      try; PormG.Configuration.close_pool!(db152_path); catch; end
+      try; delete!(PormG.config, db152_path); catch; end
+      try; ispath(db152_path) && rm(db152_path, recursive=true); catch; end
+    end
+  end
+end
+

--- a/test/unit/test_migrations_runner.jl
+++ b/test/unit/test_migrations_runner.jl
@@ -144,6 +144,52 @@ using Dates
         @test occursin("ALTER COLUMN", all_sql)
     end
 
+    @testset "Statement Ordering: CREATE INDEX after rebuild (#152)" begin
+        # #152: a newly-added db_index field queues its "Create index on X" BEFORE the same-table rebuild
+        # ("Alter table: t") in insertion order. On SQLite the rebuild DROP TABLEs the table (dropping every
+        # secondary index) and only re-creates the planning-time live-snapshot indexes — which exclude the
+        # just-queued one — so a fresh index is silently lost. _order_statements must defer every field
+        # CREATE INDEX to run AFTER the rebuild (and keep the ADD COLUMN before it, so the rebuild's
+        # INSERT..SELECT can still copy the new column).
+        plan = [
+            OrderedDict{String,String}(
+                "Add field: flag"      => """ALTER TABLE "t" ADD COLUMN "flag" INTEGER;""",
+                "Create index on flag" => """CREATE INDEX IF NOT EXISTS "t_flag_ab12cd34_idx" ON "t" ("flag");""",
+                "Alter table: t"       => """DROP TABLE IF EXISTS "t_new";\nCREATE TABLE "t_new" (...);\nINSERT INTO "t_new" SELECT * FROM "t";\nDROP TABLE "t";\nALTER TABLE "t_new" RENAME TO "t";""",
+            ),
+        ]
+
+        ordered, _ = Migrations._order_statements(plan)
+
+        add_pos     = findfirst(s -> occursin("ADD COLUMN", s), ordered)
+        rebuild_pos = findfirst(s -> occursin("RENAME TO", s), ordered)   # last step of the rebuild block
+        index_pos   = findfirst(s -> occursin("CREATE INDEX", s), ordered)
+
+        @test add_pos !== nothing && rebuild_pos !== nothing && index_pos !== nothing
+        # ADD COLUMN stays BEFORE the rebuild (so the rebuild's INSERT..SELECT finds the new column).
+        @test add_pos < rebuild_pos
+        # The #152 fix: CREATE INDEX runs AFTER the rebuild — otherwise the rebuild's DROP TABLE loses it.
+        # Mutation gate: without the index_execution bucket, index_pos (2) < rebuild_pos (3) and this fails.
+        @test index_pos > rebuild_pos
+
+        # A "Remove index …" key must NOT be swept into the deferred bucket (different prefix); it stays in
+        # its normal (last_execution) position, and a "Create many-to-many unique index" is likewise not a
+        # field index — neither should collide with the "Create index on <field>" match.
+        plan2 = [
+            OrderedDict{String,String}(
+                "Remove index on old" => """DROP INDEX IF EXISTS "t_old_idx";""",
+                "Alter table: t"      => """ALTER TABLE "t_new" RENAME TO "t";""",
+                "Create index on new" => """CREATE INDEX IF NOT EXISTS "t_new_zz_idx" ON "t" ("new");""",
+            ),
+        ]
+        ordered2, _ = Migrations._order_statements(plan2)
+        remove_pos  = findfirst(s -> occursin("DROP INDEX", s), ordered2)
+        rebuild2    = findfirst(s -> occursin("RENAME TO", s), ordered2)
+        create2     = findfirst(s -> occursin("CREATE INDEX", s), ordered2)
+        @test remove_pos < rebuild2          # DROP INDEX not deferred — runs before the rebuild
+        @test create2 > rebuild2             # CREATE INDEX deferred past the rebuild
+    end
+
     # ==============================================================================
     # SECTION 4: History Table DDL Generation
     #


### PR DESCRIPTION
## Summary

On SQLite, adding a `db_index=true` field **and** triggering a table rebuild on the **same** table in one migration silently lost the new index — no error, the index just vanished. The rebuild's `DROP TABLE` drops the freshly-created index, and the rebuild only re-creates indexes it snapshotted from the **live** schema at planning time (`get_secondary_index_ddls` reads `sqlite_master`), which never included an index queued in the *same* migration. Pre-existing; reachable through every rebuild path (add-NOT-NULL-with-default, field alteration, and the #116/#150/#151 FK/rename/unique/PK-deletion rebuilds). Third of the SQLite migration-rebuild siblings discovered during #116 (with #150, #151).

## Root cause

The runner's [`_order_statements`](src/migrations/runner.jl) is the single execution-ordering choke point (`dry_run`, `migrate`/PG, and `migrate`/SQLite all route through it). It buckets statements into phases: New model → Drop table → Rename field → everything-else. Both `"Create index on X"` and the `"Alter table:"` rebuild land in the last (everything-else) bucket in insertion order, and the field's `CREATE INDEX` is inserted **first** — so it runs before the rebuild's `DROP TABLE` and is lost.

## Fix

Add a fifth `index_execution` bucket to `_order_statements`, appended **after** the last bucket, matching `startswith(key, "Create index")`. Every field `CREATE INDEX` now runs after all rebuilds, so a freshly-added index lands on the rebuilt table.

Chosen over "union the queued index into the rebuild's preserved set" (index names carry a `randstring(8)` suffix that defeats `IF NOT EXISTS` dedup → would double-create) and "derive preserved indexes from the desired model" (would drop user-custom indexes the model doesn't track). This single centralized change:
- fixes **every** rebuild path at once (trigger-agnostic);
- leaves #116's dropped-column index filtering (`get_secondary_index_ddls` / `_sqlite_rebuild_preserving_indexes`) completely untouched — the rebuild still re-creates *live* indexes from its snapshot, and the *new* field's separate `CREATE INDEX` runs afterward (no double-create);
- is backend-agnostic — indexes-last is correct for PostgreSQL too;
- excludes `"Remove index …"` (different prefix) and the m2m `"Create many-to-many unique index"` (separate join table, not this scenario).

## Blast radius

This globally reorders every migration's field `CREATE INDEX` to run last, on both backends, and changes `all_sql`/checksum for any plan containing a `CREATE INDEX`. Safe: a `CREATE INDEX` only needs its table+column to exist (guaranteed by the earlier buckets), and no DDL depends on a secondary index pre-existing. Verified across the full migration suite on both backends (below).

## Tests

- **Unit** (`test/unit/test_migrations_runner.jl`): `_order_statements` now defers `CREATE INDEX` past the `"Alter table:"` rebuild while keeping `ADD COLUMN` before it; a second sub-case proves `"Remove index …"` is *not* deferred. Mutation gate documented (drop the bucket → index runs before the rebuild).
- **Integration (SQLite, isolated DB mirroring #82)**: in one migration, add a `db_index` field *and* alter an existing field (forcing a rebuild); assert the new field's index **survives** (`user_idx` non-empty + a `PRAGMA index_info` proof that an index covers the new column) and the seeded row is intact.

**Verification:** unit **2741/2741**; SQLite edge cases **159/159** (new #152 testset **7/7**, #82 **11/11**); PostgreSQL edge cases **150/150** (no ordering/checksum regression from the reorder).

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
