### PR TITLE
fix(#157): share Model_Type on deepcopy instead of throwing on its Module

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -11,7 +11,6 @@ import PormG: SQLConn, config, Configuration
 import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING, PROTECT
 # import PormG: make_password, check_password, password_needs_upgrade, DEFAULT_PBKDF2_ITERATIONS
 using Printf
-import Base.deepcopy
 using Decimals
 
 
@@ -52,29 +51,22 @@ end
   owner_model_resolved::Union{PormGModel, Nothing} = nothing
   related_model_resolved::Union{PormGModel, Nothing} = nothing
 end
-function deepcopy(model::Model_Type)
-  try
-    return Model_Type(
-      model.name,
-      model.verbose_name,
-      deepcopy(model.fields),
-      deepcopy(model.field_names),
-      deepcopy(model.related_objects),
-      model._module,
-      model.connect_key,
-      deepcopy(model.cache)
-    )
-  catch e
-    @error("Failed to deepcopy Model_Type: $(e)")
-    rethrow(e)
-  end
-end
+# A Model_Type is resolved schema state — its `fields`, `_module`, and `related_objects` are built once
+# by `set_models` and treated as an immutable, SHARED reference everywhere (the query builder copies query
+# state but shares the model verbatim: `SQLObjectQuery` deepcopy sets `model=obj.model`). Deep-copying a
+# model is never wanted and, worse, throws: the moment recursion reaches a relation field's resolved
+# `.to` (another Model_Type) it descends into `_module::Module` → "deepcopy of Modules not supported".
+# Override the recursion hook to SHARE — return the same model, registered in `stackdict` so its identity
+# is stable across the surrounding copy. So `deepcopy(model) === model`, and any container/field that
+# holds a model shares it rather than cloning the schema graph. Mirrors the `ManyToManyRelation` override
+# below (#65) and resolves the module-traversal throw (#157).
+Base.deepcopy_internal(m::Model_Type, stackdict::IdDict) = get!(stackdict, m, m)
 
 # #65: a ManyToManyRelation now carries resolved model objects (owner/related). Those are shared,
 # derived state — `set_models` repopulates them — so deep-copying them would needlessly clone the
-# whole related-model graph (a Model_Type's `related_objects` holds these relations, and
-# `deepcopy(model)` above recurses into it). Copy the value-type String/Bool fields; SHARE the two
-# resolved-model references. Mirrors the targeted override for SQLiteParameterizedQuery.
+# whole related-model graph (a Model_Type's `related_objects` holds these relations). Copy the
+# value-type String/Bool fields; SHARE the two resolved-model references — consistent with the
+# `Model_Type` share hook above (#157) and the targeted override for SQLiteParameterizedQuery.
 function Base.deepcopy_internal(r::ManyToManyRelation, stackdict::IdDict)
   haskey(stackdict, r) && return stackdict[r]
   new = ManyToManyRelation(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ end
     @testset "Composite Uniqueness (unique_together #19)" include("unit/test_unique_constraints.jl")
     @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")
     @testset "custom_join Copy Isolation (#112)" include("unit/test_custom_join_copy.jl")
+    @testset "Model_Type deepcopy Shares (#157)" include("unit/test_model_deepcopy.jl")
     @testset "cjoin_on Anchor-less Joins (#45)" include("unit/test_cjoin_on.jl")
     @testset "Operator SQL Generation" include("unit/test_operators.jl")
     @testset "pormg_lower UDF (#78)" include("unit/test_pormg_lower_udf.jl")

--- a/test/unit/test_model_deepcopy.jl
+++ b/test/unit/test_model_deepcopy.jl
@@ -1,0 +1,88 @@
+"""
+Unit coverage for `deepcopy` of a relation-bearing Model_Type (#157).
+
+`deepcopy(model)` used to CLONE the model's containers while sharing `_module`, but the custom
+top-level method never intercepted a model reached *nested* during recursion. So the moment a
+relation field's resolved `.to` (another Model_Type) was deep-copied — e.g. via `deepcopy(model.fields)`
+— it fell to the GENERIC `deepcopy_internal(::Model_Type)`, descended into `_module::Module`, and threw
+`"deepcopy of Modules not supported"`. Every realistic model has an FK/O2O/M2M, so this was latent but real.
+
+The fix (`Base.deepcopy_internal(::Model_Type, ::IdDict)` in src/Models.jl) treats a Model_Type as the
+immutable, SHARED schema reference the rest of the codebase already assumes (`SQLObjectQuery` deepcopy
+shares `model` verbatim): the recursion hook returns the same model. So `deepcopy(model) === model`, and
+any container/field that holds a model shares it instead of cloning the schema graph into a Module it
+can't traverse.
+
+Deterministic and DB-free: a mock PostgreSQL connection + an inline F1-flavored model whose FK `.to` is a
+resolved Model_Type carrying `_module` (the exact throwing input). `sForeignKey`, `ManyToManyField` and
+`OneToOneField` all hold `.to::PormGModel`, so the FK case exercises the shared mechanism for all three.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+# Dedicated config key so this file can't contaminate / be contaminated by other unit files in Main.
+struct ModelDeepcopyMockPostgres <: PormG.PormGPostgres end
+
+PormG.config["mdc_mock"] = PormG.Configuration.Settings(
+  connections = ModelDeepcopyMockPostgres(),
+  change_data = true,
+  db_def_folder = "mdc_mock",
+)
+
+# Inline models in their own module so `set_models` binds `_module` and resolves the FK `.to` to the
+# Mdc_driver Model_Type — reproducing the "a field's .to is a model carrying a Module" hazard.
+module ModelDeepcopyModels
+import PormG
+import PormG.Models
+
+Mdc_driver = Models.Model("mdc_driver",
+  driverid = Models.IDField(),
+  surname = Models.CharField(),
+)
+
+Mdc_results = Models.Model("mdc_results",
+  id = Models.IDField(),
+  driverid = Models.ForeignKey(Mdc_driver, pk_field = "driverid", on_delete = "RESTRICT"),
+  points = Models.IntegerField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "mdc_mock")
+end
+
+const MDC = ModelDeepcopyModels
+
+@testset "deepcopy of a relation-bearing Model_Type (#157)" begin
+  results = MDC.Mdc_results
+  driver  = MDC.Mdc_driver
+
+  # Precondition: the setup actually reproduces the throwing shape — the FK `.to` is a resolved
+  # Model_Type carrying a bound `_module` (otherwise the test would pass vacuously).
+  fk = results.fields["driverid"]
+  @test fk.to isa PormG.PormGModel
+  @test fk.to === driver
+  @test results._module !== nothing
+
+  # ── The core regression: deep-copying the model no longer throws, and shares it ──
+  # Pre-fix `deepcopy(model)` cloned containers; now a Model_Type is an immutable shared reference.
+  model_copy = deepcopy(results)
+  @test model_copy === results                 # shared, not cloned (the new contract)
+  @test model_copy._module === results._module # never a fresh/traversed Module
+
+  # ── The exact failing path: recursion that reaches a field's resolved `.to` model ──
+  # `deepcopy(model.fields)` is what the old method did internally; pre-fix it threw
+  # "deepcopy of Modules not supported" on the FK's `.to._module`. It must now succeed and SHARE the
+  # nested target model rather than clone the schema graph. (Revert the share hook → this throws.)
+  fields_copy = deepcopy(results.fields)
+  # FIELDS are still deep-copied (a PormGField is itself <: PormGModel, but the hook dispatches on the
+  # concrete Model_Type, NOT PormGModel — so fields stay cloneable and copy-isolation, #43/#112, holds)…
+  @test fields_copy["driverid"] !== results.fields["driverid"]
+  # …while the resolved target model reached through the cloned field is SHARED (Module never traversed).
+  @test fields_copy["driverid"].to === driver
+
+  # ── A model reached nested inside an arbitrary container is shared, not cloned ──
+  bag = deepcopy(Dict("m" => driver, "fk" => fk))
+  @test bag["m"] === driver                    # container recursion shares the model…
+  @test bag["fk"].to === driver                # …and the model reached via a field's `.to`
+end


### PR DESCRIPTION
Closes #157.

## Problem
`deepcopy(model::Model_Type)` shared `_module` at the top level but then cloned `model.fields`. A relation field's resolved `.to` is another `Model_Type`, and that *nested* model was copied through the **generic** `deepcopy_internal` (the custom top-level method never intercepts nested occurrences) — which descended into `_module::Module` and threw `"deepcopy of Modules not supported"`. Latent today (no live caller deep-copies a relation-bearing model), but real for any future feature that copies a model graph.

## Fix
Replace the custom top-level clone method (and the now-unused `import Base.deepcopy`) with one recursion hook that treats a `Model_Type` as the immutable, shared schema reference the rest of the codebase already assumes — `SQLObjectQuery` deepcopy shares `model` verbatim (`# PormGModel doesn't need deep copy (immutable reference)`):

```julia
Base.deepcopy_internal(m::Model_Type, stackdict::IdDict) = get!(stackdict, m, m)
```

So `deepcopy(model) === model`, and any container/field holding a model **shares** it rather than cloning the schema graph into a Module it can't traverse. This also makes `deepcopy(query)` strictly more robust (a nested model that used to throw now shares).

**Why the hook dispatches on the concrete `Model_Type`, not `PormGModel`:** because `PormGField <: PormGModel`, a `::PormGModel` hook would also match every field and wrongly *share* them — breaking the field-cloning that `.copy()` isolation (#43/#112) depends on. That hierarchy quirk (and two sibling instances) is tracked separately in #186.

## Design note
Chosen over keeping the container-clone method: one consistent invariant ("a `Model_Type` is always shared on copy") matching the querybuilder, instead of an asymmetry where top-level `deepcopy` clones but nested shares. The removed method had no live caller.

## Tests
New `test/unit/test_model_deepcopy.jl` (registered in `test/runtests.jl`): a relation-bearing model (FK `.to` = a resolved `Model_Type` carrying a bound `_module`) deep-copies without throwing, shares the model / `_module` / nested `.to`, and — the guard for the `PormGField <: PormGModel` subtlety — still **clones** the fields. Mutation-gated: reverting the hook makes the test throw `"deepcopy of Modules not supported"`.

- **Full unit suite: 4031/4031.**
- Reviewed per `.github/skills/pormg-changed-code-review` (independent pass) — mutation gate verified by revert, import-removal and semantic change confirmed to have no dependent code paths; no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)