### PR TITLE
fix(#182): color-agnostic update_or_create validation-error tests

### DIFF
--- a/.github/skills/pormg-issue-management/SKILL.md
+++ b/.github/skills/pormg-issue-management/SKILL.md
@@ -53,7 +53,7 @@ ones idempotently with `gh label create <name> --color <hex> --description "…"
 | Kind | Labels |
 |------|--------|
 | Type | `enhancement`, `bug`, `documentation`, `tech-debt` |
-| Subsystem | `postgres`, `sqlite`, `migrations`, `cjoin`, `performance`, `infrastructure` |
+| Subsystem | `postgres`, `sqlite`, `migrations`, `cjoin`, `performance`, `infrastructure`, `connection-pool` |
 | Release gating | `pre-publish` (must be settled before the first General-registry publish) |
 
 ## Safety: issues are public and outward-facing

--- a/test/unit/test_update_or_create.jl
+++ b/test/unit/test_update_or_create.jl
@@ -111,7 +111,10 @@ function _uoc_error(f)
     e
   end
   @test err isa ArgumentError
-  return err === nothing ? "" : sprint(showerror, err)
+  # Strip ANSI so the content assertions are color-agnostic: CI runs --color=yes, which bakes the
+  # field-name highlight (\e[4m\e[31m…\e[0m) into the message via _argerr/_emsg. Reuse the repo's own
+  # stripper so the assertions still check the message TEXT (incl. the offending field name), not TTY state.
+  return err === nothing ? "" : PormG._emsg(sprint(showerror, err); color = false)
 end
 
 @testset "update_or_create validation errors" begin


### PR DESCRIPTION
Closes #182. Fixes the red `main` CI (follow-up to #30).

## Problem

The `update_or_create` validation-error tests fail under `--color=yes` (CI), while passing locally (color off). `_uoc_error` compared a plain substring across an ANSI-highlighted field name:

```
occursin("lookup field nope is not a field",
  "…lookup field \e[4m\e[31mnope\e[0m is not a field of dash_dim_cbo")  → false
```

`object_manager.jl` correctly routes these errors through `_argerr`/`_emsg`, which **keep** the highlight when `Base.have_color` is true (CI). So this is a **test-only** bug — the product code is right (color-on-TTY is the intended, separately-tested behavior).

## Fix

Make `_uoc_error` color-agnostic by stripping ANSI through the repo's own helper, preserving the stronger assertion that the offending field name is reported:

```julia
return err === nothing ? "" : PormG._emsg(sprint(showerror, err); color = false)
```

## Also in this PR

`docs(issue-mgmt)`: adds the new `connection-pool` subsystem label to the issue-management skill's taxonomy table. The label was created and applied across the pool series (#37/#124/#125/#126/#127/#72/#179/#128/#47) plus the connection-lifecycle issues (#71/#138/#139/#147), so the whole pool history is now filterable via `gh issue list --label connection-pool --state all`.

## Verification

- Full unit suite under `--color=yes` (reproduces CI): **3999/3999**
- Mechanism confirmed: with `Base.have_color = true`, the old helper yields `false` for the `occursin`, the new helper yields `true` with no escape codes remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
