### PR TITLE
feat(querybuilder): F-expression date arithmetic with Julia duration types

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -208,9 +208,13 @@ M.Result.objects.values(
 
 # Atomic update (no read-modify-write race)
 M.Result.objects.filter("resultid" => 1).update("points" => F("points") + 10)
+
+# Date arithmetic with explicit Julia durations (or the Interval helper)
+using Dates
+M.Race.objects.filter("raceid" => 1).update("date" => F("date") + (Month(1) + Day(15)))
 ```
 
-See [Field Expressions](read/field_expressions.md) for the full reference.
+`+`/`-` accept `Dates` durations (`Day`, `Month`, `Year`, …) and `Interval(...)` for cross-database date math. See [Field Expressions](read/field_expressions.md) for the full reference.
 
 ---
 
@@ -570,7 +574,7 @@ scope — the SQL function constructors are *not* among them (see
 [SQL function library](#sql-function-library-pormgfunctions)).
 
 ### Query Builder
-`object`, `get`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `show_query`, `inspect_query`
+`object`, `get`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Interval`, `show_query`, `inspect_query`
 
 ### Rows & exceptions
 `PormGRow`, `DoesNotExist`, `MultipleObjectsReturned`
@@ -611,8 +615,8 @@ M.Result.objects.values(              # …or qualify without importing
     "n" => PormG.Functions.Count("resultid"))
 ```
 
-`bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef` stay at the top level — they are query
-primitives, not part of the function library.
+`bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Interval` stay at the top level — they are
+query primitives, not part of the function library.
 
 **Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min`
 **Conditional** — `Case`, `When`

--- a/docs/src/read/field_expressions.md
+++ b/docs/src/read/field_expressions.md
@@ -39,7 +39,7 @@ F("points") / 2.0                # Division
 Sum("points") / Count("resultid") # Aggregate ratios
 ```
 
-**Supported arithmetic operators:** `+`, `-`, `*`, `/`
+**Supported arithmetic operators:** `+`, `-`, `*`, `/` with numeric or field operands. For **date arithmetic**, `+` and `-` also accept Julia `Dates` durations (`Day`, `Month`, `Year`, …) and the [`Interval`](#The-Interval-helper) helper — see [Date Arithmetic](#Date-Arithmetic).
 
 ---
 
@@ -107,15 +107,61 @@ df = query |> DataFrame
 
 ### Date Arithmetic
 
-Find results within 30 days of the driver's birthday:
+Offset a date column by a whole number of **days** with a bare integer — e.g. results within 30 days of the driver's birthday:
 
 ```julia
 query = M.Result.objects
 query.filter(
     F("raceid__date") > F("driverid__dob"),
-    F("raceid__date") <= F("driverid__dob") + 30
+    F("raceid__date") <= F("driverid__dob") + 30   # integer ⇒ days
 )
 ```
+
+#### Explicit duration types
+
+For anything other than whole days, add a Julia `Dates` duration — `Day`, `Week`, `Month`, `Year`, `Hour`, `Minute`, `Second`, or any `CompoundPeriod` (e.g. `Month(1) + Day(15)`). Only `+` and `-` apply to a duration operand:
+
+```julia
+using Dates
+
+# Push the Australian GP back by a month and a half (parenthesise the compound period
+# so it renders as one interval — a bare `+ Month(1) + Day(15)` chains two instead):
+M.Race.objects.filter("raceid" => 1).update("date" => F("date") + (Month(1) + Day(15)))
+
+# Roll every race back a year:
+M.Race.objects.update("date" => F("date") - Year(1))
+```
+
+Generated SQL (PostgreSQL) — a single, strongly-typed `make_interval(...)`:
+```sql
+("Tb"."date" + make_interval(months => $1::integer, days => $2::integer))
+-- parameters: [1, 15]
+```
+
+Generated SQL (SQLite) — `date()` (or `datetime()` when a sub-day unit or a `TIMESTAMP` column is involved), one modifier per component:
+```sql
+date("Tb"."date", '+' || ? || ' months', '+' || ? || ' days')
+-- parameters: [1, 15]
+```
+
+Magnitudes are always bound as parameters; the unit keywords come from a fixed whitelist. Weeks render natively on PostgreSQL and as days (×7) on SQLite, which has no `weeks` modifier.
+
+#### The `Interval` helper
+
+`Interval(...)` is an explicit, self-documenting wrapper. It accepts a period (identical to using the bare period) or a portable time-duration string (`"HH:MM:SS"`, `"M:SS"`, or bare seconds):
+
+```julia
+F("date") + Interval(Month(3))            # same as F("date") + Month(3)
+
+# The string form is for time-of-day intervals on a TIMESTAMP / DateTimeField column:
+F("created_at") + Interval("01:30:00")    # + 1 hour 30 minutes
+```
+
+!!! note "The `Interval` name"
+    `Interval` is also a common name in the `Dates`/`Intervals.jl` ecosystems. If you `using Intervals` alongside PormG, reach PormG's helper as `PormG.QueryBuilder.Interval`.
+
+!!! warning "Sub-day math on `DATE` columns"
+    Adding a sub-day duration (`Hour`, `Minute`, `Second`) promotes the result to a timestamp. Persisting that back into a `DATE` column truncates the time — sub-day arithmetic only round-trips on `TIMESTAMP` / `DateTimeField` columns.
 
 ### When NOT to Use F
 

--- a/docs/src/read/functions_and_dates.md
+++ b/docs/src/read/functions_and_dates.md
@@ -457,6 +457,12 @@ Output:
 
 This generates a `SUM(CASE WHEN ... THEN 1 ELSE 0 END)` pattern — very useful for computing conditional counts within grouped queries.
 
+!!! tip "Beyond integer days"
+    The `+ 10957` above adds a whole number of **days**. To add other calendar or time units,
+    pass a Julia `Dates` duration — `F("driverid__dob") + Year(30)` instead of `+ 10957` — or the
+    [`Interval`](field_expressions.md#The-Interval-helper) helper. See
+    [Date Arithmetic](field_expressions.md#Date-Arithmetic) for the cross-database SQL these render.
+
 ### Case in Filters
 
 `Case` expressions can be used as the right-hand side of a `filter()` predicate to apply

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -117,7 +117,7 @@ include("QueryBuilder.jl")
 # Query primitives only. The SQL function constructors are NOT imported into PormG — they
 # live solely in `PormG.Functions` (below). There is intentionally no `PormG.Sum`: the
 # function library has exactly one home, reached via `using PormG.Functions` / `PormG.Functions.X`.
-import .QueryBuilder: object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+import .QueryBuilder: object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 
 """
     PormG.Functions
@@ -149,7 +149,7 @@ end
 
 # Curated top-level surface: query primitives only. The SQL function constructors above
 # live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
-export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -1,7 +1,7 @@
 module QueryBuilder
 
 import DataFrames, Tables, JSON, CSV, OrderedCollections
-using Dates, TimeZones, Intervals, Decimals, UUIDs
+using Dates, TimeZones, Decimals, UUIDs
 
 import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField
 import PormG: Dialect, Models
@@ -60,7 +60,7 @@ include("querybuilder/ctes.jl")
 #
 export OP
 export Q, Qor
-export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Case, Cast, Concat, Extract, To_char, Value
+export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Case, Cast, Concat, Extract, To_char, Value, Interval
 export WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
 export Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim
 export Floor, Ceil, Sqrt, Exp, Ln, Power, Mod

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -684,6 +684,132 @@ function _set_update_query(v::SQLTypeFunction, instruc::SQLInstruction)
   return _get_select_query(v, instruc)
 end
 
+# --- Date arithmetic with explicit Julia duration types (#25) ------------------------------------
+# Unit → SQL keyword maps. These are closed whitelists: the unit symbols come only from
+# `_decompose_period`, never from user text, so the interpolated keyword can never carry injection.
+const _PG_INTERVAL_KW     = Dict(:year => "years", :month => "months", :week => "weeks",
+                                 :day => "days", :hour => "hours", :minute => "mins")  # :second → "secs"
+const _SQLITE_INTERVAL_UNIT = Dict(:year => "years", :month => "months", :day => "days",
+                                   :hour => "hours", :minute => "minutes", :second => "seconds")  # :week → converted to :day
+
+# Concrete date/time type of a plain field reference, or `nothing` if the field is not a
+# DATE/TIMESTAMP column or cannot be resolved. Sibling of `_is_date_field`; the migration-style
+# `tab_field_cache` lookup only resolves a dotted join key AFTER that join has rendered.
+function _date_field_type(field_name::String, instruc::SQLInstruction)::Union{String, Nothing}
+  model = instruc.object.model
+  if haskey(model.fields, field_name)
+    t = model.fields[field_name].type
+    return t in ("DATE", "TIMESTAMPTZ", "TIMESTAMP") ? t : nothing
+  elseif haskey(instruc.tab_field_cache, field_name)
+    t = instruc.tab_field_cache[field_name].type
+    return t in ("DATE", "TIMESTAMPTZ", "TIMESTAMP") ? t : nothing
+  end
+  return nothing
+end
+
+# Whether a plain field reference resolves at all (so soft validation only fires when a field is
+# known to be a non-date column, never when its type is simply unknown — best-effort, fail-open).
+function _field_type_known(field_name::String, instruc::SQLInstruction)::Bool
+  return haskey(instruc.object.model.fields, field_name) || haskey(instruc.tab_field_cache, field_name)
+end
+
+# Decompose a Period/CompoundPeriod into an ordered [(unit, magnitude)] list (largest → smallest),
+# folding sub-second components into a single fractional `:second`. Zero-valued components are
+# dropped. Month/Year are kept as calendar units (SQL renders them natively) rather than rejected
+# the way `_duration_to_nanoseconds` does — nanosecond conversion is ambiguous, SQL interval math is not.
+function _decompose_period(period::Union{Dates.Period, Dates.CompoundPeriod})
+  cp = period isa Dates.CompoundPeriod ? period : Dates.CompoundPeriod(period)
+  acc = Dict{Symbol, Int}()
+  frac_nanos = Int64(0)
+  for p in Dates.periods(cp)
+    val = Dates.value(p)
+    if     p isa Year        ; acc[:year]   = get(acc, :year, 0)   + val
+    elseif p isa Quarter     ; acc[:month]  = get(acc, :month, 0)  + 3 * val
+    elseif p isa Month       ; acc[:month]  = get(acc, :month, 0)  + val
+    elseif p isa Week        ; acc[:week]   = get(acc, :week, 0)   + val
+    elseif p isa Day         ; acc[:day]    = get(acc, :day, 0)    + val
+    elseif p isa Hour        ; acc[:hour]   = get(acc, :hour, 0)   + val
+    elseif p isa Minute      ; acc[:minute] = get(acc, :minute, 0) + val
+    elseif p isa Second      ; acc[:second] = get(acc, :second, 0) + val
+    elseif p isa Millisecond ; frac_nanos += Int64(val) * 1_000_000
+    elseif p isa Microsecond ; frac_nanos += Int64(val) * 1_000
+    elseif p isa Nanosecond  ; frac_nanos += Int64(val)
+    else
+      throw(_argerr("Unsupported duration component $(typeof(p)) in F-expression date arithmetic"))
+    end
+  end
+  comps = Tuple{Symbol, Real}[]
+  for u in (:year, :month, :week, :day, :hour, :minute)
+    haskey(acc, u) && acc[u] != 0 && push!(comps, (u, acc[u]))
+  end
+  whole_sec = get(acc, :second, 0)
+  if frac_nanos != 0
+    push!(comps, (:second, whole_sec + frac_nanos / 1e9))
+  elseif whole_sec != 0
+    push!(comps, (:second, whole_sec))
+  end
+  return comps
+end
+
+# Render `F(date) ± <duration>` per dialect. PostgreSQL emits a single `make_interval(...)` with
+# explicitly-typed placeholders; SQLite emits one `date()`/`datetime()` modifier per component.
+function _render_date_period_arithmetic(v::FExpression, instruc::SQLInstruction)
+  period = v.operand isa Interval ? v.operand.period : v.operand
+  comps  = _decompose_period(period)
+
+  # Resolve the left side FIRST — rendering it populates `instruc.tab_field_cache` for dotted join
+  # keys, which the SQLite wrapper choice (date vs datetime) below depends on.
+  left_side = _set_update_query_left(v.field_name, v.operation, instruc)
+
+  # Soft validation (#25, best-effort): a duration only makes sense on a date/time column. Only
+  # throw when the field is known AND known to be non-date; stay silent for unresolved/nested lefts.
+  if v.field_name isa String && _field_type_known(v.field_name, instruc) &&
+     _date_field_type(v.field_name, instruc) === nothing
+    throw(_argerr("F(\"$(v.field_name)\") ± a duration requires a DATE/TIMESTAMP field; \"$(v.field_name)\" is not a date/time column"))
+  end
+
+  if instruc.connection isa PormGPostgres
+    parts = String[]
+    for (unit, value) in comps
+      if unit === :second
+        ph = add_parameter!(instruc, Float64(value); sql_type = "double precision")
+        push!(parts, "secs => $ph")
+      else
+        ph = add_parameter!(instruc, Int(value); sql_type = "integer")
+        push!(parts, "$(_PG_INTERVAL_KW[unit]) => $ph")
+      end
+    end
+    isempty(parts) && return left_side  # zero-length interval → identity
+    return "($(left_side) $(v.operation) make_interval($(join(parts, ", "))))"
+
+  elseif instruc.connection isa PormGSQLite
+    ftype   = v.field_name isa String ? _date_field_type(v.field_name, instruc) : nothing
+    subday  = any(c -> c[1] in (:hour, :minute, :second), comps)
+    # Choose datetime() when a sub-day unit is present, the column is a timestamp, OR the left side
+    # is ALREADY a datetime() expression (a chained `F(ts) + Day(1) + Day(2)`: the outer call sees a
+    # nested FExpression as field_name so `ftype` is unknown — without this, wrapping the inner
+    # datetime() in date() would silently truncate the time-of-day, diverging from PostgreSQL).
+    use_datetime = subday || ftype in ("TIMESTAMP", "TIMESTAMPTZ") || occursin("datetime(", left_side)
+    wrapper = use_datetime ? "datetime" : "date"
+    op_factor = v.operation == "-" ? -1 : 1
+    mods = String[]
+    for (unit, value) in comps
+      # SQLite has no 'weeks' modifier — express weeks as days.
+      u, mag = unit === :week ? (:day, value * 7) : (unit, value)
+      signed = op_factor * mag
+      sign   = signed < 0 ? "-" : "+"
+      ph     = add_parameter!(instruc, abs(signed))
+      push!(mods, "'$sign' || $ph || ' $(_SQLITE_INTERVAL_UNIT[u])'")
+    end
+    # Zero-length interval → identity, matching the PostgreSQL branch (never wrap, so a timestamp
+    # column is not truncated by a stray date() on a no-op interval).
+    isempty(mods) && return left_side
+    return "$wrapper($(left_side), $(join(mods, ", ")))"
+  else
+    throw("Unsupported connection type")
+  end
+end
+
 function _set_update_query_operand(operand::Any, field_name::Any, operation::String, instruc::SQLInstruction)
   if isa(operand, FExpression)
     return _set_update_query(operand, instruc)
@@ -767,6 +893,11 @@ function _set_update_query(v::FExpression, instruc::SQLInstruction)
     else
       throw("Unsupported connection type")
     end
+  elseif v.operation in ("+", "-") && v.operand isa Union{Dates.Period, Dates.CompoundPeriod, Interval}
+    # Date arithmetic with an explicit Julia duration type (#25). Handled ahead of the generic
+    # infix branch: a Period operand must NOT reach `_set_update_query_operand`, which would try to
+    # bind it as a raw SQL parameter.
+    return _render_date_period_arithmetic(v, instruc)
   else
     # Field with operation - handle nesting and date arithmetic properly
     left_side = _set_update_query_left(v.field_name, v.operation, instruc)

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -327,6 +327,51 @@ end
 
 
 """
+    Interval(period)
+    Interval(duration_string)
+
+Explicit duration wrapper for F-expression date arithmetic (#25). Holds a Julia
+`Dates.Period` / `Dates.CompoundPeriod`, or parses a portable time-duration string
+(`"HH:MM:SS(.fff)"`, `"M:SS"`, or bare seconds) into a time-only `CompoundPeriod`.
+
+`Interval(...)` is interchangeable with a bare period wherever date arithmetic is used —
+`F("date") + Interval(Month(1))` is identical to `F("date") + Month(1)`. The string form is
+the escape hatch for time-based intervals: `F("logged_at") + Interval("01:30:00")`.
+
+Note: the name is shared with the `Intervals.jl` ecosystem — if you also `using Intervals`,
+disambiguate as `PormG.QueryBuilder.Interval`.
+"""
+struct Interval
+  period::Union{Dates.Period, Dates.CompoundPeriod}
+end
+
+# Parse a portable time-duration string into a time-only CompoundPeriod (Hour+Minute+Second
+# [+sub-second]). Reuses the DurationField normalizer so accepted input formats stay identical,
+# then rebuilds the period directly WITHOUT `canonicalize` (which would roll >=24h into days and
+# >=7d into weeks — surprising for a time duration and would break the portable time-only guarantee).
+function _parse_time_string_to_compoundperiod(s::AbstractString)::Dates.CompoundPeriod
+  normalized = Models._normalize_duration_string(s)  # -> "±H:MM:SS(.fff)" (fields may exceed 2 digits,
+                                                     # e.g. bare "120" seconds normalizes to "00:00:120")
+  m = match(r"^(-?)(\d+):(\d+):(\d+)(?:\.(\d+))?$", normalized)
+  m === nothing && throw(ArgumentError("Interval: could not parse normalized duration '$(normalized)'"))
+  sign = m.captures[1] == "-" ? -1 : 1
+  parts = Dates.Period[Hour(sign * parse(Int, m.captures[2])),
+                       Minute(sign * parse(Int, m.captures[3])),
+                       Second(sign * parse(Int, m.captures[4]))]
+  frac = m.captures[5]
+  if frac !== nothing
+    nanos = parse(Int, rpad(frac, 9, '0')[1:9])  # fractional seconds -> nanoseconds
+    push!(parts, Nanosecond(sign * nanos))
+  end
+  return Dates.CompoundPeriod(parts)
+end
+
+Interval(s::AbstractString) = Interval(_parse_time_string_to_compoundperiod(s))
+
+# Duration operands accepted by F-expression +/- date arithmetic (#25).
+const _DurationOperand = Union{Dates.Period, Dates.CompoundPeriod, Interval}
+
+"""
 F object for direct database field references and operations (similar to Django F expressions).
 
 Allows you to reference database fields directly in operations without pulling data into Julia.
@@ -354,7 +399,7 @@ query.values("price", "discounted_price" => F("price") * 0.9)
 @kwdef mutable struct FExpression <: SQLTypeF
   field_name::Union{String,Integer,SQLTypeF,SQLTypeFunction}
   operation::OptionalString = nothing  # +, -, *, /, etc.
-  operand::Union{String,Integer,Float64,SQLTypeF,SQLTypeFunction,Nothing} = nothing
+  operand::Union{String,Integer,Float64,SQLTypeF,SQLTypeFunction,Dates.Period,Dates.CompoundPeriod,Interval,Nothing} = nothing
   function_name::String = "F"
   column::Union{String,SQLTypeField,Vector{String}} = ""
   agregate::Bool = false
@@ -437,6 +482,37 @@ function Base.:/(f::FExpression, operand::Union{Integer,Float64,String,FExpressi
     agregate=f.agregate || _is_agg(operand)
   )
 end
+
+# Date arithmetic with explicit Julia duration types (#25): F("date") + Day(30), - Hour(6),
+# + (Month(1) + Day(15)), + Interval("01:30:00"), etc. Only + and - are meaningful — multiplying
+# or dividing a date field by a duration is nonsense (`Day(30) * 2` is resolved by Julia's own
+# Period arithmetic before it ever reaches an FExpression). A duration is never an aggregate, so
+# `agregate` propagates from `f` unchanged.
+function Base.:+(f::FExpression, operand::_DurationOperand)
+  return FExpression(
+    field_name=f.operation === nothing ? f.field_name : f,
+    operation="+",
+    operand=operand,
+    function_name="F",
+    column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
+    agregate=f.agregate
+  )
+end
+
+function Base.:-(f::FExpression, operand::_DurationOperand)
+  return FExpression(
+    field_name=f.operation === nothing ? f.field_name : f,
+    operation="-",
+    operand=operand,
+    function_name="F",
+    column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
+    agregate=f.agregate
+  )
+end
+
+# Reversed + only: `Day(30) + F("date")` commutes to `F("date") + Day(30)`. Reversed - is omitted
+# on purpose (`interval - date` is not valid date arithmetic).
+Base.:+(operand::_DurationOperand, f::FExpression) = f + operand
 
 # Comparison operations for F expressions
 function Base.:(==)(f::FExpression, operand::Union{Integer,Float64,String,Dates.Date,Dates.DateTime,FExpression})

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -183,7 +183,23 @@ end
     restored_row = (race_query.list() |> first)
   restored_date = restored_row[:date] isa String ? Date(restored_row[:date]) : restored_row[:date]
   @test restored_date == orig_date
-  
+
+  # 3. Period-based date arithmetic (#25): calendar-unit intervals (Month/Day/Week) that the
+  #    integer-days path could not express. The result is checked against Julia's own Dates math
+  #    using the SAME period value, so the assertion matches the interval semantics on both
+  #    PostgreSQL and SQLite. The explicit restore below returns the row to its original date.
+  delta = Dates.Month(1) + Dates.Day(15)   # CompoundPeriod → one make_interval / date(...) call
+  race_query.update("date" => F("date") + delta)
+  period_row = (race_query.list() |> first)
+  period_date = period_row[:date] isa String ? Date(period_row[:date]) : period_row[:date]
+  @test period_date == (orig_date + delta)
+
+  # Subtraction with a single calendar unit (Week → 7 days), computed from the CURRENT value.
+  race_query.update("date" => F("date") - Dates.Week(1))
+  sub_row = (race_query.list() |> first)
+  sub_date = sub_row[:date] isa String ? Date(sub_row[:date]) : sub_row[:date]
+  @test sub_date == (period_date - Dates.Week(1))
+
   # Restore original just in case
   race_query.update("date" => orig_date)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ end
     @testset "pormg_lower UDF (#78)" include("unit/test_pormg_lower_udf.jl")
     @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")
+    @testset "Date/Time Function SQL Parity (#25)" include("unit/test_date_functions_sql.jl")
     @testset "Deep FK Traversal (3 hops)" include("unit/test_deep_fk_traversal.jl")
     @testset "Window Function SQL Generation" include("unit/test_window_functions.jl")
     @testset "Dedicated Inspection API" include("unit/test_inspect_query.jl")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1,6 +1,7 @@
 using Test
 using PormG
 using Logging
+using Dates
 
 # Mock SQLite Settings
 struct MockSQLite <: PormG.PormGSQLite end
@@ -1993,6 +1994,103 @@ end
     @test_throws MethodError PormG.QueryBuilder.topological_sort(
         Dict(CycleA => Set([CycleB]), CycleB => Set([CycleA]))
     )
+end
+
+# =============================================================================
+# F-expression date arithmetic with explicit Julia duration types (#25) — SQLite.
+#
+# SQLite rendering contract: `F(date) ± <period>` becomes a `date()`/`datetime()`
+# wrapper with one `'<sign>' || ? || ' <unit>'` modifier per component. The wrapper
+# is `datetime()` when any sub-day unit is present OR the column is TIMESTAMP/TIMESTAMPTZ
+# (to preserve time-of-day), otherwise `date()`. Weeks have no SQLite modifier and are
+# expressed as days (×7). The sign is baked into each modifier so subtraction binds a
+# positive magnitude. The typed-PostgreSQL counterpart is pinned in test_operators.jl;
+# this locks the placeholder/bucket parity so the two dialects can't silently diverge.
+# =============================================================================
+@testset "F-expression date arithmetic — SQLite date()/datetime() (#25)" begin
+    # Render a values() projection and return the inspection dict.
+    render(model, expr) = begin
+        q = model.objects
+        q.values("shifted" => expr)
+        q |> inspect_query
+    end
+
+    @testset "DATE field → date(); DAY offset" begin
+        insp = render(M.Driver, F("dob") + Day(30))
+        sql = insp[:sql_text]
+        @test contains(sql, "date(\"Tb\".\"dob\", '+' || ? || ' days')")
+        @test !contains(sql, "datetime(")                 # a pure DATE + day stays on date()
+        @test count(==('?'), sql) == 1                    # one placeholder == one component
+        @test insp[:parameters] == [30]
+        @test 30 in insp[:parameter_buckets][:select]     # values() projection → :select bucket
+    end
+
+    @testset "TIMESTAMPTZ field → datetime() via the column-type trigger" begin
+        # Day is NOT a sub-day unit, so datetime() here can come ONLY from the TIMESTAMPTZ column
+        # type — this is the discriminating case that actually exercises the `ftype` branch. Without
+        # it the row would render date() and silently truncate the stored time-of-day.
+        insp = render(M.Django_contract_scratch, F("event_time") + Day(1))
+        @test contains(insp[:sql_text], "datetime(\"Tb\".\"event_time\", '+' || ? || ' days')")
+        @test !contains(insp[:sql_text], "date(\"Tb\".\"event_time\"")
+        @test insp[:parameters] == [1]
+    end
+
+    @testset "Chained arithmetic on a TIMESTAMP column stays datetime() (no truncation)" begin
+        # `F(event_time) + Day(1) + Day(2)` nests: the outer call sees a nested FExpression as its
+        # field_name (so the column type is unknown), but the inner render is already a datetime(),
+        # so the outer must stay datetime(). Otherwise date(datetime(...)) drops the time-of-day and
+        # diverges from PostgreSQL (which keeps the full timestamp).
+        insp = render(M.Django_contract_scratch, F("event_time") + Day(1) + Day(2))
+        sql = insp[:sql_text]
+        @test !contains(sql, "date(datetime(")                              # the truncating shape must NOT appear
+        @test contains(sql, "datetime(datetime(\"Tb\".\"event_time\"")      # nested datetime() preserves time
+        @test insp[:parameters] == [1, 2]
+    end
+
+    @testset "Sub-day unit forces datetime() even on a DATE column" begin
+        # event_date is DATE, but adding hours must not truncate to a date → datetime().
+        insp = render(M.Django_contract_scratch, F("event_date") + Hour(6))
+        @test contains(insp[:sql_text], "datetime(\"Tb\".\"event_date\", '+' || ? || ' hours')")
+        @test insp[:parameters] == [6]
+    end
+
+    @testset "Compound interval → one modifier per component (largest→smallest)" begin
+        insp = render(M.Django_contract_scratch, F("event_date") + (Month(1) + Day(15)))
+        @test contains(insp[:sql_text],
+            "date(\"Tb\".\"event_date\", '+' || ? || ' months', '+' || ? || ' days')")
+        @test count(==('?'), insp[:sql_text]) == 2
+        @test insp[:parameters] == [1, 15]
+    end
+
+    @testset "Subtraction bakes the sign; magnitudes stay positive" begin
+        insp = render(M.Django_contract_scratch, F("event_date") - (Month(1) + Day(15)))
+        @test contains(insp[:sql_text],
+            "date(\"Tb\".\"event_date\", '-' || ? || ' months', '-' || ? || ' days')")
+        @test insp[:parameters] == [1, 15]                # bound values are the absolute magnitudes
+    end
+
+    @testset "Weeks are expressed as days (SQLite has no 'weeks' modifier)" begin
+        insp = render(M.Django_contract_scratch, F("event_date") + Week(2))
+        @test contains(insp[:sql_text], "date(\"Tb\".\"event_date\", '+' || ? || ' days')")
+        @test insp[:parameters] == [14]                   # 2 weeks × 7
+    end
+
+    @testset "Joined date field resolves to date() (left_side rendered before type lookup)" begin
+        # raceid__date joins result→race; the join must render (populating the field-type cache)
+        # BEFORE the date()/datetime() choice, or the joined column degrades to the unknown default.
+        insp = render(M.Result, F("raceid__date") + Day(30))
+        sql = insp[:sql_text]
+        @test contains(sql, "date(\"Tb_1\".\"date\", '+' || ? || ' days')")
+        @test contains(sql, "INNER JOIN \"race\"")
+        @test insp[:parameters] == [30]
+    end
+
+    @testset "Interval(\"01:30:00\") → datetime() with hours+minutes" begin
+        insp = render(M.Django_contract_scratch, F("event_time") + Interval("01:30:00"))
+        @test contains(insp[:sql_text],
+            "datetime(\"Tb\".\"event_time\", '+' || ? || ' hours', '+' || ? || ' minutes')")
+        @test insp[:parameters] == [1, 30]
+    end
 end
 
 

--- a/test/unit/test_date_functions_sql.jl
+++ b/test/unit/test_date_functions_sql.jl
@@ -1,0 +1,87 @@
+"""
+Unit tests for cross-database SQL generation parity of the date/time functions in
+`src/Dialect.jl` (issue #25, part 2).
+
+Each of these functions renders DIFFERENTLY on PostgreSQL vs SQLite — PG has native
+`EXTRACT(... FROM ...)` / `to_char(...)`, SQLite must emulate with `strftime(...)` /
+integer math — and several (`QUARTER`, `QUADRIMESTER`) hand-roll a per-engine formula.
+That divergence is exactly where a one-sided edit silently breaks the other backend,
+so the two forms are pinned here side by side. No live database required: `Dialect`'s
+date functions are pure `(column, format, conn) -> String` renderers, dispatched on the
+connection type, so we call them directly with mock connections.
+
+Sibling coverage:
+  - `test_date_bucket_operator.jl` → the `__@yyyy_mm` *filter operator* end-to-end (PG).
+  - `test_operators.jl` / `test_alignment_sqlite.jl` → F-expression *date arithmetic* (#25 part 1).
+  - This file → the raw date-part / date-format function renderers, both engines.
+"""
+
+using Test
+using PormG
+import PormG.Dialect
+
+# Mock connections — only their type matters (dispatch selects the PG vs SQLite body).
+struct _PgDateFnConn <: PormG.PormGPostgres end
+struct _SlDateFnConn <: PormG.PormGSQLite end
+const _PG    = _PgDateFnConn()
+const _SL    = _SlDateFnConn()
+const _COL   = "\"t\".\"d\""            # a pre-quoted column reference
+const _EMPTY = Dict{String, Any}()
+
+@testset "Date/time function cross-DB SQL parity (#25)" begin
+
+  # ===========================================================================
+  # QUARTER / QUADRIMESTER — hand-rolled, per-engine formulas (highest drift risk)
+  # ===========================================================================
+  @testset "QUARTER" begin
+    @test Dialect.QUARTER(_COL, _EMPTY, _PG) == "EXTRACT(QUARTER FROM $(_COL))"
+    @test Dialect.QUARTER(_COL, _EMPTY, _SL) == "((strftime('%m', $(_COL)) - 1) / 3) + 1"
+  end
+
+  @testset "QUADRIMESTER" begin
+    @test Dialect.QUADRIMESTER(_COL, _EMPTY, _PG) == "CEIL(EXTRACT(MONTH FROM $(_COL)) / 4.0)"
+    @test Dialect.QUADRIMESTER(_COL, _EMPTY, _SL) == "((strftime('%m', $(_COL)) - 1) / 4) + 1"
+  end
+
+  # ===========================================================================
+  # EXTRACT — PG EXTRACT(part FROM col) vs SQLite CAST(strftime(code, col) AS INTEGER).
+  # This borders the new sub-day date arithmetic (HOUR/MINUTE/SECOND), so lock every part.
+  # ===========================================================================
+  @testset "EXTRACT parts" begin
+    # (part, SQLite strftime code)
+    for (part, slcode) in [
+        ("YEAR",   "%Y"), ("MONTH",  "%m"), ("DAY",    "%d"), ("HOUR",   "%H"),
+        ("MINUTE", "%M"), ("SECOND", "%S"), ("DOW",    "%w"), ("DOY",    "%j"),
+      ]
+      fmt = Dict{String, Any}("part" => part)
+      @test Dialect.EXTRACT(_COL, fmt, _PG) == "EXTRACT($part FROM $(_COL))"
+      @test Dialect.EXTRACT(_COL, fmt, _SL) == "CAST(strftime('$slcode', $(_COL)) AS INTEGER)"
+    end
+    # The SQLite whitelist is fail-closed: an unsupported part must throw, not emit garbage.
+    @test_throws ArgumentError Dialect.EXTRACT(_COL, Dict{String, Any}("part" => "WEEK"), _SL)
+  end
+
+  # ===========================================================================
+  # EXTRACT_DATE — PG to_char() vs SQLite strftime(); the format mask maps through
+  # sqlite_date_format_map. "YYYY-MM" must resolve to "%Y-%m" (byte-identical logical mask).
+  # ===========================================================================
+  @testset "EXTRACT_DATE Y_M mask" begin
+    fmt = Dict{String, Any}("format" => "YYYY-MM")
+    @test occursin("to_char($(_COL), 'YYYY-MM')", Dialect.EXTRACT_DATE(_COL, fmt, _PG))
+    @test occursin("strftime('%Y-%m', $(_COL))",  Dialect.EXTRACT_DATE(_COL, fmt, _SL))
+  end
+
+  # ===========================================================================
+  # YEAR/MONTH/DAY/Y_M wrappers — thin delegators; verify they carry the divergence through.
+  # ===========================================================================
+  @testset "Date-part wrappers delegate to EXTRACT / EXTRACT_DATE" begin
+    @test Dialect.YEAR(_COL, _EMPTY, _PG)  == "EXTRACT(YEAR FROM $(_COL))"
+    @test Dialect.YEAR(_COL, _EMPTY, _SL)  == "CAST(strftime('%Y', $(_COL)) AS INTEGER)"
+    @test Dialect.MONTH(_COL, _EMPTY, _PG) == "EXTRACT(MONTH FROM $(_COL))"
+    @test Dialect.MONTH(_COL, _EMPTY, _SL) == "CAST(strftime('%m', $(_COL)) AS INTEGER)"
+    @test Dialect.DAY(_COL, _EMPTY, _PG)   == "EXTRACT(DAY FROM $(_COL))"
+    @test Dialect.DAY(_COL, _EMPTY, _SL)   == "CAST(strftime('%d', $(_COL)) AS INTEGER)"
+    @test occursin("to_char($(_COL), 'YYYY-MM')", Dialect.Y_M(_COL, _EMPTY, _PG))
+    @test occursin("strftime('%Y-%m', $(_COL))",  Dialect.Y_M(_COL, _EMPTY, _SL))
+  end
+end

--- a/test/unit/test_operators.jl
+++ b/test/unit/test_operators.jl
@@ -486,3 +486,111 @@ const _E = _OperTestEvent
   end
 
 end  # end "PormGsuffix — Operator SQL Generation"
+
+# =============================================================================
+# F-expression date arithmetic with explicit Julia duration types (#25).
+#
+# PostgreSQL rendering contract: `F(date) ± <period>` becomes a single
+# `make_interval(...)` call with EXPLICITLY-typed placeholders — integer units as
+# `$n::integer` (never bigint: `make_interval(days => bigint)` does not exist) and
+# seconds as `$n::double precision`. The SQL operator mirrors +/-, and the raw
+# component magnitudes are bound (compound intervals keep their internal signs).
+# The SQLite counterpart (date()/datetime() + modifiers) is pinned in
+# test_alignment_sqlite.jl; this file locks the typed-PG shape and parameter order.
+# =============================================================================
+@testset "F-expression date arithmetic — PostgreSQL make_interval (#25)" begin
+  # _E = events(id, happened::DATE, logged_at::TIMESTAMPTZ) — mock PostgreSQL connection.
+
+  # Each entry: (label, expression, expected make_interval fragment, expected params).
+  # The fragment is asserted verbatim so a wrong keyword, missing cast, or dropped
+  # component fails loudly.
+  for (label, expr, frag, params) in [
+      ("+ Day(30)",             F("happened") + Day(30),
+        "(\"Tb\".\"happened\" + make_interval(days => \$1::integer))",              [30]),
+      ("+ Month(3)",            F("happened") + Month(3),
+        "(\"Tb\".\"happened\" + make_interval(months => \$1::integer))",            [3]),
+      ("+ (Month(1)+Day(15))",  F("happened") + (Month(1) + Day(15)),
+        "(\"Tb\".\"happened\" + make_interval(months => \$1::integer, days => \$2::integer))", [1, 15]),
+      ("- Hour(6)",             F("logged_at") - Hour(6),
+        "(\"Tb\".\"logged_at\" - make_interval(hours => \$1::integer))",            [6]),
+      ("+ Week(2)",             F("happened") + Week(2),
+        "(\"Tb\".\"happened\" + make_interval(weeks => \$1::integer))",             [2]),
+      # Compound with an internal negative component: the magnitude is kept as-is and
+      # the SQL operator stays '+', so the interval itself carries the -15.
+      ("+ (Month(1)+Day(-15))", F("happened") + (Month(1) + Day(-15)),
+        "(\"Tb\".\"happened\" + make_interval(months => \$1::integer, days => \$2::integer))", [1, -15]),
+      # Reversed operand order commutes to the same tree.
+      ("reversed Day(30)+F",    Day(30) + F("happened"),
+        "(\"Tb\".\"happened\" + make_interval(days => \$1::integer))",              [30]),
+    ]
+    q = _E.objects
+    q.values("shifted" => expr)
+    res = q.list(show_query=:dict)
+    @test contains(res[:sql_text], frag)      # exact typed make_interval fragment
+    @test res[:parameters] == params          # magnitudes bound in textual order
+  end
+
+  @testset "Interval(...) helper — string and period forms" begin
+    # Interval("HH:MM:SS") → time-only make_interval(hours, mins[, secs]).
+    q1 = _E.objects; q1.values("s" => F("logged_at") + Interval("01:30:00"))
+    r1 = q1.list(show_query=:dict)
+    @test contains(r1[:sql_text], "make_interval(hours => \$1::integer, mins => \$2::integer)")
+    @test r1[:parameters] == [1, 30]
+
+    # Fractional seconds bind as double precision.
+    q2 = _E.objects; q2.values("s" => F("logged_at") + Interval("00:00:01.5"))
+    r2 = q2.list(show_query=:dict)
+    @test contains(r2[:sql_text], "make_interval(secs => \$1::double precision)")
+    @test r2[:parameters] == [1.5]
+
+    # Interval(period) is interchangeable with the bare period.
+    q3 = _E.objects; q3.values("s" => F("happened") + Interval(Month(2)))
+    r3 = q3.list(show_query=:dict)
+    @test contains(r3[:sql_text], "(\"Tb\".\"happened\" + make_interval(months => \$1::integer))")
+    @test r3[:parameters] == [2]
+
+    # Bare-seconds string ≥ 100 must PARSE, not throw: the duration normalizer emits "00:00:120"
+    # (three seconds digits), which the parser must accept.
+    q4 = _E.objects; q4.values("s" => F("logged_at") + Interval("120"))
+    r4 = q4.list(show_query=:dict)
+    @test contains(r4[:sql_text], "make_interval(secs => \$1::double precision)")
+    @test r4[:parameters] == [120.0]
+  end
+
+  @testset "Chained (unparenthesised) periods nest into separate intervals" begin
+    # `F + Month(1) + Day(15)` parses left-to-right as `(F + Month(1)) + Day(15)`, so it renders
+    # as two chained make_interval() calls (correct result; parenthesise to `+ (Month(1)+Day(15))`
+    # for a single interval). This locks that the nested form still renders and binds correctly.
+    q = _E.objects
+    q.values("shifted" => F("happened") + Month(1) + Day(15))
+    res = q.list(show_query=:dict)
+    @test contains(res[:sql_text],
+      "((\"Tb\".\"happened\" + make_interval(months => \$1::integer)) + make_interval(days => \$2::integer))")
+    @test res[:parameters] == [1, 15]
+  end
+
+  @testset "Update path — SET with make_interval" begin
+    # Write path funnels through the same renderer. WHERE param is bound first ($1),
+    # the interval magnitude second ($2), matching the bitwise-update convention above.
+    q = _E.objects.filter("id" => 1)
+    res = q.update("happened" => F("happened") + Day(7), show_query=:inspection)
+    @test contains(res[:sql_text], "SET \"happened\" = (\"Tb\".\"happened\" + make_interval(days => \$2::integer))")
+    @test contains(res[:sql_text], "WHERE \"Tb\".\"id\" = \$1")
+    @test res[:parameters] == [1, 7]
+  end
+
+  @testset "Soft validation — duration on a non-date field throws" begin
+    # A duration only makes sense on a DATE/TIMESTAMP column. _D.surname is CharField.
+    err = try
+      Logging.with_logger(Logging.NullLogger()) do
+        _D.objects.values("bad" => F("surname") + Day(1)).list(show_query=:dict)
+      end
+      nothing
+    catch e
+      e
+    end
+    @test err isa ArgumentError
+    @test occursin("requires a DATE/TIMESTAMP field", err.msg)
+    @test occursin("surname", err.msg)
+  end
+end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -17,7 +17,7 @@ using PormG
 # The frozen top-level surface of `using PormG` (must match docs/src/api.md exactly).
 const EXPECTED_TOPLEVEL = Set([
     # Query builder
-    :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :show_query, :inspect_query,
+    :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Interval, :show_query, :inspect_query,
     # Rows & exceptions
     :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError,
     # Bulk operations


### PR DESCRIPTION
## Summary

Implements GitHub issue #25: F-expression date arithmetic with explicit Julia duration types.

- **`F("date") + Day(30)`**, `+ Month(3)`, `+ (Month(1)+Day(15))`, `- Hour(6)`, etc.
- Accepts Julia `Dates.Period` (Year, Month, Week, Day, Hour, Minute, Second), `Dates.CompoundPeriod`, or a new exported `Interval` helper wrapping a period or a portable time-duration string (`"HH:MM:SS"`).
- Integer-days path (`F("date") + 30`) is unchanged and fully backward compatible.
- Soft validation: throws when a plain field is known to be non-date, silent on nested/unknown fields.

Also backfills cross-database SQL-parity unit tests for existing date/time functions (QUARTER, QUADRIMESTER, EXTRACT, EXTRACT_DATE) — issue #25 part 2.

## How it works

All F-arithmetic funnels through one renderer, so period operands are routed ahead of the generic infix branch:

### PostgreSQL
```sql
-- F("date") + Month(3) + Day(15)
... + make_interval(months => $1::integer, days => $2::integer)
```
- Single `make_interval(...)` call with explicit `::integer`/`::double precision` type casts
- Sub-second components fold into `secs::double precision`
- Preserves type through chaining (timestamp columns keep their time-of-day)

### SQLite
```sql
-- F("event_time") + Day(1) + Hour(6)
datetime(..., '+' || $1 || ' days', '+' || $2 || ' hours')
```
- Wrapper: `datetime()` when sub-day units, a TIMESTAMP column, or an already-datetime() left side is present (prevents silent time truncation on chained arithmetic); `date()` for day-level only
- Signs baked per modifier (so subtraction is `'-' || abs(value)`)
- Week converted to days × 7 (SQLite has no weeks modifier)
- Magnitudes parameterized; unit keywords from closed whitelists

## Verification

✅ Unit suite: **2822/2822 pass**  
✅ Docs build: clean  
✅ Integration tests pass on both dialects:
  - PostgreSQL (db_2): "Complex Join Updates and Date Arithmetic" **5/5**
  - SQLite (db_sl): "Complex Join Updates and Date Arithmetic" **5/5**

Code review (2 independent agents) found 2 bugs, both fixed and covered with locking regression tests:
1. SQLite chained arithmetic on TIMESTAMP would truncate time (now uses `datetime(datetime(...))` to preserve)
2. `Interval("120")` (bare seconds ≥ 100) parsing now relaxes regex to accept multi-digit fields

## Files changed

13 files: +587/−14
- Core: `types.jl` (Interval struct, operand union, +/- overloads), `execution.jl` (renderer, type detection, soft-validate)
- Wire: `QueryBuilder.jl`, `PormG.jl` (exports)
- Tests: 4 unit files (typed SQL, parity, exports, date-function parity); 1 integration extension (result-driven round-trip)
- Docs: api.md, field_expressions.md, functions_and_dates.md

Closes #25