### PR TITLE
feat(querybuilder): JSONB path lookups + containment operators (#27)

### DIFF
--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -163,6 +163,78 @@ M.Driver.objects.filter(Qor(
 
 ---
 
+## JSON / JSONB Lookups and Operators
+
+For a [`JSONField`](../fields.md) column you can reach *inside* the stored document with a `__`
+path, and (on PostgreSQL) test containment and key existence.
+
+### Path lookups (`field__key`, `field__0__key`)
+
+Append the JSON keys to the field name with `__`. A numeric segment is a JSON **array index**.
+The value is extracted as **text** and compared to your filter value. Works on **both** backends
+(PostgreSQL `#>>`, SQLite `json_extract`).
+
+Assume `Constructor` has a `metadata` JSONField holding, e.g.,
+`{"principal": "Toto Wolff", "wins": 121, "drivers": [{"name": "Russell"}]}`:
+
+```julia
+# Equality on a nested key
+M.Constructor.objects.filter("metadata__principal" => "Toto Wolff")
+
+# Array index then key: drivers[0].name
+M.Constructor.objects.filter("metadata__drivers__0__name" => "Russell")
+
+# Numeric comparison — PostgreSQL casts the extracted text to numeric; SQLite compares natively
+M.Constructor.objects.filter("metadata__wins__@gte" => 100)
+
+# Presence: a missing key extracts to NULL
+M.Constructor.objects.filter("metadata__sponsor__@isnull" => true)
+
+# Project an extracted value (the alias is the dotted path)
+M.Constructor.objects.values("name", "metadata__principal")
+```
+
+Supported comparisons on a path lookup: `=` (default), `@ne`, `@gt`, `@gte`, `@lt`, `@lte`, and
+`@isnull`. Path lookups also work in `.values(...)` and `.order_by(...)`.
+
+> [!NOTE]
+> Keys must be simple (letters, digits, underscore) or an integer array index — a key with
+> spaces, dots, or quotes is not addressable via the `__` path and raises an `ArgumentError`.
+> Extraction is text-based: comparisons are string comparisons unless you use a numeric operator
+> (`@gte` etc.), which casts to numeric on PostgreSQL. Equality against a numeric JSON value
+> (`"metadata__wins" => 121`) works on both backends.
+>
+> A numeric segment is always treated as an **array index**. An object key that is a number
+> (e.g. `{"2024": …}`) is therefore not portably addressable: PostgreSQL's `#>>` may still resolve
+> it as an object key, but SQLite treats `[2024]` as an array subscript and returns nothing —
+> avoid numeric object keys in a `__` path.
+
+### Containment and key-existence operators (PostgreSQL only)
+
+These map to the PostgreSQL JSONB operators and apply to a JSON **column** (not a nested path).
+On SQLite they raise an `ArgumentError`:
+
+| Lookup | JSONB operator | Meaning | Example |
+| :--- | :--- | :--- | :--- |
+| `@jcontains` | `@>` | Column contains the given document | `"metadata__@jcontains" => Dict("wins" => 121)` |
+| `@has_key` | `?` | Top-level key exists | `"metadata__@has_key" => "principal"` |
+| `@has_any_keys` | `?\|` | Any of the given keys exists | `"metadata__@has_any_keys" => ["principal", "ceo"]` |
+| `@has_keys` | `?&` | All of the given keys exist | `"metadata__@has_keys" => ["principal", "wins"]` |
+
+```julia
+# Rows whose metadata contains this sub-document (deep match)
+M.Constructor.objects.filter("metadata__@jcontains" => Dict("drivers" => [Dict("name" => "Russell")]))
+
+# Rows that have BOTH keys
+M.Constructor.objects.filter("metadata__@has_keys" => ["principal", "wins"])
+```
+
+`@jcontains` accepts a `Dict`, `Vector`, `NamedTuple`, or a raw JSON string (validated at build
+time). `@has_any_keys` / `@has_keys` take a vector of keys. All values are sent as bound
+parameters.
+
+---
+
 ## IN and NOT IN
 
 ### Value In Set

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -1064,6 +1064,70 @@ end
 
 _like_escape_clause() = " ESCAPE '\\'"
 
+# ---
+# #27: JSON/JSONB support
+# ---
+
+# JSON path extraction as TEXT. `segments` are pre-validated (safe identifier charset or a
+# non-negative integer index) by `_validate_json_key_segments`, so interpolating them into the
+# path literal is injection-safe. A numeric segment is a JSON array index.
+function _json_extract_expr(::PormGPostgres, column::String, segments::Vector{String})::String
+  # `#>>` takes a text[] path and returns text; a numeric element indexes an array. Non-numeric
+  # keys are double-quoted so a key literally named `null`/`true`/`false` is a normal path element
+  # rather than an array-literal keyword (segments are pre-validated, so no escaping is needed).
+  parts = map(s -> tryparse(Int, s) === nothing ? "\"$s\"" : s, segments)
+  return string(column, " #>> '{", join(parts, ","), "}'")
+end
+function _json_extract_expr(::PormGSQLite, column::String, segments::Vector{String})::String
+  # SQLite JSONPath: numeric segment => [n] (array index); key => .key.
+  path = "\$" * join(map(s -> tryparse(Int, s) === nothing ? ".$s" : "[$s]", segments))
+  return string("json_extract(", column, ", '", path, "')")
+end
+
+# PostgreSQL JSONB containment/overlap operators (PG-only; SQLite + abstract throw a friendly
+# error, mirroring iunaccent_*). LibPQ binds `$N` placeholders, so a literal `?`/`?|`/`?&` here is
+# the jsonb operator, never a bind marker. The RHS placeholder already carries any needed cast
+# (`::jsonb` for @>, `::text[]` for ?|/?&) from add_parameter!.
+function jcontains(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) @> $(value)"                    # jsonb contains the given document
+end
+function jcontains(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
+end
+function jcontains(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
+end
+
+function has_key(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) ? $(value)"                     # top-level key exists
+end
+function has_key(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
+end
+function has_key(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
+end
+
+function has_any_keys(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) ?| $(value)"                    # any of the given keys exists
+end
+function has_any_keys(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
+end
+function has_any_keys(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
+end
+
+function has_keys(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) ?& $(value)"                    # all of the given keys exist
+end
+function has_keys(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
+end
+function has_keys(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
+end
+
 function contains(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) LIKE $(value)$(_like_escape_clause())"
 end

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -1299,6 +1299,12 @@ include("models/fields.jl")
 is_many_to_many_field(::PormGField)::Bool = false
 is_many_to_many_field(::sManyToManyField)::Bool = true
 
+# #27: type predicate for JSON/JSONB columns, mirroring is_many_to_many_field. Used by the
+# querybuilder to (a) treat a non-terminal JSON field path as a value extraction (data__key)
+# rather than a join hop, and (b) gate the JSON containment operators (@>, ?, ?|, ?&).
+is_json_field(::PormGField)::Bool = false
+is_json_field(::sJSONField)::Bool = true
+
 function _model_reference_name(model_ref::Union{String, PormGModel})::String
   return model_ref isa PormGModel ? model_ref.name : String(model_ref)
 end

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -7,7 +7,7 @@ import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_sym
 import PormG: Dialect, Models
 import PormG: config
 import PormG: SQLType, SQLConn, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
-import PormG: PormGsuffix, PormGtransform, run_in_transaction
+import PormG: PormGsuffix, PormGtransform, JSON_CONTAINMENT_OPERATORS, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -47,7 +47,18 @@ const PormGsuffix = Dict{String,Union{Int64, String}}(
   "startswith" => "startswith",
   "endswith" => "endswith",
   "range" => "BETWEEN",
+  # #27: PostgreSQL JSONB containment/overlap operators. Each maps to a Dialect renderer of the
+  # same name (PG emits the operator; SQLite/abstract throw a friendly PG-only error). Distinct
+  # from the LIKE `contains` above — a JSON `@>` and a string LIKE are different operations.
+  "jcontains" => "jcontains",         # @>  (jsonb contains the given document)
+  "has_key" => "has_key",             # ?   (top-level key exists)
+  "has_any_keys" => "has_any_keys",   # ?|  (any of the given keys exists)
+  "has_keys" => "has_keys",           # ?&  (all of the given keys exist)
 )
+
+# #27: the JSON containment/overlap operators, routed to a dedicated render branch in
+# _get_filter_query(::SQLTypeOper) and gated PostgreSQL-only.
+const JSON_CONTAINMENT_OPERATORS = ("jcontains", "has_key", "has_any_keys", "has_keys")
 
 const PormGtransform = Dict{String,Union{Int64, String}}(
   "date" => "DATE",

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -235,17 +235,36 @@ function _get_pair_to_oper(x::Pair{Vector{String},T}) where T<:SQLTypeFunction
   end
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Vector{T}}) where T<:Union{Missing,AbstractString,Number,Bool,Dates.TimeType,Dates.Period,Dates.CompoundPeriod}
-  if x.first[end] in ["in", "nin"]
+  suffix = x.first[end]
+  if suffix in ["in", "nin"]
     @pormg_debug false
-    return OperObject(operator=PormGsuffix[x.first[end]], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
-  elseif x.first[end] == "range"
+    return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
+  elseif suffix == "range"
     if length(x.second) != 2
       throw(_argerr("Error in filter, 'range' operator requires exactly 2 values, got $(length(x.second))"))
     end
-    return OperObject(operator=PormGsuffix[x.first[end]], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
+    return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
+  elseif suffix in ("has_any_keys", "has_keys")
+    # #27: JSONB overlap operators (?| / ?&) take an array of keys; the render branch binds the
+    # vector as a single text[] parameter.
+    return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
+  elseif suffix == "jcontains"
+    # #27: JSONB array containment (@>) with a vector RHS — serialize to a JSON document string at
+    # parse time so OperObject.values stays a String (no downstream type-union change).
+    return OperObject(operator="jcontains", values=Models.format_json_sql(x.second), column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    _raise_invalid_filter_operator(x.first, "vector", ["in", "nin", "range"])
+    _raise_invalid_filter_operator(x.first, "vector", ["in", "nin", "range", "has_any_keys", "has_keys", "jcontains"])
   end
+end
+# #27: JSONB document containment (@>) with a Dict / NamedTuple RHS — serialize at parse time so
+# OperObject.values stays a String.
+function _get_pair_to_oper(x::Pair{Vector{String},<:AbstractDict})
+  x.first[end] == "jcontains" || _raise_invalid_filter_operator(x.first, "dict", ["jcontains"])
+  return OperObject(operator="jcontains", values=Models.format_json_sql(x.second), column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
+end
+function _get_pair_to_oper(x::Pair{Vector{String},<:NamedTuple})
+  x.first[end] == "jcontains" || _raise_invalid_filter_operator(x.first, "namedtuple", ["jcontains"])
+  return OperObject(operator="jcontains", values=Models.format_json_sql(x.second), column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Tuple{T,T}}) where T
   if x.first[end] == "range"
@@ -919,9 +938,96 @@ function _get_filter_query(v::SQLTypeField, instruc::SQLInstruction)
     return v_copy.field
   end
 end
+# Coerce a JSON numeric-comparison RHS to an actual Julia number, so BOTH dialects compare
+# numerically (PostgreSQL casts the extracted text `::numeric`; SQLite's json_extract returns a
+# native number). Binding a string here would make SQLite compare number-vs-text and silently
+# invert every comparison.
+function _json_numeric_rhs(value)
+  value isa Bool && return Int(value)
+  value isa Integer && return value
+  value isa AbstractFloat && return value
+  s = strip(string(value))
+  n = tryparse(Int, s); n !== nothing && return n
+  f = tryparse(Float64, s); (f !== nothing && isfinite(f)) && return f
+  throw(_argerr("A numeric JSON comparison requires a number; got \e[31m$(value)\e[0m."))
+end
+
+# #27: render a comparison against a JSON path lookup (e.g. `payload__driver`). The RHS binds
+# dialect-aware — NOT through the JSON field's formater (which would reject a plain string like
+# "hamilton"):
+#   - PostgreSQL `#>>` always yields TEXT, so equality binds text and `<`/`>` cast the LHS
+#     `::numeric`.
+#   - SQLite `json_extract` returns the value's NATIVE type, so equality binds the raw Julia value
+#     (a JSON number stays a number → `5 = 5`, not `5 = '5'`) and comparisons need no cast.
+function _render_json_lookup_comparison(v::SQLTypeOper, column::String, instruc::SQLInstruction)::String
+  op = v.operator
+  is_pg = instruc.connection isa PormGPostgres
+  if op == "ISNULL"
+    # Render IS NULL directly — the shared ISNULL() rejects any column containing "(", which a
+    # legitimate SQLite json_extract(...) expression trips.
+    return string(column, v.values == true ? " IS NULL" : " IS NOT NULL")
+  elseif op in ("=", "!=", "<>")
+    # PG: bind text (LHS is text). SQLite: bind the native value (LHS keeps its JSON type).
+    ph = add_parameter!(instruc, is_pg ? string(v.values) : v.values)
+    return string(column, " ", op, " ", ph)
+  elseif op in (">", ">=", "<", "<=")
+    lhs = is_pg ? "($(column))::numeric" : column
+    ph = add_parameter!(instruc, _json_numeric_rhs(v.values))
+    return string(lhs, " ", op, " ", ph)
+  else
+    throw(_argerr("The operator \e[31m$(op)\e[0m is not supported on a JSON path lookup. Use =, !=, <, <=, >, >=, or __@isnull."))
+  end
+end
+
+# #27: render a JSONB containment/overlap operator (@>, ?, ?|, ?&). The LHS must be a JSON COLUMN
+# (terminal), not a nested key path. Binds the RHS per operator (jsonb document / text key /
+# text[] key array) and dispatches to the per-dialect Dialect renderer (PG emits the operator;
+# SQLite throws PG-only).
+function _render_json_operator(v::SQLTypeOper, column::String, instruc::SQLInstruction)::String
+  col_as = isa(v.column, SQLTypeField) ? v.column._as : nothing
+  if col_as !== nothing && haskey(instruc.json_lookup_cache, col_as)
+    throw(_argerr("The \e[31m@$(v.operator)\e[0m operator applies to a JSON column, not a nested key path (\e[31m$(col_as)\e[0m); this is not supported in v1."))
+  end
+  base = _resolve_json_operator_field(v, instruc)
+  (base !== nothing && Models.is_json_field(base)) ||
+    throw(_argerr("The \e[31m@$(v.operator)\e[0m operator requires a JSONField column; \e[31m$(something(col_as, "the target"))\e[0m is not JSON."))
+  op = v.operator
+  ph = if op == "jcontains"
+    add_parameter!(instruc, Models.format_json_sql(v.values); sql_type="jsonb")
+  elseif op == "has_key"
+    add_parameter!(instruc, string(v.values))
+  else  # has_any_keys / has_keys
+    v.values isa AbstractVector ||
+      throw(_argerr("The \e[31m@$(op)\e[0m operator requires an array of keys, e.g. filter(\"col__@$(op)\" => [\"a\", \"b\"]); got a single value."))
+    add_parameter!(instruc, String.(v.values); sql_type="text[]")
+  end
+  return getfield(Dialect, Symbol(op))(instruc.connection, column, ph)
+end
+
+# Resolve the base PormGField a JSON operator targets: a bare column name lives on the model;
+# an FK-reached terminal JSON column was cached in tab_field_cache when `column` resolved.
+function _resolve_json_operator_field(v::SQLTypeOper, instruc::SQLInstruction)
+  isa(v.column, SQLTypeField) || return nothing
+  fld = v.column.field
+  if fld isa String && !contains(fld, "__")
+    return get(instruc.object.model.fields, fld, nothing)
+  end
+  return v.column._as === nothing ? nothing : get(instruc.tab_field_cache, v.column._as, nothing)
+end
+
 function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
   @pormg_debug false
   column = _get_filter_query(v.column, instruc)
+  # #27: JSONB containment/overlap operators (@>, ?, ?|, ?&) — dedicated binding + PG-only render.
+  if v.operator in JSON_CONTAINMENT_OPERATORS
+    return _render_json_operator(v, column, instruc)
+  end
+  # #27: comparison against a JSON path lookup (payload__key). Resolving `column` above populated
+  # json_lookup_cache; the dedicated branch binds the RHS as plain text (the generic path would run
+  # the JSON formater on the RHS and throw on plain strings) and applies the PG numeric cast for </>.
+  if isa(v.column, SQLTypeField) && v.column._as !== nothing && haskey(instruc.json_lookup_cache, v.column._as)
+    return _render_json_lookup_comparison(v, column, instruc)
+  end
   if isa(v.values, SQLTypeF)
     @pormg_debug false
     # F expressions are safe since they reference model fields    

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -176,8 +176,37 @@ function _apply_many_to_many_branch(
   return (tb_alias, row_join, foreign_model, last_field)
 end
 
+# #27: validate JSON path key segments fail-closed. A segment is either a non-negative integer
+# (JSON array index) or a safe identifier (SAFE_IDENTIFIER_PATTERN — the same contract as SQL
+# identifiers). Anything else (spaces, dots, quotes, braces, empty) is rejected, so the validated
+# segments are safe to interpolate into the path literal. Returns the segments unchanged.
+function _validate_json_key_segments(segments::Vector{String})::Vector{String}
+  for seg in segments
+    if occursin(r"^\d+$", seg) || occursin(SAFE_IDENTIFIER_PATTERN, seg)
+      continue
+    end
+    throw(_argerr("Invalid JSON key segment \e[31m$(seg)\e[0m in a JSON path lookup. Segments must be a non-negative integer (array index) or a simple key (letters, digits, underscore). Keys with spaces, dots, or quotes are not addressable via the `__` path syntax."))
+  end
+  return segments
+end
+
+# #27: render a JSON path lookup (e.g. `payload__driver`, `payload__0__name`) as a TEXT extraction
+# on the resolved column. The base field is a non-terminal JSONField, so the trailing segments are
+# a value path, not join hops. Records the resolved path in json_lookup_cache (so the filter-render
+# branch binds the RHS as plain text) and tab_field_cache (so downstream sees the base field type).
+function _render_json_lookup(instruct::SQLInstruction, alias::String, json_field::PormGField,
+    field_name::String, key_segments::Vector{String}, full_field::Vector{String})::String
+  segs = _validate_json_key_segments(key_segments)
+  col = string(quote_identifier(alias, instruct.connection), ".",
+               quote_identifier(Models.field_db_column(json_field, field_name), instruct.connection))
+  path = join(full_field, "__")
+  instruct.json_lookup_cache[path] = (json_field, segs)
+  instruct.tab_field_cache[path] = json_field
+  return Dialect._json_extract_expr(instruct.connection, col, segs)
+end
+
 function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bool=true)
-  vector = copy(field) 
+  vector = copy(field)
   foreign_table_name::Union{String, PormGModel, Nothing} = nothing
   foreing_table_module::Module = instruct.object.model._module::Module
   row_join = sizehint!(Dict{String, Union{String, Vector{FilterType}}}(), 8)
@@ -188,6 +217,17 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
   last_field::Union{Nothing, PormGField} = nothing
   join_path = field[1]
   m2m_inserted = false
+
+  # #27: a non-terminal JSON base field is a value extraction (`payload__key`, `payload__0__name`),
+  # not a join hop. Fire before the CTE/FK cascade — otherwise `payload` enters the forward-FK
+  # branch and crashes in `_determine_join_type` (a JSONField has no `.how`). A TERMINAL JSON field
+  # (length == 1) is left to resolve as a plain jsonb column (the target of the containment operators).
+  if haskey(instruct.object.model.fields, first_column) &&
+     Models.is_json_field(instruct.object.model.fields[first_column]) &&
+     length(vector) > 1
+    return _render_json_lookup(instruct, instruct.alias,
+      instruct.object.model.fields[first_column], first_column, String.(vector[2:end]), field)
+  end
 
   # Check if first_column references a CTE table
   if haskey(instruct.object.ctes, vector[1])
@@ -368,6 +408,13 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     join_path = join(field[1:length(field)-length(vector) + 1], "__")
     new_object = foreign_table_name isa PormGModel ? foreign_table_name : getfield(foreing_table_module, foreign_table_name |> Symbol)
     first_column = _resolve_django_join_field(new_object, vector[1], instruct)
+
+    # #27: a non-terminal JSON field reached through FK joins (e.g. `fk__payload__key`) is a value
+    # extraction on the joined table's alias, not a further hop. size(vector) > 1 here, so the
+    # trailing segments are a JSON path.
+    if haskey(new_object.fields, first_column) && Models.is_json_field(new_object.fields[first_column])
+      return _render_json_lookup(instruct, tb_alias, new_object.fields[first_column], first_column, String.(vector[2:end]), field)
+    end
 
     # Create a new Dict for this join to avoid mutating previously inserted joins
     prev_how = row_join["how"]

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -71,6 +71,11 @@ end
   row_path::Vector{String} = [] # array of path to map the row_join (model__model__ etc)
   # array_join::Array{String, 2} = Array{String, 2}(undef, 30, 8) # array to be used in join query (meaby the best way to do this)
   tab_field_cache::Dict{String,PormGField} = sizehint!(Dict{String,PormGField}(), 12) # cache to be used in join query
+  # #27: records each resolved JSON-lookup path (e.g. "payload__driver") → (JSON base field,
+  # validated key segments). Set when the JSON-path gate renders an extraction; read by the
+  # filter-render branch to bind the RHS as plain text (not through the JSON formater) and to
+  # reject containment operators on a nested key path.
+  json_lookup_cache::Dict{String,Tuple{PormGField,Vector{String}}} = Dict{String,Tuple{PormGField,Vector{String}}}()
   connection::ConnType = nothing
   # array_defs::SQLTypeArrays = SQLArrays()
   cache::Dict{String,SQLTypeField} = sizehint!(Dict{String,SQLTypeField}(), 12)

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -52,6 +52,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Advisory Locks"               begin include("test_advisorylock.jl")       end
     @testset "Having (Aggregates)"          begin include("test_having.jl")             end
     @testset "Field Validation DB Tests"    begin include("test_field_validation_db_roundtrip.jl") end
+    @testset "JSON/JSONB Lookups (#27)"      begin include("test_json_fields.jl")         end
     @testset "Django Data-Type Contracts"   begin include("test_django_contract.jl")    end
     @testset "Importer / Introspection"     begin include("test_importers_introspection.jl") end
     # ── Phase 4: Internals & Security ────────────────────────────────

--- a/test/integration/test_json_fields.jl
+++ b/test/integration/test_json_fields.jl
@@ -1,0 +1,129 @@
+"""
+Integration round-trips for JSON/JSONB path lookups and containment operators (#27).
+
+Reuses the existing `Field_validation_scratch.payload` JSONField (no schema migration). Seeds one
+row with a nested payload, then exercises:
+  - JSON path lookups (BOTH backends): equality, array-index, numeric comparison, `.values()`
+    projection, `__@isnull` on a missing key, and a non-matching negative.
+  - JSON containment operators (PostgreSQL ONLY — SQLite has no equivalent): @>, ?, ?|, ?&.
+
+Result-driven: every assertion checks that the right row is (or is not) returned, so a wrong
+extraction path or operator fails the test rather than silently returning nothing.
+"""
+
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+# Active backend: the JSON containment operators are PostgreSQL-only.
+_json_backend_is_pg() = PormG.config[PORMG_DB_FOLDER].connections isa PormG.PormGPostgres
+
+@testset "JSON/JSONB lookups and operators (#27)" begin
+    slug = "json27-scratch-seed"
+    seeded = Dict(
+        "driver" => "hamilton",
+        "points" => 15,
+        "active" => true,
+        "standings" => [Dict("name" => "Max"), Dict("name" => "Lewis")],
+    )
+
+    # Clean any stale row, then seed exactly one.
+    cleanup = M.Field_validation_scratch.objects
+    cleanup.filter("slug" => slug)
+    cleanup.exists() && cleanup.delete()
+
+    M.Field_validation_scratch.objects.create(
+        "uuid_token" => string(UUIDs.uuid4()),
+        "canonical_url" => "https://example.com/json27",
+        "slug" => slug,
+        "payload" => seeded,
+    )
+
+    # Narrow every query to the seeded row so counts are deterministic regardless of other data.
+    base = () -> (q = M.Field_validation_scratch.objects; q.filter("slug" => slug); q)
+
+    try
+        # ── JSON path lookups (both backends) ────────────────────────────────
+        @testset "path lookups (both dialects)" begin
+            # equality on a top-level key
+            q = base(); q.filter("payload__driver" => "hamilton")
+            @test q.count() == 1
+
+            # equality that must NOT match (negative discriminates a broken extraction)
+            q = base(); q.filter("payload__driver" => "norris")
+            @test q.count() == 0
+
+            # equality on a NUMERIC JSON value — SQLite json_extract returns a native number, so the
+            # RHS must bind native (5=5), not text (5='5' → 0 rows). Regression for the type bug.
+            q = base(); q.filter("payload__points" => 15)
+            @test q.count() == 1
+            q = base(); q.filter("payload__points" => 99)
+            @test q.count() == 0
+
+            # array index + nested key: standings[0].name == "Max"
+            q = base(); q.filter("payload__standings__0__name" => "Max")
+            @test q.count() == 1
+            q = base(); q.filter("payload__standings__1__name" => "Max")
+            @test q.count() == 0     # standings[1].name is "Lewis"
+
+            # numeric comparison (PG casts ::numeric; SQLite native)
+            q = base(); q.filter("payload__points__@gte" => 10)
+            @test q.count() == 1
+            q = base(); q.filter("payload__points__@gte" => 100)
+            @test q.count() == 0
+
+            # __@isnull on a MISSING key → extraction is NULL → matches
+            q = base(); q.filter("payload__missing__@isnull" => true)
+            @test q.count() == 1
+            q = base(); q.filter("payload__driver__@isnull" => true)
+            @test q.count() == 0     # present key is NOT null
+
+            # .values() projection returns the extracted value
+            q = base(); q.values("payload__driver")
+            row = q.list() |> first
+            @test string(row[:payload__driver]) == "hamilton"
+
+            # order_by on a JSON path executes on BOTH backends (the DB-free unit test cannot reach
+            # the SQLite ORDER BY path — it trips the #75 version probe on a mock — so a real
+            # connection covers that clause-path here).
+            q = base(); q.values("id", "payload__driver"); q.order_by("payload__driver")
+            ordered = q.list()
+            @test length(ordered) == 1
+            @test string(ordered[1][:payload__driver]) == "hamilton"
+        end
+
+        # ── JSON containment operators (PostgreSQL only) ─────────────────────
+        if _json_backend_is_pg()
+            @testset "containment operators (PostgreSQL)" begin
+                q = base(); q.filter("payload__@has_key" => "driver")
+                @test q.count() == 1
+                q = base(); q.filter("payload__@has_key" => "nope")
+                @test q.count() == 0
+
+                q = base(); q.filter("payload__@jcontains" => Dict("driver" => "hamilton"))
+                @test q.count() == 1
+                q = base(); q.filter("payload__@jcontains" => Dict("driver" => "norris"))
+                @test q.count() == 0
+
+                q = base(); q.filter("payload__@has_any_keys" => ["driver", "nope"])
+                @test q.count() == 1
+                q = base(); q.filter("payload__@has_any_keys" => ["nope1", "nope2"])
+                @test q.count() == 0
+
+                q = base(); q.filter("payload__@has_keys" => ["driver", "points"])
+                @test q.count() == 1
+                q = base(); q.filter("payload__@has_keys" => ["driver", "nope"])
+                @test q.count() == 0
+            end
+        else
+            @testset "containment operators throw on SQLite" begin
+                q = base(); q.filter("payload__@has_key" => "driver")
+                @test_throws ArgumentError q.count()
+            end
+        end
+    finally
+        cleanup = M.Field_validation_scratch.objects
+        cleanup.filter("slug" => slug)
+        cleanup.exists() && cleanup.delete()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,8 @@ end
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
+    @testset "JSON Path Lookups (#27)" include("unit/test_json_lookups.jl")
+    @testset "JSON Containment Operators (#27)" include("unit/test_json_operators.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")

--- a/test/unit/test_json_lookups.jl
+++ b/test/unit/test_json_lookups.jl
@@ -1,0 +1,222 @@
+"""
+Unit coverage for JSON/JSONB path lookups (#27): `filter("payload__key" => …)`,
+`payload__0__name` (array index), nested paths, numeric comparisons, `__@isnull`, projection,
+and ORDER BY — with deterministic per-dialect SQL and parameter checks (no live database).
+
+A non-terminal JSONField in a `__` path is a value **extraction**, not a join hop:
+  - PostgreSQL: `<col> #>> '{seg,…}'` (text[] path; numeric segment = array index).
+  - SQLite:     `json_extract(<col>, '\$.seg[0]…')`.
+Extraction is TEXT; comparisons bind the RHS as plain text, and `<`/`>` cast the extracted text to
+numeric on PostgreSQL (`#>>` always yields text) while SQLite's `json_extract` returns native types.
+
+Key segments are validated fail-closed and interpolated (NOT parameterized) so the resolved
+selector carries no placeholder — see test_parameters.jl for the cross-clause bucket-alignment guard.
+
+Sibling coverage:
+  - `test_json_operators.jl` → the PostgreSQL-only containment operators (@>, ?, ?|, ?&).
+  - `test/integration/test_json_fields.jl` → round-trip against the real `payload` JSONField.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+struct JsonLookupMockSQLite <: PormG.PormGSQLite end
+struct JsonLookupMockPostgres <: PormG.PormGPostgres end
+const _JL_SL = JsonLookupMockSQLite()
+const _JL_PG = JsonLookupMockPostgres()
+
+PormG.config["json_lookup_mock"] = PormG.Configuration.Settings(
+  connections = _JL_SL, change_data = true, db_def_folder = "json_lookup_mock",
+)
+
+# Inline model with a JSONField (dedicated key/module so this file is collision-safe in runtests).
+module JsonLookupModels
+import PormG
+import PormG.Models
+Json_scratch = Models.Model("json_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(),
+  payload = Models.JSONField(null = true),
+)
+PormG.Models.set_models(@__MODULE__, "json_lookup_mock")
+end
+
+const JL = JsonLookupModels
+import PormG.QueryBuilder: inspect_query
+
+# Resolve a query's SQL under a specific dialect (default = mock SQLite).
+_sql(q; conn = nothing) = (conn === nothing ? inspect_query(q) : inspect_query(q; connection = conn))
+
+@testset "JSON path lookups (#27)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Equality lookup — the core `payload__key => value` shape on both dialects
+  # PG extracts via `#>>` (text[] path), SQLite via `json_extract` (JSONPath); the RHS binds as a
+  # single plain-text parameter (NOT through the JSON formater, which would reject "hamilton").
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "equality: payload__nome => value (both dialects)" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__nome" => "hamilton"); q.values("id"); q)
+
+    sl = _sql(mkq())
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.nome') = ?", sl[:sql_text])
+    @test sl[:parameters] == ["hamilton"]
+
+    pg = _sql(mkq(); conn = _JL_PG)
+    @test occursin("\"Tb\".\"payload\" #>> '{\"nome\"}' = \$1", pg[:sql_text])   # keys quoted in the path
+    @test pg[:parameters] == ["hamilton"]
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Numeric VALUE equality binds dialect-appropriately (regression for the SQLite type bug)
+  # SQLite json_extract returns a native number, so `payload__n => 5` must bind the native Int 5
+  # (5 = 5), NOT the text "5" (which SQLite evaluates 5 = '5' → false → wrong rows). PostgreSQL
+  # `#>>` yields text, so it binds "5" (text = text).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "numeric value equality binds native on SQLite, text on PG" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__count" => 5); q.values("id"); q)
+    @test _sql(mkq())[:parameters] == [5]              # SQLite: native Int 5
+    @test _sql(mkq(); conn = _JL_PG)[:parameters] == ["5"]   # PG: text "5"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Nested path + array index — `payload__standings__0__name`
+  # A numeric segment is a JSON array index on both dialects: PG `{standings,0,name}`,
+  # SQLite `$.standings[0].name`.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "nested + array index path" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__standings__0__name" => "Max"); q.values("id"); q)
+
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.standings[0].name') = ?", _sql(mkq())[:sql_text])
+    @test occursin("\"Tb\".\"payload\" #>> '{\"standings\",0,\"name\"}' = \$1", _sql(mkq(); conn = _JL_PG)[:sql_text])
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Numeric comparison — PostgreSQL casts the extracted text to numeric; SQLite does not
+  # `#>>` always yields text, so `>=` needs `::numeric`. SQLite json_extract returns native types.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "numeric comparison casts on PG, not SQLite" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__count__@gte" => 5); q.values("id"); q)
+
+    sl = _sql(mkq())
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.count') >= ?", sl[:sql_text])
+    @test !occursin("::numeric", sl[:sql_text])          # SQLite: no cast
+    @test sl[:parameters] == [5]
+
+    pg = _sql(mkq(); conn = _JL_PG)
+    @test occursin("(\"Tb\".\"payload\" #>> '{\"count\"}')::numeric >= \$1", pg[:sql_text])   # PG: cast
+    @test pg[:parameters] == [5]
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # __@isnull on a JSON path — IS NULL / IS NOT NULL, no parameter
+  # Rendered directly (the shared ISNULL() rejects any column containing "(", which a legitimate
+  # SQLite json_extract(...) expression trips).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "__@isnull renders IS NULL on both dialects" begin
+    mk(v) = (q = JL.Json_scratch.objects; q.filter("payload__opt__@isnull" => v); q.values("id"); q)
+
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.opt') IS NULL", _sql(mk(true))[:sql_text])
+    @test occursin("\"Tb\".\"payload\" #>> '{\"opt\"}' IS NULL", _sql(mk(true); conn = _JL_PG)[:sql_text])
+    @test occursin("IS NOT NULL", _sql(mk(false))[:sql_text])
+    @test _sql(mk(true))[:parameters] == []   # presence check binds no parameter
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Projection + ORDER BY on a JSON path — alias is the dotted path; reuses the resolved selector
+  # (SELECT asserted on SQLite; ORDER BY on PG — a mock SQLite trips the #75 version probe in the
+  # ORDER BY path, unrelated to JSON. The JSON-path resolution itself is dialect-independent.)
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset ".values() projection alias on a JSON path (SQLite)" begin
+    q = JL.Json_scratch.objects
+    q.values("id", "payload__nome")
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.nome') as \"payload__nome\"", _sql(q)[:sql_text])
+  end
+
+  @testset "order_by on a JSON path resolves the extraction (PG)" begin
+    q = JL.Json_scratch.objects
+    q.values("id")
+    q.order_by("payload__nome")
+    @test occursin(r"ORDER BY\s+\"Tb\".\"payload\" #>> '\{\"nome\"\}'", _sql(q; conn = _JL_PG)[:sql_text])
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # A key literally named `null` is quoted in the PG path so it isn't parsed as an array-literal
+  # NULL element (which would make `#>>` return NULL for every row).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "reserved-looking key is quoted in the PG path" begin
+    q = JL.Json_scratch.objects
+    q.filter("payload__null" => "x")
+    q.values("id")
+    @test occursin("\"Tb\".\"payload\" #>> '{\"null\"}'", _sql(q; conn = _JL_PG)[:sql_text])
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Fail-closed key validation — segments are interpolated (not parameterized), so anything
+  # outside the safe charset (space, dot, quote, brace, paren) must be rejected with the specific
+  # "Invalid JSON key segment" error, proving the interpolation can't be broken out of.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "invalid key segments are rejected fail-closed" begin
+    for bad in ("payload__bad key", "payload__a.b", "payload__x\")", "payload__x'}")
+      q = JL.Json_scratch.objects
+      q.filter(bad => "x")
+      q.values("id")
+      @test_throws "Invalid JSON key segment" inspect_query(q)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # `!=` (@ne) uses the same dialect-aware RHS binding as `=`; an unsupported operator is rejected
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "@ne binds native/text per dialect; unsupported operator rejected" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__count__@ne" => 5); q.values("id"); q)
+    sl = _sql(mkq())
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$.count') != ?", sl[:sql_text])
+    @test sl[:parameters] == [5]                          # SQLite: native
+    @test _sql(mkq(); conn = _JL_PG)[:parameters] == ["5"]   # PG: text
+
+    # A string/LIKE operator on a JSON path is not a supported comparison → clear error.
+    q = JL.Json_scratch.objects; q.filter("payload__nome__@startswith" => "ham"); q.values("id")
+    @test_throws "not supported on a JSON path lookup" inspect_query(q)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # PG projection alias (SQLite projection is covered above; this closes the other dialect)
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "PG .values() projection alias on a JSON path" begin
+    q = JL.Json_scratch.objects
+    q.values("id", "payload__nome")
+    @test occursin("\"Tb\".\"payload\" #>> '{\"nome\"}' as \"payload__nome\"", _sql(q; conn = _JL_PG)[:sql_text])
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # A numeric segment is an ARRAY INDEX on both dialects — the documented PG/SQLite divergence for
+  # numeric OBJECT keys (SQLite `[n]` is array-only; PG `{n}` may also resolve an object key).
+  # Pinned as SQL shape so the divergence is intentional and visible, not a silent surprise.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "numeric segment renders as an array index (documented divergence)" begin
+    mkq() = (q = JL.Json_scratch.objects; q.filter("payload__2024__revenue" => "x"); q.values("id"); q)
+    @test occursin("json_extract(\"Tb\".\"payload\", '\$[2024].revenue')", _sql(mkq())[:sql_text])   # SQLite: array subscript
+    @test occursin("\"Tb\".\"payload\" #>> '{2024,\"revenue\"}'", _sql(mkq(); conn = _JL_PG)[:sql_text])  # PG: bare element
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # SQLite bucket alignment (the Option-B design guard)
+  # The same JSON path appears in .values() (:select) AND .filter() (:where). The resolved
+  # extraction is cached and reused verbatim across clauses; because the keys are interpolated
+  # (NOT parameterized), the cached selector carries NO placeholder, so the positional `?`
+  # parameters stay perfectly aligned. Parameterizing the path (rejected design) would push a `?`
+  # into the :select bucket that the :where reuse cannot account for, shifting every later param.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "same JSON path in values() + filter(): SQLite bucket alignment" begin
+    q = JL.Json_scratch.objects
+    q.values("id", "payload__nome")           # :select
+    q.filter("payload__nome" => "hamilton")   # :where
+    insp = _sql(q)                            # SQLite (positional ?)
+    @test count(==('?'), insp[:sql_text]) == length(insp[:parameters])   # placeholders == params
+    @test insp[:parameters] == ["hamilton"]
+    @test insp[:parameter_buckets][:where] == ["hamilton"]
+    @test insp[:parameter_buckets][:select] == []   # the SELECT extraction bound no parameter
+  end
+
+end

--- a/test/unit/test_json_operators.jl
+++ b/test/unit/test_json_operators.jl
@@ -1,0 +1,137 @@
+"""
+Unit coverage for the PostgreSQL-only JSONB containment/overlap operators (#27):
+`__@jcontains` (@>), `__@has_key` (?), `__@has_any_keys` (?|), `__@has_keys` (?&).
+
+These are PostgreSQL-only (SQLite has no equivalent): the SQLite renderer throws a friendly
+ArgumentError, mirroring the `iunaccent_*` precedent. The RHS binds per operator — a jsonb
+document (`::jsonb`) for @>, a text key for ?, a text[] key array for ?|/?&. LibPQ binds `\$N`
+placeholders, so a literal `?`/`?|`/`?&` in the SQL is the operator, not a bind marker.
+
+Sibling coverage: `test_json_lookups.jl` (both-dialect path lookups); `test/integration/test_json_fields.jl`.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+struct JsonOpMockSQLite <: PormG.PormGSQLite end
+struct JsonOpMockPostgres <: PormG.PormGPostgres end
+const _JO_SL = JsonOpMockSQLite()
+const _JO_PG = JsonOpMockPostgres()
+
+PormG.config["json_operator_mock"] = PormG.Configuration.Settings(
+  connections = _JO_PG, change_data = true, db_def_folder = "json_operator_mock",
+)
+
+module JsonOperatorModels
+import PormG
+import PormG.Models
+Json_op_scratch = Models.Model("json_op_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(),                 # a non-JSON field, to test the operator's type guard
+  payload = Models.JSONField(null = true),
+)
+PormG.Models.set_models(@__MODULE__, "json_operator_mock")
+end
+
+const JO = JsonOperatorModels
+import PormG.QueryBuilder: inspect_query
+
+# Default dialect is mock Postgres (the operators are PG-only).
+_pg(q) = inspect_query(q; connection = _JO_PG)
+
+@testset "JSONB containment/overlap operators (#27)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # PostgreSQL SQL shape + bound parameter for each operator
+  # @> binds a jsonb document; ? a text key; ?|/?& a text[] key array.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "PostgreSQL renders @>, ?, ?|, ?& with the right bound value" begin
+    # @> (jcontains) with a Dict → serialized jsonb document, cast ::jsonb
+    q = JO.Json_op_scratch.objects; q.filter("payload__@jcontains" => Dict("nome" => "hamilton")); q.values("id")
+    r = _pg(q)
+    @test occursin("\"Tb\".\"payload\" @> \$1::jsonb", r[:sql_text])
+    @test r[:parameters] == ["{\"nome\":\"hamilton\"}"]
+
+    # ? (has_key) with a single key → text
+    q = JO.Json_op_scratch.objects; q.filter("payload__@has_key" => "nome"); q.values("id")
+    r = _pg(q)
+    @test occursin("\"Tb\".\"payload\" ? \$1", r[:sql_text])
+    @test r[:parameters] == ["nome"]
+
+    # ?| (has_any_keys) with a key array → text[]
+    q = JO.Json_op_scratch.objects; q.filter("payload__@has_any_keys" => ["nome", "team"]); q.values("id")
+    r = _pg(q)
+    @test occursin("\"Tb\".\"payload\" ?| \$1::text[]", r[:sql_text])
+    @test r[:parameters] == [["nome", "team"]]
+
+    # ?& (has_keys) with a key array → text[]
+    q = JO.Json_op_scratch.objects; q.filter("payload__@has_keys" => ["nome", "team"]); q.values("id")
+    r = _pg(q)
+    @test occursin("\"Tb\".\"payload\" ?& \$1::text[]", r[:sql_text])
+    @test r[:parameters] == [["nome", "team"]]
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # jcontains accepts Dict / Vector / NamedTuple / raw JSON string — all serialize identically
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "jcontains accepts Dict / Vector / NamedTuple / JSON string" begin
+    mk(v) = (q = JO.Json_op_scratch.objects; q.filter("payload__@jcontains" => v); q.values("id"); q)
+    @test _pg(mk(Dict("a" => 1)))[:parameters]         == ["{\"a\":1}"]
+    @test _pg(mk([1, 2, 3]))[:parameters]              == ["[1,2,3]"]
+    @test _pg(mk((a = 1,)))[:parameters]               == ["{\"a\":1}"]
+    @test _pg(mk("{\"a\":1}"))[:parameters]            == ["{\"a\":1}"]     # raw JSON string passes through
+    # a raw JSON string is passed through VERBATIM (validated, not re-canonicalized) — whitespace kept
+    @test _pg(mk("{ \"a\" : 1 }"))[:parameters]        == ["{ \"a\" : 1 }"]
+    # an invalid JSON string is rejected at build time (format_json_sql validates)
+    @test_throws ArgumentError _pg(mk("not json"))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # PostgreSQL-only: every operator throws a friendly error on SQLite
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "SQLite rejects all four operators" begin
+    for (suffix, val) in [("has_key", "nome"), ("jcontains", Dict("a" => 1)),
+                          ("has_any_keys", ["a", "b"]), ("has_keys", ["a", "b"])]
+      q = JO.Json_op_scratch.objects
+      q.filter("payload__@$(suffix)" => val)
+      q.values("id")
+      # message-match so an unrelated ArgumentError can't masquerade as the PG-only guard
+      @test_throws "requires PostgreSQL" inspect_query(q; connection = _JO_SL)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Type guard: an operator on a non-JSON column is rejected
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "operator on a non-JSON field is rejected" begin
+    q = JO.Json_op_scratch.objects
+    q.filter("name__@has_key" => "x")          # `name` is a CharField
+    q.values("id")
+    @test_throws ArgumentError _pg(q)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Scope guard: a containment operator on a NESTED key path is rejected (v1)
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "operator on a nested key path is rejected (v1)" begin
+    q = JO.Json_op_scratch.objects
+    q.filter("payload__meta__@has_key" => "x")
+    q.values("id")
+    @test_throws ArgumentError _pg(q)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Shape guard: ?| / ?& require an array of keys, not a scalar
+  # A scalar reaches the array branch and would otherwise bind a malformed text[] — reject clearly.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "has_any_keys / has_keys require an array" begin
+    for suffix in ("has_any_keys", "has_keys")
+      q = JO.Json_op_scratch.objects
+      q.filter("payload__@$(suffix)" => "single")   # scalar, not a vector
+      q.values("id")
+      @test_throws ArgumentError _pg(q)
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary

Closes #27. Adds JSON/JSONB query support on `JSONField` columns — the two remaining checkboxes on the issue.

### JSON path lookups (both backends)

Reach into a stored document with a `__` path; a numeric segment is an **array index**. Text extraction — PostgreSQL `#>>`, SQLite `json_extract`.

```julia
M.Constructor.objects.filter("metadata__principal" => "Toto Wolff")
M.Constructor.objects.filter("metadata__drivers__0__name" => "Russell")   # array index
M.Constructor.objects.filter("metadata__wins__@gte" => 100)               # numeric comparison
M.Constructor.objects.filter("metadata__sponsor__@isnull" => true)        # missing key → NULL
M.Constructor.objects.values("name", "metadata__principal")               # projection
```

Supported comparisons: `=`, `@ne`, `@gt`/`@gte`/`@lt`/`@lte`, `@isnull`. Also works in `.values()` and `.order_by()`.

### Containment / overlap operators (PostgreSQL only)

Apply to a JSON **column**; on SQLite they raise a friendly `ArgumentError`.

| Lookup | JSONB op | Meaning |
|---|---|---|
| `@jcontains` | `@>` | Column contains the given document |
| `@has_key` | `?` | Top-level key exists |
| `@has_any_keys` | `?\|` | Any of the given keys exists |
| `@has_keys` | `?&` | All of the given keys exist |

## Design

A non-terminal `JSONField` in a `__` path is a value **extraction**, not a join hop (gate in `_build_row_join`). JSON path keys are validated **fail-closed** (letters/digits/underscore, or an integer array index) and **interpolated — not parameterized** — so the resolved selector carries no placeholder and SQLite's per-clause parameter buckets stay aligned when the same path appears in both `.values()` and `.filter()`. RHS values are bound parameters, dialect-aware: PostgreSQL `#>>` yields text (bind text), SQLite `json_extract` returns native types (bind native) so numeric equality is correct on both. Non-numeric PG path keys are quoted so a key named `null` isn't parsed as an array-literal keyword.

## Review

Two adversarial agents (correctness + tests/cross-dialect):
- **3 correctness fixes** — SQLite numeric-comparison type mismatch (HIGH), `?|`/`?&` scalar guard, PG `null`-key quoting.
- **6 hardening items** — numeric-key divergence doc+test, both-dialect projection/order_by coverage, message-matched rejects, `@ne`/unsupported-op tests, raw-JSON-string pass-through.

## Verification

| Check | Result |
|---|---|
| Full unit suite | **3044 / 3044** |
| Integration — PostgreSQL (db_2) | **21/21** |
| Integration — SQLite (db_sl) | **14/14** |

## Out of scope

jsonb-typed extraction/equality, `<@`/`#-`/`jsonb_set`, JSON writes/partial updates, keys with spaces/dots/quotes via `__`, numeric object keys, and SQLite emulation of the containment operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)