### PR TITLE
fix(#72): fast-fail unopenable connections with a typed PoolConnectError

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,57 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Connect fast-fail (`PoolConnectError`, `fail_fast_on_connect`)
+
+- **PormG ref**: issue #72 (AC2; follow-up to #37/#124) ; `src/ConnectionPool.jl`, `src/Configuration.jl`,
+  `src/Backend.jl`, `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl`, `src/PormG.jl`
+- **Recorded**: 2026-07-18
+- **Severity**: **mostly additive** (new exported `PoolConnectError`, opt-in `fail_fast_on_connect`, default
+  on). **One behavior change to check:** an unopenable pool now raises `PoolConnectError`, not
+  `PoolTimeoutError`. Only apps that *catch `PoolTimeoutError` specifically* around a connection failure
+  need a look.
+
+### What changed
+
+`acquire_connection` used to treat "can't open a connection" (bad password, missing role/database,
+unopenable SQLite path) the same as "healthy pool saturated": it waited the full `pool_timeout` (~30 s),
+then threw `PoolTimeoutError` ("raise pool_size"). It now:
+
+- **classifies** the driver error via a new backend hook (`backend_is_permanent_connect_error`): permanent
+  = PostgreSQL auth / missing role|database, SQLite `unable to open database file`;
+- **fast-fails** a permanent error immediately with a new catchable **`PoolConnectError`** (exported)
+  carrying the driver `cause` + a redacted connection string (remedy: fix credentials, not `pool_size`);
+- surfaces `PoolConnectError` (not `PoolTimeoutError`) for *any* connect failure that reaches the deadline,
+  including ambiguous host/DNS errors (which are still waited out, not fast-failed);
+- adds a `fail_fast_on_connect` config key (`connection.yml` + `register_connection` kwarg; default `true`)
+  to opt out;
+- (fix) redacts the connection string in SQLite pool logs, matching the PostgreSQL path.
+
+A healthy-but-saturated pool still raises `PoolTimeoutError` — unchanged.
+
+### How to find the calls to migrate
+
+Grep each app for a `catch` that special-cases pool saturation on a connection acquire/fetch:
+
+```
+rg -n "PoolTimeoutError" <app>/src
+```
+
+If a handler means "the database is unreachable / misconfigured", widen it to also catch
+`PoolConnectError` (or catch both). If it only means "pool is saturated, back off and retry", leave it —
+`PoolConnectError` is intentionally a *different*, non-retryable signal.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | — | check for `catch PoolTimeoutError` around acquire/fetch; else additive |
+| app-2 | — | — |
+| app-3 | — | — |
+| app-4 | — | — |
+
+---
+
 ## Pool metrics (`pool_stats`) + leak detection (`leak_detection_threshold`)
 
 - **PormG ref**: issue #127 (follow-up to #37) ; `src/ConnectionPool.jl`, `src/Configuration.jl`, `src/PormG.jl`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -644,7 +644,7 @@ scope — the SQL function constructors are *not* among them (see
 `with_advisory_lock`
 
 ### Connection pool
-`pool_stats`, `PoolTimeoutError`
+`pool_stats`, `PoolTimeoutError`, `PoolConnectError`
 
 ### Utilities & lifecycle
 `setup`, `install_ai_skills`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -26,6 +26,17 @@ dev:
   ```
 
   An explicit per-call `acquire_connection(pool; timeout_seconds=…)` still overrides it, and `Configuration.register_connection` accepts the same `pool_timeout` kwarg. A value `≤ 0` falls back to the 30 s default (a "never wait" setting is ambiguous and a footgun). Absent means the historical 30 s — zero behavior change.
+- **Connect failures (`PoolConnectError`, `fail_fast_on_connect`):** `pool_timeout` covers a *saturated healthy* pool. A pool that can never open a connection — a wrong password, a missing role/database, an unopenable SQLite path — is a different failure: waiting `pool_timeout` for it to "free up" is pointless, and blaming `pool_size` is misleading. `acquire_connection` therefore classifies the driver error: a **permanent** one (PostgreSQL auth / missing role or database; SQLite `unable to open database file`) **fails fast** with a catchable `PoolConnectError` (exported) that carries the underlying driver cause and a **redacted** connection string — remedy: fix credentials/host/database, not `pool_size`. Ambiguous errors (host/DNS/network — possibly a transient blip) are *not* fast-failed; they wait to the deadline as before and then also surface `PoolConnectError` (with the cause) rather than `PoolTimeoutError`. Set `fail_fast_on_connect: false` to opt out of the fast-fail and keep waiting the full `pool_timeout`:
+
+  ```yaml
+  dev:
+    adapter: PostgreSQL
+    database: 'formula1'
+    pool_size: 10
+    fail_fast_on_connect: false   # default true; false = wait pool_timeout even on a bad password
+  ```
+
+  Default is `true` (zero-config: a misconfigured deploy fails immediately instead of hanging every request for 30 s). `register_connection` accepts the same `fail_fast_on_connect` kwarg. Transient recovery is *not* retried inside the pool — retry the whole operation at the application layer (the same rule as lost connections inside a transaction).
 - **Idle reaping & max-lifetime (opt-in):** By default the pool never shrinks after a burst and reuses connections indefinitely (a dropped connection is caught reactively by the liveness check on the next checkout). For long-lived services — or databases/proxies that drop idle connections — you can enable a background reaper via `connection.yml` (both in **seconds**, `0`/absent = off):
 
   ```yaml

--- a/ext/PormGLibPQExt.jl
+++ b/ext/PormGLibPQExt.jl
@@ -57,6 +57,19 @@ function PormG.backend_is_connection_error(pool::PormGPostgres, e)
          occursin("connection not open", msg)
 end
 
+# Is `e` a *permanent* connect failure (won't succeed on retry) rather than transient? Scoped to
+# high-confidence config/auth classes only — bad password, missing role/database, no pg_hba.conf entry.
+# Host/DNS/network failures are deliberately NOT matched: they can be a transient blip during a deploy,
+# so they degrade to the normal wait-to-deadline path. LibPQ raises the same `PQConnectionError` (message
+# only, no SQLSTATE) for auth and host failures alike, so this is message-substring based (#72).
+function PormG.backend_is_permanent_connect_error(pool::PormGPostgres, e)
+  msg = lowercase(string(e))
+  return occursin("password authentication failed", msg) ||
+         occursin("no pg_hba.conf entry", msg) ||
+         (occursin("role ", msg) && occursin("does not exist", msg)) ||
+         (occursin("database ", msg) && occursin("does not exist", msg))
+end
+
 PormG.backend_num_affected_rows(pool::PormGPostgres, result) = LibPQ.num_affected_rows(result)
 PormG.backend_num_rows(pool::PormGPostgres, result) = LibPQ.num_rows(result)
 

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -132,6 +132,16 @@ function PormG.backend_is_connection_error(pool::PormGSQLite, e)
          occursin("disk i/o error", msg)
 end
 
+# Is `e` a *permanent* connect failure (won't succeed on retry) rather than transient? SQLite has no
+# auth; the realistic permanent case is an unopenable path (missing parent dir / permissions →
+# SQLITE_CANTOPEN, "unable to open database file"). Everything else stays ambiguous (return false),
+# degrading to the normal wait-to-deadline path. Message-substring based — SQLite.jl exposes one
+# `SQLiteException` type for every open failure, so type-matching can't separate causes (#72).
+function PormG.backend_is_permanent_connect_error(pool::PormGSQLite, e)
+  msg = lowercase(string(e))
+  return occursin("unable to open database file", msg)
+end
+
 # Window-function support probe used by src/Dialect.jl.
 PormG.backend_sqlite_version(pool::PormGSQLite) = Int(SQLite.C.sqlite3_libversion_number())
 

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -33,12 +33,14 @@ const _SQLITE_DRIVER_HINT = "PormG: the SQLite backend requires SQLite. Run `usi
 #   backend_execute(pool, conn, sql, params)           -> SYNC execute (SQLite worker; PG parity)
 #   backend_execute_async(pool, conn, sql, params)     -> async handle (PG: LibPQ.AsyncResult)
 #   backend_is_connection_error(pool, e)               -> Bool: is `e` a dropped-connection error
+#   backend_is_permanent_connect_error(pool, e)        -> Bool: is `e` a permanent connect failure (auth/cantopen) vs transient
 #   backend_num_affected_rows(pool, result)            -> Int matched-row count (PG)
 #   backend_num_rows(pool, result)                     -> Int row count (PG)
 #   backend_copy_in!(pool, conn, sql, data_itr)        -> PostgreSQL COPY FROM STDIN
 #   backend_sqlite_version(pool)                        -> Int SQLite library version number
 for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
            :backend_execute, :backend_execute_async, :backend_is_connection_error,
+           :backend_is_permanent_connect_error,
            :backend_num_affected_rows, :backend_num_rows, :backend_copy_in!,
            :backend_sqlite_version)
   @eval begin

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -236,6 +236,16 @@ function _config_secs(settings::SQLConn, key::String, default::Float64 = 0.0)::F
   return v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), default)
 end
 
+# Parse a boolean pool setting from connection.yml. Returns `default` when the key is absent; otherwise
+# accepts a native Bool or the usual truthy/falsey strings. Consolidates the truthy idiom already used
+# for `sqlite_split_read_write` so new bool keys (e.g. `fail_fast_on_connect`, #72) don't re-duplicate it.
+function _config_bool(settings::SQLConn, key::String, default::Bool)::Bool
+  haskey(settings.db_config_settings, key) || return default
+  v = settings.db_config_settings[key]
+  v isa Bool && return v
+  return lowercase(strip(string(v))) in ("1", "true", "yes", "on")
+end
+
 # Enforce the pool_timeout policy: `<= 0` ("never wait") is a cross-framework footgun, so fall back to
 # DEFAULT_POOL_TIMEOUT and warn once. Shared by both entry points — `_build_connection_pool!` (YAML) and
 # `register_connection` (kwarg) — so the guard and its message live in one place (#126, #179).
@@ -259,6 +269,10 @@ function _build_connection_pool!(settings::SQLConn, path::String)
   idle_timeout             = _config_secs(settings, "idle_timeout")
   max_lifetime             = _config_secs(settings, "max_lifetime")
   leak_detection_threshold = _config_secs(settings, "leak_detection_threshold")
+
+  # Fast-fail permanent connect errors (bad password / unopenable path) instead of waiting the full
+  # pool_timeout, then raise a truthful PoolConnectError (#72). Default on; set `false` to keep waiting.
+  fail_fast_on_connect = _config_bool(settings, "fail_fast_on_connect", true)
 
   sqlite_split_read_write = false
   if haskey(settings.db_config_settings, "sqlite_split_read_write")
@@ -292,7 +306,7 @@ function _build_connection_pool!(settings::SQLConn, path::String)
 
     @pormg_debug false
     CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
-    settings.connections = CP.SQLiteConnectionPool(db_path; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout)
+    settings.connections = CP.SQLiteConnectionPool(db_path; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout, fail_fast_on_connect=fail_fast_on_connect)
 
   elseif settings.db_config_settings["adapter"] == "PostgreSQL"
     dns = String[]
@@ -318,7 +332,7 @@ function _build_connection_pool!(settings::SQLConn, path::String)
 
     # Use parent module reference to avoid circular dependency during module loading
     CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
-    settings.connections = CP.PostgresConnectionPool(dns_str; pool_size=pool_size, pool_timeout=pool_timeout)
+    settings.connections = CP.PostgresConnectionPool(dns_str; pool_size=pool_size, pool_timeout=pool_timeout, fail_fast_on_connect=fail_fast_on_connect)
 
   else
     adapter = settings.db_config_settings["adapter"]
@@ -621,7 +635,7 @@ end
 Register a new database connection pool dynamically using a connection URL.
 Useful for multi-tenant applications or connecting to dynamic data sources.
 """
-function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = DEFAULT_POOL_TIMEOUT, leak_detection_threshold::Real = 0)
+function register_connection(key::String, url::String; adapter::String = "PostgreSQL", pool_size::Int = 3, sqlite_split_read_write::Bool = false, idle_timeout::Real = 0, max_lifetime::Real = 0, pool_timeout::Real = DEFAULT_POOL_TIMEOUT, leak_detection_threshold::Real = 0, fail_fast_on_connect::Bool = true)
   # SAFETY: Deny using folder paths as dynamic keys to avoid hijacking static configs
   if isdir(key)
     throw(ArgumentError("Cannot register dynamic connection using key '$(key)'. Folder paths are reserved for static configurations loaded via 'load()'."))
@@ -654,15 +668,16 @@ function register_connection(key::String, url::String; adapter::String = "Postgr
     "idle_timeout" => idle_timeout,
     "max_lifetime" => max_lifetime,
     "pool_timeout" => pool_timeout,
-    "leak_detection_threshold" => leak_detection_threshold
+    "leak_detection_threshold" => leak_detection_threshold,
+    "fail_fast_on_connect" => fail_fast_on_connect
   )
 
   CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
 
   if adapter == "PostgreSQL"
-    settings.connections = CP.PostgresConnectionPool(url; pool_size=pool_size, pool_timeout=pool_timeout)
+    settings.connections = CP.PostgresConnectionPool(url; pool_size=pool_size, pool_timeout=pool_timeout, fail_fast_on_connect=fail_fast_on_connect)
   elseif adapter == "SQLite"
-    settings.connections = CP.SQLiteConnectionPool(url; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout)
+    settings.connections = CP.SQLiteConnectionPool(url; pool_size=pool_size, split_read_write=sqlite_split_read_write, pool_timeout=pool_timeout, fail_fast_on_connect=fail_fast_on_connect)
   else
     throw(ArgumentError("Unsupported adapter: $adapter"))
   end

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -9,12 +9,13 @@ import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLi
 import PormG: @pormg_debug
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
 import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
-              backend_execute_async, backend_is_connection_error, backend_copy_in!
+              backend_execute_async, backend_is_connection_error, backend_is_permanent_connect_error,
+              backend_copy_in!
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, atomic, with_savepoint
 export acquire_connection, release_connection, finalize_transaction_connection!
-export PoolTimeoutError
+export PoolTimeoutError, PoolConnectError
 export pool_stats
 # NOTE: close_pool! is intentionally NOT exported here. Configuration owns the public
 # `close_pool!` (it dispatches on a pool OR a db-name String and delegates the pool case to
@@ -51,6 +52,29 @@ Base.showerror(io::IO, e::PoolTimeoutError) = print(io,
   "PoolTimeoutError: no available ", e.adapter, " connection after ", e.attempts, " attempts / ",
   round(e.elapsed_seconds, digits=1), "s (pool_size=", e.pool_size, ", max=", e.max_size,
   "). Raise pool_size (connection.yml `pool_size:`) to add capacity.")
+
+"""
+    PoolConnectError <: Exception
+
+Thrown by `acquire_connection` when it could not *open* a physical connection — a permanently-bad
+connection string (wrong password, missing role/database, an unopenable SQLite path). Distinct from
+`PoolTimeoutError` (a healthy pool that is merely saturated): the remedy here is to fix credentials /
+host / database, not to raise `pool_size` (#72). Carries the underlying driver exception (`cause`) and a
+redacted connection string; catchable so apps can translate it distinctly (e.g. a 500, not a 503-retry).
+"""
+struct PoolConnectError <: Exception
+  adapter::String        # "PostgreSQL" | "SQLite"
+  cause                  # underlying driver exception (untyped: a driver may throw a non-Exception)
+  connection::String     # redacted connection string
+  attempts::Int
+  elapsed_seconds::Float64
+end
+
+Base.showerror(io::IO, e::PoolConnectError) = print(io,
+  "PoolConnectError: could not open a ", e.adapter, " connection after ", e.attempts, " attempt(s) / ",
+  round(e.elapsed_seconds, digits=1), "s: ",
+  (e.cause isa Exception ? sprint(showerror, e.cause) : string(e.cause)),
+  " (connection=", e.connection, "). Check credentials, host, and database name in connection.yml.")
 
 function _run_before_connect!(pool::Union{PormGPostgres, PormGSQLite})
   if !ensure_before_connect!(pool)
@@ -99,6 +123,7 @@ mutable struct PostgresConnectionPool <: PormGPostgres
   connection_string::String
   pool_size::Int
   pool_timeout::Float64   # default acquire_connection timeout, seconds (#126; connection.yml `pool_timeout`)
+  fail_fast_on_connect::Bool  # fast-fail permanent connect errors instead of waiting pool_timeout (#72)
   lock::ReentrantLock  # For thread safety
 end
 
@@ -108,6 +133,7 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
   connection_string::String
   pool_size::Int
   pool_timeout::Float64   # default acquire_connection timeout, seconds (#126; connection.yml `pool_timeout`)
+  fail_fast_on_connect::Bool  # fast-fail permanent connect errors instead of waiting pool_timeout (#72)
   split_read_write::Bool
   writer_slot::Int
   reader_cursor::Int
@@ -121,14 +147,14 @@ mutable struct SQLiteConnectionPool <: PormGSQLite
   write_lock::ReentrantLock
 end
 
-function PostgresConnectionPool(connection_string::String; pool_size::Int = 3, pool_timeout::Real = DEFAULT_POOL_TIMEOUT)
+function PostgresConnectionPool(connection_string::String; pool_size::Int = 3, pool_timeout::Real = DEFAULT_POOL_TIMEOUT, fail_fast_on_connect::Bool = true)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
-  PostgresConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), lock)
+  PostgresConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), fail_fast_on_connect, lock)
 end
 
-function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false, pool_timeout::Real = DEFAULT_POOL_TIMEOUT)
+function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, split_read_write::Bool = false, pool_timeout::Real = DEFAULT_POOL_TIMEOUT, fail_fast_on_connect::Bool = true)
   connections = Vector{Any}(nothing, pool_size)
   available = fill(true, pool_size)
   lock = ReentrantLock()
@@ -136,7 +162,7 @@ function SQLiteConnectionPool(connection_string::String; pool_size::Int = 3, spl
   if split_read_write && !effective_split
     @warn "SQLite split read/write mode requires pool_size > 1; falling back to shared pool" pool_size=pool_size
   end
-  SQLiteConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), effective_split, 1, 0, lock, ReentrantLock())
+  SQLiteConnectionPool(connections, available, connection_string, pool_size, Float64(pool_timeout), fail_fast_on_connect, effective_split, 1, 0, lock, ReentrantLock())
 end
 
 # Default acquire timeout (seconds) for a pool. Dispatch + generic fallback so the pool-shaped mock
@@ -144,6 +170,32 @@ end
 _pool_timeout(pool::PostgresConnectionPool) = pool.pool_timeout
 _pool_timeout(pool::SQLiteConnectionPool)   = pool.pool_timeout
 _pool_timeout(pool) = DEFAULT_POOL_TIMEOUT
+
+# Whether to fast-fail a permanently-bad connection instead of waiting the full pool_timeout (#72).
+# Dispatch + generic fallback so pool-shaped mocks (which don't carry the field) default to `true`.
+_fail_fast_on_connect(pool::PostgresConnectionPool) = pool.fail_fast_on_connect
+_fail_fast_on_connect(pool::SQLiteConnectionPool)   = pool.fail_fast_on_connect
+_fail_fast_on_connect(pool) = true
+
+# Record a failed `backend_connect` and decide whether to fast-fail. Returns true only when the error is
+# classified permanent (auth / cantopen — see `backend_is_permanent_connect_error`) AND fast-fail is
+# enabled for the pool. `last_ref` persists the cause across acquire passes so the terminal branch can
+# raise a truthful `PoolConnectError`. Shared by both acquire twins so the PG/SQLite policy can't drift (#72).
+function _on_connect_failure!(pool, e, last_ref::Base.RefValue{Any})
+  last_ref[] = e
+  return _fail_fast_on_connect(pool) && backend_is_permanent_connect_error(pool, e)
+end
+
+# Choose the terminal acquire error. If any `backend_connect` failed during this call, the pool could not
+# be (fully) opened → raise a truthful `PoolConnectError` carrying the driver cause (its remedy is
+# credentials/host, not `pool_size`). Otherwise the pool is healthy but saturated → `PoolTimeoutError`.
+# Shared by both twins' `:timeout` / `:wait`-timeout branches (#72).
+function _acquire_terminal_error(pool, adapter::String, last_connect_error, pool_size::Int,
+                                 ceiling::Int, attempts::Int, elapsed::Float64)
+  last_connect_error === nothing &&
+    return PoolTimeoutError(adapter, pool_size, ceiling, attempts, elapsed)
+  return PoolConnectError(adapter, last_connect_error, redact_secret(pool.connection_string), attempts, elapsed)
+end
 
 function _sqlite_is_read_query(sql::String)::Bool
   cleaned = strip(sql)
@@ -582,6 +634,9 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
   # validated/materialized. `nothing` when we are doing a normal scan.
   owned::Union{Nothing, Int} = nothing
   ceiling = _pool_ceiling(pool)
+  # Most recent `backend_connect` failure this call. When set, the terminal branch raises a truthful
+  # PoolConnectError (the pool couldn't be opened) instead of the saturation PoolTimeoutError (#72).
+  last_connect_error = Ref{Any}(nothing)
 
   while true
     attempts += 1
@@ -603,8 +658,12 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
           _monitor_note_create!(pool, i)                  # fresh connection timestamp (#125)
           return (:got, new_conn)
         catch e
-          @error "Failed to materialize handed-off PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
-          _handoff_or_free!(pool, i)                    # pass the slot on / free it, then rescan
+          # Free/hand-off the leased slot BEFORE we return either way — on a fast-fail bail too, so the
+          # slot handed to us (#124) is never leaked (#72).
+          fast_fail = _on_connect_failure!(pool, e, last_connect_error)
+          _handoff_or_free!(pool, i)                    # pass the slot on / free it
+          fast_fail && return (:connect_failed, e)
+          @debug "Failed to materialize handed-off PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
           return (:retry, nothing)
         end
       end
@@ -626,7 +685,8 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
             _monitor_note_create!(pool, i)                 # fresh connection timestamp (#125)
             return (:got, new_conn)
           catch e
-            @error "Failed to create PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
+            _on_connect_failure!(pool, e, last_connect_error) && return (:connect_failed, e)
+            @debug "Failed to create PG connection $i: $e" connection_string=redact_secret(pool.connection_string)
             pool.available[i] = true
             continue
           end
@@ -650,7 +710,8 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
           end
           return (:got, new_conn)
         catch e
-          @error "Failed to expand PG pool: $e"
+          _on_connect_failure!(pool, e, last_connect_error) && return (:connect_failed, e)
+          @debug "Failed to expand PG pool: $e" connection_string=redact_secret(pool.connection_string)
         end
       end
 
@@ -675,13 +736,20 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
     elseif kind === :retry
       owned = nothing
       continue
+    elseif kind === :connect_failed
+      # Permanent connect failure (bad password / missing role|db) with fast-fail on: don't wait the
+      # full timeout — raise the truthful cause now (#72).
+      throw(PoolConnectError("PostgreSQL", outcome[2], redact_secret(pool.connection_string), attempts, time() - start_time))
     elseif kind === :timeout
-      if attempts >= max_retries
-        @warn "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
-      else
-        @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+      err = _acquire_terminal_error(pool, "PostgreSQL", last_connect_error[], pool.pool_size, ceiling, attempts, time() - start_time)
+      if err isa PoolTimeoutError
+        if attempts >= max_retries
+          @warn "Exceeded maximum retry attempts ($max_retries) to acquire PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        else
+          @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        end
       end
-      throw(PoolTimeoutError("PostgreSQL", pool.pool_size, ceiling, attempts, time() - start_time))
+      throw(err)
     else # :wait — park until a connection is handed to us or the deadline elapses.
       w = outcome[2]
       timer = Timer(_ -> _pool_wait_timeout!(pool, w), max(deadline - time(), 0.0))
@@ -691,8 +759,10 @@ function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing,
         close(timer)
       end
       if handed === _POOL_WAIT_TIMEOUT
-        @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
-        throw(PoolTimeoutError("PostgreSQL", pool.pool_size, ceiling, attempts, time() - start_time))
+        err = _acquire_terminal_error(pool, "PostgreSQL", last_connect_error[], pool.pool_size, ceiling, attempts, time() - start_time)
+        err isa PoolTimeoutError &&
+          @warn "Timeout after $(to) seconds waiting for available PG connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        throw(err)
       end
       owned = handed::Int                                # loop back to materialize the handed slot
       continue
@@ -715,6 +785,8 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
   before_connect_done = false
   owned::Union{Nothing, Int} = nothing
   ceiling = _pool_ceiling(pool)
+  # See the PormGPostgres twin: most recent connect failure this call → truthful PoolConnectError (#72).
+  last_connect_error = Ref{Any}(nothing)
 
   while true
     attempts += 1
@@ -736,8 +808,11 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
           _monitor_note_create!(pool, i)                  # fresh connection timestamp (#125)
           return (:got, new_conn)
         catch e
-          @error "Failed to materialize handed-off SQLite connection $i: $e" connection_string=pool.connection_string
+          # Free/hand-off the leased slot BEFORE we return either way, fast-fail included (#72/#124).
+          fast_fail = _on_connect_failure!(pool, e, last_connect_error)
           _handoff_or_free!(pool, i)
+          fast_fail && return (:connect_failed, e)
+          @debug "Failed to materialize handed-off SQLite connection $i: $e" connection_string=redact_secret(pool.connection_string)
           return (:retry, nothing)
         end
       end
@@ -759,7 +834,8 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
             _monitor_note_create!(pool, i)                 # fresh connection timestamp (#125)
             return (:got, new_conn)
           catch e
-            @error "Failed to create SQLite connection $i: $e" connection_string=pool.connection_string
+            _on_connect_failure!(pool, e, last_connect_error) && return (:connect_failed, e)
+            @debug "Failed to create SQLite connection $i: $e" connection_string=redact_secret(pool.connection_string)
             pool.available[i] = true
             continue
           end
@@ -778,13 +854,14 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
           _monitor_note_create!(pool, length(pool.connections))   # grow monitor vectors in lockstep (#125)
           new_size = length(pool.connections)
           if new_size == ceiling
-            @warn "SQLite pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=pool.connection_string
+            @warn "SQLite pool reached its maximum size; raise pool_size to add capacity" max_size=new_size pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
           else
             @debug "SQLite pool expanded beyond initial size" current_size=new_size initial_size=pool.pool_size
           end
           return (:got, new_conn)
         catch e
-          @error "Failed to expand SQLite pool: $e"
+          _on_connect_failure!(pool, e, last_connect_error) && return (:connect_failed, e)
+          @debug "Failed to expand SQLite pool: $e" connection_string=redact_secret(pool.connection_string)
         end
       end
 
@@ -807,11 +884,16 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
     elseif kind === :retry
       owned = nothing
       continue
+    elseif kind === :connect_failed
+      # Permanent connect failure (unopenable path) with fast-fail on: raise the truthful cause now (#72).
+      throw(PoolConnectError("SQLite", outcome[2], redact_secret(pool.connection_string), attempts, time() - start_time))
     elseif kind === :timeout
-      @warn (attempts >= max_retries ?
-        "Exceeded maximum retry attempts ($max_retries) to acquire SQLite connection" :
-        "Timeout after $(to) seconds waiting for available SQLite connection") pool_size=pool.pool_size connection_string=pool.connection_string
-      throw(PoolTimeoutError("SQLite", pool.pool_size, ceiling, attempts, time() - start_time))
+      err = _acquire_terminal_error(pool, "SQLite", last_connect_error[], pool.pool_size, ceiling, attempts, time() - start_time)
+      err isa PoolTimeoutError &&
+        @warn (attempts >= max_retries ?
+          "Exceeded maximum retry attempts ($max_retries) to acquire SQLite connection" :
+          "Timeout after $(to) seconds waiting for available SQLite connection") pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+      throw(err)
     else # :wait
       w = outcome[2]
       timer = Timer(_ -> _pool_wait_timeout!(pool, w), max(deadline - time(), 0.0))
@@ -821,8 +903,10 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
         close(timer)
       end
       if handed === _POOL_WAIT_TIMEOUT
-        @warn "Timeout after $(to) seconds waiting for available SQLite connection" pool_size=pool.pool_size connection_string=pool.connection_string
-        throw(PoolTimeoutError("SQLite", pool.pool_size, ceiling, attempts, time() - start_time))
+        err = _acquire_terminal_error(pool, "SQLite", last_connect_error[], pool.pool_size, ceiling, attempts, time() - start_time)
+        err isa PoolTimeoutError &&
+          @warn "Timeout after $(to) seconds waiting for available SQLite connection" pool_size=pool.pool_size connection_string=redact_secret(pool.connection_string)
+        throw(err)
       end
       owned = handed::Int
       continue

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -167,6 +167,7 @@ export object, get, PormGRow, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, 
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)
+export PoolConnectError  # thrown by acquire_connection when a connection can't be opened (#72)
 export pool_stats  # connection-pool health snapshot (#127)
 export with_tx_context, in_transaction_context  # Transaction context helpers
 export setup, install_ai_skills

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,6 +10,7 @@ import Logging
     "dummy_connection_string",
     0,
     DEFAULT_POOL_TIMEOUT,   # pool_timeout (#126, #179)
+    true,                   # fail_fast_on_connect (#72)
     ReentrantLock()
   )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ end
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
+    @testset "Connect-Failure Fast-Fail Typed Error (#72)" include("unit/test_connection_pool_connect_error.jl")
     @testset "close_pool! Skips Non-pool Mocks (#147)" include("unit/test_close_pool_mock_skip.jl")
     @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "No Lost-Connection Retry Inside Transactions (#138)" include("unit/test_fetch_retry_transaction.jl")

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -345,6 +345,50 @@ end
     end
 end
 
+# Config-wiring for connect fast-fail (#72): both user entry points — `connection.yml fail_fast_on_connect`
+# and `register_connection(...; fail_fast_on_connect=…)` — set the pool's `fail_fast_on_connect` field
+# (read by `acquire_connection` to decide whether to fast-fail a permanent connect error). DB-free.
+@testset "fail_fast_on_connect config wiring sets the pool default (#72)" begin
+    # (1) connection.yml false overrides the on-by-default.
+    mktempdir() do temp_root
+        db_dir = joinpath(temp_root, "db")
+        mkpath(db_dir)
+        open(joinpath(db_dir, "connection.yml"), "w") do f
+            write(f,
+                "test:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  fail_fast_on_connect: false\n" *
+                "  config:\n" *
+                "    change_db: true\n" *
+                "    change_data: true\n")
+        end
+
+        PormG.Configuration.load(db_dir; env="test")
+        pool = PormG.Configuration.get_settings(db_dir).connections
+        @test pool.fail_fast_on_connect == false      # yaml key flipped the default off
+        _cleanup_configuration_test_keys([db_dir])
+    end
+
+    # (2) register_connection kwarg sets the dynamic pool's flag.
+    key_off = "ffc_off_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_off, ":memory:"; adapter="SQLite", fail_fast_on_connect=false)
+        @test PormG.config[key_off].connections.fail_fast_on_connect == false
+    finally
+        _cleanup_configuration_test_keys([key_off])
+    end
+
+    # (3) absent key → on by default (the new, better behavior; zero-config).
+    key_def = "ffc_def_$(getpid())"
+    try
+        PormG.Configuration.register_connection(key_def, ":memory:"; adapter="SQLite")
+        @test PormG.config[key_def].connections.fail_fast_on_connect == true
+    finally
+        _cleanup_configuration_test_keys([key_def])
+    end
+end
+
 # Config-wiring for leak detection (#127): both entry points reach `enable_leak_detection!`, which
 # registers a PoolMonitorState carrying the leak_threshold. DB-free: assert on the shared registry.
 @testset "leak_detection_threshold config wiring (#127)" begin

--- a/test/unit/test_connection_pool_connect_error.jl
+++ b/test/unit/test_connection_pool_connect_error.jl
@@ -1,0 +1,97 @@
+# ============================================================
+# test/unit/test_connection_pool_connect_error.jl
+#
+# Connect-failure classification + fast-fail → typed PoolConnectError (#72, AC2).
+#
+# CONTRACT being tested:
+#   When `acquire_connection` cannot OPEN a physical connection (permanently-bad string: bad password,
+#   missing role/db, an unopenable SQLite path) it must NOT wait the full pool_timeout and then blame
+#   pool saturation. It fast-fails (when the error is classified permanent AND fail_fast_on_connect is
+#   on) with a catchable `PoolConnectError` carrying the underlying driver cause + a redacted connection
+#   string. A healthy-but-saturated pool still raises `PoolTimeoutError` (covered in
+#   test_connection_pool_timeout.jl); the two paths must stay distinct.
+#
+# Deterministic and server-free: a SQLite pool pointed at a path whose PARENT directory does not exist
+# makes SQLite raise CANTOPEN ("unable to open database file") on every connect attempt — the realistic
+# "permanent" SQLite case. Classification itself is a pure, message-substring function, tested directly.
+# ============================================================
+
+using Test
+using PormG
+
+# SQLite/LibPQ are weakdeps since #34 — load the driver extensions so the backend hooks resolve.
+include(joinpath(@__DIR__, "..", "load_drivers.jl"))
+
+const CP = PormG.ConnectionPool
+
+@testset "backend_is_permanent_connect_error classifies auth/cantopen only (#72)" begin
+  # Pools build lazily (no connect), so these are safe to construct with dummy strings.
+  pg = CP.PostgresConnectionPool("host=localhost dbname=x user=y")
+  sl = CP.SQLiteConnectionPool(":memory:")
+
+  # NOTE: the classifier is a pure `lowercase(string(e))` substring match, so proxying the driver
+  # messages with ErrorException tests exactly the classification contract. The PG *end-to-end* path
+  # (a real LibPQ.PQConnectionError from a live server) is left to the integration suite; SQLite is
+  # exercised end-to-end below against a real SQLiteException.
+  # PostgreSQL — permanent (config/auth) classes fast-fail…
+  @test PormG.backend_is_permanent_connect_error(pg, ErrorException("FATAL: password authentication failed for user \"y\""))
+  @test PormG.backend_is_permanent_connect_error(pg, ErrorException("FATAL: role \"y\" does not exist"))
+  @test PormG.backend_is_permanent_connect_error(pg, ErrorException("FATAL: database \"x\" does not exist"))
+  @test PormG.backend_is_permanent_connect_error(pg, ErrorException("no pg_hba.conf entry for host \"1.2.3.4\""))
+  # …but host/DNS/network stay AMBIGUOUS (must NOT fast-fail — could be a transient blip).
+  @test !PormG.backend_is_permanent_connect_error(pg, ErrorException("could not translate host name \"db\" to address"))
+  @test !PormG.backend_is_permanent_connect_error(pg, ErrorException("could not connect to server: Connection timed out"))
+
+  # SQLite — unopenable path is permanent; a locked/disk error is not a permanent OPEN failure.
+  @test PormG.backend_is_permanent_connect_error(sl, SQLite.SQLiteException("unable to open database file"))
+  @test !PormG.backend_is_permanent_connect_error(sl, SQLite.SQLiteException("database is locked"))
+end
+
+# A SQLite pool that can never open a connection (parent directory of the DB file does not exist →
+# SQLITE_CANTOPEN). `close_pool!` on such a pool is a harmless no-op (nothing was ever opened).
+_unopenable_sqlite_pool(; kwargs...) =
+  CP.SQLiteConnectionPool(joinpath(tempname(), "db.sqlite"); kwargs...)
+
+@testset "fast-fail raises PoolConnectError (not PoolTimeoutError) well under the deadline (#72)" begin
+  pool = _unopenable_sqlite_pool(pool_size = 1)     # fail_fast_on_connect defaults to true
+  try
+    t0 = time()
+    err = try
+      CP.acquire_connection(pool; timeout_seconds = 5)   # would wait 5s if it did NOT fast-fail
+      nothing
+    catch e; e end
+    elapsed = time() - t0
+
+    @test err isa PormG.PoolConnectError               # truthful type — NOT PoolTimeoutError
+    @test !(err isa PormG.PoolTimeoutError)
+    @test err.adapter == "SQLite"
+    @test err.cause isa SQLite.SQLiteException          # underlying driver cause preserved
+    @test err.attempts >= 1
+    @test 0.0 <= err.elapsed_seconds < 1.0              # the field itself reflects the fast-fail, not the 5s budget
+    @test elapsed < 1.0                                 # MUTATION GATE: fast-fail, not the 5s deadline
+    @test occursin("could not open", sprint(showerror, err))
+    @test occursin("unable to open database file", sprint(showerror, err))   # cause surfaced in message
+  finally
+    try; CP.close_pool!(pool); catch; end
+  end
+end
+
+@testset "fail_fast_on_connect=false waits to the deadline, still PoolConnectError (#72)" begin
+  # Same unopenable pool, but fast-fail disabled → it must fall through to the normal wait-to-deadline
+  # path (proving the toggle) and STILL surface the truthful PoolConnectError (not PoolTimeoutError).
+  pool = _unopenable_sqlite_pool(pool_size = 1, fail_fast_on_connect = false)
+  try
+    t0 = time()
+    err = try
+      CP.acquire_connection(pool; timeout_seconds = 1)
+      nothing
+    catch e; e end
+    elapsed = time() - t0
+
+    @test err isa PormG.PoolConnectError               # truthful cause even without fast-fail
+    @test err.cause isa SQLite.SQLiteException
+    @test elapsed >= 0.8                               # discriminator: it waited ~the full 1s budget
+  finally
+    try; CP.close_pool!(pool); catch; end
+  end
+end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -19,7 +19,7 @@ const EXPECTED_TOPLEVEL = Set([
     # Query builder
     :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Interval, :show_query, :inspect_query,
     # Rows & exceptions
-    :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :pool_stats,
+    :PormGRow, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :PoolConnectError, :pool_stats,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API


### PR DESCRIPTION
Closes #72 (AC2).

## Problem
`acquire_connection` treated "can't open a connection" (wrong password, missing role/database, unopenable SQLite path) the same as a saturated *healthy* pool: it waited the full `pool_timeout` (~30 s), then threw `PoolTimeoutError` — whose remedy is *"raise pool_size"*, actively misleading when the real cause is a bad connection string. (AC1 — typed vs raw-`String` throws — was already delivered by #37; this is AC2.)

## Change
- **New exported `PoolConnectError <: Exception`** carrying the underlying driver `cause` + a **redacted** connection string. `PoolTimeoutError` stays purely "healthy pool saturated".
- **New backend hook `backend_is_permanent_connect_error(pool, e)`** (`Backend.jl` generic + LibPQ/SQLite impls). Permanent = PG auth / missing role|database / no `pg_hba.conf` entry; SQLite `unable to open database file`. Host/DNS is **not** classified permanent (a transient blip during a deploy). Message-substring based, mirroring the existing `backend_is_connection_error` — neither driver exposes a structured code at *connect* time.
- **Both acquire twins rewired** via two shared helpers (`_on_connect_failure!`, `_acquire_terminal_error`) so the PG/SQLite policy can't drift. Permanent + fast-fail-on ⇒ immediate `PoolConnectError`; otherwise the existing park-to-deadline path runs and the terminal branch raises `PoolConnectError` (if any connect failed this call) else `PoolTimeoutError`. **No new sleeps/backoff.** Fast-fail also frees the handed-off slot before bailing (no slot leak).
- **`fail_fast_on_connect` config** (`connection.yml` + `register_connection` kwarg, default `true`) via a new `_config_bool` helper; set `false` to keep waiting the full `pool_timeout`.
- **Fix (secret leak):** the SQLite acquire path logged `pool.connection_string` unredacted; now routed through `redact_secret` like the PG twin.

## Behavior change for downstream apps
Mostly additive, but **one thing to check**: an unopenable pool now raises `PoolConnectError`, not `PoolTimeoutError`. Only apps that catch `PoolTimeoutError` *specifically* around a connection failure need a look (widen to also catch `PoolConnectError`, which is a distinct, non-retryable signal). Recorded in `UPGRADING.md`.

## How other frameworks informed the design
SQLAlchemy structurally separates "create a connection" (fails now) from "wait for a busy one" (`TimeoutError`) — PormG already has that split, so only the connect-failure branch changed. HikariCP uses a distinct type per failure mode → `PoolConnectError` alongside `PoolTimeoutError`. PostgreSQL's SQLSTATE class 08 (transient) vs 28 (permanent auth) is the canonical axis, but LibPQ.jl only attaches SQLSTATE to *query-result* errors, so connect-time classification is necessarily message-based.

## Tests
- New `test/unit/test_connection_pool_connect_error.jl`: classification (PG + SQLite, positive **and** negative — host/DNS must *not* fast-fail); end-to-end fast-fail against a real unopenable SQLite pool (`elapsed < 1.0` vs a 5 s budget — the mutation gate); `fail_fast_on_connect=false` waits to the deadline and still surfaces `PoolConnectError`.
- New config-wiring testset in `test_configuration_api.jl` (both entry points); `:PoolConnectError` added to the frozen export set.
- **Full unit suite green: 4023/4023.** Docs build clean.
- Reviewed per `.github/skills/pormg-changed-code-review` (independent pass) — no blocking issues; the two actionable findings (a branch-(A) slot leak on fast-fail; a vacuous test assertion) were fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)