### PR TITLE
feat(#123): bulk_insert ON CONFLICT support (DO NOTHING / DO UPDATE)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,76 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `bulk_insert` conflict handling via `on_conflict=` (ON CONFLICT)
+
+- **PormG ref**: issue #123 ; `src/querybuilder/execution_bulk.jl`, `src/Dialect.jl`
+- **Recorded**: 2026-07-15
+- **Severity**: new feature — **additive, non-breaking**. Default behavior unchanged; no forced code edit.
+
+### What changed
+
+`bulk_insert` accepts an `on_conflict=` keyword that renders an `ON CONFLICT` clause (PostgreSQL
+and SQLite ≥ 3.24, identical syntax), so overlapping batches skip or merge duplicates instead of
+erroring:
+
+```julia
+bulk_insert(M.Status.objects, df, on_conflict = :nothing)                       # ON CONFLICT DO NOTHING
+bulk_insert(M.Status.objects, df,
+    on_conflict = (action = :nothing, target = ["statusid"]))                   # targeted skip
+bulk_insert(M.Status.objects, df,
+    on_conflict = (action = :update, target = ["statusid"], set = ["status"]))  # upsert
+```
+
+With `on_conflict` set, the duplicate-key → sequence-resync retry is skipped (a conflict is
+expected there, not a desync). See [Conflict Handling](docs/src/write/bulk.md).
+
+This exists to delete the raw-SQL workaround: seeding a shared dimension from concurrent workers
+previously required hand-written `LibPQ.execute("INSERT … ON CONFLICT … DO NOTHING")` with manual
+value escaping, bypassing PormG's parameterization and connection routing.
+
+### How to find the calls to migrate
+
+Nothing breaks — purely additive. **Optional adoption:** grep each app for raw conflict-handling
+inserts and replace them with the ORM call:
+
+```
+grep -rn "ON CONFLICT" src/ | grep -i "execute"
+```
+
+Concrete known call site (esus_back `src/auxiliar.jl`, `at_dim_cbo` — seeds the global
+`dash_dim_cbo` dimension from concurrent municípios):
+
+```julia
+# ✗ before — raw LibPQ with hand-built VALUES and manual '' escaping
+valores = join(map(eachrow(df)) do r
+  nome = ismissing(r.no_cbo) ? "null" : "'" * replace(string(r.no_cbo), "'" => "''") * "'"
+  "($(r.id), 0, '$(r.co_cbo)', $nome)"
+end, ", ")
+LibPQ.execute(db, """
+  INSERT INTO dash_dim_cbo (id, cat_cbo_id, co_cbo, no_cbo)
+  VALUES $valores
+  ON CONFLICT (id) DO NOTHING
+""")
+
+# ✓ after — dash_dim_cbo modeled as biM.Dim_CBO; parameterized, pooled, chunked
+df.cat_cbo_id = fill(0, nrow(df))   # was a literal in the raw INSERT
+bulk_insert(biM.Dim_CBO, df, on_conflict = (action = :nothing, target = ["id"]))
+```
+
+(The issue #123 comment sketched `(:nothing, target = ["id"])` — that tuple form is not valid
+Julia; the shipped API is the NamedTuple shown above.)
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| esus_back | ⏳ | `src/auxiliar.jl` `at_dim_cbo` — apply the before → after above (needs `dash_dim_cbo` modeled) |
+| app-2 | — | no raw ON CONFLICT inserts known |
+| app-3 | — | no raw ON CONFLICT inserts known |
+| app-4 | — | no raw ON CONFLICT inserts known |
+
+---
+
 ## Composite uniqueness (`unique_together`) via `Models.UniqueConstraint`
 
 - **PormG ref**: issue #19 ; `src/Models.jl`, `src/migrations/planner.jl`, `src/migrations/importers.jl`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -386,6 +386,15 @@ df = DataFrame([
 result = bulk_insert(M.Driver, df)
 ```
 
+Duplicates can be skipped or merged instead of erroring with the `on_conflict=` keyword (PostgreSQL and SQLite ≥ 3.24; see [Conflict Handling](write/bulk.md#conflict-handling-on-conflict)):
+
+```julia
+bulk_insert(M.Status, df, on_conflict = :nothing)                                  # ON CONFLICT DO NOTHING
+bulk_insert(M.Status, df, on_conflict = (action = :nothing, target = ["statusid"]))  # targeted skip
+bulk_insert(M.Status, df,                                                          # upsert
+    on_conflict = (action = :update, target = ["statusid"], set = ["status"]))
+```
+
 ### `bulk_update`
 
 Updates multiple records in a single operation.

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -61,6 +61,53 @@ VALUES
   -- ... (batched up to chunk_size rows)
 ```
 
+### Conflict Handling (ON CONFLICT)
+
+By default a duplicate key aborts the batch. When overlap is *expected* — idempotent re-seeding, or concurrent loaders filling one shared dimension table — attach an `ON CONFLICT` clause with `on_conflict=` instead of catching the error. PostgreSQL and SQLite (≥ 3.24) share the syntax, so the same call works on both backends.
+
+```julia
+# The status dimension is re-seeded on every deploy; some rows already exist.
+statuses_df = DataFrame(
+    statusid = [1, 3, 4, 130],
+    status   = ["Finished", "Accident", "Collision", "Withdrew"],
+)
+
+# Skip any row whose insert violates a unique constraint
+bulk_insert(M.Status.objects, statuses_df, on_conflict = :nothing)
+
+# Skip only when a specific target conflicts
+bulk_insert(M.Status.objects, statuses_df,
+    on_conflict = (action = :nothing, target = ["statusid"]))
+
+# Upsert: keep the existing row, refresh its label
+bulk_insert(M.Status.objects, statuses_df,
+    on_conflict = (action = :update, target = ["statusid"], set = ["status"]))
+```
+
+**Generated SQL (PostgreSQL):**
+```sql
+INSERT INTO "status" ("statusid", "status")
+VALUES ($1, $2), ($3, $4), ($5, $6), ($7, $8)
+ON CONFLICT ("statusid") DO UPDATE SET "status" = EXCLUDED."status"
+```
+
+**Accepted forms:**
+
+- `nothing` (default) — no clause; a duplicate key raises, exactly as before.
+- `:nothing` — `ON CONFLICT DO NOTHING`, untargeted: *any* unique violation skips the row.
+- `(action = :nothing, target = ["field"])` — skip only when the named columns conflict.
+- `(action = :update, target = ["field"], set = ["field", ...])` — upsert: on a `target` conflict, overwrite each `set` column with the value the batch tried to insert (`EXCLUDED.column` in SQL). Both `target` and `set` are required for `:update`.
+
+**Rules and behavior:**
+
+- `target` and `set` take **logical model field names**; PormG resolves `db_column` mappings and renders the quoted physical column names.
+- `set` columns must participate in the INSERT (be present in the DataFrame / `columns=` selection). `EXCLUDED.col` for a non-inserted column would silently write the column *default* instead of a caller value, so PormG rejects it up front.
+- `target` columns must exist on the model, but are **not** required to be declared `unique`/`primary_key` there — the database is the source of truth (partial indexes, constraints created outside PormG). A target with no matching constraint surfaces as the backend's own error (PostgreSQL: *"there is no unique or exclusion constraint matching the ON CONFLICT specification"*).
+- **Dedupe the DataFrame on `target` first** when using `:update`. A batch that conflicts with *itself* diverges across engines: PostgreSQL raises *"cannot affect row a second time"*, while SQLite applies rows serially (last one wins). `unique(df, [:statusid])` before the call keeps behavior identical on both.
+- With `on_conflict` set, the duplicate-key → sequence-resync retry is **skipped**: a conflict is expected, not a symptom of a stale sequence. A duplicate-key error that still surfaces (a *different* constraint than your target) propagates immediately. The normal post-insert sequence synchronization for explicit primary keys still runs.
+- Under `DO NOTHING` with server-generated primary keys, PostgreSQL still consumes sequence values for skipped rows — the standard harmless gaps.
+- `bulk_copy()` cannot express `ON CONFLICT` (the COPY protocol has no such clause); use `bulk_insert(...; on_conflict=...)` when duplicates are possible.
+
 ### Auto-Generated Primary Keys
 
 Do not prefill an auto-increment primary key with `max(id) + 1` before calling `bulk_insert()` or `bulk_copy()`.
@@ -148,6 +195,7 @@ end
 
 ```julia
 # Detect duplicate key errors
+# (if duplicates are EXPECTED, prefer on_conflict = :nothing — see Conflict Handling above)
 try
     bulk_insert(M.Driver.objects, df)
 catch e
@@ -197,6 +245,9 @@ For truly massive datasets, PormG provides `bulk_copy()`, which uses PostgreSQL'
 - **Raw Speed**: Bypasses the SQL statement parser.
 - **Memory Efficient**: Streams data to the database.
 - **Safe by Design**: Inherently immune to SQL injection.
+
+!!! note
+    The COPY protocol cannot express `ON CONFLICT` — a single duplicate row makes the whole COPY fail. When duplicates are possible, use `bulk_insert(...; on_conflict = ...)` instead (see [Conflict Handling](#conflict-handling-on-conflict)).
 
 ### Basic Usage
 

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -756,6 +756,33 @@ function create_unique_index(conn::PormGSQLite, index_name::String, table_name::
   return """CREATE UNIQUE INDEX IF NOT EXISTS $(index_name) ON $(table_name) ($(join(columns, ", ")));"""
 end
 
+"""
+    on_conflict_clause(action, target, set, conn) -> String
+
+Render an `ON CONFLICT` clause for an INSERT statement (#123). `target` and `set` must be
+pre-quoted physical column identifiers — quoting stays with the caller, like `create_index`.
+PostgreSQL and SQLite (≥3.24) share this syntax, so one method covers both backends.
+
+- `(:nothing, [], [])`        → `ON CONFLICT DO NOTHING`
+- `(:nothing, cols, [])`      → `ON CONFLICT (cols) DO NOTHING`
+- `(:update, cols, setcols)`  → `ON CONFLICT (cols) DO UPDATE SET c = EXCLUDED.c, …`
+"""
+function on_conflict_clause(action::Symbol, target::Vector{String}, set::Vector{String},
+                            conn::Union{PormGPostgres, PormGSQLite})::String
+  action in (:nothing, :update) ||
+    throw(ArgumentError("on_conflict_clause: action must be :nothing or :update, got :$action"))
+  target_sql = isempty(target) ? "" : " ($(join(target, ", ")))"
+  if action === :nothing
+    return "ON CONFLICT$(target_sql) DO NOTHING"
+  end
+  isempty(target) &&
+    throw(ArgumentError("on_conflict_clause: action :update requires a non-empty conflict target"))
+  isempty(set) &&
+    throw(ArgumentError("on_conflict_clause: action :update requires a non-empty set column list"))
+  assignments = join(["$col = EXCLUDED.$col" for col in set], ", ")
+  return "ON CONFLICT$(target_sql) DO UPDATE SET $(assignments)"
+end
+
 function add_foreign_key(conn::PormGPostgres, table_name::Union{Symbol,String}, constraint_name::String, field_name::String, ref_table_name::String, ref_field_name::String; on_delete::Union{String,Nothing}=nothing)
   on_delete_clause = on_delete !== nothing ? " ON DELETE $on_delete" : ""
   return """ALTER TABLE $table_name ADD CONSTRAINT $constraint_name FOREIGN KEY ($field_name) REFERENCES $ref_table_name ($ref_field_name)$on_delete_clause DEFERRABLE INITIALLY DEFERRED;"""

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -799,7 +799,21 @@ Inserts multiple rows into the database in bulk from a DataFrame.
   - `df_o::DataFrames.DataFrame`: The DataFrame containing the data to be inserted.
   - `columns`: Optional. Specifies the columns to insert and their mappings. Can be `nothing`, a `String`, a `Pair{String, String}`, or a `Vector` of these. If `nothing`, all columns from the DataFrame are used.
   - `chunk_size::Integer`: Optional. The number of rows to insert in each batch (default: 1000).
-  - `show_query::Bool`: Optional. If true, prints the generated SQL query (default: false).
+  - `show_query::Symbol`: Optional. Return the generated SQL instead of executing it — `:sql`,
+    `:dict`, `:inspection`, or `:params` (see Query Inspection). Defaults to `:execute` (run it).
+  - `on_conflict`: Optional (#123). Attaches an `ON CONFLICT` clause so duplicate rows are
+    skipped or merged instead of erroring (PostgreSQL and SQLite share the syntax). Accepts:
+    - `nothing` (default): no clause — a duplicate key raises, as before.
+    - `:nothing`: `ON CONFLICT DO NOTHING` (untargeted — any unique violation skips the row).
+    - `(action = :nothing, target = ["field"])`: `ON CONFLICT (col) DO NOTHING`.
+    - `(action = :update, target = ["field"], set = ["field"])`:
+      `ON CONFLICT (col) DO UPDATE SET col = EXCLUDED.col, …` (upsert).
+    `target`/`set` take logical model field names (resolved through `db_column`). `set` fields
+    must participate in the INSERT column list. `target` is not required to be declared unique
+    in the model — the database is the source of truth for matching constraints. When
+    `on_conflict` is set, the duplicate-key → sequence-resync retry is skipped: a conflict is
+    expected there, not a sequence desync, so any duplicate-key error that still surfaces
+    (a different constraint than the target) propagates.
 
   The caller's DataFrame is never mutated (and never copied — the pipeline works on a
   zero-copy wrapper), so there is no `copy=` knob to think about.
@@ -827,7 +841,8 @@ Inserts multiple rows into the database in bulk from a DataFrame.
 function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
     columns = nothing,
     chunk_size::Integer = 1000,
-    show_query::Symbol = :execute
+    show_query::Symbol = :execute,
+    on_conflict = nothing
   )
   model = objct.object.model
   ensure_model_transaction_scope(model)
@@ -853,6 +868,14 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   # Prepare columns and DataFrame using centralized helpers
   _columns = _normalize_bulk_columns(columns)
   mapping, fields_df, pk_exist, pk_field = _prepare_bulk_df!(df, model, _columns, :insert, settings)
+
+  # Normalize/validate on_conflict against the participating insert columns (#123), then render
+  # the clause once here — it is identical for every chunk, and its `nothing`-ness is the flag
+  # that gates the sequence-resync retry inside _bulk_insert. Purely local (no DB round-trip),
+  # so :sql/:dict/:params modes validate and render identically.
+  _on_conflict = _normalize_on_conflict(on_conflict, model, fields_df, connection)
+  on_conflict_sql = _on_conflict === nothing ? nothing :
+    Dialect.on_conflict_clause(_on_conflict.action, _on_conflict.target, _on_conflict.set, connection)
 
   # Cap the chunk so `effective_chunk × ncols` stays under the backend's bind-parameter limit
   # (#84). Each INSERT row binds one param per field and adds nothing else, so per_row = ncols
@@ -891,7 +914,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
       count += 1
       if count == effective_chunk || index == total
         # @pormg_debug
-        res = _bulk_insert(model, connection, fields_df, rows, pk_exist, pk_field, settings, django_prefix, show_query, parameters)
+        res = _bulk_insert(model, connection, fields_df, rows, pk_exist, pk_field, settings, django_prefix, show_query, parameters; on_conflict_sql = on_conflict_sql)
         push!(results, res)
         count = 0
         rows = String[]
@@ -940,6 +963,9 @@ This is significantly faster than `bulk_insert` for large datasets.
 
 The caller's DataFrame is never mutated (and never copied — the pipeline works on a
 zero-copy wrapper).
+
+The COPY protocol cannot express `ON CONFLICT` — rows that violate a unique constraint make
+the whole COPY fail. To skip or merge duplicates, use `bulk_insert(...; on_conflict = ...)` (#123).
 
 # Example
 ```julia
@@ -1059,21 +1085,115 @@ function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{St
   end  
 end
 
-function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGSQLite}, 
-  fields::Vector{String}, rows::Vector{String}, 
-  pk_exist::Bool, pk_field::Vector{String}, settings::SQLConn, 
-  django_prefix::Bool, show_query::Symbol, parameters:: AbstractPormGParam)
+# Normalize/validate `bulk_insert`'s `on_conflict` kwarg into the canonical
+# `(action, target, set)` NamedTuple consumed by `_bulk_insert` (#123), where `target`/`set`
+# are already-quoted physical column identifiers. Returns `nothing` when no clause is wanted.
+# `fields_df` is the participating insert column list from `_prepare_bulk_df!` — `set` must be
+# a subset of it, because `EXCLUDED.col` for a non-inserted column silently yields the column
+# default instead of a caller value.
+function _normalize_on_conflict(on_conflict, model::PormGModel, fields_df::Vector{String},
+    connection::Union{PormGPostgres, PormGSQLite})
+  on_conflict === nothing && return nothing
+
+  local action::Symbol
+  local target::Vector{String}
+  local set::Vector{String}
+
+  if on_conflict isa Symbol
+    on_conflict === :nothing ||
+      throw(_argerr("Error in bulk_insert, on_conflict Symbol form only accepts :nothing " *
+        "(got :$(on_conflict)); use (action = :update, target = [...], set = [...]) for upserts"))
+    action, target, set = :nothing, String[], String[]
+  elseif on_conflict isa NamedTuple
+    extra = setdiff(keys(on_conflict), (:action, :target, :set))
+    isempty(extra) ||
+      throw(_argerr("Error in bulk_insert, on_conflict has unknown key(s) $(join(extra, ", ")); " *
+        "accepted keys are action, target and set"))
+    haskey(on_conflict, :action) ||
+      throw(_argerr("Error in bulk_insert, on_conflict NamedTuple requires an action key " *
+        "(:nothing or :update)"))
+    action = on_conflict.action
+    action in (:nothing, :update) ||
+      throw(_argerr("Error in bulk_insert, on_conflict action must be :nothing or :update, " *
+        "got :$(action)"))
+    target = _on_conflict_column_list(on_conflict, :target)
+    set = _on_conflict_column_list(on_conflict, :set)
+  else
+    throw(_argerr("Error in bulk_insert, on_conflict must be nothing, :nothing or a NamedTuple " *
+      "like (action = :nothing, target = [\"field\"]), got $(typeof(on_conflict))"))
+  end
+
+  if action === :update
+    isempty(target) &&
+      throw(_argerr("Error in bulk_insert, on_conflict action :update requires a non-empty target " *
+        "column list (the conflicting unique/primary-key columns)"))
+    isempty(set) &&
+      throw(_argerr("Error in bulk_insert, on_conflict action :update requires a non-empty set " *
+        "column list (the columns to overwrite with EXCLUDED values)"))
+  elseif on_conflict isa NamedTuple && haskey(on_conflict, :set)
+    throw(_argerr("Error in bulk_insert, on_conflict set is only valid with action :update — " *
+      "DO NOTHING never writes columns"))
+  end
+
+  insert_cols = Set(fields_df)
+  for (kind, cols) in ((:target, target), (:set, set))
+    length(unique(cols)) == length(cols) ||
+      throw(_argerr("Error in bulk_insert, on_conflict $kind has duplicate column entries"))
+    for col in cols
+      haskey(model.fields, col) ||
+        throw(_argerr("Error in bulk_insert, on_conflict $kind column $(col) is not a field of " *
+          "model $(model.name)"))
+      kind === :set && !(col in insert_cols) &&
+        throw(_argerr("Error in bulk_insert, on_conflict set column $(col) does not participate " *
+          "in this INSERT (not in the DataFrame/columns selection), so EXCLUDED.$(col) would be " *
+          "the column default — include it in the insert or drop it from set"))
+    end
+  end
+  # `target` columns are deliberately NOT required to be declared unique/primary_key on the
+  # model: the database is the source of truth (partial indexes, constraints created outside
+  # PormG). A non-matching target surfaces as the backend's own clear error.
+
+  # Explicit `String[...]` comprehensions (not `map`) so the element type is Vector{String}
+  # even for an empty target/set, which the typed `on_conflict_clause` signature requires.
+  quoted(col) = quote_identifier(Models.model_column(model, col), connection)
+  return (action = action,
+          target = String[quoted(col) for col in target],
+          set = String[quoted(col) for col in set])
+end
+
+# Fetch `key` from the on_conflict NamedTuple as a Vector{String}, tolerating any
+# AbstractString/AbstractVector flavor; a missing key means "no columns".
+function _on_conflict_column_list(on_conflict::NamedTuple, key::Symbol)
+  haskey(on_conflict, key) || return String[]
+  value = on_conflict[key]
+  value isa AbstractVector && all(v -> v isa AbstractString, value) ||
+    throw(_argerr("Error in bulk_insert, on_conflict $key must be a vector of field-name strings, " *
+      "got $(typeof(value))"))
+  return String[string(v) for v in value]
+end
+
+function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGSQLite},
+  fields::Vector{String}, rows::Vector{String},
+  pk_exist::Bool, pk_field::Vector{String}, settings::SQLConn,
+  django_prefix::Bool, show_query::Symbol, parameters:: AbstractPormGParam;
+  on_conflict_sql::Union{Nothing, String} = nothing)
 
   # Security: Quote table name and physical column names (db_column when set, #50).
   # VALUES rows are positional and built in `fields` order, so they still align.
   safe_table_name = safe_table_identifier(string(model.name), connection)
   quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields]
 
-  # Construct the bulk insert SQL.
+  # Construct the bulk insert SQL. The ON CONFLICT clause (#123) is rendered once by the caller
+  # and binds no parameters, so the chunk-size math and the VALUES placeholders are untouched;
+  # appending it before the show_query branch means every show mode carries the clause. A
+  # non-`nothing` clause also means "on_conflict active" and gates the sequence-resync retry below.
   sql = """
   INSERT INTO $(safe_table_name) ($(join(quoted_fields, ", ")))
   VALUES $(join(rows, ", "))
   """
+  if on_conflict_sql !== nothing
+    sql *= on_conflict_sql * "\n"
+  end
 
   # Execute the query or just show it
   if show_query !== :execute
@@ -1082,8 +1202,9 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
     # Execute the query for the given connection type.
     if connection isa PormGPostgres
       # Use a savepoint when inside an active transaction and the model has a PK field.
-      # This lets the sequence-sync retry stay on the same TX connection.
-      use_savepoint = !isempty(pk_field)
+      # This lets the sequence-sync retry stay on the same TX connection. With on_conflict
+      # active there is no retry (see below), so the savepoint is skipped too.
+      use_savepoint = !isempty(pk_field) && on_conflict_sql === nothing
       try
         if use_savepoint
           with_savepoint(settings, "pormg_bulk_insert_retry") do
@@ -1093,7 +1214,10 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
           fetch(settings, sql, parameters)
         end
       catch e
-        if occursin("duplicate key value violates unique constraint", e |> string)
+        # With ON CONFLICT active a surviving duplicate-key error means a DIFFERENT constraint
+        # than the clause target conflicted — the values came from the DataFrame, not a stale
+        # sequence, so the resync-and-retry below would fail identically. Propagate instead.
+        if on_conflict_sql === nothing && occursin("duplicate key value violates unique constraint", e |> string)
           if !isempty(pk_field)
             # with_savepoint already rolled back and released the savepoint; the outer
             # transaction is still usable. Fix the sequence and retry without a savepoint.

--- a/test/integration/test_inserts.jl
+++ b/test/integration/test_inserts.jl
@@ -800,3 +800,81 @@ end
         end
     end
 end
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ON CONFLICT bulk_insert (#123)
+#
+# bulk_insert(...; on_conflict=...) attaches an ON CONFLICT clause so overlapping
+# batches skip (DO NOTHING) or merge (DO UPDATE) duplicates instead of erroring —
+# the idempotent re-seed pattern. PostgreSQL and SQLite share the syntax, so the
+# same assertions run on both backends. Uses M.Status (explicit pk statusid), the
+# same duplicate-key fixture as "Schema Evolution and Error Recovery" above.
+# The batches deliberately never repeat a statusid WITHIN one batch: PostgreSQL
+# rejects a same-batch double-conflict ("cannot affect row a second time") while
+# SQLite applies rows serially — cross-engine behavior diverges, so callers must
+# dedupe on the target first (documented in docs/src/write/bulk.md).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ON CONFLICT bulk_insert (#123)" begin
+    status_ids = [330001, 330002, 330003, 330004]
+    created_pk = Ref{Union{Nothing, Int}}(nothing)
+    q = M.Status.objects.filter("statusid__@in" => status_ids)
+    q.exists() && q.delete()
+
+    try
+        # Seed two of the four ids.
+        bulk_insert(M.Status.objects, DataFrame(
+            statusid = status_ids[1:2],
+            status   = ["Finished", "Collision"],
+        ))
+
+        # 1. Untargeted DO NOTHING: an overlapping re-insert must not throw, must
+        # leave the existing row untouched, and must add only the new row.
+        overlap_df = DataFrame(
+            statusid = [status_ids[1], status_ids[3]],   # 330001 duplicates the seed
+            status   = ["Overwritten?", "Engine"],
+        )
+        bulk_insert(M.Status.objects, overlap_df, on_conflict = :nothing)
+
+        @test M.Status.objects.filter("statusid__@in" => status_ids).count() == 3
+        row1 = M.Status.objects.filter("statusid" => status_ids[1]).values("status").list() |> first
+        @test row1[:status] == "Finished"    # DO NOTHING skipped the duplicate
+        @test M.Status.objects.filter("statusid" => status_ids[3], "status" => "Engine").count() == 1
+
+        # 2. Targeted DO NOTHING on the pk behaves identically (fully-overlapping batch).
+        bulk_insert(M.Status.objects, overlap_df,
+            on_conflict = (action = :nothing, target = ["statusid"]))
+        @test M.Status.objects.filter("statusid__@in" => status_ids).count() == 3
+        row1 = M.Status.objects.filter("statusid" => status_ids[1]).values("status").list() |> first
+        @test row1[:status] == "Finished"
+
+        # 3. DO UPDATE (upsert): conflicting rows take the batch's values, the new row
+        # inserts, and chunk_size=2 puts conflicts on both sides of a chunk boundary.
+        bulk_insert(M.Status.objects, DataFrame(
+                statusid = status_ids,
+                status   = ["+1 Lap", "Accident", "Gearbox", "Hydraulics"],
+            ),
+            chunk_size  = 2,
+            on_conflict = (action = :update, target = ["statusid"], set = ["status"]))
+
+        @test M.Status.objects.filter("statusid__@in" => status_ids).count() == 4
+        by_id = Dict(r[:statusid] => r[:status] for r in
+            M.Status.objects.filter("statusid__@in" => status_ids).values("statusid", "status").list())
+        @test by_id[status_ids[1]] == "+1 Lap"        # conflict in chunk 1 → updated
+        @test by_id[status_ids[2]] == "Accident"      # conflict in chunk 1 → updated
+        @test by_id[status_ids[3]] == "Gearbox"       # conflict in chunk 2 → updated
+        @test by_id[status_ids[4]] == "Hydraulics"    # no conflict → inserted
+
+        # 4. Sequence consistency survives on_conflict: the post-insert resync still
+        # ran, so a follow-up create() without an explicit pk must not collide with
+        # the explicit ids above (meaningful on PostgreSQL; harmless on SQLite).
+        next_row = M.Status.objects.create("status" => "Sequence Check (#123)")
+        created_pk[] = next_row[:statusid]
+        @test next_row[:statusid] isa Integer
+        @test !(next_row[:statusid] in status_ids)
+    finally
+        cleanup_ids = created_pk[] === nothing ? status_ids : vcat(status_ids, created_pk[])
+        q = M.Status.objects.filter("statusid__@in" => cleanup_ids)
+        q.exists() && q.delete()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ end
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
     @testset "Bulk No-Mutation Contract (#132)" include("unit/test_bulk_no_mutation.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
+    @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")

--- a/test/unit/test_bulk_on_conflict.jl
+++ b/test/unit/test_bulk_on_conflict.jl
@@ -1,0 +1,235 @@
+using Test
+using DataFrames
+using PormG
+using PormG.Models: Model, CharField, IDField
+import PormG.ConnectionPool: fetch
+
+# ─────────────────────────────────────────────────────────────────────────────
+# bulk_insert ON CONFLICT (#123)
+#
+# DB-free: `show_query=:dict` returns the rendered SQL before any database call,
+# so the clause text, parameter alignment, and validation errors are all
+# assertable against bare mock connections. The retry-skip testset uses a
+# recording mock `fetch` like test_sequence_sync.jl.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Mirrors esus_back's dash_dim_cbo — the concrete use case from issue #123 —
+# with a db_column-mapped field to prove the clause renders physical names.
+ConflictCbo = Model("dash_dim_cbo",
+  id = IDField(),
+  co_cbo = CharField(),
+  no_cbo = CharField(db_column = "nome_cbo"),
+)
+ConflictCbo.connect_key = "on_conflict_pg"
+
+ConflictCboSl = Model("dash_dim_cbo",
+  id = IDField(),
+  co_cbo = CharField(),
+  no_cbo = CharField(db_column = "nome_cbo"),
+)
+ConflictCboSl.connect_key = "on_conflict_sqlite"
+
+struct MockPgConflict <: PormG.PormGPostgres end
+struct MockSqliteConflict <: PormG.PormGSQLite end
+# The bare mock has no driver body; answer the version probe (#84 bind-parameter
+# limit math) with a modern SQLite so the end-to-end :dict path needs no database.
+PormG.backend_sqlite_version(::MockSqliteConflict) = 3045000
+
+PormG.config["on_conflict_pg"] = PormG.Configuration.Settings(
+  connections = MockPgConflict(),
+  change_data = true,
+)
+PormG.config["on_conflict_sqlite"] = PormG.Configuration.Settings(
+  connections = MockSqliteConflict(),
+  change_data = true,
+)
+
+const CBO_DF_123 = DataFrame(
+  id = [1, 2],
+  co_cbo = ["225125", "225130"],
+  no_cbo = ["Cardiologista", "Neurologista"],
+)
+
+_cbo_sql(on_conflict; model = ConflictCbo, kwargs...) =
+  PormG.QueryBuilder.bulk_insert(model, CBO_DF_123;
+    show_query = :dict, on_conflict = on_conflict, kwargs...)[:sql_text]
+
+@testset "on_conflict SQL rendering (PostgreSQL mock)" begin
+  # Default stays a bare INSERT — regression guard for existing callers.
+  @test !occursin("ON CONFLICT", _cbo_sql(nothing))
+
+  # Untargeted DO NOTHING via the Symbol shorthand.
+  sql_nothing = _cbo_sql(:nothing)
+  @test occursin("ON CONFLICT DO NOTHING", sql_nothing)
+  @test !occursin("ON CONFLICT (", sql_nothing)
+
+  # Targeted DO NOTHING.
+  @test occursin("ON CONFLICT (\"id\") DO NOTHING",
+    _cbo_sql((action = :nothing, target = ["id"])))
+
+  # Upsert: multi-column set, db_column field rendered by its physical name.
+  sql_update = _cbo_sql((action = :update, target = ["id"], set = ["co_cbo", "no_cbo"]))
+  @test occursin("ON CONFLICT (\"id\") DO UPDATE SET " *
+    "\"co_cbo\" = EXCLUDED.\"co_cbo\", \"nome_cbo\" = EXCLUDED.\"nome_cbo\"", sql_update)
+  @test !occursin("no_cbo\" = EXCLUDED", sql_update)   # logical name must not leak
+
+  # db_column field as the conflict target resolves to the physical column too.
+  @test occursin("ON CONFLICT (\"nome_cbo\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\"",
+    _cbo_sql((action = :update, target = ["no_cbo"], set = ["co_cbo"])))
+
+  # Documented allowance: `set` may overlap `target` (harmless self-assignment; PG/SQLite permit it).
+  @test occursin("ON CONFLICT (\"id\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"co_cbo\" = EXCLUDED.\"co_cbo\"",
+    _cbo_sql((action = :update, target = ["id"], set = ["id", "co_cbo"])))
+
+  # Documented allowance: a `target` column need NOT participate in the INSERT — only `set` must.
+  # Here `columns=` drops no_cbo from the insert, yet it is a valid conflict target (existence-only).
+  @test occursin("ON CONFLICT (\"nome_cbo\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\"",
+    _cbo_sql((action = :update, target = ["no_cbo"], set = ["co_cbo"]); columns = ["id", "co_cbo"]))
+end
+
+@testset "on_conflict binds no parameters and reaches every chunk" begin
+  res_plain = PormG.QueryBuilder.bulk_insert(ConflictCbo, CBO_DF_123; show_query = :dict)
+  res_clause = PormG.QueryBuilder.bulk_insert(ConflictCbo, CBO_DF_123;
+    show_query = :dict, on_conflict = (action = :update, target = ["id"], set = ["no_cbo"]))
+  @test res_clause[:parameters] == res_plain[:parameters]
+
+  # chunk_size=1 splits the 2-row frame into 2 statements — each carries the clause.
+  chunked = PormG.QueryBuilder.bulk_insert(ConflictCbo, CBO_DF_123;
+    show_query = :dict, chunk_size = 1, on_conflict = :nothing)
+  @test chunked isa Vector
+  @test length(chunked) == 2
+  @test all(res -> occursin("ON CONFLICT DO NOTHING", res[:sql_text]), chunked)
+end
+
+@testset "on_conflict SQLite end-to-end and shared renderer" begin
+  # Same clause through the SQLite mock end-to-end (syntax is shared, SQLite ≥3.24).
+  @test occursin("ON CONFLICT (\"id\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\"",
+    _cbo_sql((action = :update, target = ["id"], set = ["co_cbo"]); model = ConflictCboSl))
+
+  # The Dialect renderer is one Union method: identical output for both backends.
+  for (action, target, set, expected) in (
+    (:nothing, String[], String[], "ON CONFLICT DO NOTHING"),
+    (:nothing, ["\"id\""], String[], "ON CONFLICT (\"id\") DO NOTHING"),
+    (:update, ["\"id\""], ["\"co_cbo\"", "\"nome_cbo\""],
+      "ON CONFLICT (\"id\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\", \"nome_cbo\" = EXCLUDED.\"nome_cbo\""),
+  )
+    pg_clause = PormG.Dialect.on_conflict_clause(action, target, set, MockPgConflict())
+    sl_clause = PormG.Dialect.on_conflict_clause(action, target, set, MockSqliteConflict())
+    @test pg_clause == expected
+    @test sl_clause == expected
+  end
+
+  # Renderer guards (PR 2 will call it directly, so they must hold without the
+  # bulk_insert normalization in front).
+  @test_throws ArgumentError PormG.Dialect.on_conflict_clause(:merge, ["\"id\""], String[], MockPgConflict())
+  @test_throws ArgumentError PormG.Dialect.on_conflict_clause(:update, String[], ["\"co_cbo\""], MockPgConflict())
+  @test_throws ArgumentError PormG.Dialect.on_conflict_clause(:update, ["\"id\""], String[], MockPgConflict())
+end
+
+# Runs bulk_insert with :dict (validation fires before any DB call) and hands
+# back the ArgumentError message for assertion.
+function _cbo_error(on_conflict; kwargs...)
+  err = try
+    PormG.QueryBuilder.bulk_insert(ConflictCbo, CBO_DF_123;
+      show_query = :dict, on_conflict = on_conflict, kwargs...)
+    nothing
+  catch e
+    e
+  end
+  @test err isa ArgumentError
+  return err === nothing ? "" : sprint(showerror, err)
+end
+
+@testset "on_conflict validation errors" begin
+  @test occursin("only accepts :nothing", _cbo_error(:ignore))
+  @test occursin("must be nothing, :nothing or a NamedTuple", _cbo_error(42))
+  @test occursin("requires an action key", _cbo_error((target = ["id"],)))
+  @test occursin("unknown key", _cbo_error((action = :nothing, taget = ["id"])))
+  @test occursin("must be :nothing or :update", _cbo_error((action = :merge, target = ["id"], set = ["co_cbo"])))
+  @test occursin("non-empty target", _cbo_error((action = :update, set = ["co_cbo"])))
+  @test occursin("non-empty target", _cbo_error((action = :update, target = String[], set = ["co_cbo"])))
+  @test occursin("non-empty set", _cbo_error((action = :update, target = ["id"])))
+  @test occursin("only valid with action :update", _cbo_error((action = :nothing, target = ["id"], set = ["co_cbo"])))
+  @test occursin("must be a vector of field-name strings", _cbo_error((action = :nothing, target = "id")))
+  @test occursin("duplicate column entries", _cbo_error((action = :update, target = ["id", "id"], set = ["co_cbo"])))
+  @test occursin("is not a field", _cbo_error((action = :nothing, target = ["not_a_field"])))
+  @test occursin("is not a field", _cbo_error((action = :update, target = ["id"], set = ["not_a_field"])))
+  # `set` must participate in the INSERT: EXCLUDED.col for a non-inserted column
+  # would silently write the column default instead of a caller value.
+  @test occursin("does not participate",
+    _cbo_error((action = :update, target = ["id"], set = ["no_cbo"]); columns = ["id", "co_cbo"]))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Retry-skip (#123 × sequence resync): with on_conflict active, a surviving
+# duplicate-key error means a DIFFERENT constraint than the clause target
+# conflicted — the resync-and-retry path must NOT run (it would fail
+# identically), and the error must propagate after exactly one attempt.
+# Contrast: test_sequence_sync.jl pins the retry WITHOUT on_conflict.
+# ─────────────────────────────────────────────────────────────────────────────
+struct MockPgConflictRetry <: PormG.PormGPostgres end
+
+const ON_CONFLICT_RETRY_SQL = String[]
+const ON_CONFLICT_INSERT_ATTEMPTS = Ref(0)
+
+function fetch(connection::MockPgConflictRetry, sql::String;
+  conn = nothing,
+  params = nothing,
+  ignore_tx::Bool = false)
+  push!(ON_CONFLICT_RETRY_SQL, sql)
+
+  if occursin("INSERT INTO", sql)
+    ON_CONFLICT_INSERT_ATTEMPTS[] += 1
+    throw(ErrorException("duplicate key value violates unique constraint"))
+  elseif occursin("pg_get_serial_sequence", sql)
+    return DataFrame(pg_get_serial_sequence = ["public.dash_dim_cbo_id_seq"])
+  elseif occursin("setval", sql)
+    return DataFrame(setval = [3])
+  end
+
+  return DataFrame()
+end
+
+@testset "on_conflict skips the duplicate-key sequence-resync retry" begin
+  empty!(ON_CONFLICT_RETRY_SQL)
+  ON_CONFLICT_INSERT_ATTEMPTS[] = 0
+
+  settings = PormG.Configuration.Settings(
+    connections = MockPgConflictRetry(),
+    change_db = true,
+    change_data = true,
+  )
+
+  params = PormG.QueryBuilder.PgParameterizedQuery("", Any[], 0)
+  PormG.QueryBuilder.add_parameter!(params, 1)
+  PormG.QueryBuilder.add_parameter!(params, "225125")
+
+  err = try
+    PormG.QueryBuilder._bulk_insert(
+      ConflictCbo,
+      settings.connections,
+      ["id", "co_cbo"],
+      ["(\$1, \$2)"],
+      true,
+      ["id"],
+      settings,
+      false,
+      :execute,
+      params;
+      on_conflict_sql = "ON CONFLICT DO NOTHING",   # pre-rendered clause; non-nothing gates the retry off
+    )
+    nothing
+  catch e
+    e
+  end
+
+  # The duplicate-key error propagates untouched after a single attempt…
+  @test err !== nothing
+  @test occursin("duplicate key value violates unique constraint", string(err))
+  @test ON_CONFLICT_INSERT_ATTEMPTS[] == 1
+  # …the executed statement really carried the clause…
+  @test any(sql -> occursin("ON CONFLICT DO NOTHING", sql), ON_CONFLICT_RETRY_SQL)
+  # …and no sequence-resync machinery ever ran.
+  @test !any(sql -> occursin("pg_get_serial_sequence", sql), ON_CONFLICT_RETRY_SQL)
+  @test !any(sql -> occursin("setval", sql), ON_CONFLICT_RETRY_SQL)
+end


### PR DESCRIPTION
Closes #123.

## Problem

`bulk_insert` rendered a bare `INSERT INTO … VALUES …` with no way to attach `ON CONFLICT`,
forcing callers (e.g. esus_back `at_dim_cbo`, seeding a shared global dimension from concurrent
workers) into raw interpolated `LibPQ.execute` — losing PormG's parameterization and connection
routing. Separately, the PostgreSQL duplicate-key handler assumed every duplicate meant a
sequence desync and retried, which is wrong for a genuine expected conflict.

## Fix

Add an opt-in `on_conflict=` keyword. PostgreSQL and SQLite (≥ 3.24) share the syntax, so one
shared renderer covers both. Default (`nothing`) is unchanged — existing callers are unaffected.

```julia
bulk_insert(M.Status.objects, df, on_conflict = :nothing)                       # ON CONFLICT DO NOTHING
bulk_insert(M.Status.objects, df,
    on_conflict = (action = :nothing, target = ["statusid"]))                   # targeted skip
bulk_insert(M.Status.objects, df,
    on_conflict = (action = :update, target = ["statusid"], set = ["status"]))  # upsert
```

- **`src/Dialect.jl`** — new shared `on_conflict_clause(action, target, set, conn)` (one `Union`
  method; PR 2 / #30 `update_or_create` will reuse it). Pre-quoted identifiers, guarded.
- **`src/querybuilder/execution_bulk.jl`** — `_normalize_on_conflict` validates the kwarg up
  front (unknown keys, non-field columns, `set` not in the insert column list, duplicates) and
  resolves `db_column` → quoted physical names. The clause is rendered **once** and threaded into
  `_bulk_insert` as `on_conflict_sql`; its non-`nothing`-ness gates off the duplicate-key
  sequence-resync **retry and savepoint** — a surviving duplicate-key error (a different
  constraint than the target) then propagates. `bulk_copy` docstring notes COPY cannot express
  ON CONFLICT.

`target` is intentionally not required to be declared unique/pk on the model — the database is
the source of truth (partial indexes, constraints made outside PormG). `set` must participate in
the INSERT, else `EXCLUDED.col` would silently write the column default.

## Tests

- **`test/unit/test_bulk_on_conflict.jl`** (new, DB-free): clause rendering incl. `db_column`
  mapping, parameter invariance, per-chunk clause, both-backend renderer + guards, a full
  validation `@test_throws` matrix, the documented allowances (set∩target overlap; target not in
  the insert set), and a mock-driven retry-skip.
- **`test/integration/test_inserts.jl`**: `M.Status` DO NOTHING / targeted skip / DO UPDATE
  upsert across a `chunk_size=2` boundary / sequence post-condition.

Verification: unit **2788 pass**; integration **db_2 1685 pass**, **db_sl 1650 pass** (0 fail);
docs build exit 0; live db_sl doc-example round-trip verified.

## Docs

`docs/src/write/bulk.md` "Conflict Handling (ON CONFLICT)" section (F1 re-seed example + generated
SQL + rules, incl. the cross-engine dedupe-on-target caveat), `docs/src/api.md` entry, and an
additive `UPGRADING.md` entry with the esus_back `at_dim_cbo` before → after.

## Follow-up

This ships the shared `ON CONFLICT` renderer that #30 (row-level `update_or_create`) will build on
— tracked as PR 2, per the cross-reference on #30/#123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)