### PR TITLE
feat(#26): full transaction control — nested atomic savepoints + select_for_update

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -457,6 +457,48 @@ end
 
 See [Transactions](write/transaction.md) for the full reference including savepoints and multithreaded patterns.
 
+### `atomic`
+
+Friendly, Django-flavored alias for `run_in_transaction`. A **nested** `atomic` on the same database
+automatically becomes a `SAVEPOINT`, so a failing inner block rolls back only to its savepoint while the
+outer transaction survives (works identically on PostgreSQL and SQLite):
+
+```julia
+atomic("db") do
+    M.Result.objects.create("raceid" => 1, "driverid" => 1, "points" => 25)
+    try
+        atomic("db") do                 # nested → SAVEPOINT
+            M.Result.objects.create("raceid" => 1, "driverid" => 1, "points" => 18)
+            error("validation failed")  # rolls back to the savepoint only
+        end
+    catch
+        # outer transaction still usable here
+    end
+end
+```
+
+Pass `durable = true` to require the block be the outermost transaction (raises if one is already active).
+
+### `select_for_update`
+
+Query-builder method that adds a `FOR UPDATE` clause to lock the selected rows until the surrounding
+transaction commits — the guard for a safe read-modify-write. Keyword options `nowait`, `skip_locked`,
+and `no_key` map to `FOR UPDATE NOWAIT` / `FOR UPDATE SKIP LOCKED` / `FOR NO KEY UPDATE` (`nowait` and
+`skip_locked` are mutually exclusive). On PostgreSQL it must run inside a transaction; **on SQLite it is
+a silent no-op** (no row-level locking). See [Row-Level Locking](write/transaction.md#Row-Level-Locking).
+
+```julia
+atomic("db") do
+    row = M.Constructor_standings.objects.
+        filter("constructorstandingsid" => 1).
+        select_for_update().
+        list() |> first
+    M.Constructor_standings.objects.
+        filter("constructorstandingsid" => row[:constructorstandingsid]).
+        update("points" => row[:points] + 25)
+end
+```
+
 ---
 
 ## Async Execution
@@ -595,7 +637,7 @@ scope — the SQL function constructors are *not* among them (see
 `fetch_async`, `await_result`, `FetchTask`
 
 ### Transactions
-`run_in_transaction`, `with_savepoint`, `with_tx_context`, `in_transaction_context`
+`run_in_transaction`, `atomic`, `with_savepoint`, `with_tx_context`, `in_transaction_context`
 
 ### Locking
 `with_advisory_lock`

--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -12,6 +12,8 @@ Because every operation runs through the async core, even synchronous-looking co
 - [Bulk Operations in Transactions](#Bulk-Operations-in-Transactions)
 - [Multithreaded Work](#Multithreaded-Work)
 - [Error Handling and Rollback](#Error-Handling-and-Rollback)
+- [Nested Transactions and Savepoints](#Nested-Transactions-and-Savepoints)
+- [Row-Level Locking](#Row-Level-Locking)
 - [Lower-Level Helpers](#Lower-Level-Helpers)
 
 ---
@@ -434,6 +436,112 @@ end
 
 ---
 
+## Nested Transactions and Savepoints
+
+`run_in_transaction` and its friendly alias **`atomic`** are **reentrant**. Calling `atomic` again
+*inside* an already-open transaction on the **same** database does not open a second, independent
+transaction — it creates a **savepoint** on the same connection. If the nested block throws, only its
+savepoint is rolled back; the outer transaction stays alive and usable (catch the error *outside* the
+nested block to keep going). This mirrors Django's `atomic()`. `atomic(db)` and `run_in_transaction(db)`
+are interchangeable — `atomic` just reads better when you nest.
+
+```julia
+# Import a batch of race results; one malformed result must not abort the whole import.
+atomic("db_2") do
+  for row in incoming_results
+    try
+      atomic("db_2") do                          # nested → SAVEPOINT
+        M.Result.objects.create(
+          "raceid"        => row.raceid,
+          "driverid"      => row.driverid,
+          "positionorder" => row.position,
+          "points"        => row.points,
+        )
+      end
+    catch e
+      # Only this result rolled back to its savepoint; the outer import transaction continues.
+      @warn "Skipping malformed result" raceid = row.raceid exception = e
+    end
+  end
+end   # every result that didn't roll back commits together
+```
+
+Semantics:
+
+- The **outermost** `atomic` opens the real transaction (`BEGIN`); each **nested** `atomic` on the same
+  database opens a savepoint (`SAVEPOINT pormg_sp_<depth>`).
+- A nested block that returns normally **releases** its savepoint — its work stays part of the outer
+  transaction and is undone only if the **outer** transaction later rolls back.
+- A nested block that throws **rolls back to** its savepoint and re-raises, leaving the outer
+  transaction unaffected until the exception reaches it.
+- A nested `atomic` targeting a **different** database opens its own independent transaction.
+
+Savepoints behave **identically on PostgreSQL and SQLite** — both support `SAVEPOINT` /
+`RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT` natively.
+
+Pass `durable = true` to assert a block is the outermost transaction; it raises if one is already active:
+
+```julia
+atomic("db_2"; durable = true) do
+  # guaranteed to be a real, top-level transaction — never a nested savepoint
+end
+```
+
+---
+
+## Row-Level Locking
+
+`select_for_update()` appends a `FOR UPDATE` clause so a read **locks** the selected rows until the
+surrounding transaction commits or rolls back — the standard guard for a safe read-modify-write.
+
+```julia
+# Read-modify-write a constructor's running points total without a lost update.
+atomic("db_2") do
+  standing = M.Constructor_standings.objects.
+    filter("constructorid" => 131, "raceid" => 1120).
+    select_for_update().                       # locks the matched rows until COMMIT
+    list() |> first
+
+  M.Constructor_standings.objects.
+    filter("constructorstandingsid" => standing[:constructorstandingsid]).
+    update("points" => standing[:points] + 25)
+end
+```
+
+Options (PostgreSQL):
+
+| Call | SQL | Meaning |
+|------|-----|---------|
+| `select_for_update()` | `FOR UPDATE` | Wait for conflicting locks to clear, then lock. |
+| `select_for_update(skip_locked = true)` | `FOR UPDATE SKIP LOCKED` | Skip rows another transaction already holds (claim-next-available pattern). |
+| `select_for_update(nowait = true)` | `FOR UPDATE NOWAIT` | Raise immediately if a matched row is already locked. |
+| `select_for_update(no_key = true)` | `FOR NO KEY UPDATE` | Weaker lock that still allows FK-referencing inserts. |
+
+`nowait` and `skip_locked` are mutually exclusive. On PostgreSQL a locked read **must run inside a
+transaction** — calling it under autocommit raises, because the lock would be released immediately.
+
+```julia
+# Process pit stops for a race, one worker at a time, skipping rows another worker already holds.
+atomic("db_2") do
+  next_stop = M.Pit_stops.objects.
+    filter("raceid" => 1120).
+    order_by("stop").
+    select_for_update(skip_locked = true).
+    list() |> first
+  # … process next_stop …
+end
+```
+
+!!! warning "Row locking on SQLite"
+    SQLite has no `SELECT ... FOR UPDATE`. On SQLite, `select_for_update()` is a **silent no-op** — no
+    lock clause is emitted and no error is raised, so identical query code runs on both backends (this
+    matches Django, SQLAlchemy, and Rails). SQLite already serializes writers per database file via
+    `BEGIN IMMEDIATE` (see [Multithreaded Work](#Multithreaded-Work)); if you need explicit
+    write-serialization there, rely on the transaction itself rather than a row lock. An `OF <table>`
+    target is not yet supported on either backend (a planned follow-up).
+
+---
+
 ## Lower-Level Helpers
 
 If you need finer control (e.g., manual `SAVEPOINT` or multi-statement blocks), PormG exposes:
@@ -444,6 +552,11 @@ If you need finer control (e.g., manual `SAVEPOINT` or multi-statement blocks), 
 - **`finalize_transaction_connection!(settings, conn; rollback_error=nothing)`**: Return `conn` to the pool exactly once from a terminal `finally`. Pass `rollback_error=nothing` when the COMMIT succeeded or the cleanup ROLLBACK ran cleanly; pass the caught error when the cleanup ROLLBACK itself threw, and a non-benign one causes the connection to be renewed or discarded instead of released.
 
 ### Example: Manual Savepoint
+
+!!! tip "Prefer nested `atomic` for savepoints"
+    For savepoints, reach for nested [`atomic`](#Nested-Transactions-and-Savepoints) — it manages the
+    `SAVEPOINT` / `RELEASE` / `ROLLBACK TO` lifecycle and naming for you, on both backends. The
+    hand-rolled version below is shown only to illustrate the underlying mechanics.
 
 ```julia
 import PormG.Configuration: with_tx_context, get_tx_connection
@@ -499,10 +612,12 @@ end
 
 | Pattern | Use Case |
 |---------|----------|
-| `run_in_transaction(settings) do ... end` | Most common; automatic commit/rollback |
+| `run_in_transaction(settings) do ... end` / `atomic(settings) do ... end` | Most common; automatic commit/rollback |
+| Nested `atomic` on the same database | Automatic savepoint; roll back part of the work without aborting the whole transaction |
+| `select_for_update()` | Lock rows for a safe read-modify-write (PostgreSQL; no-op on SQLite) |
 | Async tasks inside transaction | Spawn concurrent workers that share the connection |
 | Bulk operations inside transaction | Ensure all-or-nothing for large batch inserts/updates |
-| Manual `with_tx_context` + `with_transaction` | Fine-grained control; savepoints; multi-statement workflows |
+| Manual `with_tx_context` + `with_transaction` | Fine-grained control; hand-rolled multi-statement workflows |
 
-Start with `run_in_transaction` for all your database work. Drop to the lower-level helpers only when you need explicit savepoints or multi-database coordination.
+Start with `run_in_transaction`/`atomic` for all your database work. Nest `atomic` for savepoints. Drop to the lower-level helpers only for hand-rolled multi-statement workflows or multi-database coordination.
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -11,7 +11,7 @@ import PormG: backend_num_rows, backend_is_alive
 using Base.ScopedValues: ScopedValue, with
 
 export env, Settings, connection, close_pool!, get_settings
-export with_tx_context, in_transaction_context, register_connection, unregister_connection, set_connection_resolver
+export with_tx_context, in_transaction_context, current_transaction_depth, register_connection, unregister_connection, set_connection_resolver
 export set_before_connect_hook, ensure_before_connect!
 
 const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
@@ -119,6 +119,17 @@ Check if we're currently inside a transaction context.
 """
 function in_transaction_context()
   return _tx_context[].depth > 0
+end
+
+"""
+    current_transaction_depth() -> Int
+
+Return the current transaction nesting depth (`0` when not inside any transaction).
+The outermost `run_in_transaction`/`atomic` block is depth `1`; each nested savepoint
+block increments it. Used to derive deterministic, per-level savepoint names (#26).
+"""
+function current_transaction_depth()::Int
+  return _tx_context[].depth
 end
 
 function with_tx_context(f::Function, pool::Union{PormGPostgres, PormGSQLite}, conn)

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -12,7 +12,7 @@ import PormG: backend_connect, backend_renew_connection, backend_is_alive, backe
               backend_execute_async, backend_is_connection_error, backend_copy_in!
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
-export with_transaction, with_transaction_async, run_in_transaction, with_savepoint
+export with_transaction, with_transaction_async, run_in_transaction, atomic, with_savepoint
 export acquire_connection, release_connection, finalize_transaction_connection!
 export PoolTimeoutError
 # NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
@@ -21,7 +21,7 @@ export PoolTimeoutError
 # ambiguous and therefore undefined (#35). Callers in this package use `CP.close_pool!`.
 
 # Import transaction context helpers from Configuration
-import PormG.Configuration: get_tx_connection, get_tx_pool, with_tx_context, transaction_connection_for, get_settings, ensure_before_connect!, connection_key_for_pool
+import PormG.Configuration: get_tx_connection, get_tx_pool, with_tx_context, transaction_connection_for, get_settings, ensure_before_connect!, connection_key_for_pool, in_transaction_context, current_transaction_depth
 
 const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
 
@@ -965,17 +965,22 @@ with_transaction_async(pool::SQLConn, sql::String; conn = nothing, params::Union
 """
     with_savepoint(f::Function, settings::SQLConn, name::String) -> result
 
-Execute `f()` wrapped in a PostgreSQL savepoint named `name`. On success, releases the
-savepoint. On error, rolls back to the savepoint, releases it, and rethrows so the outer
-transaction remains usable.
+Execute `f()` wrapped in a savepoint named `name`. On success, releases the savepoint.
+On error, rolls back to the savepoint, releases it, and rethrows so the outer transaction
+remains usable.
 
-Transparently no-ops when called outside an active transaction context or on a
-non-PostgreSQL backend, so callers do not need to guard the call site.
+Works on **both** PostgreSQL and SQLite — the `SAVEPOINT` / `RELEASE SAVEPOINT` /
+`ROLLBACK TO SAVEPOINT` statements are identical on both backends (#26). Transparently
+no-ops when called outside an active transaction context on `settings`' pool, so callers
+do not need to guard the call site.
+
+`name` must be a fixed, non-user-controlled identifier (it is interpolated into the SQL,
+not parameterized — savepoint names are identifiers). Internal callers pass constants;
+the reentrant `atomic`/`run_in_transaction` path passes `_savepoint_name(depth)`.
 """
 function with_savepoint(f::Function, settings::SQLConn, name::String)
-  pool = settings.connections
-  if !(pool isa PormGPostgres) || transaction_connection_for(settings) === nothing
-    return f()
+  if transaction_connection_for(settings) === nothing
+    return f()   # not inside a transaction on this pool → nothing to savepoint
   end
 
   fetch(settings, "SAVEPOINT $(name);")
@@ -1068,12 +1073,46 @@ end
 ```
 """
 function run_in_transaction(f::Function, pool::Union{PormGPostgres, PormGSQLite})
+  # Reentrancy (#26): a nested run_in_transaction / atomic on the SAME pool becomes a
+  # SAVEPOINT on the already-pinned connection instead of a second independent BEGIN.
+  # A nested call targeting a DIFFERENT pool (e.g. a second database) still opens its own
+  # transaction — correct multi-DB behavior, already guarded by ensure_model_transaction_scope.
+  if in_transaction_context() && get_tx_pool() === pool
+    return _nested_savepoint(f, _settings_for_pool(pool))
+  end
   # Serialize SQLite writers around the whole BEGIN..COMMIT so concurrent write
   # transactions never race on `BEGIN IMMEDIATE` (see `with_sqlite_write_lock`).
   # Acquire the write lock BEFORE the pool connection so a waiting writer does not
   # hold a pooled connection idle while blocked. No-op on PostgreSQL.
   return with_sqlite_write_lock(pool) do
     _run_in_transaction_impl(f, pool)
+  end
+end
+
+# Deterministic, per-depth savepoint name. Fixed `pormg_sp_<int>` format → no
+# identifier-injection surface (the integer suffix is the only variable part). Pure and
+# unit-testable in isolation.
+_savepoint_name(depth::Integer) = "pormg_sp_$(depth)"
+
+# Resolve the registered SQLConn for a pool so the reentrant savepoint path (which needs
+# `settings` for `with_savepoint`/`fetch`) can route through the pinned connection.
+function _settings_for_pool(pool::Union{PormGPostgres, PormGSQLite})::SQLConn
+  key = connection_key_for_pool(pool)
+  key === nothing && throw(ArgumentError("Cannot resolve connection settings for the active transaction pool"))
+  return get_settings(key)
+end
+
+# Run `f()` as a nested SAVEPOINT inside the already-open transaction on `settings`' pool.
+# Enters a new tx context (bumping depth) so the savepoint name is unique per nesting level,
+# then delegates to `with_savepoint` for the SAVEPOINT/RELEASE/ROLLBACK-TO lifecycle. Reuses
+# the pinned connection: no new connection is acquired, no BEGIN is issued, the SQLite write
+# lock (already held reentrantly by the outermost block) is not re-taken, and the outermost
+# block still owns the single connection release.
+function _nested_savepoint(f::Function, settings::SQLConn)
+  pool = settings.connections
+  conn = transaction_connection_for(settings)
+  return with_tx_context(pool, conn) do
+    with_savepoint(f, settings, _savepoint_name(current_transaction_depth()))
   end
 end
 
@@ -1155,5 +1194,43 @@ function run_in_transaction(f::Function, db::String)
 end
 
 run_in_transaction(f::Function, settings::SQLConn) = run_in_transaction(f, settings.connections)
+
+"""
+    atomic(f::Function, db; durable::Bool=false) -> result
+
+Run `f()` in a database transaction — the friendly, Django-flavored alias for
+[`run_in_transaction`](@ref). `db` may be a pool, a db-key `String` (e.g. `"db_2"`), or an
+`SQLConn`.
+
+A **nested** `atomic`/`run_in_transaction` block on the *same* database automatically becomes
+a `SAVEPOINT`: if `f()` throws, only that inner block is rolled back to its savepoint and the
+error propagates, leaving the outer transaction intact (catch it outside the inner block to
+continue). Works identically on PostgreSQL and SQLite (#26).
+
+```julia
+atomic("db_2") do
+  driver = M.Driver.objects.create("forename" => "Alice", "surname" => "Lane", ...)
+  try
+    atomic("db_2") do                 # nested → SAVEPOINT
+      M.Result.objects.create(...)    # rolled back to the savepoint on error…
+      error("validation failed")
+    end
+  catch
+    # …outer transaction still usable here
+  end
+end
+```
+
+Pass `durable=true` to require this block be the outermost transaction — it throws if a
+transaction is already active (mirrors Django's `atomic(durable=True)`).
+"""
+function atomic(f::Function, pool::Union{PormGPostgres, PormGSQLite}; durable::Bool=false)
+  if durable && in_transaction_context()
+    throw(ArgumentError("atomic(durable=true) must be the outermost transaction, but a transaction is already active"))
+  end
+  return run_in_transaction(f, pool)
+end
+atomic(f::Function, db::String; durable::Bool=false) = atomic(f, get_settings(db).connections; durable=durable)
+atomic(f::Function, settings::SQLConn; durable::Bool=false) = atomic(f, settings.connections; durable=durable)
 
 end # module

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -783,6 +783,27 @@ function on_conflict_clause(action::Symbol, target::Vector{String}, set::Vector{
   return "ON CONFLICT$(target_sql) DO UPDATE SET $(assignments)"
 end
 
+"""
+    for_update_clause(nowait, skip_locked, no_key, conn) -> String
+
+Render a row-level locking clause for a SELECT (#26), appended after ORDER BY / LIMIT / OFFSET.
+
+- **PostgreSQL** → `FOR [NO KEY] UPDATE [NOWAIT | SKIP LOCKED]`.
+- **SQLite** → `""`. SQLite has no row-level locking, so the clause is a silent no-op — the one
+  intentional PostgreSQL/SQLite divergence for this feature (keeps `select_for_update` portable;
+  see `docs/src/write/transaction.md`).
+
+An `OF <table>` target is a deferred follow-up (it must name the query's generated FROM alias).
+"""
+function for_update_clause(nowait::Bool, skip_locked::Bool, no_key::Bool, conn::PormGPostgres)::String
+  lock_sql = no_key ? "FOR NO KEY UPDATE" : "FOR UPDATE"
+  wait_sql = nowait ? " NOWAIT" : (skip_locked ? " SKIP LOCKED" : "")
+  return "$(lock_sql)$(wait_sql) \n"
+end
+function for_update_clause(nowait::Bool, skip_locked::Bool, no_key::Bool, conn::PormGSQLite)::String
+  return ""  # SQLite: no row-level locking — silent no-op (documented divergence, #26)
+end
+
 function add_foreign_key(conn::PormGPostgres, table_name::Union{Symbol,String}, constraint_name::String, field_name::String, ref_table_name::String, ref_field_name::String; on_delete::Union{String,Nothing}=nothing)
   on_delete_clause = on_delete !== nothing ? " ON DELETE $on_delete" : ""
   return """ALTER TABLE $table_name ADD CONSTRAINT $constraint_name FOREIGN KEY ($field_name) REFERENCES $ref_table_name ($ref_field_name)$on_delete_clause DEFERRABLE INITIALLY DEFERRED;"""

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -151,7 +151,7 @@ end
 # live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
 export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
-export fetch_async, await_result, FetchTask, run_in_transaction, with_savepoint  # Async-first API
+export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)
 export with_tx_context, in_transaction_context  # Transaction context helpers
 export setup, install_ai_skills

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -14,6 +14,7 @@ import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task, finalize_transaction_connection!
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,
 	get_sqlite_reserved_primary_key_max, register_sqlite_reserved_primary_key_max!,
+	in_transaction_context,
 	get_settings as get_configuration_settings
 import PormG: @pormg_debug
 import Base: first, get

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -263,15 +263,36 @@ function query(q::SQLObjectHandler;
   if q.object.offset !== 0
     print(io, "OFFSET ", q.object.offset, " \n")
   end
-  
+
+  # #26: row-level locking clause (FOR UPDATE …) must follow ORDER BY / LIMIT / OFFSET. No-op on
+  # SQLite (Dialect.for_update_clause renders "" there). PostgreSQL rejects FOR UPDATE with
+  # DISTINCT, so fail early with a friendly message rather than a raw DB error.
+  let fu = q.object.for_update
+    if fu !== nothing
+      # PostgreSQL rejects FOR UPDATE + DISTINCT; fail early with a friendly message. SQLite is
+      # exempt — there the lock renders "" (pure no-op), so select_for_update never raises (#26).
+      if q.object.distinct && instruction.connection isa PormGPostgres
+        throw(_argerr("select_for_update() cannot be combined with distinct() — a locking read must return concrete rows."))
+      end
+      print(io, Dialect.for_update_clause(fu.nowait, fu.skip_locked, fu.no_key, instruction.connection))
+    end
+  end
+
   resposta = String(take!(io))
-  
+
   # Store the final parameters object with all CTEs + main query parameters
   q.object.parameters = instruction.parameters
-  
+
   if show_query !== :execute
-    return _show_query_result(show_query, resposta, instruction.connection, q.object.model.name, :select; 
+    return _show_query_result(show_query, resposta, instruction.connection, q.object.model.name, :select;
                             parameters=instruction.parameters)
+  end
+  # #26: a locked read executed OUTSIDE a transaction on PostgreSQL is a footgun — the lock is
+  # taken then immediately released at autocommit. Fail loudly (Django's TransactionManagementError
+  # analog). Guarded on the execute path only, so inspect_query/show_query still render FOR UPDATE
+  # without a live transaction. SQLite never locks (clause rendered ""), so it is exempt.
+  if q.object.for_update !== nothing && instruction.connection isa PormGPostgres && !in_transaction_context()
+    throw(_argerr("select_for_update() must run inside a transaction (run_in_transaction/atomic) on PostgreSQL; otherwise the row lock is released immediately at autocommit."))
   end
   return resposta
 end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -126,6 +126,18 @@ function distinct!(q::SQLObject, value)
   throw("Invalid argument: $(value) (::$(typeof(value))); please use a boolean value (true or false)")
 end
 
+# #26: mark the query for row-level locking. Renders `FOR [NO KEY] UPDATE [NOWAIT|SKIP LOCKED]`
+# on PostgreSQL; a silent no-op on SQLite. `nowait` and `skip_locked` are mutually exclusive
+# (Django parity). Always builds a fresh ForUpdateClause (set-once semantics). (An `of=` target
+# is a deferred follow-up — it must name the query's generated FROM alias, not yet exposed.)
+function select_for_update!(q::SQLObject; nowait::Bool=false, skip_locked::Bool=false, no_key::Bool=false)
+  if nowait && skip_locked
+    throw(_argerr("select_for_update: `nowait` and `skip_locked` are mutually exclusive — pass at most one."))
+  end
+  q.for_update = ForUpdateClause(nowait, skip_locked, no_key)
+  return q
+end
+
 # function distinct!(q::SQLObject, value)
 #   throw("Invalid argument: $(value) (::$(typeof(value))); please use a boolean value (true or false)")
 # end
@@ -221,6 +233,10 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     return ChainCaller(page!, q)
   elseif sym === :distinct
     return ChainCaller(distinct!, q)
+  elseif sym === :select_for_update
+    # Chainable: query.select_for_update(; nowait=false, skip_locked=false, no_key=false)
+    # Closure (not ChainCaller) so keyword arguments are forwarded correctly (#26).
+    return (; kwargs...) -> (select_for_update!(q.object; kwargs...); q)
   elseif sym === :with
     # Chainable: query.with("cte_name" => sub_query; join_field=..., join_type=...)
     # Uses closure (not ChainCaller) so keyword arguments are forwarded correctly.

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -149,6 +149,18 @@ Base.deepcopy(x::SQLTypeOrder) = SQLOrder(x.field, x.order, x.orientation, x._as
 # SQLObject Objects (main object to build a query)
 #
 
+# #26: row-level locking clause carried on a SELECT. `nothing` on the query means no lock;
+# a `ForUpdateClause` renders `FOR [NO KEY] UPDATE [NOWAIT|SKIP LOCKED]` on PostgreSQL and is a
+# silent no-op on SQLite (which has no row-level locking). Immutable/set-once — the
+# `select_for_update!` mutator always builds a fresh clause, so it is shared by reference on copy.
+# (An `OF <table>` target is a deferred follow-up: it must name the query's generated FROM alias,
+# which is not yet exposed — see the row-locking follow-up issue.)
+struct ForUpdateClause
+  nowait::Bool
+  skip_locked::Bool
+  no_key::Bool                 # PostgreSQL: FOR NO KEY UPDATE (weaker lock, allows FK-referencing inserts)
+end
+
 mutable struct SQLObjectQuery <: SQLObject
   model::PormGModel
   connect_key::OptionalString # Override for multi-tenant scenarios
@@ -163,13 +175,14 @@ mutable struct SQLObjectQuery <: SQLObject
   list_joins::Vector{String} # is ther a better way to do this?
   row_join::Vector{Dict{String,Any}}
   distinct::Bool # Add distinct field
+  for_update::Union{Nothing,ForUpdateClause} # #26: row-level lock clause (nothing = no lock)
   ctes::Dict{String,CTEDict}
   custom_join::Dict{String,Any}
   parameters::Union{Nothing,AbstractPormGParam}
 
   SQLObjectQuery(; model=nothing, connect_key=nothing, values=[], filter=[], insert=OrderedCollections.OrderedDict{String,Any}(), limit=0, offset=0,
-    order=[], group=[], having=[], list_joins=[], row_join=[], distinct=false, ctes=Dict{String,CTEDict}(), custom_join=Dict{String,Any}(), parameters=nothing) = # Add ctes and custom_join to constructor
-    new(model, connect_key, values, filter, insert, limit, offset, order, group, having, list_joins, row_join, distinct, ctes, custom_join, parameters) # Add ctes and custom_join to new
+    order=[], group=[], having=[], list_joins=[], row_join=[], distinct=false, for_update=nothing, ctes=Dict{String,CTEDict}(), custom_join=Dict{String,Any}(), parameters=nothing) = # Add ctes and custom_join to constructor
+    new(model, connect_key, values, filter, insert, limit, offset, order, group, having, list_joins, row_join, distinct, for_update, ctes, custom_join, parameters) # Add ctes and custom_join to new
 end
 
 function Base.deepcopy(obj::SQLObjectHandler)
@@ -239,6 +252,7 @@ function Base.deepcopy(obj::SQLObjectQuery)
       list_joins=deepcopy(obj.list_joins),
       row_join=deepcopy(obj.row_join),
       distinct=obj.distinct,
+      for_update=obj.for_update,  # #26: immutable/set-once lock clause — share by reference (like distinct)
       ctes=_copy_ctes(obj.ctes),  # #43: independent CTE state (deep sub-query, drop transient "model")
       custom_join=_copy_custom_join(obj.custom_join)  # #112: fresh per-join dicts; "field" shared by ref (Module — deepcopy can't traverse)
     )

--- a/test/integration/test_transactions.jl
+++ b/test/integration/test_transactions.jl
@@ -525,4 +525,97 @@ settings = PormG.config[PORMG_DB_FOLDER]
     end
   end
 
+  # ============================================================================
+  # #26: Nested atomic → savepoints, and select_for_update row locking.
+  # Runs on BOTH backends (savepoints now work on SQLite too).
+  # ============================================================================
+
+  @testset "Nested atomic: inner rollback keeps the outer transaction (#26)" begin
+    # A failing inner atomic must roll back ONLY to its savepoint; caught outside the inner block,
+    # the outer transaction stays usable and its work (before AND after the failed savepoint)
+    # commits. Guards the SAVEPOINT / ROLLBACK-TO / RELEASE mechanics on both backends.
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+    PormG.atomic(PORMG_DB_FOLDER) do
+      q = M.Just_a_test_deletion.objects
+      q.create("name" => "outer", "test_result" => nothing)      # outer work — must survive
+      try
+        PormG.atomic(PORMG_DB_FOLDER) do                          # nested → SAVEPOINT
+          M.Just_a_test_deletion.objects.create("name" => "inner", "test_result" => nothing)
+          error("force inner rollback")                           # → ROLLBACK TO SAVEPOINT
+        end
+      catch
+        # swallowed outside the inner block → outer transaction continues
+      end
+      q.create("name" => "after", "test_result" => nothing)       # outer keeps writing post-savepoint
+    end
+    # Outer committed: "outer" + "after" persisted; "inner" was undone by the savepoint rollback.
+    names = sort((M.Just_a_test_deletion.objects |> DataFrame).name)
+    @test names == ["after", "outer"]
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+  end
+
+  @testset "Nested atomic is part of the outer transaction (#26)" begin
+    # The discriminating test: a nested atomic that SUCCEEDS (releases its savepoint) is still part
+    # of the OUTER transaction. When the outer then rolls back, the inner row is undone too. If the
+    # nested block had (wrongly) opened an INDEPENDENT transaction, "inner" would have committed on
+    # its own connection and survived — the pre-#26 footgun this guards against.
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+    got_error = false
+    try
+      PormG.atomic(PORMG_DB_FOLDER) do
+        M.Just_a_test_deletion.objects.create("name" => "outer", "test_result" => nothing)
+        PormG.atomic(PORMG_DB_FOLDER) do                          # nested savepoint that SUCCEEDS
+          M.Just_a_test_deletion.objects.create("name" => "inner", "test_result" => nothing)
+        end
+        error("force OUTER rollback after the inner savepoint released")
+      end
+    catch
+      got_error = true
+    end
+    @test got_error
+    # Both rows gone: the released inner savepoint was part of the outer tx, so the outer ROLLBACK
+    # undid it too. (Independent-transaction behavior would leave count == 1.)
+    @test M.Just_a_test_deletion.objects.count() == 0
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+  end
+
+  @testset "select_for_update row locking (#26)" begin
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+    M.Just_a_test_deletion.objects.create("name" => "lockme", "test_result" => nothing)
+
+    if adapter_name == "PostgreSQL"
+      # A locked read inside a transaction renders FOR UPDATE and returns the row.
+      rows = PormG.atomic(PORMG_DB_FOLDER) do
+        q = M.Just_a_test_deletion.objects.filter("name" => "lockme")
+        q.select_for_update()
+        @test contains(q.list(show_query = :sql), "FOR UPDATE")
+        q.list()
+      end
+      @test length(rows) == 1
+
+      # skip_locked executes cleanly too (the "claim next available row" queue pattern).
+      claimed = PormG.atomic(PORMG_DB_FOLDER) do
+        M.Just_a_test_deletion.objects.filter("name" => "lockme").select_for_update(skip_locked = true).list()
+      end
+      @test length(claimed) == 1
+
+      # Guard: a locked read OUTSIDE a transaction fails loudly (autocommit-release footgun).
+      autocommit_err = try
+        M.Just_a_test_deletion.objects.filter("name" => "lockme").select_for_update().list(); nothing
+      catch e; e end
+      @test autocommit_err isa ArgumentError && occursin("transaction", autocommit_err.msg)
+    else
+      # SQLite: select_for_update is a pure no-op — returns rows normally and never raises,
+      # both inside and outside a transaction (the documented PG/SQLite divergence).
+      outside = M.Just_a_test_deletion.objects.filter("name" => "lockme").select_for_update().list()
+      @test length(outside) == 1
+      inside = PormG.atomic(PORMG_DB_FOLDER) do
+        M.Just_a_test_deletion.objects.filter("name" => "lockme").select_for_update(skip_locked = true).list()
+      end
+      @test length(inside) == 1
+    end
+
+    M.Just_a_test_deletion.objects.delete(allow_delete_all = true)
+  end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ end
     @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "No Lost-Connection Retry Inside Transactions (#138)" include("unit/test_fetch_retry_transaction.jl")
     @testset "Failed COMMIT Holds Conn Until Rollback (#139)" include("unit/test_commit_failure_release.jl")
+    @testset "Savepoint Naming (#26)" include("unit/test_savepoint_naming.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -2093,4 +2093,39 @@ end
     end
 end
 
+@testset "SQLite: select_for_update is a silent no-op (#26)" begin
+    # SQLite has no `SELECT ... FOR UPDATE`. select_for_update() must render WITHOUT any FOR UPDATE
+    # clause and must NOT raise, so cross-backend code stays portable — the one intentional
+    # PostgreSQL/SQLite divergence for row locking (PostgreSQL rendering lives in test_inspect_query.jl).
+    q = M.Result.objects
+    q.filter("positionorder" => 1)
+    q.select_for_update()
+    insp = q |> inspect_query                     # must not throw
+    sql = insp[:sql_text]
+    @test !contains(sql, "FOR UPDATE")
+    @test !contains(sql, "SKIP LOCKED")
+
+    # Even with the full option set, SQLite renders nothing lock-related and never raises.
+    q2 = M.Result.objects
+    q2.select_for_update(skip_locked = true, no_key = true)
+    sql2 = (q2 |> inspect_query)[:sql_text]
+    @test !contains(sql2, "FOR UPDATE")
+    @test !contains(sql2, "SKIP LOCKED")
+    @test !contains(sql2, "NO KEY")
+
+    # DISTINCT + select_for_update is allowed on SQLite (the lock is a no-op) — it must NOT raise,
+    # unlike PostgreSQL where the combination is rejected. This is the portability guarantee.
+    q3 = M.Result.objects
+    q3.distinct(true)
+    q3.select_for_update()
+    @test contains((q3 |> inspect_query)[:sql_text], "DISTINCT")   # renders fine, no throw
+
+    # The mutual-exclusion validation is backend-independent (it happens at mutation time). Assert
+    # the specific cause so an unrelated ArgumentError can't masquerade as a pass.
+    excl_err = try
+      M.Result.objects.select_for_update(nowait = true, skip_locked = true); nothing
+    catch e; e end
+    @test excl_err isa ArgumentError && occursin("mutually exclusive", excl_err.msg)
+end
+
 

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -800,4 +800,63 @@ PormG.config["default"] = MockSettings
     @test_throws ErrorException q.inspect_query
   end
 
+  # ===== Section: Row-level locking — select_for_update (#26) =====
+  # Render-only assertions on the PostgreSQL mock: the FOR UPDATE clause and every option map
+  # to the right SQL, land after ORDER BY / LIMIT, and invalid combinations fail fast. Execution
+  # (and the "must be inside a transaction" guard) is covered by the integration suite.
+  @testset "select_for_update renders FOR UPDATE (#26)" begin
+    # Plain lock → bare FOR UPDATE, no OF / NOWAIT / SKIP LOCKED / NO KEY.
+    q = DriverModel.objects
+    q.select_for_update()
+    sql = inspect_query(q)[:sql_text]
+    @test contains(sql, "FOR UPDATE")
+    @test !contains(sql, "NO KEY")
+    @test !contains(sql, "NOWAIT")
+    @test !contains(sql, "SKIP LOCKED")
+
+    # skip_locked → FOR UPDATE SKIP LOCKED (the "claim next available row" queue pattern).
+    q = DriverModel.objects
+    q.select_for_update(skip_locked = true)
+    sql = inspect_query(q)[:sql_text]
+    @test contains(sql, "FOR UPDATE") && contains(sql, "SKIP LOCKED")
+
+    # nowait → FOR UPDATE NOWAIT (raise instead of block on a locked row).
+    q = DriverModel.objects
+    q.select_for_update(nowait = true)
+    sql = inspect_query(q)[:sql_text]
+    @test contains(sql, "FOR UPDATE") && contains(sql, "NOWAIT")
+
+    # no_key → the weaker FOR NO KEY UPDATE (PostgreSQL).
+    q = DriverModel.objects
+    q.select_for_update(no_key = true)
+    @test contains(inspect_query(q)[:sql_text], "FOR NO KEY UPDATE")
+
+    # Clause ORDER: FOR UPDATE must come AFTER ORDER BY / LIMIT (invalid SQL otherwise).
+    q = DriverModel.objects
+    q.order_by("surname")
+    q.limit(5)
+    q.select_for_update()
+    sql = inspect_query(q)[:sql_text]
+    @test first(findfirst("FOR UPDATE", sql)) > first(findfirst("LIMIT", sql))
+    @test first(findfirst("LIMIT", sql)) > first(findfirst("ORDER BY", sql))
+
+    # Chainable terminal returns the handler, so it composes with other builder calls.
+    q = DriverModel.objects
+    @test q.select_for_update() === q
+
+    # nowait and skip_locked are mutually exclusive → fail at mutation time (Django parity).
+    # Assert the SPECIFIC cause (not just "an ArgumentError") so an unrelated error can't pass.
+    excl_err = try
+      DriverModel.objects.select_for_update(nowait = true, skip_locked = true); nothing
+    catch e; e end
+    @test excl_err isa ArgumentError && occursin("mutually exclusive", excl_err.msg)
+
+    # FOR UPDATE + DISTINCT is invalid on PostgreSQL → friendly error at render time.
+    q = DriverModel.objects
+    q.distinct(true)
+    q.select_for_update()
+    dist_err = try inspect_query(q); nothing catch e; e end
+    @test dist_err isa ArgumentError && occursin("distinct", dist_err.msg)
+  end
+
 end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -25,7 +25,7 @@ const EXPECTED_TOPLEVEL = Set([
     # Async API
     :fetch_async, :await_result, :FetchTask,
     # Transactions
-    :run_in_transaction, :with_savepoint, :with_tx_context, :in_transaction_context,
+    :run_in_transaction, :atomic, :with_savepoint, :with_tx_context, :in_transaction_context,
     # Locking
     :with_advisory_lock,
     # Utilities & lifecycle

--- a/test/unit/test_savepoint_naming.jl
+++ b/test/unit/test_savepoint_naming.jl
@@ -1,0 +1,31 @@
+# ==============================================================================
+# UNIT TEST: Deterministic savepoint naming (#26)
+#
+# `_savepoint_name(depth)` builds the fixed `pormg_sp_<int>` identifier used by the reentrant
+# run_in_transaction / atomic savepoint path. The fixed prefix + integer suffix means the name
+# is never user-controlled (safe to interpolate as a SQL identifier), and keying it on the
+# transaction nesting depth makes savepoint names unique and LIFO-safe across nesting levels.
+#
+# Pure function — no database, no mocks.
+# ==============================================================================
+
+using Test
+using PormG
+
+@testset "Savepoint naming (#26)" begin
+    # Exact format for representative depths.
+    @test PormG.ConnectionPool._savepoint_name(1) == "pormg_sp_1"
+    @test PormG.ConnectionPool._savepoint_name(2) == "pormg_sp_2"
+    @test PormG.ConnectionPool._savepoint_name(10) == "pormg_sp_10"
+
+    # Fixed prefix + integer suffix only → no identifier-injection surface.
+    for d in 1:6
+        name = PormG.ConnectionPool._savepoint_name(d)
+        @test startswith(name, "pormg_sp_")
+        @test occursin(r"^pormg_sp_\d+$", name)
+    end
+
+    # Distinct depths yield distinct names (uniqueness across nesting levels).
+    names = [PormG.ConnectionPool._savepoint_name(d) for d in 1:6]
+    @test length(unique(names)) == 6
+end


### PR DESCRIPTION
Closes #26.

Implements the two halves of "full transaction control": user-facing **savepoints / nested atomic blocks** and **row-level locking**. Django-flavored surface, with the one intentional PG/SQLite divergence (row locking) documented.

## Part 1 — Savepoints / nested `atomic`
- **`with_savepoint` generalized to SQLite** — dropped the PG-only guard; `SAVEPOINT` / `RELEASE SAVEPOINT` / `ROLLBACK TO SAVEPOINT` are identical on both backends (SQLite bulk-insert retry now gets savepoint protection too).
- **`run_in_transaction` is now reentrant** — a nested call on the *same* pool becomes a `SAVEPOINT` (`pormg_sp_<depth>`) on the pinned connection instead of an independent transaction. Fixes the latent footgun where nesting opened a second transaction on a different connection. A nested call on a *different* database still opens its own transaction.
- **`atomic`** added as the friendly alias (+ `durable=true`, which raises if a transaction is already active). Exported and pinned in `test_public_exports`.

## Part 2 — `select_for_update`
- `for_update` state on `SQLObjectQuery` (constructor / positional `new` / `deepcopy`), a `select_for_update(; nowait, skip_locked, no_key)` fluent method, and a `Dialect.for_update_clause` pair.
- **PostgreSQL** renders `FOR [NO KEY] UPDATE [NOWAIT | SKIP LOCKED]`; **SQLite is a silent no-op** (no row-level locking) — same query code runs on both backends, matching Django/SQLAlchemy/Rails.
- Guards: raise when a locked read runs outside a transaction on PG (autocommit-release footgun), and on a `distinct()` combination.
- `nowait` and `skip_locked` are mutually exclusive.

## Deferred (follow-up #169)
- `of=` target — a first cut emitted the bare table name, but PormG aliases tables (`as "Tb"`), which PostgreSQL rejects. Needs FROM-alias resolution; tracked in #169 (along with SQLAlchemy-style `for_share`).

## Tests & docs
- **Unit:** PG render (`test_inspect_query`), SQLite no-op (`test_alignment_sqlite`), savepoint naming (`test_savepoint_naming`, new).
- **Integration** (both backends, `test_transactions.jl`): nested-savepoint isolation (inner fails → outer survives), reentrancy vs independent-transaction discriminator (inner succeeds, outer fails → inner also rolls back), row locking + `skip_locked` + the autocommit guard on PG, and the SQLite no-op path.
- **Docs:** new "Nested Transactions and Savepoints" + "Row-Level Locking" sections in `docs/src/write/transaction.md` (with a documented SQLite-divergence admonition) and `api.md` entries. Formula 1 examples.

## Verification
- Unit suite: **2919/2919**
- Integration SQLite (db_sl): 42 (+1 intentional PG-only skip)
- Integration PostgreSQL (db_2): **48/48**
- Docs build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)