### PR TITLE
fix(#179): consolidate pool-config parsing + centralize the pool_timeout default

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -2,7 +2,7 @@ module Configuration
 
 import YAML, Logging
 import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
-import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE
+import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
 import PormG: Generator
 import PormG: @pormg_debug
 # Backend generics — driver bodies live in the weakdep extensions (no direct LibPQ/SQLite here).
@@ -226,32 +226,39 @@ function _resolve_loaded_key(path_or_key::String)::Union{Nothing, String}
   return nothing
 end
 
+# Parse a seconds-valued pool setting from connection.yml. Returns `default` when the key is absent OR
+# the value can't be parsed to a Float64. Pure parser — no `> 0` policy; callers pick the default and
+# any enforcement. Consolidates the tryparse idiom for pool_timeout / idle_timeout / max_lifetime /
+# leak_detection_threshold (#179).
+function _config_secs(settings::SQLConn, key::String, default::Float64 = 0.0)::Float64
+  haskey(settings.db_config_settings, key) || return default
+  v = settings.db_config_settings[key]
+  return v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), default)
+end
+
+# Enforce the pool_timeout policy: `<= 0` ("never wait") is a cross-framework footgun, so fall back to
+# DEFAULT_POOL_TIMEOUT and warn once. Shared by both entry points — `_build_connection_pool!` (YAML) and
+# `register_connection` (kwarg) — so the guard and its message live in one place (#126, #179).
+function _normalize_pool_timeout(v::Real)::Float64
+  v > 0 && return Float64(v)
+  @warn "pool_timeout must be > 0; using the default $(DEFAULT_POOL_TIMEOUT)s" got=v
+  return DEFAULT_POOL_TIMEOUT
+end
+
 function _build_connection_pool!(settings::SQLConn, path::String)
   # Extract pool size from config (defaults to 3)
   pool_size = haskey(settings.db_config_settings, "pool_size") ?
               parse(Int, string(settings.db_config_settings["pool_size"])) : 3
 
-  # Default acquire timeout (#126), seconds; absent = 30. Values <= 0 fall back to 30 (a "never wait"
-  # setting is ambiguous across frameworks and a footgun), warned once at build.
-  pool_timeout = haskey(settings.db_config_settings, "pool_timeout") ?
-    (let v = settings.db_config_settings["pool_timeout"]
-       v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), 30.0)
-     end) : 30.0
-  if pool_timeout <= 0
-    @warn "pool_timeout must be > 0; using the default 30s" got=pool_timeout
-    pool_timeout = 30.0
-  end
+  # Default acquire timeout (#126), seconds; absent = DEFAULT_POOL_TIMEOUT. Values <= 0 fall back (a
+  # "never wait" setting is ambiguous across frameworks and a footgun), warned once at build.
+  pool_timeout = _normalize_pool_timeout(_config_secs(settings, "pool_timeout", DEFAULT_POOL_TIMEOUT))
 
-  # Optional idle-connection reaping / max-lifetime (#125), in seconds; absent or 0 = off.
-  _reap_secs(key) = begin
-    haskey(settings.db_config_settings, key) || return 0.0
-    v = settings.db_config_settings[key]
-    v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), 0.0)
-  end
-  idle_timeout = _reap_secs("idle_timeout")
-  max_lifetime = _reap_secs("max_lifetime")
-  # Optional connection-leak detection (#127), in seconds; absent or 0 = off.
-  leak_detection_threshold = _reap_secs("leak_detection_threshold")
+  # Optional idle-connection reaping / max-lifetime (#125) and leak detection (#127), in seconds;
+  # absent or 0 = off (gated by the `> 0` checks in the enable-wiring below).
+  idle_timeout             = _config_secs(settings, "idle_timeout")
+  max_lifetime             = _config_secs(settings, "max_lifetime")
+  leak_detection_threshold = _config_secs(settings, "leak_detection_threshold")
 
   sqlite_split_read_write = false
   if haskey(settings.db_config_settings, "sqlite_split_read_write")
@@ -614,15 +621,14 @@ end
 Register a new database connection pool dynamically using a connection URL.
 Useful for multi-tenant applications or connecting to dynamic data sources.
 """
-function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = 30, leak_detection_threshold::Real = 0)
+function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = DEFAULT_POOL_TIMEOUT, leak_detection_threshold::Real = 0)
   # SAFETY: Deny using folder paths as dynamic keys to avoid hijacking static configs
   if isdir(key)
     throw(ArgumentError("Cannot register dynamic connection using key '$(key)'. Folder paths are reserved for static configurations loaded via 'load()'."))
   end
 
-  # Default acquire timeout (#126); <= 0 falls back to 30 (see _build_connection_pool!).
-  pool_timeout = pool_timeout > 0 ? Float64(pool_timeout) :
-    (@warn "pool_timeout must be > 0; using the default 30s" got=pool_timeout; 30.0)
+  # Default acquire timeout (#126); <= 0 falls back to DEFAULT_POOL_TIMEOUT (shared with _build_connection_pool!).
+  pool_timeout = _normalize_pool_timeout(pool_timeout)
 
   if haskey(config, key)
     existing = config[key]

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -5,7 +5,7 @@ import Logging
 # caller to qualify it and conflicts with Base.fetch on `using` (#35). PormG owns the
 # first-argument types (PormGPostgres/PormGSQLite/SQLConn), so this is not type piracy.
 import Base: fetch
-import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel
+import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel, DEFAULT_POOL_TIMEOUT
 import PormG: @pormg_debug
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
 import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
@@ -121,14 +121,14 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
   write_lock::ReentrantLock
 end
 
-function PostgresConnectionPool(connection_string::String; pool_size::Int = 3, pool_timeout::Real = 30)
+function PostgresConnectionPool(connection_string::String; pool_size::Int = 3, pool_timeout::Real = DEFAULT_POOL_TIMEOUT)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
   PostgresConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), lock)
 end
 
-function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false, pool_timeout::Real = 30)
+function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false, pool_timeout::Real = DEFAULT_POOL_TIMEOUT)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
@@ -140,10 +140,10 @@ function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, spl
 end
 
 # Default acquire timeout (seconds) for a pool. Dispatch + generic fallback so the pool-shaped mock
-# structs (which don't carry `pool_timeout`) resolve to the historical 30 s default with zero changes.
+# structs (which don't carry `pool_timeout`) resolve to DEFAULT_POOL_TIMEOUT with zero changes.
 _pool_timeout(pool::PostgresConnectionPool) = pool.pool_timeout
 _pool_timeout(pool::SQLiteConnectionPool)   = pool.pool_timeout
-_pool_timeout(pool) = 30.0
+_pool_timeout(pool) = DEFAULT_POOL_TIMEOUT
 
 function _sqlite_is_read_query(sql::String)::Bool
   cleaned = strip(sql)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -13,6 +13,12 @@ const DBDF_PATH       = joinpath(DB_PATH, DBDF_FOLDER_NAME)
 
 const PORMG_DB_CONFIG_FILE_NAME = "connection.yml"
 
+# Default acquire-connection timeout (seconds) when neither connection.yml nor register_connection
+# specify `pool_timeout` (#126). Single source of truth shared by Configuration, ConnectionPool, and
+# precompile.jl (#179) — matches the cross-framework norm (HikariCP `CONNECTION_TIMEOUT`, SQLAlchemy
+# `pool_timeout`, both 30s).
+const DEFAULT_POOL_TIMEOUT = 30.0
+
 const TEST_FILE_IDENTIFIER = "_test.jl"
 
 const LAST_INSERT_ID_LABEL = "LAST_INSERT_ID"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,7 +9,7 @@ import Logging
     Bool[],
     "dummy_connection_string",
     0,
-    30.0,   # pool_timeout (#126)
+    DEFAULT_POOL_TIMEOUT,   # pool_timeout (#126, #179)
     ReentrantLock()
   )
 

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -293,6 +293,9 @@ end
 # and `register_connection(...; pool_timeout=…)` — set the pool's `pool_timeout` field (the default that
 # `acquire_connection` reads). DB-free: pools construct lazily, so assert the field directly.
 @testset "pool_timeout config wiring sets the pool default (#126)" begin
+    # Anchor the centralized default (#179): any future change to the const is a deliberate, visible edit.
+    @test PormG.DEFAULT_POOL_TIMEOUT == 30.0
+
     # (1) connection.yml path via _build_connection_pool!.
     mktempdir() do temp_root
         db_dir = joinpath(temp_root, "db")
@@ -327,7 +330,7 @@ end
     key_def = "ptimeout_def_$(getpid())"
     try
         PormG.Configuration.register_connection(key_def, ":memory:"; adapter="SQLite")
-        @test PormG.config[key_def].connections.pool_timeout == 30.0
+        @test PormG.config[key_def].connections.pool_timeout == PormG.DEFAULT_POOL_TIMEOUT
     finally
         _cleanup_configuration_test_keys([key_def])
     end
@@ -336,7 +339,7 @@ end
     key_neg = "ptimeout_neg_$(getpid())"
     try
         PormG.Configuration.register_connection(key_neg, ":memory:"; adapter="SQLite", pool_timeout=-1)
-        @test PormG.config[key_neg].connections.pool_timeout == 30.0
+        @test PormG.config[key_neg].connections.pool_timeout == PormG.DEFAULT_POOL_TIMEOUT
     finally
         _cleanup_configuration_test_keys([key_neg])
     end


### PR DESCRIPTION
## Summary
- Replace the duplicated tryparse-seconds idiom (repeated across `pool_timeout`, `idle_timeout`, `max_lifetime`, `leak_detection_threshold` parsing) with a single `_config_secs` helper in `src/Configuration.jl`.
- Replace the scattered `pool_timeout <= 0 → 30` guard (previously inlined at two call sites) with a single `_normalize_pool_timeout` helper, shared by `_build_connection_pool!` and `register_connection`.
- Add `DEFAULT_POOL_TIMEOUT = 30.0` in `src/constants.jl` as the single source of truth, referenced by `src/ConnectionPool.jl` (`PostgresConnectionPool`/`SQLiteConnectionPool` defaults, `_pool_timeout` generic fallback), `src/Configuration.jl`, and `src/precompile.jl` — replacing ~4 independently-written `30` literals that previously had to be kept in sync by hand.
- No behavior change: traced every branch (key absent/present, parseable/unparseable, `≤0`/`>0`) against the pre-refactor code to confirm identical outcomes.

Closes #179.

## Test plan
- [x] `test/unit/test_configuration_api.jl` — 100% pass (incl. a new anchor test on `DEFAULT_POOL_TIMEOUT`, and two existing assertions switched from the `30.0` literal to the named const)
- [x] Full unit suite (`test/runtests.jl`) — 4000/4000 pass
- [x] Reviewed per `.github/skills/pormg-changed-code-review/SKILL.md`; one advisory finding (a `@warn` message string hardcoding `"30s"` instead of interpolating the new const) found and fixed in the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)