### PR TITLE
fix(#186): close two non-"is-a" subtyping holes + drop dead AbstractModel

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -602,7 +602,8 @@ PormG's type hierarchy provides the foundation for the query builder and model s
 | Type | Description |
 | :--- | :--- |
 | `PormGAbstractType` | Base abstract type for all PormG types. |
-| `SQLConn` | Represents a database connection (subtypes: `PormGPostgres`, `PormGSQLite`). |
+| `SQLConn` | The connection-settings/config type (`Configuration.Settings` is a subtype). |
+| `PormGBackend` | Base for the database backend/dialect markers (subtypes: `PormGPostgres`, `PormGSQLite`), the dispatch key for SQL rendering and driver selection. |
 | `SQLObject` | Base for objects that can be stored in the database. |
 | `SQLObjectHandler` | Handles operations on SQL objects (the query builder). |
 | `SQLTableAlias` | Manages table aliases in SQL queries. |

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -1,7 +1,7 @@
 module Configuration
 
 import YAML, Logging
-import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
+import PormG: SQLConn, PormGBackend, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
 import PormG: Generator
 import PormG: @pormg_debug
@@ -872,7 +872,9 @@ end
 # Add this to your module cleanup if needed
 function __cleanup__()
   for (path, settings) in config
-    if settings.connections isa SQLConn
+    # `settings.connections` is a pool (PormGBackend) or nothing. It used to be checked with
+    # `isa SQLConn` back when pools were <: SQLConn (#186 moved them under PormGBackend).
+    if settings.connections isa PormGBackend
       close_pool!(settings.connections)
     end
   end

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -2,7 +2,7 @@ module Dialect
 using Dates, TimeZones
 using DataFrames
 import Tables
-import PormG: SQLConn, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeOper, SQLObject, AbstractModel, PormGModel, PormGField, PormGPostgres, PormGSQLite, PormGAbstractType
+import PormG: SQLConn, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeOper, SQLObject, PormGModel, PormGField, PormGPostgres, PormGSQLite, PormGAbstractType
 import PormG: backend_sqlite_version  # SQLite library-version probe (driver body in the weakdep extension)
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -38,8 +38,12 @@ import DataFrames, OrderedCollections, Dates, Logging, Millboard, YAML
 
 abstract type PormGAbstractType end
 abstract type SQLConn <: PormGAbstractType end
-abstract type PormGPostgres <: SQLConn end
-abstract type PormGSQLite <: SQLConn end
+# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: SQLConn —
+# SQLConn is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
+# PostgresConnectionPool <: PormGPostgres and SQLiteConnectionPool <: PormGSQLite.
+abstract type PormGBackend <: PormGAbstractType end
+abstract type PormGPostgres <: PormGBackend end
+abstract type PormGSQLite <: PormGBackend end
 abstract type AbstractPormGParam <: PormGAbstractType end  # Base type for all parameterized queries
 abstract type PormGPostgresParam <: AbstractPormGParam end  # PostgreSQL numbered params ($1, $2...)
 abstract type PormGSQLiteParam <: AbstractPormGParam end    # SQLite positional params with contextual buckets
@@ -60,9 +64,10 @@ abstract type SQLTypeOrder <: SQLTypeField end # Order to be used in the query
 abstract type SQLTypeCTE <: SQLType end # Common Table Expression (WITH clause)
 
 
-abstract type AbstractModel <: PormGAbstractType end
 abstract type PormGModel <: PormGAbstractType end
-abstract type PormGField <: PormGModel end # define the type of the column from the model
+# A field is a COMPONENT of a model, not a kind of model — a sibling, not a subtype, so it does not
+# satisfy ::PormGModel signatures (which all read model-only attributes) (#186).
+abstract type PormGField <: PormGAbstractType end # define the type of the column from the model
 
 abstract type Migration <: PormGAbstractType end
 

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -358,7 +358,11 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
   end
 end
 
-function Base.getproperty(m::PormGModel, sym::Symbol)
+# Dispatches on the concrete Model_Type (the sole concrete PormGModel). It was on `::PormGModel` and
+# carried a `hasfield(…, :cache)` guard only because fields used to be `<: PormGModel` and would recurse
+# into their absent `.cache` (a StackOverflowError, #108). Fields are no longer `<: PormGModel` (#186),
+# so that guard is gone and field property access uses Julia's default getproperty.
+function Base.getproperty(m::Models.Model_Type, sym::Symbol)
   if sym === :objects
     # Self-healing: Ensure models are initialized before returning objects
     Models.ensure_model_initialized(m)
@@ -370,13 +374,7 @@ function Base.getproperty(m::PormGModel, sym::Symbol)
     # M2M accessor names are validated through format_fild_name which rejects reserved
     # names, so a user-defined M2M field cannot shadow a Model_Type struct field.
     return getfield(m, sym)
-  elseif hasfield(typeof(m), :cache) && hasfield(typeof(m), :related_objects) &&
-         Models.has_many_to_many_accessor(m, String(sym))
-    # Guard the M2M branch on the `cache`/`related_objects` struct fields it reads. Only Model_Type
-    # has them; PormGField subtypes are also <: PormGModel but do NOT, so without this guard
-    # has_many_to_many_accessor would re-enter getproperty on a field's absent `.cache` and recurse
-    # forever — a StackOverflowError on ANY absent-property access to a field object (issue #108).
-    # Fields fall through to the plain getfield below, which raises a clean FieldError.
+  elseif Models.has_many_to_many_accessor(m, String(sym))
     Models.ensure_model_initialized(m)
     return ManyToManyDescriptor(m, String(sym), Models.get_many_to_many_relation(m, String(sym)))
   else

--- a/test/unit/test_commit_failure_release.jl
+++ b/test/unit/test_commit_failure_release.jl
@@ -178,13 +178,14 @@ end
 # ── Drive the REAL PormG.Migrations._execute_migration_lifecycle (not a reproduction) against the
 #    mock, so a future revert of the caller's `release_conn` is caught by CI. The mock returns empty
 #    result tables (so the migration reads the DB as empty → no idempotency skip), no-ops the DDL and
-#    the history INSERTs, and throws on COMMIT. `SQLConn` is abstract and the mocks are subtypes, so
-#    the same pool doubles as `connection` and `settings`; `settings` is only touched by archiving,
-#    which the COMMIT-failure rethrow never reaches. Returns the caught error (or nothing). ──
+#    the history INSERTs, and throws on COMMIT. The 2nd arg is `settings::SQLConn`; since #186 a pool is
+#    no longer <: SQLConn, we pass a MockSettings139 (a Settings-like SQLConn wrapping the pool) — it is
+#    only touched by archiving, which the COMMIT-failure rethrow never reaches. Returns the error/nothing. ──
 function run_real_migration_lifecycle_139(pool)
+  settings = MockSettings139(pool)
   try
     PormG.Migrations._execute_migration_lifecycle(
-      pool, pool,
+      pool, settings,
       String["CREATE TABLE _pormg_t139 (id integer);"],
       "CREATE TABLE _pormg_t139 (id integer);",
       "v139", "commit_fail_mig", "chk139", false)
@@ -245,6 +246,13 @@ end
   pool = MockPGPool139()
   conn = CP.acquire_connection(pool)
   settings = MockSettings139(pool)
+
+  # #186: a pool and a Settings are now DISTINCT type families — a pool is NOT a SQLConn (it's a
+  # PormGBackend); only the Settings wrapper is a SQLConn. That separation is exactly what makes the
+  # two finalize_transaction_connection! overloads (pool vs SQLConn) dispatch to the right one.
+  @test !(pool isa PormG.SQLConn)
+  @test pool isa PormG.PormGBackend
+  @test settings isa PormG.SQLConn
 
   @test CP.finalize_transaction_connection!(settings, conn) === nothing   # <: SQLConn, not a pool
   @test pool.connections[1] === conn                    # delegated to pool.connections and released

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -219,19 +219,25 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Regression (#108): the getproperty override dispatches M2M accessors by calling
-# has_many_to_many_accessor(m, …), which reads m.cache / m.related_objects. Those are
-# Model_Type struct fields — but PormGField subtypes are ALSO <: PormGModel and do NOT
-# have them, so for a FIELD object the M2M branch used to re-enter getproperty on the
-# absent `.cache` and recurse forever: a StackOverflowError on ANY absent-property access
-# to a field object. The fix guards the M2M branch on `hasfield(…, :cache/:related_objects)`,
-# so field objects fall through to a clean getfield/FieldError.
+# Regression (#108, now guaranteed by #186): the Model_Type getproperty override dispatches M2M
+# accessors via has_many_to_many_accessor(m, …), which reads m.cache / m.related_objects. When fields
+# were `<: PormGModel`, a FIELD object hit that method and re-entered getproperty on its absent `.cache`,
+# recursing forever (a StackOverflowError on ANY absent-property access to a field). #108 papered over it
+# with a `hasfield(…, :cache/:related_objects)` guard; #186 removed the root cause — a field is no longer
+# a PormGModel, so it never reaches this method and uses Julia's default getproperty (clean getfield/
+# FieldError). This testset pins that the StackOverflow stays impossible.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "PormGModel.getproperty: absent property on a field object doesn't recurse (#108)" begin
-  # A field object (PormGField <: PormGModel) that lacks cache/related_objects.
+  # A field object. Since #186, PormGField is a SIBLING of PormGModel (not a subtype), so a field no
+  # longer satisfies ::PormGModel and never reaches PormGModel/Model_Type getproperty at all.
   cf = Models.CharField(max_length = 5)
 
-  # Real attribute access still works — the guard must not disturb normal field reads.
+  # #186 regression: a field is NOT a model. This is now what makes the #108 StackOverflow impossible —
+  # field property access uses Julia's default getproperty, not the Model_Type M2M-accessor path.
+  @test !(cf isa PormG.PormGModel)
+  @test cf isa PormG.PormGField
+
+  # Real attribute access still works.
   @test cf.max_length == 5
 
   # Absent property on a FIELD object must raise a clean FieldError. Pre-fix this recursed

--- a/test/unit/test_model_deepcopy.jl
+++ b/test/unit/test_model_deepcopy.jl
@@ -75,8 +75,8 @@ const MDC = ModelDeepcopyModels
   # "deepcopy of Modules not supported" on the FK's `.to._module`. It must now succeed and SHARE the
   # nested target model rather than clone the schema graph. (Revert the share hook → this throws.)
   fields_copy = deepcopy(results.fields)
-  # FIELDS are still deep-copied (a PormGField is itself <: PormGModel, but the hook dispatches on the
-  # concrete Model_Type, NOT PormGModel — so fields stay cloneable and copy-isolation, #43/#112, holds)…
+  # FIELDS are still deep-copied — the share hook dispatches on the concrete Model_Type only, so a field
+  # (a sibling of PormGModel since #186) stays cloneable and copy-isolation, #43/#112, holds…
   @test fields_copy["driverid"] !== results.fields["driverid"]
   # …while the resolved target model reached through the cloned field is SHARED (Module never traversed).
   @test fields_copy["driverid"].to === driver


### PR DESCRIPTION
Closes #186.

## Problem
Two `<:` relationships in `src/PormG.jl` were not "is-a" relationships, so a value of the wrong kind satisfied a method signature at compile time and failed only at runtime (or was papered over by a guard):
- **`PormGField <: PormGModel`** — a field is a *component* of a model, not a model. All ~60 `::PormGModel` sites read model-only attributes; a field satisfied them at the type level. It already caused a real `StackOverflowError` (#108) that a defensive guard existed to neutralize.
- **`PormGPostgres`/`PormGSQLite <: SQLConn`** — `SQLConn` is the `Settings`/config type (`config::Dict{String,SQLConn}` only stores `Settings`; every `::SQLConn` body reads `.db_config_settings`/…). Pools carry none of those fields.
- **`AbstractModel`** — a dead abstract type (defined + imported once, never subtyped or dispatched on).

All three types are **internal (unexported)** → no public-API impact.

## Change
- **`PormGField` → sibling of `PormGModel`** (`<: PormGAbstractType`). The only place a field ever flowed through a `::PormGModel` method — `Base.getproperty` at `object_manager.jl` — is narrowed to `::Model_Type` (the sole concrete `PormGModel`) and the `#108` `hasfield` guard removed. **Behavior-preserving**: fields now use Julia's default `getproperty`, which returns exactly what the guard's fall-through produced (`getfield` / `FieldError`).
- **New `PormGBackend`** groups the dialect/pool markers under `PormGAbstractType`; `PormGPostgres`/`PormGSQLite` move off `SQLConn`. The one production dependency (`__cleanup__`'s `isa SQLConn`, which would silently go false) becomes `isa PormGBackend`; the one test that passed a pool as `settings::SQLConn` now uses a `Settings` mock. Dispatch is otherwise unchanged — pool-typed methods already shadow the `::SQLConn` ones.
- **Remove dead `AbstractModel`** + its lone `Dialect.jl` import.

## Why this is safe (front-loaded analysis)
Two blast-radius maps established, before any edit, that: exactly one path routed a field through `::PormGModel`; no `::PormGModel` signature wants a field and no `::SQLConn` method wants a pool; `config` only stores `Settings`; `Model_Type` is the sole concrete `PormGModel`. There is no `setproperty!`/`propertynames` on the field/model hierarchy, so the getter narrowing introduces no get/set asymmetry (the `field.to = …` write path always used Julia's default setter).

## Tests
- `test_many_to_many.jl` — extended the `#108` getproperty testset with `@test !(cf isa PormGModel)` / `@test cf isa PormGField` (the StackOverflow is now impossible *because* a field isn't a model).
- `test_commit_failure_release.jl` — added `@test !(pool isa SQLConn)` / `@test pool isa PormGBackend` / `@test settings isa SQLConn`, and fixed the one call that passed a pool as `settings::SQLConn`.
- Stale-hierarchy comments updated in the two test files touched.

**Verification:** unit **4037/4037**; PostgreSQL integration **1748/1748**; SQLite integration **1714 pass + 1 pre-existing `@test_broken`**. Reviewed per `.github/skills/pormg-changed-code-review` (independent pass) — mutation gates confirmed, no blocking issues.

## Follow-ups (not in this PR)
Tracked in **#188** (design/discussion): the `SQLConn` misnomer (it holds config, not a connection), separating dialect identity from pool-ness, and collapsing the ~15 `Union{PormGPostgres,PormGSQLite}` sites to `::PormGBackend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)