### PR TITLE
feat(#127): connection-pool metrics (pool_stats) + opt-in leak detection

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,51 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Pool metrics (`pool_stats`) + leak detection (`leak_detection_threshold`)
+
+- **PormG ref**: issue #127 (follow-up to #37) ; `src/ConnectionPool.jl`, `src/Configuration.jl`, `src/PormG.jl`
+- **Recorded**: 2026-07-16
+- **Severity**: new feature — **additive, opt-in**. **No action needed**; `pool_stats` is a new exported
+  name, and leak detection is off unless configured.
+
+### What changed
+
+Two observability additions to the connection pool:
+
+- **`pool_stats`** (newly exported) — a health snapshot `(; pool_size, size, in_use, available, ceiling, waiting)`.
+  Call it with a pool object or a connection key: `pool_stats("db")`.
+- **`leak_detection_threshold`** in `connection.yml` (seconds; `0`/absent = off) — warns once when a
+  connection is held past the threshold without release (a likely un-awaited `fetch_async`):
+
+  ```yaml
+  dev:
+    adapter: PostgreSQL
+    database: 'formula1'
+    pool_size: 10
+    leak_detection_threshold: 30
+  ```
+
+  `Configuration.register_connection` accepts the same `leak_detection_threshold` kwarg. Internally, #125's
+  reaping state was generalized into a shared `PoolMonitorState` (leak detection reuses the existing
+  per-slot checkout timestamps) — no behavior change to reaping.
+
+### How to find the calls to migrate
+
+Nothing to grep — purely additive. `pool_stats` is a *new* name; it can only collide if a downstream app
+already defined its own top-level `pool_stats` (unlikely). **Optional adoption:** set
+`leak_detection_threshold` in long-lived services to catch un-released connections early.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | — | optional — set leak_detection_threshold; use pool_stats when debugging saturation |
+| app-2 | — | — |
+| app-3 | — | — |
+| app-4 | — | — |
+
+---
+
 ## Configurable pool acquire timeout (`pool_timeout`)
 
 - **PormG ref**: issue #126 (follow-up to #37) ; `src/ConnectionPool.jl`, `src/Configuration.jl`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -643,6 +643,9 @@ scope — the SQL function constructors are *not* among them (see
 ### Locking
 `with_advisory_lock`
 
+### Connection pool
+`pool_stats`, `PoolTimeoutError`
+
 ### Utilities & lifecycle
 `setup`, `install_ai_skills`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
 

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -38,6 +38,25 @@ dev:
   ```
 
   Reaping is **overflow-only** and never drops below the base `pool_size` (those stay warm), and never closes an in-use connection. It closes the connection and clears its slot in place — the pool's slot layout is unchanged, so a reaped slot simply opens a fresh connection on next use. Disabled by default: unset means zero behavior change. Programmatic pools accept the same `idle_timeout` / `max_lifetime` kwargs via `Configuration.register_connection`.
+- **Health snapshot (`pool_stats`):** `pool_stats` (exported) returns a `NamedTuple` for debugging saturation — pass a pool object or a connection key/path:
+
+  ```julia
+  using PormG
+  pool_stats("db")   # => (; pool_size, size, in_use, available, ceiling, waiting)
+  ```
+
+  `pool_size` is the configured floor, `size` the slots allocated so far (`== in_use + available`), `ceiling` the maximum (`pool_size × 10`), and `waiting` the callers currently parked for a connection — a non-zero `waiting` with `in_use == ceiling` is the signature of saturation (see `PoolTimeoutError`). Counts are read under the pool lock for a coherent snapshot.
+- **Leak detection (`leak_detection_threshold`, opt-in):** A connection acquired but never released (e.g. a `fetch_async` that's never awaited) is silently lost until the pool starves. Set `leak_detection_threshold` (**seconds**, `0`/absent = off) to have `acquire_connection` emit a single `@warn` — naming the slot and hold time — when a connection has been held past the threshold:
+
+  ```yaml
+  dev:
+    adapter: PostgreSQL
+    database: 'formula1'
+    pool_size: 10
+    leak_detection_threshold: 30   # warn when a connection is held > 30s without release
+  ```
+
+  The scan runs on the next `acquire_connection` (no background task), so a leak is flagged as the pool comes under pressure — pointing at the offending slot just before a `PoolTimeoutError`. Off by default; `register_connection` accepts the same `leak_detection_threshold` kwarg.
 - **Thread Safety:** PormG uses `ReentrantLock` for pool management.
 - **Failed-rollback self-healing:** If a transaction's `ROLLBACK` itself fails (e.g. the connection died mid-transaction), the pool never returns that connection as-is. It is renewed in its slot (PostgreSQL: `LibPQ.reset!`; SQLite: a fresh handle, with the old one closed so it releases the database file write-lock) or — if renewal also fails — closed and its slot cleared so the next borrower opens a fresh connection.
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -250,6 +250,8 @@ function _build_connection_pool!(settings::SQLConn, path::String)
   end
   idle_timeout = _reap_secs("idle_timeout")
   max_lifetime = _reap_secs("max_lifetime")
+  # Optional connection-leak detection (#127), in seconds; absent or 0 = off.
+  leak_detection_threshold = _reap_secs("leak_detection_threshold")
 
   sqlite_split_read_write = false
   if haskey(settings.db_config_settings, "sqlite_split_read_write")
@@ -316,10 +318,15 @@ function _build_connection_pool!(settings::SQLConn, path::String)
     throw(ArgumentError("Unsupported adapter: $(adapter)"))
   end
 
-  # Opt the pool into idle-reaping / max-lifetime if configured (#125). No-op when both are 0.
-  if idle_timeout > 0 || max_lifetime > 0
+  # Opt the pool into idle-reaping / max-lifetime (#125) and/or leak detection (#127) if configured.
+  # No-op when the respective keys are 0/absent. Both merge into one PoolMonitorState.
+  reap_on = idle_timeout > 0 || max_lifetime > 0
+  if reap_on || leak_detection_threshold > 0
     CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
-    CP.enable_reaping!(settings.connections; idle_timeout=idle_timeout, max_lifetime=max_lifetime)
+    reap_on &&
+      CP.enable_reaping!(settings.connections; idle_timeout=idle_timeout, max_lifetime=max_lifetime)
+    leak_detection_threshold > 0 &&
+      CP.enable_leak_detection!(settings.connections; threshold=leak_detection_threshold)
   end
 
   return settings
@@ -607,7 +614,7 @@ end
 Register a new database connection pool dynamically using a connection URL.
 Useful for multi-tenant applications or connecting to dynamic data sources.
 """
-function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = 30)
+function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = 30, leak_detection_threshold::Real = 0)
   # SAFETY: Deny using folder paths as dynamic keys to avoid hijacking static configs
   if isdir(key)
     throw(ArgumentError("Cannot register dynamic connection using key '$(key)'. Folder paths are reserved for static configurations loaded via 'load()'."))
@@ -640,7 +647,8 @@ function register_connection(key::String, url::String; adapter::String = "Postgr
     "sqlite_split_read_write" => sqlite_split_read_write,
     "idle_timeout" => idle_timeout,
     "max_lifetime" => max_lifetime,
-    "pool_timeout" => pool_timeout
+    "pool_timeout" => pool_timeout,
+    "leak_detection_threshold" => leak_detection_threshold
   )
 
   CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
@@ -653,9 +661,11 @@ function register_connection(key::String, url::String; adapter::String = "Postgr
     throw(ArgumentError("Unsupported adapter: $adapter"))
   end
 
-  # Opt into idle-reaping / max-lifetime if configured (#125). No-op when both are 0.
+  # Opt into idle-reaping / max-lifetime (#125) and/or leak detection (#127) if configured. No-ops when 0.
   (idle_timeout > 0 || max_lifetime > 0) &&
     CP.enable_reaping!(settings.connections; idle_timeout=idle_timeout, max_lifetime=max_lifetime)
+  leak_detection_threshold > 0 &&
+    CP.enable_leak_detection!(settings.connections; threshold=leak_detection_threshold)
 
   config[key] = settings
   return key

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -15,6 +15,7 @@ export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, atomic, with_savepoint
 export acquire_connection, release_connection, finalize_transaction_connection!
 export PoolTimeoutError
+export pool_stats
 # NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
 # `close_pool!` (it dispatches on a pool OR a db-name String and delegates the pool case to
 # this module's `close_pool!`). Exporting it from both modules made `PormG.close_pool!`
@@ -251,8 +252,9 @@ function _pool_wait_timeout!(pool, w::PoolWaiter)
   return nothing
 end
 
-# ── Idle reaping + max-lifetime (#125) ───────────────────────────────────────
-# Opt-in (connection.yml `idle_timeout`/`max_lifetime`, seconds; 0 = off). A global background sweeper
+# ── Pool monitor: idle reaping + max-lifetime (#125) + leak detection (#127) ─────────────────────────
+# One per-slot state store shared by two opt-in features. Reaping (#125): connection.yml
+# `idle_timeout`/`max_lifetime`, seconds; 0 = off. A global background sweeper
 # closes OVERFLOW connections (slot index > pool_size) that sat idle-available beyond `idle_timeout` or
 # are older than `max_lifetime`, trimming the pool back toward its base `pool_size`. Reaping closes +
 # nils the slot IN PLACE (keeps available[i]=true, NEVER deleteat!), so #124's slot-index handoff and
@@ -264,53 +266,82 @@ mutable struct ReapConfig
   max_lifetime::Float64   # seconds; 0 = off
 end
 
-# Per-pool reaping state, index-aligned (append-only) with pool.connections. Lives OUTSIDE the pool
-# structs (in `_POOL_REAP`) so mock pools without these fields are unaffected — same rationale as
+# Per-pool MONITOR state, index-aligned (append-only) with pool.connections. Lives OUTSIDE the pool
+# structs (in `_POOL_MONITOR`) so mock pools without these fields are unaffected — same rationale as
 # #124's `_POOL_WAITERS`. Mutated only inside the pool's own lock (keeps it aligned with connections).
-mutable struct ReapState
-  config::ReapConfig
-  created_at::Vector{Float64}   # when the connection now in slot i was opened
-  last_used::Vector{Float64}    # when slot i was last checked out / returned
+# Shared by reaping (#125) and leak detection (#127): `last_used[i]` is written on checkout and again on
+# return, so for a LEASED slot it is that slot's checkout instant — exactly what leak detection needs, so
+# leak detection reuses it (no separate timestamp store, no parallel checkout hooks).
+mutable struct PoolMonitorState
+  config::ReapConfig            # idle_timeout / max_lifetime (#125)
+  leak_threshold::Float64       # seconds; 0 = off (#127)
+  created_at::Vector{Float64}   # when the connection now in slot i was opened (#125)
+  last_used::Vector{Float64}    # when slot i was last checked out / returned (== checkout time while leased)
+  leak_warned::Vector{Bool}     # already warned for slot i's current lease (#127)
 end
 
-const _POOL_REAP = WeakKeyDict{Any, ReapState}()   # populated ONLY by enable_reaping!
-const _POOL_REAP_LOCK = ReentrantLock()
-# Fast path: false (default — no pool opted in) → every touch hook returns immediately. Monotonic:
-# set true by the first `enable_reaping!`, never cleared. Lock order: pool.lock → _POOL_REAP_LOCK.
-const _REAP_ANY = Threads.Atomic{Bool}(false)
+const _POOL_MONITOR = WeakKeyDict{Any, PoolMonitorState}()   # populated ONLY by enable_reaping!/enable_leak_detection!
+const _POOL_MONITOR_LOCK = ReentrantLock()
+# Fast path: false (default — no pool opted in) → every hook returns immediately. Monotonic: set true by
+# the first enable_reaping!/enable_leak_detection!, never cleared. Lock order: pool.lock → _POOL_MONITOR_LOCK.
+const _MONITOR_ANY = Threads.Atomic{Bool}(false)
 const _REAP_INTERVAL = 15.0   # seconds between background sweeps (fixed)
 
-# The pool's ReapState, or nothing when reaping is globally off / this pool never opted in.
-function _reap_state(pool)::Union{ReapState, Nothing}
-  _REAP_ANY[] || return nothing
-  Base.lock(() -> get(_POOL_REAP, pool, nothing), _POOL_REAP_LOCK)
+# The pool's PoolMonitorState, or nothing when monitoring is globally off / this pool never opted in.
+function _monitor_state(pool)::Union{PoolMonitorState, Nothing}
+  _MONITOR_ANY[] || return nothing
+  Base.lock(() -> get(_POOL_MONITOR, pool, nothing), _POOL_MONITOR_LOCK)
+end
+
+# Get-or-create the pool's monitor state (empty = all features off, vectors sized to the current pool).
+# Both enable_reaping! and enable_leak_detection! go through this so a later opt-in MERGES into the same
+# state instead of overwriting the other's config. Sizing AND registration happen inside ONE pool.lock
+# critical section (nested per the documented order pool.lock → _POOL_MONITOR_LOCK): the pool cannot
+# grow between reading `length(pool.connections)` and registering the state, so a concurrent expand's
+# `_monitor_note_create!` can never be lost — no slot is born untracked.
+function _monitor_state_for!(pool)::PoolMonitorState
+  Base.lock(pool.lock) do
+    Base.lock(_POOL_MONITOR_LOCK) do
+      st = get(_POOL_MONITOR, pool, nothing)
+      st === nothing || return st
+      n = length(pool.connections)
+      t = time()
+      st = PoolMonitorState(ReapConfig(0.0, 0.0), 0.0, fill(t, n), fill(t, n), fill(false, n))
+      _POOL_MONITOR[pool] = st
+      return st
+    end
+  end
 end
 
 # Record that slot i just received a freshly-opened connection: grow the vectors in lockstep with a
 # path-C push!, or reset timestamps for a reused/materialized slot. Call UNDER pool.lock.
-function _reap_note_create!(pool, i::Int)
-  st = _reap_state(pool); st === nothing && return
+function _monitor_note_create!(pool, i::Int)
+  st = _monitor_state(pool); st === nothing && return
   t = time()
   # Grow in lockstep (normally by exactly one). Gap entries are filled `fresh` (t), never 0.0, so an
   # accidental gap can never read as "ancient" and trigger a spurious max-lifetime retire.
   while length(st.last_used) < i
-    push!(st.last_used, t); push!(st.created_at, t)
+    push!(st.last_used, t); push!(st.created_at, t); push!(st.leak_warned, false)
   end
-  st.created_at[i] = t; st.last_used[i] = t
+  st.created_at[i] = t; st.last_used[i] = t; st.leak_warned[i] = false
   return nothing
 end
 
-# Record that slot i was just checked out or returned. Call UNDER pool.lock.
-function _reap_note_touch!(pool, i::Int)
-  st = _reap_state(pool); st === nothing && return
-  i <= length(st.last_used) && (st.last_used[i] = time())
+# Record that slot i was just checked out or returned: bump last_used and clear the leak warn so the
+# next lease starts fresh. Call UNDER pool.lock.
+function _monitor_note_touch!(pool, i::Int)
+  st = _monitor_state(pool); st === nothing && return
+  if i <= length(st.last_used)
+    st.last_used[i] = time()
+    st.leak_warned[i] = false
+  end
   return nothing
 end
 
 # Should the connection being RETURNED to slot i be retired now (max-lifetime, overflow only)?
 # Call UNDER pool.lock.
 function _reap_should_retire(pool, i::Int)::Bool
-  st = _reap_state(pool); st === nothing && return false
+  st = _monitor_state(pool); st === nothing && return false
   st.config.max_lifetime > 0 && i > pool.pool_size && i <= length(st.created_at) &&
     (time() - st.created_at[i]) > st.config.max_lifetime
 end
@@ -320,18 +351,66 @@ end
 
 Opt a pool into idle-connection reaping / max-lifetime (#125). `idle_timeout`/`max_lifetime` are in
 seconds; `0` (the default) leaves that dimension off, and if both are off this is a no-op. Registers
-the pool's `ReapState` and starts the shared background sweeper. Called by `Configuration` after a
-pool is built from `connection.yml`.
+(or updates) the pool's `PoolMonitorState` and starts the shared background sweeper. Called by
+`Configuration` after a pool is built from `connection.yml`.
+
+Re-configuring (calling again, or after `enable_leak_detection!` already registered the state) only
+swaps the reap config — the per-slot clocks are deliberately NOT reset: `created_at`/`last_used`
+keep measuring the connection's TRUE open / last-use instants, so an overflow connection that is
+already idle or over-lifetime may be retired on the very next sweep rather than being granted a
+fresh grace window from the enable instant. (Pre-#127, each call rebuilt the state with fresh
+timestamps; the unified monitor state keeps the honest clocks instead.)
 """
 function enable_reaping!(pool::Union{PormGPostgres, PormGSQLite}; idle_timeout::Real = 0, max_lifetime::Real = 0)
   (idle_timeout <= 0 && max_lifetime <= 0) && return pool
-  n = Base.lock(() -> length(pool.connections), pool.lock)
-  t = time()
-  st = ReapState(ReapConfig(Float64(idle_timeout), Float64(max_lifetime)), fill(t, n), fill(t, n))
-  Base.lock(() -> (_POOL_REAP[pool] = st), _POOL_REAP_LOCK)
-  _REAP_ANY[] = true
+  st = _monitor_state_for!(pool)
+  st.config = ReapConfig(Float64(idle_timeout), Float64(max_lifetime))   # merge: leak config (if any) preserved
+  _MONITOR_ANY[] = true
   _ensure_reaper!()
   return pool
+end
+
+"""
+    enable_leak_detection!(pool; threshold=0) -> pool
+
+Opt a pool into connection-leak detection (#127). `threshold` is in seconds; `0` (the default) is a
+no-op. When enabled, `acquire_connection` scans the leased slots and emits a single `@warn` per slot
+whose lease has exceeded `threshold` — pointing at a connection that was acquired but never released
+(e.g. a `fetch_async` that was never awaited). Reuses the shared per-slot checkout timestamps
+(`PoolMonitorState.last_used`); no background task (the scan runs on the next acquire).
+"""
+function enable_leak_detection!(pool::Union{PormGPostgres, PormGSQLite}; threshold::Real = 0)
+  threshold <= 0 && return pool
+  st = _monitor_state_for!(pool)
+  st.leak_threshold = Float64(threshold)   # merge: reaping config (if any) preserved
+  _MONITOR_ANY[] = true
+  return pool
+end
+
+# Scan LEASED slots for a lease held past the leak threshold and @warn once per culprit (#127). Directly
+# callable so tests drive it deterministically. `last_used[i]` is the checkout instant for a leased slot,
+# so no separate checkout timestamp is needed.
+function _leak_check!(pool)
+  st = _monitor_state(pool); st === nothing && return
+  st.leak_threshold <= 0 && return
+  now = time()
+  leaked = Tuple{Int, Float64}[]
+  Base.lock(pool.lock) do
+    for i in 1:length(pool.connections)
+      pool.available[i] && continue            # only LEASED (in-use) slots can leak
+      i <= length(st.leak_warned) || continue
+      st.leak_warned[i] && continue            # already warned for this lease
+      held = now - st.last_used[i]
+      if held > st.leak_threshold
+        push!(leaked, (i, held)); st.leak_warned[i] = true
+      end
+    end
+  end
+  # @warn OUTSIDE the pool lock. One actionable line per culprit; connection string redacted per house rules.
+  for (i, held) in leaked
+    @warn "Pool connection held past leak_detection_threshold — likely acquired without release; await the FetchTask or release the connection" slot=i held_s=round(held; digits=1) threshold_s=st.leak_threshold connection_string=redact_secret(pool.connection_string)
+  end
+  return nothing
 end
 
 const _reaper_lock = ReentrantLock()
@@ -359,8 +438,8 @@ end
 
 # Snapshot the registry (releasing its lock before taking any pool.lock), then reap each pool.
 function _reap_all_pools!()
-  pools = Base.lock(() -> collect(keys(_POOL_REAP)), _POOL_REAP_LOCK)
-  for pool in pools                       # a GC'd pool is absent from the WeakKeyDict → _reap_state nothing
+  pools = Base.lock(() -> collect(keys(_POOL_MONITOR)), _POOL_MONITOR_LOCK)
+  for pool in pools                       # a GC'd pool is absent from the WeakKeyDict → _monitor_state nothing
     try
       _reap_pool!(pool)
     catch e
@@ -373,7 +452,7 @@ end
 # Close idle/over-lifetime OVERFLOW connections of one pool. Directly callable so tests drive it
 # deterministically (no waiting on the Timer). Never touches a leased slot or a base slot.
 function _reap_pool!(pool)
-  st = _reap_state(pool); st === nothing && return
+  st = _monitor_state(pool); st === nothing && return
   (st.config.idle_timeout <= 0 && st.config.max_lifetime <= 0) && return
   now = time()
   to_close = Any[]
@@ -399,6 +478,46 @@ function _reap_pool!(pool)
     end
   end
   return nothing
+end
+
+# The single source of truth for the pool's growth ceiling — used by both acquire_connection
+# twins (PoolTimeoutError enforcement) and pool_stats (reporting), so they can never diverge.
+_pool_ceiling(pool)::Int = pool.pool_size * POOL_EXPANSION_FACTOR
+
+"""
+    pool_stats(pool) -> NamedTuple
+
+A snapshot of connection-pool health (#127), driver-agnostic. Returns
+`(; pool_size, size, in_use, available, ceiling, waiting)`:
+
+- `pool_size` — the configured base floor (warm minimum).
+- `size` — slots allocated so far (grows lazily under load; `== in_use + available`).
+- `in_use` — connections leased right now.
+- `available` — free slots (idle handles or not-yet-materialized slots).
+- `ceiling` — the maximum the pool can grow to (`pool_size * $(POOL_EXPANSION_FACTOR)`).
+- `waiting` — callers currently parked waiting for a connection (#124).
+
+Safe to call anytime; all counts — including `waiting` — are read in one `pool.lock` critical
+section for a coherent snapshot (waiter vectors are only ever mutated under `pool.lock`, #124).
+`PormG`'s top module adds a `pool_stats(key::AbstractString)` convenience overload. Unlike
+`close_pool!(db::String)` — a teardown that tolerates a never-built pool — that overload throws an
+`ArgumentError` for a never-built pool: a zeroed snapshot would read as a healthy empty pool.
+"""
+function pool_stats(pool::Union{PormGPostgres, PormGSQLite})
+  in_use, available, size, waiting = Base.lock(pool.lock) do
+    # Dict lookup under _POOL_WAITERS_LOCK (lock order pool.lock → _POOL_WAITERS_LOCK); the waiter
+    # Vector itself is only ever mutated under pool.lock, which we hold — so counting it here is
+    # race-free AND coherent with the slot counts.
+    ws = Base.lock(() -> get(_POOL_WAITERS, pool, PoolWaiter[]), _POOL_WAITERS_LOCK)
+    (count(!, pool.available), count(identity, pool.available), length(pool.connections),
+     count(w -> !w.done, ws))
+  end
+  return (; pool_size = pool.pool_size,
+            size,
+            in_use,
+            available,
+            ceiling = _pool_ceiling(pool),
+            waiting)
 end
 
 function close_pool!(pool::PostgresConnectionPool)
@@ -451,6 +570,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
   # per-call `timeout_seconds` still wins.
   to = timeout_seconds === nothing ? _pool_timeout(pool) : Float64(timeout_seconds)
   deadline = start_time + to
+  _MONITOR_ANY[] && _leak_check!(pool)   # leak detection (#127): warn about connections held past the threshold
   # `attempts` counts scan/materialize loop iterations (event-driven wait, not the old 100ms poll),
   # so it is small — typically 1 on a clean saturated timeout. It is a diagnostic field on
   # PoolTimeoutError; `max_retries` still bounds it as a safety limit on pathological create loops.
@@ -461,7 +581,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
   # A slot handed to us by a release/discard (leased for us) that still needs its connection
   # validated/materialized. `nothing` when we are doing a normal scan.
   owned::Union{Nothing, Int} = nothing
-  ceiling = pool.pool_size * POOL_EXPANSION_FACTOR
+  ceiling = _pool_ceiling(pool)
 
   while true
     attempts += 1
@@ -472,7 +592,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
         i = owned
         conn = pool.connections[i]
         if conn !== nothing && backend_is_alive(pool, conn)
-          _reap_note_touch!(pool, i)                   # checkout timestamp (#125)
+          _monitor_note_touch!(pool, i)                   # checkout timestamp (#125)
           return (:got, conn)                          # live handle handed over — reuse as-is
         end
         # Empty/dead slot (e.g. handed off by _discard_connection!): open a fresh connection.
@@ -480,7 +600,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
         try
           new_conn = backend_connect(pool)
           pool.connections[i] = new_conn
-          _reap_note_create!(pool, i)                  # fresh connection timestamp (#125)
+          _monitor_note_create!(pool, i)                  # fresh connection timestamp (#125)
           return (:got, new_conn)
         catch e
           @error "Failed to materialize handed-off PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
@@ -494,7 +614,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
         if pool.available[i]
           if pool.connections[i] !== nothing && backend_is_alive(pool, pool.connections[i])
             pool.available[i] = false
-            _reap_note_touch!(pool, i)                  # checkout timestamp (#125)
+            _monitor_note_touch!(pool, i)                  # checkout timestamp (#125)
             return (:got, pool.connections[i])
           end
           # Slot is empty or dead: defer creation so the before_connect hook runs off the lock.
@@ -503,7 +623,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
             new_conn = backend_connect(pool)
             pool.connections[i] = new_conn
             pool.available[i] = false
-            _reap_note_create!(pool, i)                 # fresh connection timestamp (#125)
+            _monitor_note_create!(pool, i)                 # fresh connection timestamp (#125)
             return (:got, new_conn)
           catch e
             @error "Failed to create PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
@@ -521,7 +641,7 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
           new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
-          _reap_note_create!(pool, length(pool.connections))   # grow reap vectors in lockstep (#125)
+          _monitor_note_create!(pool, length(pool.connections))   # grow monitor vectors in lockstep (#125)
           new_size = length(pool.connections)
           if new_size == ceiling
             @warn "PG pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
@@ -588,12 +708,13 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
   # per-call `timeout_seconds` still wins.
   to = timeout_seconds === nothing ? _pool_timeout(pool) : Float64(timeout_seconds)
   deadline = start_time + to
+  _MONITOR_ANY[] && _leak_check!(pool)   # leak detection (#127): warn about connections held past the threshold
   attempts = 0
   # See the PormGPostgres twin: hook runs off the lock at most once; `owned` is a slot handed to
   # us (leased) awaiting materialize; direct-handoff wait replaces the busy-poll (#124).
   before_connect_done = false
   owned::Union{Nothing, Int} = nothing
-  ceiling = pool.pool_size * POOL_EXPANSION_FACTOR
+  ceiling = _pool_ceiling(pool)
 
   while true
     attempts += 1
@@ -604,7 +725,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
         i = owned
         conn = pool.connections[i]
         if conn !== nothing && backend_is_alive(pool, conn)
-          _reap_note_touch!(pool, i)                   # checkout timestamp (#125)
+          _monitor_note_touch!(pool, i)                   # checkout timestamp (#125)
           return (:got, conn)
         end
         before_connect_done || return (:hook, nothing)
@@ -612,7 +733,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
           is_reader_slot = pool.split_read_write && i != pool.writer_slot
           new_conn = backend_connect(pool; read_only = is_reader_slot)
           pool.connections[i] = new_conn
-          _reap_note_create!(pool, i)                  # fresh connection timestamp (#125)
+          _monitor_note_create!(pool, i)                  # fresh connection timestamp (#125)
           return (:got, new_conn)
         catch e
           @error "Failed to materialize handed-off SQLite connection $i: $e" connection_string=pool.connection_string
@@ -626,7 +747,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
         if pool.available[i]
           if pool.connections[i] !== nothing && backend_is_alive(pool, pool.connections[i])
             pool.available[i] = false
-            _reap_note_touch!(pool, i)                  # checkout timestamp (#125)
+            _monitor_note_touch!(pool, i)                  # checkout timestamp (#125)
             return (:got, pool.connections[i])
           end
           before_connect_done || return (:hook, nothing)
@@ -635,7 +756,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
             new_conn = backend_connect(pool; read_only = is_reader_slot)
             pool.connections[i] = new_conn
             pool.available[i] = false
-            _reap_note_create!(pool, i)                 # fresh connection timestamp (#125)
+            _monitor_note_create!(pool, i)                 # fresh connection timestamp (#125)
             return (:got, new_conn)
           catch e
             @error "Failed to create SQLite connection $i: $e" connection_string=pool.connection_string
@@ -654,7 +775,7 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
           new_conn = backend_connect(pool)
           push!(pool.connections, new_conn)
           push!(pool.available, false)
-          _reap_note_create!(pool, length(pool.connections))   # grow reap vectors in lockstep (#125)
+          _monitor_note_create!(pool, length(pool.connections))   # grow monitor vectors in lockstep (#125)
           new_size = length(pool.connections)
           if new_size == ceiling
             @warn "SQLite pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=pool.connection_string
@@ -718,7 +839,7 @@ function release_connection(pool::PormGPostgres, conn)
           retired = pool.connections[i]
           pool.connections[i] = nothing
         else
-          _reap_note_touch!(pool, i)       # last_used = now (#125)
+          _monitor_note_touch!(pool, i)       # last_used = now (#125)
         end
         _handoff_or_free!(pool, i)         # hand the slot to a waiter (leased) or mark it available (#124)
         return true
@@ -742,7 +863,7 @@ function release_connection(pool::PormGSQLite, conn)
           retired = pool.connections[i]
           pool.connections[i] = nothing
         else
-          _reap_note_touch!(pool, i)       # last_used = now (#125)
+          _monitor_note_touch!(pool, i)       # last_used = now (#125)
         end
         _handoff_or_free!(pool, i)         # hand the slot to a waiter (leased) or mark it available (#124)
         return true

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -96,6 +96,20 @@ include("tools.jl")
 include("ConnectionPool.jl")
 using .ConnectionPool
 
+# Convenience overload: `pool_stats` by connection key/path (#127). The pool-struct method lives in
+# ConnectionPool; extend the SAME function here, where both it and `Configuration.get_settings` are in
+# scope. `import` (not just the `using` above) is required to add a method rather than shadow the name.
+import .ConnectionPool: pool_stats
+function pool_stats(key::AbstractString)
+  # String(key): get_settings is ::String-only, so a SubString/other AbstractString key would
+  # otherwise die with a raw MethodError instead of resolving. Throwing (rather than the silent
+  # no-op close_pool!(::String) uses for teardown) is deliberate for a stats query: a zeroed
+  # snapshot for a never-built pool would read as a healthy empty pool.
+  pool = Configuration.get_settings(String(key)).connections
+  pool === nothing && throw(ArgumentError("Connection '$(key)' has no pool yet (not built / not connected)."))
+  return pool_stats(pool)
+end
+
 include("Models.jl")
 using .Models
 
@@ -153,6 +167,7 @@ export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, 
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)
+export pool_stats  # connection-pool health snapshot (#127)
 export with_tx_context, in_transaction_context  # Transaction context helpers
 export setup, install_ai_skills
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,8 @@ end
     @testset "Failed COMMIT Holds Conn Until Rollback (#139)" include("unit/test_commit_failure_release.jl")
     @testset "Direct-Handoff Pool Wait (#124)" include("unit/test_connection_pool_handoff.jl")
     @testset "Idle-Reaping + Max-Lifetime Pool (#125)" include("unit/test_connection_pool_reaping.jl")
+    @testset "Pool Stats Snapshot (#127)" include("unit/test_connection_pool_stats.jl")
+    @testset "Connection-Leak Detection (#127)" include("unit/test_connection_pool_leak.jl")
     @testset "Savepoint Naming (#26)" include("unit/test_savepoint_naming.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -234,7 +234,7 @@ end
 # `ConnectionPool.enable_reaping!` and register the pool. DB-free: pools construct lazily (no
 # connection is opened here), so we assert on the registry, never on live reaping.
 @testset "reaping config wiring reaches enable_reaping! (#125)" begin
-    _reap = PormG.ConnectionPool._POOL_REAP
+    _reap = PormG.ConnectionPool._POOL_MONITOR
 
     # (1) connection.yml path via _build_connection_pool!: top-level idle_timeout/max_lifetime keys.
     mktempdir() do temp_root
@@ -258,7 +258,7 @@ end
         @test st !== nothing                       # yaml keys opted the pool in
         @test st.config.idle_timeout == 45.0
         @test st.config.max_lifetime == 900.0
-        @test PormG.ConnectionPool._REAP_ANY[]     # global flag flipped on
+        @test PormG.ConnectionPool._MONITOR_ANY[]     # global flag flipped on
 
         delete!(_reap, pool)
         _cleanup_configuration_test_keys([db_dir])
@@ -339,5 +339,56 @@ end
         @test PormG.config[key_neg].connections.pool_timeout == 30.0
     finally
         _cleanup_configuration_test_keys([key_neg])
+    end
+end
+
+# Config-wiring for leak detection (#127): both entry points reach `enable_leak_detection!`, which
+# registers a PoolMonitorState carrying the leak_threshold. DB-free: assert on the shared registry.
+@testset "leak_detection_threshold config wiring (#127)" begin
+    _mon = PormG.ConnectionPool._POOL_MONITOR
+
+    # (1) connection.yml path via _build_connection_pool!.
+    mktempdir() do temp_root
+        db_dir = joinpath(temp_root, "db")
+        mkpath(db_dir)
+        open(joinpath(db_dir, "connection.yml"), "w") do f
+            write(f,
+                "test:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  leak_detection_threshold: 12\n" *
+                "  config:\n" *
+                "    change_db: true\n" *
+                "    change_data: true\n")
+        end
+        PormG.Configuration.load(db_dir; env="test")
+        pool = PormG.Configuration.get_settings(db_dir).connections
+        st = get(_mon, pool, nothing)
+        @test st !== nothing
+        @test st.leak_threshold == 12.0
+        @test PormG.ConnectionPool._MONITOR_ANY[]
+        delete!(_mon, pool)
+        _cleanup_configuration_test_keys([db_dir])
+    end
+
+    # (2) register_connection kwarg opts the dynamic pool in.
+    key_on = "leak_on_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_on, ":memory:"; adapter="SQLite", leak_detection_threshold=20)
+        pool = PormG.config[key_on].connections
+        st = get(_mon, pool, nothing)
+        @test st !== nothing && st.leak_threshold == 20.0
+        delete!(_mon, pool)
+    finally
+        _cleanup_configuration_test_keys([key_on])
+    end
+
+    # (3) absent / 0 → not registered (default off).
+    key_off = "leak_off_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_off, ":memory:"; adapter="SQLite")
+        @test !haskey(_mon, PormG.config[key_off].connections)
+    finally
+        _cleanup_configuration_test_keys([key_off])
     end
 end

--- a/test/unit/test_connection_pool_leak.jl
+++ b/test/unit/test_connection_pool_leak.jl
@@ -1,0 +1,130 @@
+using Test
+using PormG
+using Logging
+const CP = PormG.ConnectionPool   # match the sibling pool tests' idiom
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Connection-leak detection (#127).
+#
+# DB-free: a file-local mock pool (own struct, no monitor fields → exercises the module-level
+# PoolMonitorState registry). `_leak_check!` is driven DIRECTLY; the shared checkout timestamp in
+# CP._POOL_MONITOR[pool].last_used is backdated to force a "held too long" without sleeping. Covers:
+# warn once past threshold, silent on re-scan (leak_warned), reset + re-warn on a new lease, released
+# slot never warned, below-threshold no warn, disabled = no-op.
+# ─────────────────────────────────────────────────────────────────────────────
+
+mutable struct FakeLeakConn
+  id::Int
+  closed::Bool
+end
+FakeLeakConn(id::Int) = FakeLeakConn(id, false)
+Base.close(c::FakeLeakConn) = (c.closed = true; nothing)
+
+mutable struct MockPGLeak <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+  nid::Int
+end
+MockPGLeak(n::Int) = MockPGLeak(Any[nothing for _ in 1:n], fill(true, n), "mock://pg", n, ReentrantLock(), 0)
+PormG.backend_connect(p::MockPGLeak; kwargs...) = FakeLeakConn(p.nid += 1)
+PormG.backend_is_alive(::MockPGLeak, c) = c isa FakeLeakConn && !c.closed
+
+# Lease one connection and return (conn, slot_index).
+function _lease_one(p)
+  c = CP.acquire_connection(p)
+  return c, findfirst(!, p.available)
+end
+
+@testset "leak: warns once past threshold, silent on re-scan" begin
+  p = MockPGLeak(2)
+  CP.enable_leak_detection!(p; threshold = 1.0)
+  c, i = _lease_one(p)
+  st = CP._POOL_MONITOR[p]
+  st.last_used[i] -= 100.0                       # held ~100s, well past the 1s threshold
+  @test st.leak_warned[i] == false
+
+  @test_logs (:warn, r"leak_detection_threshold") CP._leak_check!(p)
+  @test st.leak_warned[i] == true                # marked, so it won't re-warn
+
+  @test_logs min_level = Logging.Warn CP._leak_check!(p)   # second scan is silent
+
+  CP.release_connection(p, c)
+end
+
+@testset "leak: a new lease resets the warn and can warn again" begin
+  p = MockPGLeak(1)
+  CP.enable_leak_detection!(p; threshold = 1.0)
+  c, i = _lease_one(p)
+  st = CP._POOL_MONITOR[p]
+  st.last_used[i] -= 100.0
+  @test_logs (:warn, r"held") CP._leak_check!(p)
+  CP.release_connection(p, c)                    # touch resets leak_warned[i] = false
+
+  c2, i2 = _lease_one(p)                          # re-lease the same slot
+  @test st.leak_warned[i2] == false               # reset by checkout
+  st.last_used[i2] -= 100.0
+  @test_logs (:warn, r"held") CP._leak_check!(p)  # a genuinely new leak warns again
+  CP.release_connection(p, c2)
+end
+
+@testset "leak: released (free) slot is never warned" begin
+  p = MockPGLeak(2)
+  CP.enable_leak_detection!(p; threshold = 1.0)
+  c, i = _lease_one(p)
+  CP.release_connection(p, c)                    # slot i now free (available[i] == true)
+  st = CP._POOL_MONITOR[p]
+  st.last_used[i] -= 100.0                        # even if its timestamp is ancient…
+  @test_logs min_level = Logging.Warn CP._leak_check!(p)   # …a free slot can't leak → no warn
+end
+
+@testset "leak: below threshold does not warn" begin
+  p = MockPGLeak(1)
+  CP.enable_leak_detection!(p; threshold = 60.0)
+  c, i = _lease_one(p)
+  CP._POOL_MONITOR[p].last_used[i] -= 5.0        # held only 5s, under the 60s threshold
+  @test_logs min_level = Logging.Warn CP._leak_check!(p)
+  CP.release_connection(p, c)
+end
+
+@testset "leak: disabled pool is a no-op" begin
+  p = MockPGLeak(1)                               # never opted in
+  c, _ = _lease_one(p)
+  @test CP._monitor_state(p) === nothing || CP._monitor_state(p).leak_threshold == 0.0
+  @test_logs min_level = Logging.Warn CP._leak_check!(p)   # no state / threshold 0 → no warn, no error
+  CP.release_connection(p, c)
+end
+
+@testset "leak: warn redacts the connection string (never log secrets)" begin
+  p = MockPGLeak(1)
+  p.connection_string = "host=localhost user=bob password=hunter2"   # secret-bearing
+  CP.enable_leak_detection!(p; threshold = 1.0)
+  c, i = _lease_one(p)
+  CP._POOL_MONITOR[p].last_used[i] -= 100.0
+  logs, _ = Test.collect_test_logs(min_level = Logging.Warn) do
+    CP._leak_check!(p)
+  end
+  @test length(logs) == 1
+  cs = String(Dict(logs[1].kwargs)[:connection_string])
+  @test occursin("user=****", cs) && occursin("password=****", cs)   # redacted…
+  @test !occursin("bob", cs) && !occursin("hunter2", cs)             # …and the secrets are gone
+  CP.release_connection(p, c)
+end
+
+@testset "leak→reap merge keeps per-slot clocks (#127 unified monitor state)" begin
+  # enable_leak_detection! creates the state; a LATER enable_reaping! must merge config into the
+  # SAME state without resetting created_at/last_used — the clocks measure true open/last-use
+  # instants (documented in enable_reaping!'s docstring), not time-since-enable.
+  p = MockPGLeak(1)
+  CP.enable_leak_detection!(p; threshold = 5.0)
+  st = CP._POOL_MONITOR[p]
+  st.created_at[1] -= 100.0; st.last_used[1] -= 100.0    # age the slot before reaping opts in
+  before = (st.created_at[1], st.last_used[1])
+  CP.enable_reaping!(p; idle_timeout = 10.0, max_lifetime = 50.0)
+  @test CP._POOL_MONITOR[p] === st                        # merged, not overwritten
+  @test st.config.idle_timeout == 10.0 && st.config.max_lifetime == 50.0
+  @test st.leak_threshold == 5.0                          # leak config preserved
+  @test (st.created_at[1], st.last_used[1]) == before     # clocks NOT reset by the re-config
+end

--- a/test/unit/test_connection_pool_reaping.jl
+++ b/test/unit/test_connection_pool_reaping.jl
@@ -7,7 +7,7 @@ const CP = PormG.ConnectionPool   # match the sibling pool tests' idiom
 #
 # DB-free: mock pools (own struct, no reaping fields → exercises the module-level registry).
 # `_reap_pool!` is driven DIRECTLY (deterministic, no waiting on the background Timer), and
-# timestamps in CP._POOL_REAP[pool] are backdated to force expiry without sleeping. Covers:
+# timestamps in CP._POOL_MONITOR[pool] are backdated to force expiry without sleeping. Covers:
 # idle overflow reaped to base (append-only, base kept, conns closed), leased never reaped,
 # max-lifetime (sweeper + retire-on-return), reaping OFF default (no-op), SQLite split no-op.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ function _expand_and_idle(p, total)
 end
 # Backdate every slot's last_used AND created_at by `secs` so it looks idle/old.
 function _backdate!(p, secs)
-  st = CP._POOL_REAP[p]
+  st = CP._POOL_MONITOR[p]
   for i in 1:length(st.last_used); st.last_used[i] -= secs; st.created_at[i] -= secs; end
 end
 _open_count(p) = count(c -> c !== nothing, p.connections)
@@ -65,8 +65,8 @@ _open_count(p) = count(c -> c !== nothing, p.connections)
 @testset "reaping OFF by default → no-op, pool unregistered" begin
   p = MockPGReap(2)
   held = _expand_and_idle(p, 5)          # 5 open (2 base + 3 overflow)
-  @test !haskey(CP._POOL_REAP, p)        # never opted in
-  @test CP._reap_state(p) === nothing
+  @test !haskey(CP._POOL_MONITOR, p)        # never opted in
+  @test CP._monitor_state(p) === nothing
   CP._reap_pool!(p)                       # must do nothing
   @test _open_count(p) == 5
   @test length(p.connections) == 5
@@ -119,7 +119,7 @@ end
   CP.enable_reaping!(p; max_lifetime = 1.0)
   # Lease an OVERFLOW slot, backdate its created_at, then release → retired on return.
   conns = [CP.acquire_connection(p) for _ in 1:5]     # slots 1..5 leased
-  st = CP._POOL_REAP[p]
+  st = CP._POOL_MONITOR[p]
   st.created_at[5] -= 100.0                            # overflow slot 5 is now over-age
   overflow_conn = conns[5]
   CP.release_connection(p, overflow_conn)

--- a/test/unit/test_connection_pool_stats.jl
+++ b/test/unit/test_connection_pool_stats.jl
@@ -1,0 +1,51 @@
+using Test
+using PormG
+const CP = PormG.ConnectionPool   # match the sibling pool tests' idiom
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public pool_stats snapshot (#127).
+#
+# DB-free: a file-local mock pool with hand-set `available`/`connections` vectors exercises the count
+# expressions directly (no real connections needed). `waiting` reads the #124 `_POOL_WAITERS` registry,
+# so we push PoolWaiters straight into it. Verifies the derived identity size == in_use + available and
+# that only non-done waiters are counted.
+# ─────────────────────────────────────────────────────────────────────────────
+
+mutable struct MockStatsPool <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+end
+
+@testset "pool_stats reports accurate counts" begin
+  # base 3, grown to 4 slots: slot1 leased(open), slot2 free(open idle), slot3 free(nothing),
+  # slot4 leased(open) — an overflow slot.
+  p = MockStatsPool(Any["c1", "c2", nothing, "c4"], Bool[false, true, true, false], "mock://pg", 3, ReentrantLock())
+
+  s = PormG.pool_stats(p)
+  @test s.pool_size == 3
+  @test s.size == 4                         # slots allocated so far
+  @test s.in_use == 2                       # slots 1 and 4 leased
+  @test s.available == 2                    # slots 2 and 3 free
+  @test s.size == s.in_use + s.available    # derived identity
+  @test s.ceiling == 3 * CP.POOL_EXPANSION_FACTOR
+  @test s.waiting == 0                      # no waiters registered
+
+  # waiting counts only non-done #124 waiters parked for this pool.
+  w_live = CP.PoolWaiter(:any)
+  w_done = CP.PoolWaiter(:any); w_done.done = true
+  CP._POOL_WAITERS[p] = [w_live, w_done]
+  try
+    @test PormG.pool_stats(p).waiting == 1   # only the live waiter
+  finally
+    delete!(CP._POOL_WAITERS, p)
+  end
+end
+
+@testset "pool_stats on a fresh, fully-available pool" begin
+  p = MockStatsPool(Any[nothing, nothing], Bool[true, true], "mock://pg", 2, ReentrantLock())
+  s = PormG.pool_stats(p)
+  @test (s.pool_size, s.size, s.in_use, s.available, s.ceiling, s.waiting) == (2, 2, 0, 2, 20, 0)
+end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -19,7 +19,7 @@ const EXPECTED_TOPLEVEL = Set([
     # Query builder
     :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Interval, :show_query, :inspect_query,
     # Rows & exceptions
-    :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError,
+    :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :pool_stats,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API


### PR DESCRIPTION
Closes #127. Follow-up from #37 — adds an observability surface to the connection pool.

## What

- **`pool_stats(pool)` / `pool_stats(key)`** — exported, driver-agnostic snapshot: `(; pool_size, size, in_use, available, ceiling, waiting)`. All counts (including the #124 waiter count) are read in one `pool.lock` critical section for a coherent, race-free snapshot.
- **`enable_leak_detection!(pool; threshold)`** — opt-in, **off by default**. Scans leased slots at the top of `acquire_connection` and emits one structured `@warn` per slot held past the threshold (redacted connection string, no stack trace). No background task — the scan runs on the next acquire, so a leak surfaces as the pool comes under pressure.
- **Unified per-slot state** — generalizes #125's `ReapState` into a shared `PoolMonitorState`, reusing the existing checkout timestamps (`last_used[i]` is the checkout instant for a leased slot). No parallel registry, no duplicated hooks. State is sized **and** registered under `pool.lock`, so a concurrently-grown slot is never born untracked.
- **Config** — `connection.yml` `leak_detection_threshold` (seconds; `0`/absent = off), wired in both `_build_connection_pool!` and `register_connection`.

## Acceptance criteria (#127)

- [x] Public stats accessor with accurate size / in-use / available counts
- [x] Leak detection emits a single actionable `@warn` past the threshold (redacted conn string)
- [x] Zero overhead when leak detection is disabled (guarded by one atomic read)
- [x] PG and SQLite consistent; existing pool tests stay green

## Tests & verification

New DB-free unit suites for `pool_stats` and leak detection (including a redaction assertion and a leak→reap merge clock-preservation regression); reaping suite updated for the rename. Docs: `api.md`, `advanced.md`, `UPGRADING.md`.

- Pool family unit: 972/972
- Full unit suite: 3999/3999
- Docs build: clean
- PG integration (`db_2`): 1748/1748
- SQLite integration (`db_sl`): 1714/1714 (+1 pre-existing `@test_broken`)

A high-effort multi-agent review ran on the diff; all 10 surviving findings were applied (waiter-count lock coherence, `pool_stats(key)` `String` coercion, monitor-registration race, structured leak warn, `_pool_ceiling` dedup, docstring/contract fixes, redaction test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
