### PR TITLE
feat(#126): surface the pool acquire timeout as a connection.yml `pool_timeout`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,47 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Configurable pool acquire timeout (`pool_timeout`)
+
+- **PormG ref**: issue #126 (follow-up to #37) ; `src/ConnectionPool.jl`, `src/Configuration.jl`
+- **Recorded**: 2026-07-16
+- **Severity**: new feature — **additive, opt-in**. **No action needed**; zero behavior change unless
+  `pool_timeout` is set.
+
+### What changed
+
+The connection-pool acquire timeout was only reachable as a per-call kwarg
+(`acquire_connection(pool; timeout_seconds=…)`), which normal ORM users never touch. You can now set a
+default per pool in `connection.yml` (seconds; fractional allowed; absent = the historical 30 s):
+
+```yaml
+dev:
+  adapter: PostgreSQL
+  database: 'formula1'
+  pool_size: 10
+  pool_timeout: 5      # give up after 5s waiting for a connection → PoolTimeoutError
+```
+
+Stored on the pool struct and used as the default in `acquire_connection`; an explicit per-call
+`timeout_seconds` still wins. `Configuration.register_connection` accepts the same `pool_timeout` kwarg.
+A value `≤ 0` falls back to the 30 s default. See [Advanced Configuration](docs/src/configuration/advanced.md).
+
+### How to find the calls to migrate
+
+Nothing to grep — purely additive, off by default. **Optional adoption:** set `pool_timeout` in
+`connection.yml` for services that should fail fast rather than block a request when the pool is saturated.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | — | optional — set pool_timeout to fail fast under saturation |
+| app-2 | — | — |
+| app-3 | — | — |
+| app-4 | — | — |
+
+---
+
 ## Idle-connection reaping + max-lifetime (opt-in)
 
 - **PormG ref**: issue #125 (follow-up to #37) ; `src/ConnectionPool.jl`, `src/Configuration.jl`

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -15,6 +15,17 @@ dev:
   # ...
   pool_size: 10   # base 10 → grows to 100 under burst
 ```
+- **Acquire timeout (`pool_timeout`):** How long `acquire_connection` waits for a free connection before raising `PoolTimeoutError` — default **30 s**. Set `pool_timeout:` in `connection.yml` (seconds; fractional allowed) to *fail fast* instead of blocking a request while the pool is saturated:
+
+  ```yaml
+  dev:
+    adapter: PostgreSQL
+    database: 'formula1'
+    pool_size: 10
+    pool_timeout: 5   # give up after 5s waiting for a connection, then raise PoolTimeoutError
+  ```
+
+  An explicit per-call `acquire_connection(pool; timeout_seconds=…)` still overrides it, and `Configuration.register_connection` accepts the same `pool_timeout` kwarg. A value `≤ 0` falls back to the 30 s default (a "never wait" setting is ambiguous and a footgun). Absent means the historical 30 s — zero behavior change.
 - **Idle reaping & max-lifetime (opt-in):** By default the pool never shrinks after a burst and reuses connections indefinitely (a dropped connection is caught reactively by the liveness check on the next checkout). For long-lived services — or databases/proxies that drop idle connections — you can enable a background reaper via `connection.yml` (both in **seconds**, `0`/absent = off):
 
   ```yaml

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -231,6 +231,17 @@ function _build_connection_pool!(settings::SQLConn, path::String)
   pool_size = haskey(settings.db_config_settings, "pool_size") ?
               parse(Int, string(settings.db_config_settings["pool_size"])) : 3
 
+  # Default acquire timeout (#126), seconds; absent = 30. Values <= 0 fall back to 30 (a "never wait"
+  # setting is ambiguous across frameworks and a footgun), warned once at build.
+  pool_timeout = haskey(settings.db_config_settings, "pool_timeout") ?
+    (let v = settings.db_config_settings["pool_timeout"]
+       v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), 30.0)
+     end) : 30.0
+  if pool_timeout <= 0
+    @warn "pool_timeout must be > 0; using the default 30s" got=pool_timeout
+    pool_timeout = 30.0
+  end
+
   # Optional idle-connection reaping / max-lifetime (#125), in seconds; absent or 0 = off.
   _reap_secs(key) = begin
     haskey(settings.db_config_settings, key) || return 0.0
@@ -272,7 +283,7 @@ function _build_connection_pool!(settings::SQLConn, path::String)
 
     @pormg_debug false
     CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
-    settings.connections = CP.SQLiteConnectionPool(db_path; pool_size=pool_size, split_read_write=sqlite_split_read_write)
+    settings.connections = CP.SQLiteConnectionPool(db_path; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout)
 
   elseif settings.db_config_settings["adapter"] == "PostgreSQL"
     dns = String[]
@@ -298,7 +309,7 @@ function _build_connection_pool!(settings::SQLConn, path::String)
 
     # Use parent module reference to avoid circular dependency during module loading
     CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
-    settings.connections = CP.PostgresConnectionPool(dns_str; pool_size=pool_size)
+    settings.connections = CP.PostgresConnectionPool(dns_str; pool_size=pool_size, pool_timeout=pool_timeout)
 
   else
     adapter = settings.db_config_settings["adapter"]
@@ -596,11 +607,15 @@ end
 Register a new database connection pool dynamically using a connection URL.
 Useful for multi-tenant applications or connecting to dynamic data sources.
 """
-function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0)
+function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = 30)
   # SAFETY: Deny using folder paths as dynamic keys to avoid hijacking static configs
   if isdir(key)
     throw(ArgumentError("Cannot register dynamic connection using key '$(key)'. Folder paths are reserved for static configurations loaded via 'load()'."))
   end
+
+  # Default acquire timeout (#126); <= 0 falls back to 30 (see _build_connection_pool!).
+  pool_timeout = pool_timeout > 0 ? Float64(pool_timeout) :
+    (@warn "pool_timeout must be > 0; using the default 30s" got=pool_timeout; 30.0)
 
   if haskey(config, key)
     existing = config[key]
@@ -624,15 +639,16 @@ function register_connection(key::String, url::String; adapter::String = "Postgr
     "pool_size" => pool_size,
     "sqlite_split_read_write" => sqlite_split_read_write,
     "idle_timeout" => idle_timeout,
-    "max_lifetime" => max_lifetime
+    "max_lifetime" => max_lifetime,
+    "pool_timeout" => pool_timeout
   )
 
   CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
 
   if adapter == "PostgreSQL"
-    settings.connections = CP.PostgresConnectionPool(url; pool_size=pool_size)
+    settings.connections = CP.PostgresConnectionPool(url; pool_size=pool_size, pool_timeout=pool_timeout)
   elseif adapter == "SQLite"
-    settings.connections = CP.SQLiteConnectionPool(url; pool_size=pool_size, split_read_write=sqlite_split_read_write)
+    settings.connections = CP.SQLiteConnectionPool(url; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout)
   else
     throw(ArgumentError("Unsupported adapter: $adapter"))
   end

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -97,6 +97,7 @@ mutable struct PostgresConnectionPool <: PormGPostgres
   available::Vector{Bool}
   connection_string::String
   pool_size::Int
+  pool_timeout::Float64   # default acquire_connection timeout, seconds (#126; connection.yml `pool_timeout`)
   lock::ReentrantLock  # For thread safety
 end
 
@@ -105,6 +106,7 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
   available::Vector{Bool}
   connection_string::String
   pool_size::Int
+  pool_timeout::Float64   # default acquire_connection timeout, seconds (#126; connection.yml `pool_timeout`)
   split_read_write::Bool
   writer_slot::Int
   reader_cursor::Int
@@ -118,14 +120,14 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
   write_lock::ReentrantLock
 end
 
-function PostgresConnectionPool(connection_string::String; pool_size::Int = 3)
+function PostgresConnectionPool(connection_string::String; pool_size::Int = 3, pool_timeout::Real = 30)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
-  PostgresConnectionPool(connections, available, connection_string, pool_size, lock)
+  PostgresConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), lock)
 end
 
-function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false)
+function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false, pool_timeout::Real = 30)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
@@ -133,8 +135,14 @@ function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, spl
   if split_read_write && !effective_split
     @warn "SQLite split read/write mode requires pool_size > 1; falling back to shared pool" pool_size=pool_size
   end
-  SQLiteConnectionPool(connections, available, connection_string, pool_size, effective_split, 1, 0, lock, ReentrantLock())
+  SQLiteConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), effective_split, 1, 0, lock, ReentrantLock())
 end
+
+# Default acquire timeout (seconds) for a pool. Dispatch + generic fallback so the pool-shaped mock
+# structs (which don't carry `pool_timeout`) resolve to the historical 30 s default with zero changes.
+_pool_timeout(pool::PostgresConnectionPool) = pool.pool_timeout
+_pool_timeout(pool::SQLiteConnectionPool)   = pool.pool_timeout
+_pool_timeout(pool) = 30.0
 
 function _sqlite_is_read_query(sql::String)::Bool
   cleaned = strip(sql)
@@ -437,9 +445,12 @@ end
 # `config` entry) aborts with a `FieldError` the first time it reaches a leaked test mock (#147).
 close_pool!(::Union{PormGPostgres, PormGSQLite}) = nothing
 
-function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_retries::Int = 300)
+function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing, Real} = nothing, max_retries::Int = 300)
   start_time = time()
-  deadline = start_time + timeout_seconds
+  # Default acquire timeout comes from the pool (connection.yml `pool_timeout`, #126); an explicit
+  # per-call `timeout_seconds` still wins.
+  to = timeout_seconds === nothing ? _pool_timeout(pool) : Float64(timeout_seconds)
+  deadline = start_time + to
   # `attempts` counts scan/materialize loop iterations (event-driven wait, not the old 100ms poll),
   # so it is small — typically 1 on a clean saturated timeout. It is a diagnostic field on
   # PoolTimeoutError; `max_retries` still bounds it as a safety limit on pathological create loops.
@@ -548,7 +559,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
       if attempts >= max_retries
         @warn "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
       else
-        @warn "Timeout after $(timeout_seconds) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
       end
       throw(PoolTimeoutError("PostgreSQL", pool.pool_size, ceiling, attempts, time() - start_time))
     else # :wait — park until a connection is handed to us or the deadline elapses.
@@ -560,7 +571,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
         close(timer)
       end
       if handed === _POOL_WAIT_TIMEOUT
-        @warn "Timeout after $(timeout_seconds) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
         throw(PoolTimeoutError("PostgreSQL", pool.pool_size, ceiling, attempts, time() - start_time))
       end
       owned = handed::Int                                # loop back to materialize the handed slot
@@ -569,11 +580,14 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Int = 30, max_
   end
 end
 
-function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_retries::Int = 300, mode::Symbol = :any)
+function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, Real} = nothing, max_retries::Int = 300, mode::Symbol = :any)
   mode in (:any, :read, :write) || throw(ArgumentError("Invalid SQLite acquire mode: $(mode). Expected :any, :read or :write."))
 
   start_time = time()
-  deadline = start_time + timeout_seconds
+  # Default acquire timeout comes from the pool (connection.yml `pool_timeout`, #126); an explicit
+  # per-call `timeout_seconds` still wins.
+  to = timeout_seconds === nothing ? _pool_timeout(pool) : Float64(timeout_seconds)
+  deadline = start_time + to
   attempts = 0
   # See the PormGPostgres twin: hook runs off the lock at most once; `owned` is a slot handed to
   # us (leased) awaiting materialize; direct-handoff wait replaces the busy-poll (#124).
@@ -675,7 +689,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
     elseif kind === :timeout
       @warn (attempts >= max_retries ?
         "Exceeded maximum retry attempts ($max_retries) to acquire SQLite connection" :
-        "Timeout after $(timeout_seconds) seconds waiting for available SQLite connection") pool_size=pool.pool_size connection_string=pool.connection_string
+        "Timeout after $(to) seconds waiting for available SQLite connection") pool_size=pool.pool_size connection_string=pool.connection_string
       throw(PoolTimeoutError("SQLite", pool.pool_size, ceiling, attempts, time() - start_time))
     else # :wait
       w = outcome[2]
@@ -686,7 +700,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Int = 30, max_re
         close(timer)
       end
       if handed === _POOL_WAIT_TIMEOUT
-        @warn "Timeout after $(timeout_seconds) seconds waiting for available SQLite connection" pool_size=pool.pool_size connection_string=pool.connection_string
+        @warn "Timeout after $(to) seconds waiting for available SQLite connection" pool_size=pool.pool_size connection_string=pool.connection_string
         throw(PoolTimeoutError("SQLite", pool.pool_size, ceiling, attempts, time() - start_time))
       end
       owned = handed::Int

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,6 +9,7 @@ import Logging
     Bool[],
     "dummy_connection_string",
     0,
+    30.0,   # pool_timeout (#126)
     ReentrantLock()
   )
 

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -288,3 +288,56 @@ end
         _cleanup_configuration_test_keys([key_off])
     end
 end
+
+# Config-wiring for the acquire timeout (#126): both user entry points — `connection.yml pool_timeout`
+# and `register_connection(...; pool_timeout=…)` — set the pool's `pool_timeout` field (the default that
+# `acquire_connection` reads). DB-free: pools construct lazily, so assert the field directly.
+@testset "pool_timeout config wiring sets the pool default (#126)" begin
+    # (1) connection.yml path via _build_connection_pool!.
+    mktempdir() do temp_root
+        db_dir = joinpath(temp_root, "db")
+        mkpath(db_dir)
+        open(joinpath(db_dir, "connection.yml"), "w") do f
+            write(f,
+                "test:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  pool_timeout: 7\n" *
+                "  config:\n" *
+                "    change_db: true\n" *
+                "    change_data: true\n")
+        end
+
+        PormG.Configuration.load(db_dir; env="test")
+        pool = PormG.Configuration.get_settings(db_dir).connections
+        @test pool.pool_timeout == 7.0             # yaml key set the pool default
+        _cleanup_configuration_test_keys([db_dir])
+    end
+
+    # (2) register_connection kwarg sets the dynamic pool's default.
+    key_set = "ptimeout_set_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_set, ":memory:"; adapter="SQLite", pool_timeout=8)
+        @test PormG.config[key_set].connections.pool_timeout == 8.0
+    finally
+        _cleanup_configuration_test_keys([key_set])
+    end
+
+    # (3) absent key → the historical 30 s default (back-compat).
+    key_def = "ptimeout_def_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_def, ":memory:"; adapter="SQLite")
+        @test PormG.config[key_def].connections.pool_timeout == 30.0
+    finally
+        _cleanup_configuration_test_keys([key_def])
+    end
+
+    # (4) a <= 0 value falls back to the 30 s default (footgun guard).
+    key_neg = "ptimeout_neg_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_neg, ":memory:"; adapter="SQLite", pool_timeout=-1)
+        @test PormG.config[key_neg].connections.pool_timeout == 30.0
+    finally
+        _cleanup_configuration_test_keys([key_neg])
+    end
+end

--- a/test/unit/test_connection_pool_timeout.jl
+++ b/test/unit/test_connection_pool_timeout.jl
@@ -66,3 +66,66 @@ const CP = PormG.ConnectionPool
     isfile(tmp) && rm(tmp; force = true)
   end
 end
+
+# ============================================================
+# #126 — the acquire timeout is configurable via the pool (connection.yml `pool_timeout`), not just
+# the per-call kwarg. Same saturate-to-ceiling harness as #37; the discriminator is TIMING: with the
+# pool default applied, the starved 11th acquire times out fast; without the fix it would fall back to
+# the 30 s hard default and effectively hang. An explicit per-call `timeout_seconds` must still win.
+# ============================================================
+
+# Fill `pool` to its ceiling and hold every connection (none released). Returns the held handles.
+function _saturate_to_ceiling!(pool)
+  held = Any[]
+  for _ in 1:(pool.pool_size * CP.POOL_EXPANSION_FACTOR)
+    push!(held, CP.acquire_connection(pool))
+  end
+  return held
+end
+
+@testset "config pool_timeout drives the acquire default (#126)" begin
+  # (1) A short pool_timeout is the DEFAULT for acquire (no per-call timeout_seconds passed).
+  tmp = tempname() * ".sqlite"
+  pool = CP.SQLiteConnectionPool(tmp; pool_size = 1, pool_timeout = 0.5)
+  held = Any[]
+  try
+    held = _saturate_to_ceiling!(pool)
+    @test length(held) == 10
+
+    t0 = time()
+    err = try
+      CP.acquire_connection(pool)      # NO timeout_seconds → must use the pool's 0.5s default
+      nothing
+    catch e; e end
+    elapsed = time() - t0
+
+    @test err isa PormG.PoolTimeoutError
+    @test elapsed < 10.0               # discriminator: the 0.5s pool default drove it, NOT the 30s hard default
+    @test elapsed >= 0.3               # and it actually waited roughly the configured window
+  finally
+    for c in held; try; CP.release_connection(pool, c); catch; end; end
+    try; CP.close_pool!(pool); catch; end
+    isfile(tmp) && rm(tmp; force = true)
+  end
+
+  # (2) An explicit per-call timeout_seconds overrides a large pool default.
+  tmp2 = tempname() * ".sqlite"
+  pool2 = CP.SQLiteConnectionPool(tmp2; pool_size = 1, pool_timeout = 60.0)   # would hang for a minute…
+  held2 = Any[]
+  try
+    held2 = _saturate_to_ceiling!(pool2)
+    t0 = time()
+    err = try
+      CP.acquire_connection(pool2; timeout_seconds = 0.5)   # …but the explicit 0.5s wins
+      nothing
+    catch e; e end
+    elapsed = time() - t0
+
+    @test err isa PormG.PoolTimeoutError
+    @test elapsed < 10.0               # explicit kwarg overrode the 60s pool default
+  finally
+    for c in held2; try; CP.release_connection(pool2, c); catch; end; end
+    try; CP.close_pool!(pool2); catch; end
+    isfile(tmp2) && rm(tmp2; force = true)
+  end
+end


### PR DESCRIPTION
Closes #126 (follow-up to #37 — completes the pool-config surface after the #37/#124/#125 trilogy).

## Problem

The connection-pool acquire timeout was only reachable as a **per-call kwarg** — `acquire_connection(pool; timeout_seconds=30)` — which a normal ORM user going through `fetch` / `M.Model.objects` never touches (both call `acquire_connection` with the bare defaults). The only override anywhere was the internal health-check ping. So there was no way to say "fail fast after 5 s," the way every other pooling framework allows.

**Framework survey:** every pooling framework exposes a checkout/acquire timeout as config — SQLAlchemy `pool_timeout` (30 s), Rails `checkout_timeout` (5 s), HikariCP `connectionTimeout` (30 s), node-postgres `connectionTimeoutMillis`, Ecto `queue_target`/`queue_interval`. **None exposes a retry budget** — modern pools are event-driven (PormG became so in #124).

## What changed (opt-in, zero behavior change when unset)

A `pool_timeout` key in `connection.yml` (seconds; fractional allowed) sets the default acquire timeout per pool:

```yaml
dev:
  adapter: PostgreSQL
  database: 'formula1'
  pool_size: 10
  pool_timeout: 5      # give up after 5s waiting for a connection → PoolTimeoutError
```

- **Stored on the pool struct**, read via a dispatch-based accessor `_pool_timeout(pool)` with a generic fallback → `30.0`, so the 10 pool-shaped **mock structs need zero changes** (cleaner than a 3rd `WeakKeyDict`).
- `acquire_connection`'s `timeout_seconds` kwarg now defaults to `nothing` and resolves to the pool default; an **explicit per-call value still wins** (the health-check `=5` path is unchanged). Applied **identically to PG and SQLite**.
- **Absent → 30 s** (matches SQLAlchemy/HikariCP; the historical default) → back-compat. A value **`≤ 0` falls back to 30 s** with a warning (a "never wait" setting is ambiguous across frameworks and a footgun).
- `Configuration.register_connection` accepts the same `pool_timeout` kwarg.
- **`max_retries` stays internal-only** — post-#124 it's a vestigial safety cap (`attempts ≈ 1` at a genuine timeout); no framework surfaces it.
- Fixes the one **positional** `PostgresConnectionPool(...)` construction (`src/precompile.jl`) that the new field would otherwise break.

## Tests

- **`test_connection_pool_timeout.jl`** (#37 file, +1 testset): same saturate-to-ceiling harness; a short `pool_timeout` drives the acquire default (no per-call kwarg) and the starved acquire times out fast — the discriminator that the *config* default was applied, not the 30 s hard default; a large pool default with an explicit small `timeout_seconds` still times out fast (explicit override wins).
- **`test_configuration_api.jl`** (+1 DB-free testset): `connection.yml pool_timeout` and `register_connection(...; pool_timeout=…)` both set the field; absent → 30, `≤ 0` → 30.

## Verification

| Check | Result |
|---|---|
| Pool family in runtests order (#37/#126 → #124 → #125) | 950 pass |
| Full unit suite | 3967 pass, 0 fail |
| Integration db_2 (PostgreSQL) | 1748 pass, 0 fail |
| Integration db_sl (SQLite) | 1714 pass, 0 fail (+1 pre-existing broken) |
| Docs build | exit 0 |

Docs: `docs/src/configuration/advanced.md` + `UPGRADING.md` (additive/opt-in entry).

A follow-up tech-debt item to consolidate the pool-config parsing and centralize the default is tracked in #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)