### PR TITLE
feat(#30): row-level update_or_create (Django-style upsert)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,10 @@
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-*(none — the gating list is empty; new `pre-publish`-labeled issues appear here as they open)*
+- [#166](https://github.com/PingoLee/PormG.jl/issues/166) — write-path return-type consistency:
+  `create()`/`insert()` return `Dict` while `get()`/`first()`/`save()`/`update_or_create()` return
+  `PormGRow`. Decide the contract (likely `create()`/`insert()` → `PormGRow`) before publish, since
+  it is a breaking return-type change. Surfaced by `update_or_create` (#30).
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,53 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Row-level `update_or_create` (Django-style upsert)
+
+- **PormG ref**: issue #30 ; `src/querybuilder/execution.jl`, `src/querybuilder/object_manager.jl`
+- **Recorded**: 2026-07-15
+- **Severity**: new feature — **additive, non-breaking**. No existing API changed; no forced code edit.
+
+### What changed
+
+`M.Model.objects.update_or_create(lookup...; defaults=[...])` performs a single-row upsert built on
+the `ON CONFLICT` renderer from #123. The lookup pair(s) are the conflict target; `defaults` are set
+on conflict and merged into the insert. It returns `(row, created::Bool)`, where `row` is a `PormGRow`
+(dot-access + `.save()`, like `get()`) and `created` distinguishes insert from update (PostgreSQL via
+`RETURNING (xmax = 0)`; SQLite via a pre-check in its serialized write lock).
+
+```julia
+row, created = M.Status.objects.update_or_create(
+    "statusid" => 3; defaults = ["status" => "Accident"])
+```
+
+Requires the lookup columns to be backed by a UNIQUE/PRIMARY KEY constraint in the database.
+`auto_now` fields refresh on the update arm. See [Update or Create](docs/src/write/create.md#update-or-create).
+
+### How to find the calls to migrate
+
+Nothing breaks — purely additive. **Optional adoption:** replace hand-rolled get-then-create/update
+blocks (a `filter(...).exists()` followed by `create()` or `update()`) with a single
+`update_or_create`, which is atomic and race-free.
+
+```
+grep -rn "exists()" src/ | grep -iE "create|update"
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | optional — replace get-then-create/update blocks with `update_or_create` |
+| app-2 | ⏳ | optional |
+| app-3 | ⏳ | optional |
+| app-4 | ⏳ | optional |
+
+> **Note (pre-publish):** `create()`/`insert()` still return a `Dict` while `update_or_create()` (and
+> `get()`/`first()`/`save()`) return a `PormGRow`. That inconsistency is tracked for a decision before
+> publish in [#166](https://github.com/PingoLee/PormG.jl/issues/166).
+
+---
+
 ## `bulk_insert` conflict handling via `on_conflict=` (ON CONFLICT)
 
 - **PormG ref**: issue #123 ; `src/querybuilder/execution_bulk.jl`, `src/Dialect.jl`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,7 @@ These methods finalize the query and execute it against the database:
 | `.get(filters...)` | `PormGRow` | Returns exactly one row, or raises `DoesNotExist` / `MultipleObjectsReturned`. |
 | `.create(key => value, ...)` | `Dict` | Inserts a single record and returns it. |
 | `.update(key => value, ...)` | — | Updates all matching records. |
+| `.update_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Row-level upsert: inserts on a fresh lookup or updates `defaults` on conflict; returns `(row, created)`. See [Update or Create](write/create.md#update-or-create). |
 | `.delete()` | — | Deletes all matching records. |
 
 ### `PormGRow` Instance Methods

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -140,6 +140,49 @@ RETURNING *
 -- Parameters: ["Max", "Verstappen", "Dutch", "max_verstappen", '1997-04-01']
 ```
 
+## Update or Create
+
+`update_or_create` is a Django-style row-level upsert: it inserts a row when the lookup doesn't exist yet, or updates it when it does — in a single atomic `INSERT ... ON CONFLICT ... DO UPDATE` statement (PostgreSQL and SQLite ≥ 3.24). It returns a `(row, created)` tuple, where `row` is a [`PormGRow`](../read/index.md) (dot-access + `.save()`, just like `get()`/`first()`) and `created` is `true` when a new row was inserted, `false` when an existing one was updated.
+
+```julia
+# Idempotently seed a status: insert it the first time, refresh its label on re-runs.
+row, created = M.Status.objects.update_or_create(
+    "statusid" => 3;                       # lookup — becomes the ON CONFLICT target
+    defaults = ["status" => "Accident"],   # SET on a conflict, and merged into the INSERT
+)
+
+if created
+    @info "inserted" row.status
+else
+    @info "updated existing" row.status
+end
+
+# The returned PormGRow can be edited and re-saved (further round-trip):
+row.status = "Collision"
+row.save()
+```
+
+**Generated SQL (PostgreSQL):**
+```sql
+INSERT INTO "status" ("statusid", "status")
+VALUES ($1, $2)
+ON CONFLICT ("statusid") DO UPDATE SET "status" = EXCLUDED."status"
+RETURNING *, (xmax = 0) AS "__pormg_created"
+-- Parameters: [3, "Accident"]
+```
+
+`(xmax = 0)` is how PostgreSQL reports whether the row was freshly inserted (`created = true`) or updated (`false`); PormG strips that sentinel column from the returned row.
+
+**On SQLite** the statement is the same `INSERT ... ON CONFLICT ... DO UPDATE` **without** `RETURNING` (which PormG avoids on SQLite — see the note in the single-record section). `created` is derived from a pre-check + read-back run inside SQLite's serialized write transaction (`BEGIN IMMEDIATE` + the writer lock), so it is exact under the writer serialization that always guards writes.
+
+### Rules and behavior
+
+- **Lookup → conflict target.** The lookup pair(s) identify the row and become the `ON CONFLICT (...)` columns. A composite key is fully supported — pass several lookup pairs: `update_or_create("year" => 2024, "round" => 8; defaults = [...])`. The target must be backed by a real UNIQUE/PRIMARY KEY constraint in the database (PormG does not require it to be declared on the model — the database is the source of truth; a missing constraint surfaces as the backend's own error).
+- **`defaults` is required** and is the DO UPDATE `SET`. Fields in `defaults` are also merged into the INSERT. `update_or_create` always updates on conflict; a no-update *get-or-create* is a planned follow-up.
+- **Lookup and `defaults` must not overlap** — each field is either a match key or an updated value, never both.
+- **`auto_now` fields refresh on the update arm.** Any field with `auto_now = true` is appended to the SET so a conflict updates its timestamp (matching `.save()`/`.update()`); `auto_now_add` fields are create-only and are not refreshed.
+- **Field names are logical.** `db_column` mappings are resolved to the physical column names in the rendered SQL.
+
 ## Creating with Relationships
 
 To create a record with a `ForeignKey` relationship, you need the ID of the related record. You can either:

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -429,27 +429,16 @@ function _row_to_field_keyed_dict(row, model::PormGModel)::Dict{Symbol,Any}
   return Dict{Symbol,Any}(get(rev, string(k), Symbol(k)) => v for (k, v) in pairs(row))
 end
 
-function insert(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = nothing, connection::Union{Nothing, PormGPostgres, PormGSQLite} = nothing, show_query::Symbol = :execute)
-real_obj = objct isa SQLObjectHandler ? objct.object : objct
-  model = real_obj.model
-  ensure_model_transaction_scope(model)
-  
-  # Resolve settings
-  settings, connection, conn_key = get_settings(objct, connection=connection)
-  
-  # colect name of the fields
+# Shared row-level INSERT marshalling, extracted from insert() (#30) so insert() and
+# _update_or_create() build the identical VALUES body from one place. Fills each missing field
+# (default → auto_now/auto_now_add → UUID → skip-if-null-or-pk → else error), reserves a SQLite id
+# when the transaction pre-allocated one, then validates every field and collects the quoted physical
+# columns and bound params. MUTATES `real_obj.insert` (fills) and `parameters` (binds). Returns
+# (quoted_field_columns, param_values, pk_exist, pk_field). The change_data guard stays with the
+# caller so it fires before any fill.
+function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection, parameters)
   fields = model.field_names
 
-  # Collect column names and parameter values
-  quoted_field_columns = []
-  param_values = []
-  parameters = get_parameter(connection)
-  # For INSERT, all params go into :select bucket (VALUES clause is the only positioned section)
-  set_context!(parameters, :select)
-  
-  # check if is allowed to insert
-  !settings.change_data && throw(_argerr("Error in insert, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
-  
   # check if the fields are in objct.insert
   for field in fields
     if !haskey(real_obj.insert, field)
@@ -484,6 +473,8 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     end
   end
 
+  quoted_field_columns = []
+  param_values = []
   pk_exist::Bool = false
   pk_field::Vector{String} = []
   for field in keys(real_obj.insert)
@@ -501,8 +492,31 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     push!(param_values, add_parameter!(parameters, real_obj.insert[field] |> model.fields[field].formater))
 
   end
- 
-  # TODO: insert a function to handle with the different types of connection and modulate the code
+
+  return quoted_field_columns, param_values, pk_exist, pk_field
+end
+
+function insert(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = nothing, connection::Union{Nothing, PormGPostgres, PormGSQLite} = nothing, show_query::Symbol = :execute)
+real_obj = objct isa SQLObjectHandler ? objct.object : objct
+  model = real_obj.model
+  ensure_model_transaction_scope(model)
+  
+  # Resolve settings
+  settings, connection, conn_key = get_settings(objct, connection=connection)
+  
+  # Collect column names and parameter values
+  parameters = get_parameter(connection)
+  # For INSERT, all params go into :select bucket (VALUES clause is the only positioned section)
+  set_context!(parameters, :select)
+
+  # check if is allowed to insert
+  !settings.change_data && throw(_argerr("Error in insert, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+
+  # Fill defaults/auto_now/auto_now_add/UUID, reserve SQLite ids, validate, and collect the quoted
+  # physical columns + bound VALUES params. Shared with _update_or_create (#30) so both build the
+  # identical INSERT body from one place.
+  quoted_field_columns, param_values, pk_exist, pk_field =
+    _prepare_row_insert!(real_obj, model, settings, connection, parameters)
 
   # construct the SQL statement
   safe_table_name = safe_table_identifier(string(model.name), connection)
@@ -556,6 +570,111 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     throw("Unsupported connection type")
   end
 
+end
+
+# Row-level upsert (#30) behind `objects.update_or_create`. Builds the same INSERT body as insert()
+# via _prepare_row_insert!, appends `ON CONFLICT (target) DO UPDATE SET set…` (reusing #123's
+# Dialect.on_conflict_clause), and returns `(PormGRow, created::Bool)`.
+#
+# `target_fields` (the lookup keys) and `set_fields` (defaults + auto_now) are LOGICAL field names,
+# resolved to quoted physical columns here (like bulk_insert). Caller (up_update_or_create!) has
+# already merged lookup+defaults into real_obj.insert and validated the fields.
+#
+# created detection per backend:
+#   PostgreSQL — single atomic `... RETURNING *, (xmax = 0) AS "__pormg_created"`; xmax = 0 ⇒ inserted.
+#   SQLite     — RETURNING is avoided (see insert()) and last_insert_rowid() is unreliable on DO
+#                UPDATE, so: pre-check existence by the target, run the upsert, read the row back by
+#                the target — all on one pinned connection under BEGIN IMMEDIATE + the writer lock,
+#                which serializes writers so `existed` is race-free.
+function _update_or_create(objct::SQLObject; target_fields::Vector{String},
+    set_fields::Vector{String}, show_query::Symbol = :execute)
+  real_obj = objct isa SQLObjectHandler ? objct.object : objct
+  model = real_obj.model
+  ensure_model_transaction_scope(model)
+
+  settings, connection, conn_key = get_settings(objct)
+
+  parameters = get_parameter(connection)
+  set_context!(parameters, :select)
+
+  !settings.change_data && throw(_argerr("Error in update_or_create, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+
+  quoted_field_columns, param_values, pk_exist, pk_field =
+    _prepare_row_insert!(real_obj, model, settings, connection, parameters)
+
+  safe_table_name = safe_table_identifier(string(model.name), connection)
+
+  # Logical → quoted physical (db_column-aware), exactly as bulk_insert renders its clause.
+  qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
+  qset    = String[quote_identifier(Models.model_column(model, f), connection) for f in set_fields]
+  clause  = Dialect.on_conflict_clause(:update, qtarget, qset, connection)
+
+  sql = """
+  INSERT INTO $(safe_table_name) (
+    $(join(quoted_field_columns, ", "))
+  ) VALUES (
+    $(join(param_values, ", "))
+  )
+  $(clause)
+  """
+
+  if connection isa PormGPostgres
+    # Atomic upsert; `(xmax = 0)` distinguishes the inserted vs updated tuple version.
+    exec_sql = sql * " RETURNING *, (xmax = 0) AS \"__pormg_created\";"
+    if show_query !== :execute
+      return _show_query_result(show_query, exec_sql, connection, model.name, :insert; parameters=parameters)
+    end
+    result = fetch(settings, exec_sql, parameters)
+    dict = _row_to_field_keyed_dict(Tables.rowtable(result) |> Base.first, model)
+    # Strip the sentinel so it isn't a phantom field; fail safe (false) if it is ever absent.
+    created_raw = pop!(dict, Symbol("__pormg_created"), false)
+    created = created_raw === true || created_raw == 1   # always a Bool (xmax = 0 → PG boolean)
+    pk_exist && _update_sequence(model, connection, pk_field, settings)
+    return (PormGRow(dict, model), created)
+
+  elseif connection isa PormGSQLite
+    if show_query !== :execute
+      # Honest to what executes: INSERT + ON CONFLICT, no RETURNING (created detection is out-of-band).
+      return _show_query_result(show_query, sql, connection, model.name, :insert; parameters=parameters)
+    end
+
+    # Conflict-target WHERE on the physical target columns. The placeholder is a positional `?`
+    # (this branch is SQLite-only), so the WHERE text is stable and is built once; the pre-check and
+    # read-back each bind a FRESH parameter object (no cross-fetch reuse). The bound values are the
+    # formatted lookup values — matching exactly what the INSERT bound.
+    target_where = join(
+      ["$(quote_identifier(Models.model_column(model, f), connection)) = ?" for f in target_fields],
+      " AND ")
+    precheck_sql = "SELECT 1 FROM $(safe_table_name) WHERE $(target_where) LIMIT 1;"
+    readback_sql = "SELECT * FROM $(safe_table_name) WHERE $(target_where) LIMIT 1;"
+    make_target_params = () -> begin
+      tp = get_parameter(connection)
+      set_context!(tp, :where)
+      for f in target_fields
+        add_parameter!(tp, real_obj.insert[f] |> model.fields[f].formater)
+      end
+      tp
+    end
+
+    do_upsert = () -> begin
+      existed = !isempty(fetch(settings, precheck_sql, make_target_params()) |> Tables.rowtable)
+      fetch(settings, sql, parameters)
+      rows = fetch(settings, readback_sql, make_target_params()) |> Tables.rowtable
+      dict = isempty(rows) ?
+        Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(real_obj.insert)) :
+        _row_to_field_keyed_dict(rows[1], model)
+      (dict, !existed)
+    end
+
+    # Pre-check + upsert + read-back must share one connection under one BEGIN IMMEDIATE.
+    dict, created = transaction_connection_for(settings) !== nothing ?
+      do_upsert() : run_in_transaction(do_upsert, settings)
+
+    pk_exist && _update_sequence(model, connection, pk_field, settings)
+    return (PormGRow(dict, model), created)
+  else
+    throw("Unsupported connection type")
+  end
 end
 
 function _get_owned_sequence_name(connection::PormGPostgres, model::PormGModel, field::String; ignore_tx::Bool = false)

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -86,6 +86,69 @@ function up_update!(q::SQLObject, values; kwargs...)
   return update(q, show_query=show_query)
 end
 
+# Coerce a lookup/defaults argument into a Vector{Pair}, tolerating a tuple (positional args),
+# a vector, or a single bare Pair; reject any non-Pair element with an actionable error.
+function _normalize_uoc_pairs(x, what::AbstractString)
+  items = x isa Pair ? (x,) : x
+  out = Pair[]
+  for item in items
+    item isa Pair ||
+      throw(_argerr("Error in update_or_create, each $what entry must be a `field => value` pair, got $(typeof(item))"))
+    push!(out, item)
+  end
+  return out
+end
+
+# Django-style row-level upsert (#30). `lookup` pairs identify the row — their fields become the
+# ON CONFLICT target and their values the INSERT match values; `defaults` are the columns SET on a
+# conflict (via EXCLUDED) and are merged into the INSERT. Returns `(PormGRow, created::Bool)`.
+# All validation fires here, before any DB work, so `show_query=:dict` surfaces it.
+function up_update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
+  model = q.model
+  lookup_pairs  = _normalize_uoc_pairs(lookup, "lookup")
+  default_pairs = _normalize_uoc_pairs(defaults, "defaults")
+
+  isempty(lookup_pairs) &&
+    throw(_argerr("Error in update_or_create, at least one lookup pair is required (it becomes the ON CONFLICT target)"))
+  isempty(default_pairs) &&
+    throw(_argerr("Error in update_or_create, `defaults` must be non-empty — ON CONFLICT DO UPDATE needs a SET; a no-update get_or_create is a planned follow-up (#30)"))
+
+  lookup_keys  = String[string(k) for (k, _) in lookup_pairs]
+  default_keys = String[string(k) for (k, _) in default_pairs]
+
+  for k in lookup_keys
+    haskey(model.fields, k) ||
+      throw(_argerr("Error in update_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+  end
+  for k in default_keys
+    haskey(model.fields, k) ||
+      throw(_argerr("Error in update_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+  end
+  length(unique(lookup_keys)) == length(lookup_keys) ||
+    throw(_argerr("Error in update_or_create, duplicate lookup field(s)"))
+  length(unique(default_keys)) == length(default_keys) ||
+    throw(_argerr("Error in update_or_create, duplicate defaults field(s)"))
+  overlap = intersect(Set(lookup_keys), Set(default_keys))
+  isempty(overlap) ||
+    throw(_argerr("Error in update_or_create, field(s) $(join(sort(collect(overlap)), ", ")) appear in both lookup and defaults; put each in one (lookup = match key, defaults = updated on conflict)"))
+
+  # Merge into the insert map (lookup then defaults; order preserved for deterministic SQL, #97).
+  q.insert = OrderedCollections.OrderedDict{String,Any}()
+  for (k, v) in lookup_pairs;  q.insert[string(k)] = v; end
+  for (k, v) in default_pairs; q.insert[string(k)] = v; end
+
+  # target = lookup keys; SET = defaults, plus every auto_now field (refresh on conflict, matching
+  # update()) that isn't already a default and isn't a lookup key. auto_now_add is create-only and
+  # deliberately excluded; a lookup key is the conflict target and must never be in the SET.
+  target_fields = lookup_keys
+  auto_now_fields = String[f for f in model.field_names
+    if hasproperty(model.fields[f], :auto_now) && model.fields[f].auto_now === true &&
+       !(f in default_keys) && !(f in lookup_keys)]
+  set_fields = vcat(default_keys, auto_now_fields)
+
+  return _update_or_create(q; target_fields = target_fields, set_fields = set_fields, show_query = show_query)
+end
+
 """
   up_filter!(q::SQLObject, filter)
   Add filters to the SQLObject query.
@@ -244,6 +307,11 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
   elseif sym === :update
     # Same dual execute/inspect return contract as :create — see the note above.
     return (args...; kwargs...) -> up_update!(q.object, args; kwargs...)
+  elseif sym === :update_or_create
+    # Row-level upsert (#30). Execute path returns (row::PormGRow, created::Bool);
+    # show_query=:sql/:dict/:params return the inspection shape (String/Dict/Vector), same dual
+    # contract as :create/:update. `args` = lookup pairs; `defaults=`/`show_query=` via kwargs.
+    return (args...; kwargs...) -> up_update_or_create!(q.object, args; kwargs...)
   elseif sym === :count
     # count()                         -> COUNT(*)              (total rows)
     # count(distinct=true)            -> distinct rows         (subquery COUNT(*) over SELECT DISTINCT *)

--- a/test/integration/test_inserts.jl
+++ b/test/integration/test_inserts.jl
@@ -878,3 +878,60 @@ end
         q.exists() && q.delete()
     end
 end
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# update_or_create (#30)
+#
+# Row-level Django-style upsert: match on the lookup pair(s) (the ON CONFLICT target),
+# INSERT on a fresh key, DO UPDATE the `defaults` on a conflict. Returns (PormGRow, created).
+# PostgreSQL derives `created` from RETURNING (xmax = 0); SQLite from a pre-check inside its
+# serialized write lock. Same assertions run on both backends. Uses M.Status (pk statusid).
+#
+# NOTE: a composite (multi-column) conflict target is covered at the unit level (SQL rendering in
+# test/unit/test_update_or_create.jl). An end-to-end multi-column case needs a model with a real
+# composite UNIQUE/PK (a `Models.UniqueConstraint` / unique_together), which the integration
+# fixtures don't yet declare — deferred as a prerequisite follow-up rather than silently skipped.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "update_or_create (#30)" begin
+    status_id = 340001
+    created_pk = Ref{Union{Nothing, Int}}(nothing)
+    q = M.Status.objects.filter("statusid" => status_id)
+    q.exists() && q.delete()
+
+    try
+        # 1. Fresh key → INSERT, created == true, PormGRow returned with the inserted value.
+        row, created = M.Status.objects.update_or_create(
+            "statusid" => status_id; defaults = ["status" => "Created"])
+        @test created === true
+        @test row isa PormG.QueryBuilder.PormGRow
+        @test row.statusid == status_id                 # dot-access (PormGRow, like get())
+        @test row.status == "Created"
+        @test M.Status.objects.filter("statusid" => status_id).count() == 1
+
+        # 2. Same key, new defaults → DO UPDATE, created == false, value merged, count unchanged.
+        row2, created2 = M.Status.objects.update_or_create(
+            "statusid" => status_id; defaults = ["status" => "Updated"])
+        @test created2 === false
+        @test row2.status == "Updated"
+        @test M.Status.objects.filter("statusid" => status_id).count() == 1
+        persisted = M.Status.objects.filter("statusid" => status_id).values("status").list() |> first
+        @test persisted[:status] == "Updated"
+
+        # 3. The returned PormGRow round-trips through .save() (further edits persist).
+        row2.status = "Collision"
+        row2.save()
+        reread = M.Status.objects.filter("statusid" => status_id).values("status").list() |> first
+        @test reread[:status] == "Collision"
+
+        # 4. Sequence consistency: after the explicit-pk upsert, a pk-less create() must not collide.
+        next_row = M.Status.objects.create("status" => "Seq Check (#30)")
+        created_pk[] = next_row[:statusid]
+        @test next_row[:statusid] isa Integer
+        @test next_row[:statusid] != status_id
+    finally
+        cleanup_ids = created_pk[] === nothing ? [status_id] : [status_id, created_pk[]]
+        q = M.Status.objects.filter("statusid__@in" => cleanup_ids)
+        q.exists() && q.delete()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ end
     @testset "Bulk No-Mutation Contract (#132)" include("unit/test_bulk_no_mutation.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")
+    @testset "update_or_create (#30)" include("unit/test_update_or_create.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")

--- a/test/unit/test_update_or_create.jl
+++ b/test/unit/test_update_or_create.jl
@@ -1,0 +1,134 @@
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, DateTimeField
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Row-level update_or_create (#30)
+#
+# DB-free: `show_query=:sql`/`:dict` render the full statement before any DB call, so the
+# ON CONFLICT target/SET, the PG xmax created-sentinel, the SQLite RETURNING-avoidance, the
+# db_column mapping, the auto_now-on-update refresh, and every validation error are all
+# assertable against bare mock connections. Mirrors test_bulk_on_conflict.jl.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# db_column-mapped model (no_cbo -> nome_cbo) proves the clause renders physical names.
+UocCbo = Model("dash_dim_cbo",
+  id = IDField(),
+  co_cbo = CharField(),
+  no_cbo = CharField(db_column = "nome_cbo"),
+)
+UocCbo.connect_key = "uoc_pg"
+
+UocCboSl = Model("dash_dim_cbo",
+  id = IDField(),
+  co_cbo = CharField(),
+  no_cbo = CharField(db_column = "nome_cbo"),
+)
+UocCboSl.connect_key = "uoc_sqlite"
+
+# Model with an auto_now field, to prove auto_now is refreshed on the DO UPDATE arm.
+UocEvt = Model("evt",
+  id = IDField(),
+  name = CharField(),
+  updated_at = DateTimeField(auto_now = true),
+)
+UocEvt.connect_key = "uoc_pg"
+
+struct MockPgUOC <: PormG.PormGPostgres end
+struct MockSqliteUOC <: PormG.PormGSQLite end
+PormG.backend_sqlite_version(::MockSqliteUOC) = 3045000
+
+PormG.config["uoc_pg"] = PormG.Configuration.Settings(connections = MockPgUOC(), change_data = true)
+PormG.config["uoc_sqlite"] = PormG.Configuration.Settings(connections = MockSqliteUOC(), change_data = true)
+
+@testset "update_or_create SQL rendering (PostgreSQL mock)" begin
+  sql = UocCbo.objects.update_or_create("id" => 1;
+    defaults = ["co_cbo" => "225", "no_cbo" => "Cardio"], show_query = :sql)
+
+  # ON CONFLICT on the lookup field; SET lists only the defaults.
+  @test occursin("ON CONFLICT (\"id\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\", \"nome_cbo\" = EXCLUDED.\"nome_cbo\"", sql)
+  # db_column mapping: logical no_cbo renders as physical nome_cbo in the SET.
+  @test !occursin("\"no_cbo\" = EXCLUDED", sql)
+  # PG created-detection sentinel on RETURNING.
+  @test occursin("RETURNING *, (xmax = 0) AS \"__pormg_created\"", sql)
+  # The lookup field is NOT in the SET (it's the match key, not an updated column).
+  @test !occursin("\"id\" = EXCLUDED", sql)
+
+  # Multi-column lookup → composite conflict target.
+  sql_multi = UocCbo.objects.update_or_create("id" => 1, "co_cbo" => "225";
+    defaults = ["no_cbo" => "X"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"id\", \"co_cbo\") DO UPDATE SET \"nome_cbo\" = EXCLUDED.\"nome_cbo\"", sql_multi)
+
+  # db_column field as the conflict target resolves to the physical column too.
+  sql_dbcol_target = UocCbo.objects.update_or_create("no_cbo" => "Cardio";
+    defaults = ["co_cbo" => "225"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"nome_cbo\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\"", sql_dbcol_target)
+end
+
+@testset "update_or_create refreshes auto_now on the update arm" begin
+  # updated_at (auto_now) is filled into the INSERT AND appended to the SET, so a conflict
+  # refreshes it — matching update()'s auto_now behavior.
+  sql = UocEvt.objects.update_or_create("id" => 1; defaults = ["name" => "x"], show_query = :sql)
+  @test occursin("\"updated_at\"", sql)                              # in the INSERT column list
+  @test occursin("\"updated_at\" = EXCLUDED.\"updated_at\"", sql)    # refreshed in the SET
+  @test occursin("\"name\" = EXCLUDED.\"name\"", sql)
+
+  # An auto_now field used as the lookup (conflict target) must NOT be auto-added to the SET —
+  # the match key is never updated. Only the default (name) is in the SET.
+  sql_ts_lookup = UocEvt.objects.update_or_create("updated_at" => "2024-01-01"; defaults = ["name" => "x"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"updated_at\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql_ts_lookup)
+  @test !occursin("\"updated_at\" = EXCLUDED", sql_ts_lookup)        # target not written into SET
+end
+
+@testset "update_or_create parameters cover the merged insert values" begin
+  res = UocCbo.objects.update_or_create("id" => 1;
+    defaults = ["co_cbo" => "225", "no_cbo" => "Cardio"], show_query = :dict)
+  @test res isa Dict
+  @test haskey(res, :sql_text)
+  # VALUES binds one param per participating column (lookup ∪ defaults): id, co_cbo, no_cbo.
+  @test length(res[:parameters]) == 3
+  @test 1 in res[:parameters]
+  @test "225" in res[:parameters]
+  @test "Cardio" in res[:parameters]
+end
+
+@testset "update_or_create SQLite avoids RETURNING" begin
+  sql = UocCboSl.objects.update_or_create("id" => 1;
+    defaults = ["co_cbo" => "225", "no_cbo" => "Cardio"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"id\") DO UPDATE SET \"co_cbo\" = EXCLUDED.\"co_cbo\", \"nome_cbo\" = EXCLUDED.\"nome_cbo\"", sql)
+  # SQLite path deliberately avoids RETURNING (created detection is out-of-band).
+  @test !occursin("RETURNING", sql)
+  @test !occursin("__pormg_created", sql)
+  @test !occursin("xmax", sql)
+end
+
+# Runs update_or_create with :dict (validation fires before any DB call) and returns the message.
+function _uoc_error(f)
+  err = try
+    f()
+    nothing
+  catch e
+    e
+  end
+  @test err isa ArgumentError
+  return err === nothing ? "" : sprint(showerror, err)
+end
+
+@testset "update_or_create validation errors" begin
+  @test occursin("at least one lookup pair",
+    _uoc_error(() -> UocCbo.objects.update_or_create(; defaults = ["co_cbo" => "x"], show_query = :dict)))
+  @test occursin("`defaults` must be non-empty",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1; show_query = :dict)))
+  @test occursin("must be a `field => value` pair",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1; defaults = ["co_cbo"], show_query = :dict)))
+  @test occursin("lookup field nope is not a field",
+    _uoc_error(() -> UocCbo.objects.update_or_create("nope" => 1; defaults = ["co_cbo" => "x"], show_query = :dict)))
+  @test occursin("defaults field nope is not a field",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1; defaults = ["nope" => "x"], show_query = :dict)))
+  @test occursin("appear in both lookup and defaults",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1; defaults = ["id" => 2, "co_cbo" => "x"], show_query = :dict)))
+  @test occursin("duplicate lookup field",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1, "id" => 2; defaults = ["co_cbo" => "x"], show_query = :dict)))
+  @test occursin("duplicate defaults field",
+    _uoc_error(() -> UocCbo.objects.update_or_create("id" => 1; defaults = ["co_cbo" => "a", "co_cbo" => "b"], show_query = :dict)))
+end


### PR DESCRIPTION
Closes #30. PR 2 of 2 — builds on the `ON CONFLICT` renderer shipped in #123.

## What

Adds a Django-style row-level upsert:

```julia
row, created = M.Status.objects.update_or_create(
    "statusid" => 3;                       # lookup — becomes the ON CONFLICT target
    defaults = ["status" => "Accident"],   # SET on conflict, merged into the INSERT
)
```

The lookup pair(s) identify the row (the `ON CONFLICT` target + the insert match values);
`defaults` are set on conflict (`DO UPDATE SET ... = EXCLUDED. ...`) and merged into the INSERT.
Returns `(row, created::Bool)` where `row` is a **`PormGRow`** (dot-access + `.save()`, like
`get()`). Multi-column lookups (composite targets) and `db_column`-mapped fields are supported.

**Why `PormGRow`, not `Dict`:** every comparable ORM's *row-level* upsert returns the live domain
object (Django/Rails/Eloquent/Peewee/Ecto/Prisma); only *bulk/Core* upserts return dict/count/ids.
`create()` returning a bare `Dict` is PormG's outlier — tracked for a pre-publish decision in #166.

## How

- **`src/querybuilder/execution.jl`** — extracts `_prepare_row_insert!` from `insert()` (byte-identical
  marshalling, so `insert()` and the new builder share one path — proven by the insert/inspect
  regression) and adds `_update_or_create`. PostgreSQL runs a single atomic
  `INSERT ... ON CONFLICT (target) DO UPDATE SET ... RETURNING *, (xmax = 0)` (xmax = 0 ⇒ inserted).
  SQLite avoids `RETURNING` (it hangs on some table shapes; `last_insert_rowid()` is unreliable on
  DO UPDATE) and derives `created` from a pre-check + read-back **inside its serialized write lock**
  (`BEGIN IMMEDIATE`), so `existed` is race-free.
- **`src/querybuilder/object_manager.jl`** — the `:update_or_create` terminal + `up_update_or_create!`
  marshalling and validation. `auto_now` fields refresh on the update arm (matching `update()`) but a
  lookup key is never written into the SET. Validation (all before any DB work, surfaced by
  `show_query=:dict`): lookup and `defaults` must be non-empty, be model fields, and not overlap.
- `target`/`set` are logical field names resolved to quoted physical columns (db_column-aware). The
  conflict target is **not** required to be model-declared unique — the database is the source of
  truth for matching constraints (matches #123).

## Tests

- **`test/unit/test_update_or_create.jl`** (new, DB-free): PG/SQLite rendering, multi-column target,
  `db_column` mapping in target and set, `auto_now` refresh + lookup-exclusion, SQLite-has-no-RETURNING,
  and a full validation `@test_throws` matrix.
- **`test/integration/test_inserts.jl`**: `M.Status` create (`created=true`) → update (`created=false`,
  merged) → `PormGRow.save()` round-trip → sequence consistency, on both backends. (A composite-target
  end-to-end case is noted as a prerequisite follow-up — the integration fixtures don't yet declare a
  `UniqueConstraint` model; it is covered at the unit level.)

Verification: unit **2921 pass**; integration **db_2 1706** / **db_sl 1681** (0 fail); docs build exit 0;
live db_sl doc-example round-trip verified. Two `/code-review` passes (4 + 1 findings, all fixed).

## Docs

`docs/src/write/create.md` "Update or Create" section (F1 example + generated SQL for both backends,
the created-flag mechanism, the defaults-required rule, auto_now-on-update), `docs/src/api.md` entry,
and an additive `UPGRADING.md` entry (noting the Dict-vs-PormGRow follow-up #166).

## Follow-ups

- **#166** (pre-publish): decide the write-path return-type contract (`create()`/`insert()` → Dict vs
  `PormGRow` elsewhere). Added to the `TODO.md` release-gating index in a separate commit here.
- `get_or_create` (no-`defaults` variant) is deferred: `INSERT ... ON CONFLICT DO NOTHING RETURNING *`
  returns no row on conflict, so it needs a different path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)