### PR TITLE
feat(#166): create()/insert() return a PormGRow (was Dict)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,10 +28,7 @@
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-- [#166](https://github.com/PingoLee/PormG.jl/issues/166) — write-path return-type consistency:
-  `create()`/`insert()` return `Dict` while `get()`/`first()`/`save()`/`update_or_create()` return
-  `PormGRow`. Decide the contract (likely `create()`/`insert()` → `PormGRow`) before publish, since
-  it is a breaking return-type change. Surfaced by `update_or_create` (#30).
+*(none — the gating list is empty; new `pre-publish`-labeled issues appear here as they open)*
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,64 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `create()` / `insert()` return a `PormGRow` (was `Dict`)
+
+- **PormG ref**: issue #166 ; `src/querybuilder/execution.jl`
+- **Recorded**: 2026-07-16
+- **Severity**: **breaking (return type)** / behavior improvement — the row surface is now uniform.
+
+### What changed
+
+`create()` / `insert()` now return a **`PormGRow`** on the execute path — the same row object
+`get()`, `first()`, `list()`, and `update_or_create()` already return — instead of a bare
+`Dict{Symbol,Any}`. This makes the row surface consistent and lets a created row be mutated and
+`.save()`d:
+
+```julia
+row = M.Driver.objects.create("forename" => "Ayrton", "surname" => "Senna")
+row[:driverid]        # unchanged — PormGRow delegates indexing/haskey/keys/get/pairs/iterate
+row.surname           # now also works (dot-access)
+row.surname = "SENNA"; row.save()   # and it round-trips
+```
+
+`show_query=:sql/:dict/:params` still return their inspection shapes (String/Dict/Vector) — only the
+`:execute` return changed. `list(:dict)` and `values()` still return plain dicts. `update()` still
+returns a matched-row count.
+
+### How to find the calls to migrate
+
+Because `PormGRow` delegates `getindex`/`haskey`/`get`/`keys`/`values`/`pairs`/`iterate`, the common
+patterns (`row[:id]`, `haskey(row, :x)`, iterating pairs) keep working unchanged. Only these break:
+
+```
+# 1. Type checks that assumed a Dict:
+grep -rn "create(" src/ | grep -i "isa Dict"
+grep -rn "= .*\.create(" src/            # then check for `isa Dict`, `merge(`, `delete!(`
+
+# 2. Dict-only MUTATION of a create() result (PormGRow has no setindex!):
+grep -rn "\.create(" src/ | ...          # then look for `result[:x] = ...` on that result
+```
+
+### Migrate your app
+
+- `@assert result isa Dict` → `@assert result isa PormG.QueryBuilder.PormGRow` (or drop the type
+  check — field access is unchanged).
+- Adding/overwriting a key on the result: `result[:x] = v` → `result.x = v` (dot-assign), and
+  `result.save()` if you want it persisted. (Read access `result[:x]` is unchanged.)
+- Passing the result somewhere typed `::Dict`, or `merge(result, …)` / `collect(result)` /
+  `length(result)` / `result == Dict(…)`: convert first with `Dict(pairs(result))`.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | check for `isa Dict` / Dict-mutation on `create()` results; field access unaffected |
+| app-2 | ⏳ | as above |
+| app-3 | ⏳ | as above |
+| app-4 | ⏳ | as above |
+
+---
+
 ## Row-level `update_or_create` (Django-style upsert)
 
 - **PormG ref**: issue #30 ; `src/querybuilder/execution.jl`, `src/querybuilder/object_manager.jl`
@@ -84,9 +142,8 @@ grep -rn "exists()" src/ | grep -iE "create|update"
 | app-3 | ⏳ | optional |
 | app-4 | ⏳ | optional |
 
-> **Note (pre-publish):** `create()`/`insert()` still return a `Dict` while `update_or_create()` (and
-> `get()`/`first()`/`save()`) return a `PormGRow`. That inconsistency is tracked for a decision before
-> publish in [#166](https://github.com/PingoLee/PormG.jl/issues/166).
+> **Resolved:** the `create()`/`insert()` → `Dict` vs `PormGRow` inconsistency this note tracked is
+> settled by the entry above (#166) — both now return `PormGRow`.
 
 ---
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -58,14 +58,14 @@ These methods finalize the query and execute it against the database:
 | `.exists()` | `Bool` | Returns `true` if at least one row matches. |
 | `.first()` | `PormGRow` or `nothing` | Returns the first matching record or `nothing`. |
 | `.get(filters...)` | `PormGRow` | Returns exactly one row, or raises `DoesNotExist` / `MultipleObjectsReturned`. |
-| `.create(key => value, ...)` | `Dict` | Inserts a single record and returns it. |
+| `.create(key => value, ...)` | `PormGRow` | Inserts a single record and returns it as a row (dot-access + `.save()`). |
 | `.update(key => value, ...)` | — | Updates all matching records. |
 | `.update_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Row-level upsert: inserts on a fresh lookup or updates `defaults` on conflict; returns `(row, created)`. See [Update or Create](write/create.md#update-or-create). |
 | `.delete()` | — | Deletes all matching records. |
 
 ### `PormGRow` Instance Methods
 
-Rows returned by `.list()`, `.first()`, and `.get()` expose model-aware property access and instance-level persistence:
+Rows returned by `.list()`, `.first()`, `.get()`, `.create()`, and `.update_or_create()` expose model-aware property access and instance-level persistence:
 
 | Method | Return Type | Description |
 | :--- | :--- | :--- |

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -62,7 +62,7 @@ n = query.count()      # => 42
 has_any = query.exists()  # => true
 ```
 
-Rows returned by `.list()`, `.first()`, and `.get()` are `PormGRow` values. They support property access, indexed access, many-to-many relationship accessors, and dirty tracking for `row.save()`:
+Rows returned by `.list()`, `.first()`, `.get()`, `.create()`, and `.update_or_create()` are `PormGRow` values. They support property access, indexed access, many-to-many relationship accessors, and dirty tracking for `row.save()`:
 
 ```julia
 driver = M.Driver.objects.get("driverref" => "hamilton")

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -4,7 +4,7 @@ PormG provides methods for inserting data into your database, from single rows t
 
 ## Single Record Creation
 
-Use the `.create()` method to insert individual records. It returns a `Dict` containing the newly created record, including any database-generated fields (like auto-increment primary keys).
+Use the `.create()` method to insert individual records. It returns a [`PormGRow`](../read/index.md) — the same row object `get()`, `first()`, and `list()` return — containing the newly created record, including any database-generated fields (like auto-increment primary keys). Because it's a `PormGRow`, you can read fields by dot-access or key, and mutate it and call `.save()` to persist further changes.
 
 ```julia
 # Load your models (preferred: hot-reload-friendly, self-registering)
@@ -25,14 +25,21 @@ RETURNING *
 
 ### Return Value
 
-The return value is a `Dict{Symbol, Any}` with all fields of the inserted record:
+The return value is a `PormGRow` carrying all fields of the inserted record. Read them by dot-access
+(`row.name`) or by key (`row[:name]`), exactly like a row from `get()`/`first()`:
 
 ```julia
-Dict{Symbol, Any} with 4 entries:
-  :id           => 172              # Auto-generated primary key
-  :name         => "test"
-  :test_result  => 1
-  :test_result2 => missing          # Null/unset fields show as missing
+new_record.id            # 172        (auto-generated primary key)
+new_record[:name]        # "test"
+new_record.test_result   # 1
+new_record[:test_result2] # missing   (null/unset fields show as missing)
+```
+
+Because it is a live row, you can also mutate it and persist the change:
+
+```julia
+new_record.test_result = 2
+new_record.save()        # UPDATE ... WHERE id = 172
 ```
 
 You can access returned values immediately:
@@ -128,7 +135,7 @@ record = M.Driver.objects.create(
     "dob" => Date(1997, 4, 1)
 )
 
-# The returned dict includes the generated ID
+# The returned row includes the generated ID
 generated_id = record[:driverid]
 ```
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -533,11 +533,14 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
                             parameters=parameters)
   end
 
-  # Execute safely
+  # Execute safely. create()/insert() return a PormGRow (#166) — the same object get()/first()/
+  # list()/update_or_create() return — so a created row supports dot-access and create → mutate →
+  # .save(). `_row_to_field_keyed_dict` still builds the Dict; we wrap it. RETURNING */SELECT *
+  # include every column (incl. the pk), so the row is .save()-able; `_dirty` starts empty.
   if connection isa PormGPostgres
     result = fetch(settings, sql * " RETURNING *;", parameters)
     pk_exist && _update_sequence(model, connection, pk_field, settings)
-    return _row_to_field_keyed_dict(Tables.rowtable(result) |> Base.first, model)
+    return PormGRow(_row_to_field_keyed_dict(Tables.rowtable(result) |> Base.first, model), model)
   elseif connection isa PormGSQLite
     # SQLite: deliberately avoid `INSERT ... RETURNING *`. RETURNING can hang
     # indefinitely inside SQLite/libsqlite3 for some table shapes (observed: an
@@ -547,8 +550,14 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     # first INSERT had already written the row. Instead: run a plain INSERT, then
     # read the full inserted row back with a SELECT on the SAME connection
     # (last_insert_rowid() is per-connection session state). Reading the whole row
-    # keeps the returned Dict consistent with the Postgres `RETURNING *` path —
+    # keeps the returned row consistent with the Postgres `RETURNING *` path —
     # all columns present, including nullable ones the caller did not set.
+    #
+    # The empty-rows fallback (read-back returned nothing, which should not happen after a
+    # successful INSERT) builds the dict from real_obj.insert only, so it may omit an unreserved
+    # AUTOINCREMENT pk. The wrapped PormGRow is still returned; if that degenerate row is later
+    # mutated and .save()d, save() throws a clear "required key" error — no regression over the
+    # previous incomplete-Dict return.
     do_insert = () -> begin
       fetch(settings, sql, parameters)
       rows = fetch(settings,
@@ -565,7 +574,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
       do_insert() : run_in_transaction(do_insert, settings)
 
     pk_exist && _update_sequence(model, connection, pk_field, settings)
-    return result_dict
+    return PormGRow(result_dict, model)
   else
     throw("Unsupported connection type")
   end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -298,9 +298,9 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     return () -> deepcopy(q)
 
   # === CATEGORY 2: Terminal methods (return result) ===
-  # End the chain. E.g.: query.create(...) returns a Dict.
+  # End the chain. E.g.: query.create(...) returns a PormGRow.
   elseif sym === :create
-    # `args...` is intentionally untyped: the execute path returns a Dict, while
+    # `args...` is intentionally untyped: the execute path returns a PormGRow (#166), while
     # show_query=:sql/:dict/:params/:none return String/Dict/Vector/nothing. A typed
     # signature would force the inspect contract to fork, so the return stays `Any`.
     return (args...; kwargs...) -> up_create!(q.object, args; kwargs...)

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -952,8 +952,8 @@ df = query |> DataFrame
 active_users = query.count()
 
 # 3) Inserting a single row
-new = M.Status.objects.create("statusid" => 42, "status" => "Foo")  
-# returns a Dict of the inserted row
+new = M.Status.objects.create("statusid" => 42, "status" => "Foo")
+# returns a PormGRow of the inserted row (dot-access + .save())
 
 # 4) Updating a single row
 M.Status.objects.filter("statusid" => 42).update("status" => "Bar")

--- a/test/integration/test_inserts.jl
+++ b/test/integration/test_inserts.jl
@@ -209,15 +209,17 @@ end
 @testset "Insertion Result Semantics" begin
     label = "insert-return-semantics-9901"
 
-    # Clean any residual row from a prior run.
-    M.Django_contract_scratch.objects.filter("label" => label).exists() &&
-        M.Django_contract_scratch.objects.filter("label" => label).delete()
+    # Clean any residual row from a prior run — both the base label and the "-saved" form the
+    # .save() step below produces (label is unique, so a leaked "-saved" row would break save()).
+    residual = M.Django_contract_scratch.objects.filter("label__@in" => [label, label * "-saved"])
+    residual.exists() && residual.delete()
 
     try
         result = M.Django_contract_scratch.objects.create("label" => label)
 
-        # create() must return a Dict, not nothing or an integer row-count.
-        @test result isa Dict
+        # create() must return a PormGRow (#166) — the same object get()/first()/list() return,
+        # not nothing or an integer row-count. Field access still works via delegation.
+        @test result isa PormG.QueryBuilder.PormGRow
 
         # The server-generated primary key must be present and positive.
         # IDField maps to SERIAL (PostgreSQL) / AUTOINCREMENT (SQLite), so the
@@ -226,7 +228,7 @@ end
         @test result[:id] isa Integer
         @test result[:id] > 0
 
-        # auto_now_add (DateTimeField) must be populated in the returned dict.
+        # auto_now_add (DateTimeField) must be populated in the returned row.
         # Returning nothing here would break ETL code that reads created_at
         # from the create() result instead of fetching it again.
         @test haskey(result, :created_at)
@@ -236,9 +238,10 @@ end
         @test haskey(result, :updated_at)
         @test result[:updated_at] !== nothing && !ismissing(result[:updated_at])
 
-        # The value we explicitly passed must be echoed back correctly.
+        # The value we explicitly passed must be echoed back correctly (dot-access too).
         @test haskey(result, :label)
         @test result[:label] == label
+        @test result.label == label     # PormGRow dot-access
 
         # Cross-verify: re-read the row and confirm the returned id matches the DB id.
             row = M.Django_contract_scratch.objects.filter(
@@ -248,9 +251,16 @@ end
             ).list() |> first
         @test row[:id] == result[:id]
 
+        # #166: the created PormGRow round-trips through .save() — mutate then persist.
+        result.label = label * "-saved"
+        result.save()
+        reread = M.Django_contract_scratch.objects.filter("id" => result[:id]).values("label").list() |> first
+        @test reread[:label] == label * "-saved"
+
     finally
-        M.Django_contract_scratch.objects.filter("label" => label).exists() &&
-            M.Django_contract_scratch.objects.filter("label" => label).delete()
+        # The .save() above renamed the label, so clean up both the original and the "-saved" form.
+        cleanup = M.Django_contract_scratch.objects.filter("label__@in" => [label, label * "-saved"])
+        cleanup.exists() && cleanup.delete()
     end
 end
 
@@ -282,8 +292,8 @@ end
             "slug"          => slug
         )
 
-        # The return value must be a Dict, not nothing.
-        @test result isa Dict
+        # The return value must be a PormGRow (#166), not nothing.
+        @test result isa PormG.QueryBuilder.PormGRow
 
         # The auto-incremented id must be present and positive.
         @test haskey(result, :id)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")
     @testset "update_or_create (#30)" include("unit/test_update_or_create.jl")
+    @testset "create() returns PormGRow (#166)" include("unit/test_create_returns_pormgrow.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")

--- a/test/unit/test_create_returns_pormgrow.jl
+++ b/test/unit/test_create_returns_pormgrow.jl
@@ -1,0 +1,51 @@
+using Test
+using DataFrames
+using PormG
+using PormG.Models: Model, CharField, IDField
+import PormG.ConnectionPool: fetch
+
+# ─────────────────────────────────────────────────────────────────────────────
+# create()/insert() return a PormGRow (#166)
+#
+# DB-free: a mock PG connection answers the INSERT ... RETURNING * with a full row, so create()
+# on the :execute path wraps it into a PormGRow (the same object get()/first()/list() return).
+# The show_query=:dict path must still return the inspection Dict — the dual contract is unchanged.
+# (SQLite's INSERT + read-back path is covered end-to-end in test/integration/test_inserts.jl.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+CreateRowModel = Model("crow", id = IDField(), name = CharField())
+CreateRowModel.connect_key = "create_pormgrow"
+
+struct MockPgCreate <: PormG.PormGPostgres end
+
+# create() PG path issues `INSERT ... RETURNING *`; hand back a full row to wrap.
+function fetch(connection::MockPgCreate, sql::String;
+  conn = nothing, params = nothing, ignore_tx::Bool = false)
+  if occursin("INSERT INTO", sql) && occursin("RETURNING", sql)
+    return DataFrame(id = [7], name = ["Senna"])
+  end
+  return DataFrame()
+end
+
+PormG.config["create_pormgrow"] =
+  PormG.Configuration.Settings(connections = MockPgCreate(), change_data = true)
+
+@testset "create() returns a PormGRow on execute (#166)" begin
+  row = CreateRowModel.objects.create("name" => "Senna")
+
+  @test row isa PormG.QueryBuilder.PormGRow
+  @test !(row isa Dict)                 # no longer a bare Dict
+  @test row[:id] == 7                   # delegated indexing still works
+  @test row[:name] == "Senna"
+  @test row.name == "Senna"             # PormGRow dot-access
+  @test haskey(row, :id)
+  # A freshly-created row starts clean (empty dirty set) — .save() is a no-op until mutated.
+  @test isempty(getfield(row, :_dirty))
+end
+
+@testset "create(show_query=:dict) still returns the inspection Dict (dual contract)" begin
+  d = CreateRowModel.objects.create("name" => "Prost", show_query = :dict)
+  @test d isa Dict
+  @test !(d isa PormG.QueryBuilder.PormGRow)
+  @test haskey(d, :sql_text)
+end


### PR DESCRIPTION
Closes #166. Pre-publish return-type consistency — the follow-up flagged during #30.

## What

`create()` / `insert()` now return a **`PormGRow`** on the execute path — the same row object
`get()`, `first()`, `list()`, and `update_or_create()` already return — instead of a bare
`Dict{Symbol,Any}`:

```julia
row = M.Driver.objects.create("forename" => "Ayrton", "surname" => "Senna")
row[:driverid]        # unchanged (PormGRow delegates indexing/haskey/keys/get/pairs/iterate)
row.surname           # now also works (dot-access)
row.surname = "SENNA"; row.save()   # and it round-trips
```

This makes the row surface uniform and matches every comparable ORM's row-level create
(Django/Rails/Eloquent/Peewee/Ecto/Prisma return the live object, not a dict).

## Why now / breaking

It's a **breaking return-type change**, cheap now (zero General-registry users) and irreversible
after publish, so it was `pre-publish`-gated as #166. **Blast radius is small:** `PormGRow` delegates
`getindex`/`haskey`/`get`/`keys`/`values`/`pairs`/`iterate` to its `_data`, so `result[:id]`,
`haskey(result, :x)`, and iteration keep working unchanged. The only breakage is `result isa Dict`
checks and Dict-only mutation (`row[:x] = v`, `merge`, `delete!`) — see `UPGRADING.md` for the recipe.

## How

- **`src/querybuilder/execution.jl`** — wrap the two `insert()` `:execute` returns (PostgreSQL
  `RETURNING *`, SQLite read-back) in `PormGRow`; `_row_to_field_keyed_dict` still builds the `Dict`.
  `RETURNING *` / `SELECT *` include the pk, so the row is `.save()`-able and `_dirty` starts empty.
  The `show_query=:sql/:dict/:params` and inspect paths are unchanged; `update()` still returns a
  count; `list(:dict)`/`values()` still return plain dicts. The SQLite empty-read-back fallback (a
  degenerate path) is documented.

## Tests

- The two `@test result isa Dict` integration assertions → `isa PormGRow`, plus a
  **create → mutate → `.save()`** round-trip on both backends.
- New DB-free `test/unit/test_create_returns_pormgrow.jl` proving the dual contract: execute →
  `PormGRow`, `show_query=:dict` → `Dict`.

Verified: unit **2931 pass**; integration **db_2 1708** / **db_sl 1683** (0 fail); docs build exit 0;
live db_sl round-trip (create → index/dot access → mutate → save). One `/code-review` finding (a test
start-cleanup gap under a leaked-row edge) fixed.

## Docs / bookkeeping

`docs/src/write/create.md` return-value section, `api.md` table row, `read/index.md` sources.
`UPGRADING.md` breaking entry with the migration recipe (and the #30 "tracked for later" note flipped
to resolved). `TODO.md` pre-publish gating line for #166 removed — the gated decision is now made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)