### PR TITLE
feat(querybuilder): reference CTE fields via F() without join_field (#44)

### DIFF
--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -143,6 +143,48 @@ The `.with()` method:
 
 ---
 
+## Correlating a CTE with `F()` (no `join_field`)
+
+When you omit `join_field`, the CTE is emitted but not keyed to the main table. Referencing one
+of its columns with `F("<cte>__col")` then **`CROSS JOIN`s** the CTE, and the `F()` filter you
+write supplies the correlation verbatim in `WHERE` — the natural, Django-flavored way to express
+a correlated CTE:
+
+```julia
+# Races from the 1991 season
+races_91 = M.Race.objects.filter("year" => 1991).values("raceid")
+
+# Winners of those races — correlate Result.raceid with the CTE's raceid via F()
+q = M.Result.objects
+q.with("r91" => races_91)                       # no join_field
+q.filter("raceid" => F("r91__raceid"),          # ← the correlation
+         "positionorder" => 1)
+q.values("resultid", "raceid")
+df = q |> DataFrame
+```
+
+renders (SQLite shown; PostgreSQL uses `$N` placeholders):
+
+```sql
+WITH "r91" AS (SELECT "raceid" FROM "race" WHERE "year" = ?)
+SELECT "R1"."resultid", "R1"."raceid"
+FROM "result" AS "R1"
+CROSS JOIN "r91" AS "R1_1"
+WHERE "R1"."raceid" = "R1_1"."raceid" AND "R1"."positionorder" = ?
+```
+
+Notes:
+- **`CROSS JOIN + WHERE` is inner by nature** — only rows the correlation matches are returned.
+  To keep unmatched main-table rows (a *nullable* left join against a CTE), use an explicit
+  `join_field` (+ `join_type="LEFT"`) as shown above instead.
+- The correlation is ordinary `F()`, so multiple correlations and inequality/range predicates
+  work too, e.g. `filter("date__@gte" => F("r91__start"), "date__@lte" => F("r91__end"))`.
+- **Cartesian-product guard.** Referencing a CTE column with *no* constraining filter is a
+  Cartesian product; PormG emits a `@warn` naming the CTE. Add a correlating `filter(...)`, or
+  pass `join_field`.
+
+---
+
 ## CTE with Multiple Aggregated Fields
 
 ```julia

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -202,42 +202,70 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     length(vector) == 1 && throw("Error, CTE reference '$(cte_name)' must include a field name. Example: '$(cte_name)__field_name'")
 
     # Get the join field configuration from the CTE
-    join_field_pair = cte_dict["join_field"]::Pair{String, String}
-    main_table_key = join_field_pair.first    # e.g., "driverid" from main table
-    cte_table_key = join_field_pair.second    # e.g., "driverid" from CTE
-    @pormg_debug false
-    
-    if !haskey(cte_model.fields, cte_table_key)
-      available = join(collect(keys(cte_model.fields)), ", ")
-      throw(ArgumentError("CTE join_field column '$(cte_table_key)' not found in $(cte_name); available fields: $(available)"))
-    end
-    
+    jf = cte_dict["join_field"]
 
-    if (main_table_key in instruct.object.model.field_names)
+    if jf === nothing
+      # #44: no join_field → the CTE is CROSS JOINed and the correlation is supplied by the
+      # main query's `F("<cte>__col")` filter(s), which render verbatim in WHERE. `join_type`
+      # does not apply to a CROSS JOIN (INNER-like by nature).
+      if !haskey(cte_model.fields, vector[2])
+        available = join(collect(keys(cte_model.fields)), ", ")
+        throw(ArgumentError("CTE field '$(vector[2])' not found in '$(cte_name)'; available fields: $(available)"))
+      end
+      row_join["a"] = instruct.object.model.name
       row_join["alias_a"] = instruct.alias
-      # #64: resolve the main-model join field to its physical column (db_column).
-      row_join["key_a"] = Models.model_column(instruct.object.model, main_table_key)
-    elseif haskey(instruct.cache, main_table_key) || _cache_join(main_table_key, instruct)
-      cache_item = instruct.cache[main_table_key]
-      v_split = split(cache_item.field |> x -> replace(x,  '"' => ""), ".")
-      row_join["alias_a"] = v_split[1] |> string
-      row_join["key_a"] = v_split[2] |> string
+      row_join["b"] = cte_name  # CTE name becomes the table name
+      row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
+      # "how" is never emitted for a CROSS entry (build_row_join_sql_text short-circuits on the
+      # "cross" marker), but the deep-path loop below reads `row_join["how"]` as `prev_how`; set
+      # it so an over-long path like `F("r91__col__more")` fails with the same "not a foreign key"
+      # message as the keyed path instead of a cryptic KeyError.
+      row_join["how"] = "CROSS"
+      # Sentinel key columns: `_insert_join`'s dedup reads key_a/key_b directly (KeyError
+      # otherwise), and the CROSS branch of `build_row_join_sql_text` skips them. Equal empty
+      # strings also dedup repeat references to the same CTE (e.g. r91__raceid, r91__round)
+      # onto a single CROSS JOIN.
+      row_join["key_a"] = ""
+      row_join["key_b"] = ""
+      row_join["cross"] = "1"
     else
-      throw(ArgumentError("Main table join_field column '$(main_table_key)' not found in $(instruct.object.model.name); available fields: $(join(instruct.object.model.field_names, ", "))"))
-    end
-    
-    # Set up the join with the CTE
-    row_join["a"] = instruct.object.model.name
-    
-    row_join["b"] = cte_name  # CTE name becomes the table name
-    row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
-    row_join["how"] = cte_dict["join_type"]::String
+      join_field_pair = jf::Pair{String, String}
+      main_table_key = join_field_pair.first    # e.g., "driverid" from main table
+      cte_table_key = join_field_pair.second    # e.g., "driverid" from CTE
+      @pormg_debug false
 
-    # #64: the CTE side stays the FIELD NAME — a CTE is a derived table whose columns are
-    # the values() projection ALIASES (`"pk_code" AS "code"`), so the join references the
-    # alias "code", not the physical column. Only the main-table side (key_a above) is a
-    # real physical column and is db_column-resolved.
-    row_join["key_b"] = cte_table_key
+      if !haskey(cte_model.fields, cte_table_key)
+        available = join(collect(keys(cte_model.fields)), ", ")
+        throw(ArgumentError("CTE join_field column '$(cte_table_key)' not found in $(cte_name); available fields: $(available)"))
+      end
+
+
+      if (main_table_key in instruct.object.model.field_names)
+        row_join["alias_a"] = instruct.alias
+        # #64: resolve the main-model join field to its physical column (db_column).
+        row_join["key_a"] = Models.model_column(instruct.object.model, main_table_key)
+      elseif haskey(instruct.cache, main_table_key) || _cache_join(main_table_key, instruct)
+        cache_item = instruct.cache[main_table_key]
+        v_split = split(cache_item.field |> x -> replace(x,  '"' => ""), ".")
+        row_join["alias_a"] = v_split[1] |> string
+        row_join["key_a"] = v_split[2] |> string
+      else
+        throw(ArgumentError("Main table join_field column '$(main_table_key)' not found in $(instruct.object.model.name); available fields: $(join(instruct.object.model.field_names, ", "))"))
+      end
+
+      # Set up the join with the CTE
+      row_join["a"] = instruct.object.model.name
+
+      row_join["b"] = cte_name  # CTE name becomes the table name
+      row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
+      row_join["how"] = cte_dict["join_type"]::String
+
+      # #64: the CTE side stays the FIELD NAME — a CTE is a derived table whose columns are
+      # the values() projection ALIASES (`"pk_code" AS "code"`), so the join references the
+      # alias "code", not the physical column. Only the main-table side (key_a above) is a
+      # real physical column and is db_column-resolved.
+      row_join["key_b"] = cte_table_key
+    end
 
     @pormg_debug false
 

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -327,6 +327,15 @@ function build_row_join_sql_text(instruc::SQLInstruction)
     set_context!(instruc, :join)
     b_quoted = safe_table_identifier(value["b"], instruc.connection)
     alias_b_quoted = quote_identifier(value["alias_b"], instruc.connection)
+
+    # #44: a CROSS-joined CTE (no join_field) carries sentinel empty key columns and has no ON —
+    # the correlation is supplied by the main query's F() filter(s) in WHERE. Emit it and move on
+    # before touching key_a/key_b (empty strings would fail identifier validation).
+    if get(value, "cross", nothing) !== nothing
+      push!(instruc.join, """ CROSS JOIN $b_quoted AS $alias_b_quoted """)
+      continue
+    end
+
     alias_a_quoted = quote_identifier(value["alias_a"], instruc.connection)
     key_a_quoted = quote_identifier(value["key_a"], instruc.connection)
     key_b_quoted = quote_identifier(value["key_b"], instruc.connection)

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -6,14 +6,11 @@ function _preset_cte_fields(cte_name::String, query::SQLObjectHandler;
   join_field::Union{Pair{String,String},Nothing}=nothing,
   join_type::String="LEFT")
 
-  if join_field === nothing
-    # If no join fields provided, assume primary key of the model
-    if haskey(query.object.model.fields, "id")
-      join_field = Pair("id", "id")
-    else
-      throw(ArgumentError("CTE query model must have a primary key field 'id' or specify join_field"))
-    end
-  end
+  # `join_field === nothing` is intentional and supported (#44): the CTE is emitted but not
+  # keyed to the main table via a fixed ON. When the main query then references a CTE column
+  # with `F("<cte>__col")`, the CTE is CROSS JOINed and the F() filter supplies the correlation
+  # in WHERE (see the CTE branch of `_build_row_join`). No `id=>id` default — that was a latent
+  # trap that only worked when the model happened to carry an `id` column.
   table = CTEDict(
     "join_type" => join_type,
     "query" => deepcopy(query),

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -280,6 +280,24 @@ function query(q::SQLObjectHandler;
 
   resposta = String(take!(io))
 
+  # #44: warn once per CTE that is CROSS JOINed (no join_field) yet is never constrained by a
+  # WHERE/HAVING predicate — that is an unintended Cartesian product. The correlation is expected
+  # to come from a `filter("main_col" => F("<cte>__col"))` (which renders in WHERE). No false
+  # positive on the intended usage, where the alias appears in the WHERE fragment.
+  if any(rj -> get(rj, "cross", nothing) !== nothing, instruction.row_join)
+    predicate_text = string(
+      isempty(instruction._where) ? "" : join(instruction._where, " AND "),
+      isempty(instruction.having) ? "" : join(instruction.having, " AND "),
+    )
+    for rj in instruction.row_join
+      get(rj, "cross", nothing) === nothing && continue
+      cte_alias = rj["alias_b"]::String
+      if !occursin("\"$(cte_alias)\"", predicate_text)
+        @warn _emsg("PormG: CTE \e[31m$(rj["b"])\e[0m is CROSS JOINed with no correlating filter — this is a Cartesian product. Add a correlation such as \e[32mfilter(\"main_col\" => F(\"$(rj["b"])__col\"))\e[0m, or pass \e[32mjoin_field=\e[0m to .with().")
+      end
+    end
+  end
+
   # Store the final parameters object with all CTEs + main query parameters
   q.object.parameters = instruction.parameters
 

--- a/test/integration/test_cte.jl
+++ b/test/integration/test_cte.jl
@@ -162,6 +162,39 @@ end
         end
     end
 
+    @testset "F() reference without join_field: CROSS JOIN + WHERE correlation (#44)" begin
+        # #44: a CTE registered WITHOUT join_field, correlated to the main query by an F()
+        # filter. `.with("r91" => races_91).filter("raceid" => F("r91__raceid"), ...)` must emit
+        # a CROSS JOIN to the CTE and render the correlation in WHERE — returning exactly the
+        # 1991 race winners. Result-driven: cross-checked against the semantically equivalent
+        # join-filter query, so this fails if the CROSS JOIN correlation is wrong.
+        races_91_ids = Set(
+            (M.Race.objects.filter("year" => 1991).values("raceid") |> DataFrame).raceid
+        )
+
+        races_91 = M.Race.objects.filter("year" => 1991).values("raceid")
+        q = M.Result.objects
+        q.with("r91" => races_91)                       # no join_field
+        q.filter("raceid" => F("r91__raceid"),          # correlation → CROSS JOIN + WHERE
+                 "positionorder" => 1)                  # race winners only
+        q.values("resultid", "raceid", "positionorder")
+
+        insp = q |> inspect_query
+        @test occursin("CROSS JOIN", insp[:sql_text])   # the #44 join shape is actually used
+
+        df = q |> DataFrame
+        @test nrow(df) > 0
+        # Every winner belongs to a 1991 race (the CTE constrained the main query) ...
+        @test all(rid -> rid in races_91_ids, df.raceid)
+        # ... exactly one winner per distinct race (no CROSS-join fan-out) ...
+        @test all(df.positionorder .== 1)
+        @test nrow(df) == length(unique(df.raceid))
+        # ... and the count matches the equivalent keyed join-filter query (independent path).
+        expected = M.Result.objects.filter("raceid__year" => 1991, "positionorder" => 1).count()
+        @test expected > 0              # fixture actually holds 1991 winners (guards vacuity)
+        @test nrow(df) == expected
+    end
+
     @testset "self-reference: CTE on same table (LEFT and INNER)" begin
         # CTE pre-filters Driver rows born before 1980, then joined back to Driver.
         # LEFT: Hamilton (1985) appears with missing CTE column.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ end
     @testset "Field-name Case Preservation (#57)" include("unit/test_field_name_case.jl")
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
+    @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")

--- a/test/unit/test_cte_ergonomics.jl
+++ b/test/unit/test_cte_ergonomics.jl
@@ -1,0 +1,209 @@
+"""
+Unit coverage for CTE ergonomics (#44): referencing a CTE's columns with `F()` in the main
+query WITHOUT a `join_field`.
+
+When `.with("r91" => sub)` is given no `join_field`, the CTE is emitted but not keyed to the
+main table. Referencing one of its columns via `F("r91__col")` then CROSS JOINs the CTE and the
+`F()` filter supplies the correlation verbatim in WHERE — WYSIWYG. This is the natural,
+Django-flavored way to correlate a main query with a CTE (`filter("raceid" => F("r91__raceid"))`).
+
+What is pinned here (deterministic, DB-free — rendered via `inspect_query`, both dialects):
+  - No-`join_field` + `F()` correlation → a `CROSS JOIN` (no ON) and the correlation lands in
+    WHERE; CTE parameters precede WHERE parameters (positional bucket order).
+  - Regression: an explicit `join_field` still emits the keyed `INNER/LEFT JOIN … ON …` and NO
+    `CROSS JOIN` — the existing CTE path is untouched.
+  - Two references to the same CTE dedup onto a single `CROSS JOIN`.
+  - An uncorrelated CROSS reference (referenced but never filtered) emits the Cartesian-product
+    `@warn`; the correlated example does not.
+
+Sibling coverage:
+  - `test_cte.jl` (integration) → the same feature against the real F1 dataset, both backends.
+  - `test_alignment_sqlite.jl` → CTE parameter-bucket ordering with a keyed `join_field`.
+"""
+
+using Test
+using PormG
+using PormG.Models
+import Logging
+
+# Mock connections under dedicated keys so this file cannot contaminate (or be contaminated by)
+# other unit files sharing Main in runtests.jl. Only the connection TYPE matters — dispatch
+# selects SQLite `?`/`date()` vs PostgreSQL `$N` rendering.
+struct CteErgoMockSQLite <: PormG.PormGSQLite end
+struct CteErgoMockPostgres <: PormG.PormGPostgres end
+const _CTE_SL = CteErgoMockSQLite()
+const _CTE_PG = CteErgoMockPostgres()
+
+PormG.config["cte_ergo_mock"] = PormG.Configuration.Settings(
+  connections = _CTE_SL,
+  change_data = true,
+  db_def_folder = "cte_ergo_mock",
+)
+
+# Inline F1-flavored models (NOT a re-include of db_sl/models.jl — a second include would
+# redefine module `models` in the shared Main scope). `raceid` on the result table is a real FK
+# to the race table, mirroring the canonical schema so `F("r91__raceid")` correlates a real
+# main-table column against the CTE's projected `raceid`.
+module CteErgoModels
+import PormG
+import PormG.Models
+
+Cte_race = Models.Model("cte_race",
+  raceid = Models.IDField(),
+  year = Models.IntegerField(),
+  name = Models.CharField(),
+)
+
+Cte_result = Models.Model("cte_result",
+  resultid = Models.IDField(),
+  raceid = Models.ForeignKey(Cte_race, pk_field = "raceid", on_delete = "CASCADE"),
+  positionorder = Models.IntegerField(),
+)
+
+PormG.Models.set_models(@__MODULE__, "cte_ergo_mock")
+end
+
+const CE = CteErgoModels
+import PormG.QueryBuilder: F, inspect_query
+
+# The 1991-races CTE reused across cases: SELECT raceid FROM cte_race WHERE year = 1991.
+_races_91() = CE.Cte_race.objects.filter("year" => 1991).values("raceid")
+
+@testset "CTE ergonomics — F() reference without join_field (#44)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CROSS JOIN + WHERE correlation (SQLite): the issue's exact shape
+  # `.with("r91" => races_91).filter("raceid" => F("r91__raceid"), "positionorder" => 1)`
+  # must emit a CROSS JOIN (no ON) and render the F() correlation verbatim in WHERE. CTE
+  # parameter (1991) must precede the WHERE parameter (1) in the positional buckets.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "SQLite: no join_field → CROSS JOIN + WHERE correlation" begin
+    q = CE.Cte_result.objects
+    q.with("r91" => _races_91())
+    q.filter("raceid" => F("r91__raceid"), "positionorder" => 1)
+    q.values("resultid", "positionorder")
+
+    insp = inspect_query(q)          # default connection = mock SQLite
+    sql = insp[:sql_text]
+
+    # A CROSS JOIN to the CTE is emitted ...
+    @test occursin("CROSS JOIN \"r91\"", sql)
+    # ... and there is NO keyed `JOIN "r91" … ON` (alias-agnostic — a wrong keyed join under any
+    # alias must fail), and the CROSS line itself carries no ON.
+    @test !occursin(r"JOIN \"r91\"[^\n]*\bON\b", sql)     # no keyed ON to the CTE, any alias
+    @test !occursin(r"CROSS JOIN[^\n]*ON", sql)           # the CROSS line itself has no ON
+
+    # The F() correlation renders in WHERE with BOTH operands pinned: the main alias on the left,
+    # the CROSS alias on the right (not a keyed ON, not a bare unqualified column).
+    @test occursin(r"WHERE[^\n]*\"R1\"\.\"raceid\" = \"R1_1\"\.\"raceid\"", sql)
+
+    # Positional buckets: CTE filter (1991) before the WHERE filter (1).
+    buckets = insp[:parameter_buckets]
+    @test buckets[:cte] == [1991]
+    @test buckets[:where] == [1]
+    @test buckets[:join] == []             # a CROSS JOIN contributes no ON parameters
+    @test insp[:parameters] == [1991, 1]   # flat order: cte then where
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Cross-dialect parity (PostgreSQL): same query, `$N` placeholders, same join shape
+  # The PG override must render the identical CROSS JOIN + WHERE correlation, differing only
+  # in placeholder syntax ($1, $2) — locking that the feature is not SQLite-specific.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "PostgreSQL: no join_field → CROSS JOIN + WHERE correlation" begin
+    q = CE.Cte_result.objects
+    q.with("r91" => _races_91())
+    q.filter("raceid" => F("r91__raceid"), "positionorder" => 1)
+    q.values("resultid", "positionorder")
+
+    insp = inspect_query(q; connection = _CTE_PG)
+    sql = insp[:sql_text]
+
+    @test occursin("CROSS JOIN \"r91\"", sql)
+    @test !occursin(r"CROSS JOIN[^\n]*ON", sql)
+    @test occursin(r"WHERE[^\n]*\"R1\"\.\"raceid\" = \"R1_1\"\.\"raceid\"", sql)
+    # PostgreSQL uses linear $N placeholders; pin POSITION-to-placeholder (not mere presence):
+    # the CTE filter must bind $1 and the main WHERE filter $2 — CTE params are numbered first.
+    @test occursin(r"\"year\"\s*=\s*\$1", sql)            # CTE predicate binds $1
+    @test occursin(r"\"positionorder\"\s*=\s*\$2", sql)   # main WHERE binds $2
+    @test insp[:parameters] == [1991, 1]
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Regression: an explicit join_field still emits the keyed JOIN … ON (never a CROSS JOIN)
+  # The #44 CROSS path is gated on `join_field === nothing`; supplying a join_field must keep
+  # the pre-existing INNER/LEFT JOIN ON behavior byte-for-byte.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "explicit join_field keeps the keyed JOIN … ON (no CROSS)" begin
+    q = CE.Cte_result.objects
+    q.with("r91" => _races_91(), join_field = "raceid" => "raceid")
+    q.filter("positionorder" => 1)
+    q.values("resultid", "r91__raceid")
+
+    sql = inspect_query(q)[:sql_text]
+
+    @test occursin("JOIN \"r91\" AS \"R1_1\" ON \"R1\".\"raceid\" = \"R1_1\".\"raceid\"", sql)
+    @test !occursin("CROSS JOIN", sql)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Dedup: two references to the same CTE collapse to one CROSS JOIN
+  # `_insert_join` dedups on (a, b, key_a, key_b, alias_a); the empty-string key sentinels make
+  # repeated references (`r91__raceid`, `r91__year`) resolve to a single CROSS JOIN entry.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "two references to the same CTE dedup to one CROSS JOIN" begin
+    q = CE.Cte_result.objects
+    q.with("r91" => CE.Cte_race.objects.filter("year" => 1991).values("raceid", "year"))
+    q.filter("raceid" => F("r91__raceid"))
+    q.values("resultid", "r91__raceid", "r91__year")
+
+    sql = inspect_query(q)[:sql_text]
+
+    # Exactly one CROSS JOIN of "r91", even though two of its columns are referenced.
+    @test length(collect(eachmatch(r"CROSS JOIN \"r91\"", sql))) == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Cartesian-product guard: an uncorrelated CROSS reference warns; a correlated one does not
+  # Referencing `r91__raceid` in values() with NO constraining filter is a Cartesian product —
+  # PormG @warns and names the CTE. The correlated example (filter present) must stay silent.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "uncorrelated CROSS join warns; correlated stays silent" begin
+    # Uncorrelated: reference the CTE column but never filter on it → warn.
+    warn_q = () -> begin
+      q = CE.Cte_result.objects
+      q.with("r91" => _races_91())
+      q.values("resultid", "r91__raceid")
+      inspect_query(q)
+    end
+    @test_logs (:warn, r"CROSS JOINed with no correlating filter") warn_q()
+
+    # Correlated: the F() filter constrains the CTE → no warning of any kind.
+    quiet_q = () -> begin
+      q = CE.Cte_result.objects
+      q.with("r91" => _races_91())
+      q.filter("raceid" => F("r91__raceid"))
+      q.values("resultid")
+      inspect_query(q)
+    end
+    @test_logs quiet_q()
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Over-long CTE path errors cleanly — never a cryptic KeyError("how")
+  # A CTE column is terminal: `F("r91__raceid__year")` cannot traverse past `raceid`. The CROSS
+  # branch seeds a "how" sentinel so this reaches the same "not a foreign key" failure as the
+  # keyed path — a raw KeyError("how") (the pre-fix behavior) would fail the second assertion.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "over-long CTE path errors cleanly, not KeyError" begin
+    q = CE.Cte_result.objects
+    q.with("r91" => _races_91())
+    q.filter("raceid" => F("r91__raceid__year"))   # one segment too deep — raceid is terminal
+    q.values("resultid")
+
+    err = try inspect_query(q); nothing catch e; e end
+    @test err !== nothing          # it must error — a CTE column cannot be traversed further
+    @test !(err isa KeyError)      # and NOT the cryptic KeyError("how") the fix removed
+  end
+
+end


### PR DESCRIPTION
## Summary

Closes #44. Lets the main query correlate to a CTE by referencing its columns with `F()` — **without** pre-declaring a `join_field`:

```julia
races_91 = M.Race.objects.filter("year" => 1991).values("raceid")
q = M.Result.objects.with("r91" => races_91).filter(
    "raceid" => F("r91__raceid"),   # ← the correlation
    "positionorder" => 1,
)
```

When a CTE has no `join_field` and is referenced via `F("<cte>__col")`, it is emitted as a **`CROSS JOIN`** (no ON) and the `F()` filter renders verbatim in `WHERE` — WYSIWYG, inner-by-nature. An explicit `join_field` keeps the existing keyed `INNER/LEFT JOIN … ON` path unchanged.

### SQL shape (SQLite shown; PostgreSQL uses `$N`)

```sql
WITH "r91" AS (SELECT "raceid" FROM "race" WHERE "year" = ?)
SELECT "R1"."resultid", "R1"."raceid"
FROM "result" AS "R1"
CROSS JOIN "r91" AS "R1_1"
WHERE "R1"."raceid" = "R1_1"."raceid" AND "R1"."positionorder" = ?
```

## Changes

- **`ctes.jl`** — `join_field` is genuinely optional; dropped the buggy `id=>id` default (it only worked when the model happened to carry an `id` column) and its throw.
- **`build_joins.jl`** — CROSS-join branch when `join_field === nothing` (cross marker, empty-string key sentinels for `_insert_join` dedup, and a `"how"` sentinel so an over-long path errors cleanly instead of `KeyError("how")`).
- **`build_query.jl`** — emit `CROSS JOIN <cte> AS <alias>` (no ON) for cross entries.
- **`execution.jl`** — `@warn` (via `_emsg`) when a cross-joined CTE has no correlating `WHERE`/`HAVING` predicate (unintended Cartesian product).
- Tests + docs: new `test/unit/test_cte_ergonomics.jl` (21 assertions, both dialects, warn positive/negative, dedup, deep-path regression), a result-driven case in `test/integration/test_cte.jl`, and a docs subsection.

Parameter-bucket neutral: CTE params stay in `:cte`, the `F()` correlation in `:where`.

## Verification

| Check | Result |
|---|---|
| Full unit suite | **2905 / 2905** |
| Integration — PostgreSQL (db_2) | `With (CTE)` **47/47** |
| Integration — SQLite (db_sl) | `With (CTE)` **47/47** |

Reviewed with two adversarial agents (correctness + test-quality): one deep-path `KeyError` fixed, test assertions strengthened.

## Out of scope / follow-up

`update()` does not materialize CTEs, so **any** CTE in an `update()` throws "CTE … has not been materialized yet" — a **pre-existing** limitation surfaced during review, worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)