### PR TITLE
refactor(#188): rename SQLConn -> PormGSettings (config type, not a connection)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -602,7 +602,7 @@ PormG's type hierarchy provides the foundation for the query builder and model s
 | Type | Description |
 | :--- | :--- |
 | `PormGAbstractType` | Base abstract type for all PormG types. |
-| `SQLConn` | The connection-settings/config type (`Configuration.Settings` is a subtype). |
+| `PormGSettings` | The connection-settings/config type (`Configuration.Settings` is a subtype). *Renamed from `SQLConn`.* |
 | `PormGBackend` | Base for the database backend/dialect markers (subtypes: `PormGPostgres`, `PormGSQLite`), the dispatch key for SQL rendering and driver selection. |
 | `SQLObject` | Base for objects that can be stored in the database. |
 | `SQLObjectHandler` | Handles operations on SQL objects (the query builder). |

--- a/src/AdvisoryLock.jl
+++ b/src/AdvisoryLock.jl
@@ -3,7 +3,7 @@ module AdvisoryLock
 using Logging
 
 import PormG
-import PormG: SQLConn, PormGPostgres, PormGSQLite, backend_execute_async
+import PormG: PormGSettings, PormGPostgres, PormGSQLite, backend_execute_async
 import PormG.Configuration: get_settings
 import PormG.ConnectionPool: acquire_connection, release_connection
 
@@ -150,8 +150,8 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
   end
 end
 
-# Convenience wrappers for Settings/SQLConn objects
-with_advisory_lock(f::Function, settings::SQLConn, key::AbstractString; kwargs...) =
+# Convenience wrappers for Settings/PormGSettings objects
+with_advisory_lock(f::Function, settings::PormGSettings, key::AbstractString; kwargs...) =
   with_advisory_lock(f, settings.connections, key; kwargs...)
 
 # SQLite no-op (advisory locks not supported)

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -9,7 +9,7 @@
 #
 # Dispatch is keyed on the pool MARKER type (`PormGPostgres` / `PormGSQLite`), which
 # is defined in core. A concrete pool (`PostgresConnectionPool <: PormGPostgres <:
-# SQLConn`) selects the extension method when the driver is loaded; otherwise the
+# PormGBackend`) selects the extension method when the driver is loaded; otherwise the
 # varargs fallback fires with a friendly "load the driver" error.
 #
 # Type discipline: core stores connections untyped (`Any`); each extension method

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -1,7 +1,7 @@
 module Configuration
 
 import YAML, Logging
-import PormG: SQLConn, PormGBackend, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
+import PormG: PormGSettings, PormGBackend, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
 import PormG: Generator
 import PormG: @pormg_debug
@@ -169,7 +169,7 @@ function ensure_model_transaction_scope(model::PormGModel)
   throw(ArgumentError("Active transaction on connection $(active_desc) cannot include model $(model.name) bound to $(model.connect_key). Run run_in_transaction(\"$(model.connect_key)\") or move this operation outside the current transaction."))
 end
 
-function transaction_connection_for(settings::SQLConn)
+function transaction_connection_for(settings::PormGSettings)
   tx_pool = get_tx_pool()
   tx_conn = get_tx_connection()
   return tx_conn !== nothing && tx_pool === settings.connections ? tx_conn : nothing
@@ -230,7 +230,7 @@ end
 # the value can't be parsed to a Float64. Pure parser — no `> 0` policy; callers pick the default and
 # any enforcement. Consolidates the tryparse idiom for pool_timeout / idle_timeout / max_lifetime /
 # leak_detection_threshold (#179).
-function _config_secs(settings::SQLConn, key::String, default::Float64 = 0.0)::Float64
+function _config_secs(settings::PormGSettings, key::String, default::Float64 = 0.0)::Float64
   haskey(settings.db_config_settings, key) || return default
   v = settings.db_config_settings[key]
   return v isa Real ? Float64(v) : something(tryparse(Float64, strip(string(v))), default)
@@ -239,7 +239,7 @@ end
 # Parse a boolean pool setting from connection.yml. Returns `default` when the key is absent; otherwise
 # accepts a native Bool or the usual truthy/falsey strings. Consolidates the truthy idiom already used
 # for `sqlite_split_read_write` so new bool keys (e.g. `fail_fast_on_connect`, #72) don't re-duplicate it.
-function _config_bool(settings::SQLConn, key::String, default::Bool)::Bool
+function _config_bool(settings::PormGSettings, key::String, default::Bool)::Bool
   haskey(settings.db_config_settings, key) || return default
   v = settings.db_config_settings[key]
   v isa Bool && return v
@@ -255,7 +255,7 @@ function _normalize_pool_timeout(v::Real)::Float64
   return DEFAULT_POOL_TIMEOUT
 end
 
-function _build_connection_pool!(settings::SQLConn, path::String)
+function _build_connection_pool!(settings::PormGSettings, path::String)
   # Extract pool size from config (defaults to 3)
   pool_size = haskey(settings.db_config_settings, "pool_size") ?
               parse(Int, string(settings.db_config_settings["pool_size"])) : 3
@@ -372,7 +372,7 @@ Dict{Any,Any} with 6 entries:
   "adapter"  => "PostgreSQL"
 ```
 """
-function _configured_extensions(settings::SQLConn)::Vector{String}
+function _configured_extensions(settings::PormGSettings)::Vector{String}
   raw = get(settings.db_config_settings, "extensions", String[])
   (raw === nothing || raw === missing) && return String[]
 
@@ -398,7 +398,7 @@ end
 # handled by the migration runner (gated on change_db, deliberate operator step),
 # never on app boot. Here we only probe pg_extension and warn on misconfiguration
 # so a missing extension is visible before the first query fails.
-function _check_configured_extensions!(settings::SQLConn)::Nothing
+function _check_configured_extensions!(settings::PormGSettings)::Nothing
   extensions = _configured_extensions(settings)
   isempty(extensions) && return nothing
 
@@ -426,7 +426,7 @@ function _check_configured_extensions!(settings::SQLConn)::Nothing
   return nothing
 end
 
-function _install_configured_extensions!(settings::SQLConn)::Nothing
+function _install_configured_extensions!(settings::PormGSettings)::Nothing
   extensions = _configured_extensions(settings)
   isempty(extensions) && return nothing
 
@@ -448,7 +448,7 @@ function _install_configured_extensions!(settings::SQLConn)::Nothing
   return nothing
 end
 
-function _install_postgres_extension!(settings::SQLConn, extension::String)::Nothing
+function _install_postgres_extension!(settings::PormGSettings, extension::String)::Nothing
   safe_extensions = Set(["unaccent"])
   extension in safe_extensions || throw(ArgumentError("Unsupported PostgreSQL extension '$(extension)'"))
 
@@ -472,7 +472,7 @@ end
 # two-argument form with an explicit dictionary, which is safe to mark IMMUTABLE,
 # so iunaccent_contains can be backed by an expression index — e.g. a pg_trgm
 # GIN index on public.immutable_unaccent(column).
-function _install_immutable_unaccent!(settings::SQLConn)::Nothing
+function _install_immutable_unaccent!(settings::PormGSettings)::Nothing
   CP = getfield(parentmodule(@__MODULE__), :ConnectionPool)
   sql = "CREATE OR REPLACE FUNCTION public.immutable_unaccent(text) " *
         "RETURNS text LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE " *
@@ -490,7 +490,7 @@ function _install_immutable_unaccent!(settings::SQLConn)::Nothing
   return nothing
 end
 
-function read_db_connection_data(path::String, settings::SQLConn) :: Dict{String,Any}
+function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{String,Any}
   db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME) 
 
   endswith(db_settings_file, ".yml") || throw("Unknow configuration file type - expecting .yml")
@@ -537,7 +537,7 @@ function read_db_connection_data(path::String, settings::SQLConn) :: Dict{String
 end
 
 
-function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothing} = nothing, env::Union{Nothing,String} = nothing, config::Dict{String,SQLConn} = config)
+function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothing} = nothing, env::Union{Nothing,String} = nothing, config::Dict{String,PormGSettings} = config)
   # create settings if does not exists
   path === nothing && (path = DB_PATH )
   selected_env = _effective_env(env)
@@ -564,7 +564,7 @@ function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothi
   end
 
   config[path] = Settings(app_env = selected_env, db_def_folder=path)
-  settings::SQLConn = config[path]
+  settings::PormGSettings = config[path]
 
   settings.db_config_settings = read_db_connection_data(path, settings)
 
@@ -579,7 +579,7 @@ end
 Load several static configuration folders using the same environment override.
 Returns the list of connection keys that were loaded.
 """
-function load_many(paths::AbstractVector{<:AbstractString}; env::Union{Nothing,String} = nothing, config::Dict{String,SQLConn} = config)
+function load_many(paths::AbstractVector{<:AbstractString}; env::Union{Nothing,String} = nothing, config::Dict{String,PormGSettings} = config)
   loaded_keys = String[]
   for path in paths
     key = String(path)
@@ -718,7 +718,7 @@ function close_pool!(pool::Union{PormGPostgres, PormGSQLite})
 end
 
 function close_pool!(db::String)
-  settings::SQLConn = get_settings(db)
+  settings::PormGSettings = get_settings(db)
   if settings.connections !== nothing
     close_pool!(settings.connections)
   end
@@ -735,7 +735,7 @@ function ping(path_or_key::String)::Bool
   key = _resolve_loaded_key(path_or_key)
   key === nothing && return false
 
-  settings::SQLConn = config[key]
+  settings::PormGSettings = config[key]
   pool = settings.connections
   pool === nothing && return false
 
@@ -783,7 +783,7 @@ function status(path_or_key::String)
     )
   end
 
-  settings::SQLConn = config[key]
+  settings::PormGSettings = config[key]
   return (
     key = key,
     loaded = true,
@@ -802,7 +802,7 @@ end
 # Settings struct
 #
 
-mutable struct Settings <: SQLConn
+mutable struct Settings <: PormGSettings
   app_env::String
   db_def_folder::String # same then key
   model_file::String
@@ -872,8 +872,7 @@ end
 # Add this to your module cleanup if needed
 function __cleanup__()
   for (path, settings) in config
-    # `settings.connections` is a pool (PormGBackend) or nothing. It used to be checked with
-    # `isa SQLConn` back when pools were <: SQLConn (#186 moved them under PormGBackend).
+    # Close the registered pool if there is one. `settings.connections` is a PormGBackend pool or nothing.
     if settings.connections isa PormGBackend
       close_pool!(settings.connections)
     end

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -3,9 +3,9 @@ module ConnectionPool
 import Logging
 # Extend Base.fetch rather than define a fresh `fetch` — a shadowing `fetch` forces every
 # caller to qualify it and conflicts with Base.fetch on `using` (#35). PormG owns the
-# first-argument types (PormGPostgres/PormGSQLite/SQLConn), so this is not type piracy.
+# first-argument types (PormGPostgres/PormGSQLite/PormGSettings), so this is not type piracy.
 import Base: fetch
-import PormG: SQLConn, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel, DEFAULT_POOL_TIMEOUT
+import PormG: PormGSettings, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel, DEFAULT_POOL_TIMEOUT
 import PormG: @pormg_debug
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
 import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
@@ -1119,8 +1119,8 @@ function finalize_transaction_connection!(pool::Union{PormGPostgres, PormGSQLite
   end
   return nothing
 end
-# SQLConn overload — delegates to the underlying pool, mirroring with_transaction(::SQLConn).
-finalize_transaction_connection!(pool::SQLConn, conn; rollback_error = nothing) =
+# PormGSettings overload — delegates to the underlying pool, mirroring with_transaction(::PormGSettings).
+finalize_transaction_connection!(pool::PormGSettings, conn; rollback_error = nothing) =
   finalize_transaction_connection!(pool.connections, conn; rollback_error = rollback_error)
 
 # A statement that ends the current transaction (plain ROLLBACK) — deliberately NOT
@@ -1344,8 +1344,8 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
   end
 end
-fetch_async(settings::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch_async(settings::SQLConn, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::PormGSettings, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
@@ -1387,8 +1387,8 @@ function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     throw(root)
   end
 end
-fetch(settings::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch(settings::SQLConn, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::PormGSettings, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 fetch(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
@@ -1416,7 +1416,7 @@ function fetch_copy(connection::PormGPostgres, sql::String, data_itr)
     end
   end
 end
-fetch_copy(settings::SQLConn, sql::String, data_itr) = fetch_copy(settings.connections, sql, data_itr)
+fetch_copy(settings::PormGSettings, sql::String, data_itr) = fetch_copy(settings.connections, sql, data_itr)
 
 """
     with_transaction_async(pool::PormGPostgres, sql::String; ...) -> (task, conn)
@@ -1495,11 +1495,11 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
   end
 end
-with_transaction(pool::SQLConn, sql::AbstractString; conn = nothing, release_conn::Bool = false, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction(pool.connections, sql; conn=conn, release_conn=release_conn, params=params)
-with_transaction_async(pool::SQLConn, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction_async(pool.connections, sql; conn=conn, params=params)
+with_transaction(pool::PormGSettings, sql::AbstractString; conn = nothing, release_conn::Bool = false, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction(pool.connections, sql; conn=conn, release_conn=release_conn, params=params)
+with_transaction_async(pool::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing) = with_transaction_async(pool.connections, sql; conn=conn, params=params)
 
 """
-    with_savepoint(f::Function, settings::SQLConn, name::String) -> result
+    with_savepoint(f::Function, settings::PormGSettings, name::String) -> result
 
 Execute `f()` wrapped in a savepoint named `name`. On success, releases the savepoint.
 On error, rolls back to the savepoint, releases it, and rethrows so the outer transaction
@@ -1514,7 +1514,7 @@ do not need to guard the call site.
 not parameterized — savepoint names are identifiers). Internal callers pass constants;
 the reentrant `atomic`/`run_in_transaction` path passes `_savepoint_name(depth)`.
 """
-function with_savepoint(f::Function, settings::SQLConn, name::String)
+function with_savepoint(f::Function, settings::PormGSettings, name::String)
   if transaction_connection_for(settings) === nothing
     return f()   # not inside a transaction on this pool → nothing to savepoint
   end
@@ -1566,7 +1566,7 @@ write transaction) may re-enter without self-deadlock.
 """
 with_sqlite_write_lock(f::Function, pool::PormGSQLite) = Base.lock(f, pool.write_lock)
 with_sqlite_write_lock(f::Function, pool::PormGPostgres) = f()
-with_sqlite_write_lock(f::Function, settings::SQLConn) = with_sqlite_write_lock(f, settings.connections)
+with_sqlite_write_lock(f::Function, settings::PormGSettings) = with_sqlite_write_lock(f, settings.connections)
 
 """
     run_in_transaction(f::Function, pool::PormGPostgres) -> result
@@ -1630,9 +1630,9 @@ end
 # unit-testable in isolation.
 _savepoint_name(depth::Integer) = "pormg_sp_$(depth)"
 
-# Resolve the registered SQLConn for a pool so the reentrant savepoint path (which needs
+# Resolve the registered PormGSettings for a pool so the reentrant savepoint path (which needs
 # `settings` for `with_savepoint`/`fetch`) can route through the pinned connection.
-function _settings_for_pool(pool::Union{PormGPostgres, PormGSQLite})::SQLConn
+function _settings_for_pool(pool::Union{PormGPostgres, PormGSQLite})::PormGSettings
   key = connection_key_for_pool(pool)
   key === nothing && throw(ArgumentError("Cannot resolve connection settings for the active transaction pool"))
   return get_settings(key)
@@ -1644,7 +1644,7 @@ end
 # the pinned connection: no new connection is acquired, no BEGIN is issued, the SQLite write
 # lock (already held reentrantly by the outermost block) is not re-taken, and the outermost
 # block still owns the single connection release.
-function _nested_savepoint(f::Function, settings::SQLConn)
+function _nested_savepoint(f::Function, settings::PormGSettings)
   pool = settings.connections
   conn = transaction_connection_for(settings)
   return with_tx_context(pool, conn) do
@@ -1725,18 +1725,18 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
 end
 
 function run_in_transaction(f::Function, db::String)
-  settings::SQLConn = get_settings(db)
+  settings::PormGSettings = get_settings(db)
   return run_in_transaction(f, settings.connections)
 end
 
-run_in_transaction(f::Function, settings::SQLConn) = run_in_transaction(f, settings.connections)
+run_in_transaction(f::Function, settings::PormGSettings) = run_in_transaction(f, settings.connections)
 
 """
     atomic(f::Function, db; durable::Bool=false) -> result
 
 Run `f()` in a database transaction — the friendly, Django-flavored alias for
-[`run_in_transaction`](@ref). `db` may be a pool, a db-key `String` (e.g. `"db_2"`), or an
-`SQLConn`.
+[`run_in_transaction`](@ref). `db` may be a pool, a db-key `String` (e.g. `"db_2"`), or a
+`PormGSettings`.
 
 A **nested** `atomic`/`run_in_transaction` block on the *same* database automatically becomes
 a `SAVEPOINT`: if `f()` throws, only that inner block is rolled back to its savepoint and the
@@ -1767,6 +1767,6 @@ function atomic(f::Function, pool::Union{PormGPostgres, PormGSQLite}; durable::B
   return run_in_transaction(f, pool)
 end
 atomic(f::Function, db::String; durable::Bool=false) = atomic(f, get_settings(db).connections; durable=durable)
-atomic(f::Function, settings::SQLConn; durable::Bool=false) = atomic(f, settings.connections; durable=durable)
+atomic(f::Function, settings::PormGSettings; durable::Bool=false) = atomic(f, settings.connections; durable=durable)
 
 end # module

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -2,7 +2,7 @@ module Dialect
 using Dates, TimeZones
 using DataFrames
 import Tables
-import PormG: SQLConn, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeOper, SQLObject, PormGModel, PormGField, PormGPostgres, PormGSQLite, PormGAbstractType
+import PormG: PormGSettings, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeOper, SQLObject, PormGModel, PormGField, PormGPostgres, PormGSQLite, PormGAbstractType
 import PormG: backend_sqlite_version  # SQLite library-version probe (driver body in the weakdep extension)
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -1,7 +1,7 @@
 module Generator
 
 import PormG
-import PormG: MODEL_PATH, SQLConn, DB_PATH
+import PormG: MODEL_PATH, PormGSettings, DB_PATH
 import OrderedCollections: OrderedDict
 
 """
@@ -86,7 +86,7 @@ test:
     nothing
 end
 
-function generate_models_from_db(file::String, Instructions::Vector{Any}, settings::SQLConn; path::String = MODEL_PATH) :: Nothing 
+function generate_models_from_db(file::String, Instructions::Vector{Any}, settings::PormGSettings; path::String = MODEL_PATH) :: Nothing 
 
   open(joinpath(path, file), "w") do f
     write(f, """module $(basename(file) |> x -> replace(x, ".jl" => ""))\n

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -25,9 +25,9 @@ import PormG: _emsg  # shared TTY-aware error/log-message strip helper (tools.jl
 import PormG: Models, Migration, Dialect
 import PormG.Models: format_model_name
 import PormG: connection, config, get_constraints_pk, get_constraints_unique, get_constraints_check
-import PormG: PormGModel, PormGField, SQLConn, PormGPostgres, PormGSQLite
+import PormG: PormGModel, PormGField, PormGSettings, PormGPostgres, PormGSQLite
 import PormG: sqlite_type_map, postgres_type_map, sqlite_ignore_schema, postgres_ignore_table, _EXTRA_IGNORE_TABLES
-import PormG: MODEL_PATH, SQLConn, DB_PATH
+import PormG: MODEL_PATH, PormGSettings, DB_PATH
 import PormG.AdvisoryLock
 
 import PormG.Generator: generate_models_from_db, generate_migration_plan

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -7,7 +7,7 @@ import JSON
 import PormG: PormGField, PormGModel, reserved_words, Migration
 import PormG: DATETIME_FORMAT
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
-import PormG: SQLConn, config, Configuration
+import PormG: PormGSettings, config, Configuration
 import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING, PROTECT
 # import PormG: make_password, check_password, password_needs_upgrade, DEFAULT_PBKDF2_ITERATIONS
 using Printf
@@ -150,7 +150,7 @@ function get_model_pk_field(model::PormGModel)::Union{Symbol, Nothing}
   end
 end
 
-function get_model_name(model::PormGModel, settings::SQLConn, symbol::Bool=true)::Union{String, Symbol}
+function get_model_name(model::PormGModel, settings::PormGSettings, symbol::Bool=true)::Union{String, Symbol}
   value::Union{String, Symbol, Nothing} = nothing
   if settings.django_prefix !== nothing
     django_prefix = """$(settings.django_prefix)_"""
@@ -203,7 +203,7 @@ function set_models(_module::Module, path::String)::Nothing
     connect_key = path
   end
   
-  settings::SQLConn = Configuration.get_settings(connect_key)
+  settings::PormGSettings = Configuration.get_settings(connect_key)
 
   # set the original module in models and clear related objects for idempotency
   for model in models
@@ -710,9 +710,9 @@ end
 Converts a model object to a string representation to create the model.
 
 # Arguments
-    Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; contants_julia::Vector{String}=reserved_words)::String
+    Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words)::String
 - `model::Union{Model_Type, PormGModel}`: The model object to convert.
-- `settings::SQLConn`: Connection settings; supplies `django_prefix` and the target output folder.
+- `settings::PormGSettings`: Connection settings; supplies `django_prefix` and the target output folder.
 - `contants_julia::Vector{String}=reserved_words`: A vector of reserved words in Julia.
 
 # Returns
@@ -733,7 +733,7 @@ users = Models.Model("users",
 )
 ```
 """
-function Model_to_str(model::Union{Model_Type, PormGModel}, settings::SQLConn; contants_julia::Vector{String}=reserved_words)::String
+function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words)::String
   fields::String = ""
   render_failures::Vector{String} = String[]
   django_prefix::Bool = settings.django_prefix === nothing ? false : true
@@ -1344,7 +1344,7 @@ function _resolve_model_reference(models::Dict{Symbol, Dict{Symbol, Union{Bool, 
   throw(ArgumentError("The model $(model_ref) referenced by a ManyToManyField is not defined"))
 end
 
-function _many_to_many_table_name(source_model::PormGModel, field_name::String, field::sManyToManyField, settings::SQLConn)::String
+function _many_to_many_table_name(source_model::PormGModel, field_name::String, field::sManyToManyField, settings::PormGSettings)::String
   field.db_table !== nothing && return field.db_table
   source_name = get_model_name(source_model, settings, false)
   return format_model_name("$(source_name)_$(field_name)")
@@ -1374,7 +1374,7 @@ function _relation_from_many_to_many(
   field::sManyToManyField,
   related_model::PormGModel,
   related_binding::String,
-  settings::SQLConn;
+  settings::PormGSettings;
   _module::Union{Module, Nothing}=nothing,
   model_map::Union{Nothing, Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}}=nothing,
 )
@@ -1456,7 +1456,7 @@ function _cache_many_to_many_relation!(model::PormGModel, accessor::String, rela
   return relation
 end
 
-function _register_many_to_many_relation!(_module::Module, settings::SQLConn, model::PormGModel, field_name::String, field::sManyToManyField)::Nothing
+function _register_many_to_many_relation!(_module::Module, settings::PormGSettings, model::PormGModel, field_name::String, field::sManyToManyField)::Nothing
   related_model = _resolve_model_reference(_module, field.to)
   relation = _relation_from_many_to_many(
     model,
@@ -1513,7 +1513,7 @@ function strip_many_to_many_fields(model::PormGModel)::PormGModel
   )
 end
 
-function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, settings::SQLConn)
+function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, settings::PormGSettings)
   expanded = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}()
 
   for (model_name, model_info) in current_schema

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -37,9 +37,9 @@ import DataFrames, OrderedCollections, Dates, Logging, Millboard, YAML
 # and load on `using LibPQ` / `using SQLite`.
 
 abstract type PormGAbstractType end
-abstract type SQLConn <: PormGAbstractType end
-# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: SQLConn —
-# SQLConn is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
+abstract type PormGSettings <: PormGAbstractType end
+# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: PormGSettings —
+# PormGSettings is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
 # PostgresConnectionPool <: PormGPostgres and SQLiteConnectionPool <: PormGSQLite.
 abstract type PormGBackend <: PormGAbstractType end
 abstract type PormGPostgres <: PormGBackend end
@@ -71,7 +71,7 @@ abstract type PormGField <: PormGAbstractType end # define the type of the colum
 
 abstract type Migration <: PormGAbstractType end
 
-const config::Dict{String,SQLConn} = Dict()
+const config::Dict{String,PormGSettings} = Dict()
 
 if !haskey(ENV, "PORMG_ENV")
   ENV["PORMG_ENV"] = "dev"

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -6,7 +6,7 @@ using Dates, TimeZones, Decimals, UUIDs
 import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField
 import PormG: Dialect, Models
 import PormG: config
-import PormG: SQLType, SQLConn, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
+import PormG: SQLType, PormGSettings, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
 import PormG: PormGsuffix, PormGtransform, JSON_CONTAINMENT_OPERATORS, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -118,7 +118,7 @@ function import_models_from_postgres(db::String;
   ignore_table::Vector{String} = postgres_ignore_table,
   include_table::Union{Vector{String}, Nothing} = nothing,
   file::String="automatic_models.jl",
-  config::Dict{String,SQLConn} = config)
+  config::Dict{String,PormGSettings} = config)
   
   settings = Configuration.get_settings(db)
   conn = settings.connections
@@ -155,7 +155,7 @@ function import_models_from_postgres(db::String;
 end
 
 function import_models_from_postgres(;db::PormGPostgres = connection(), 
-                                  settings::SQLConn,
+                                  settings::PormGSettings,
                                   force_replace::Bool=false, 
                                   ignore_table::Vector{String} = postgres_ignore_table,
                                   include_table::Union{Vector{String}, Nothing} = nothing,
@@ -261,7 +261,7 @@ function import_models_from_django(
     parameters_ignore::Vector{String} = ["help_text"]
   )
 
-  settings::Union{Nothing, SQLConn} = nothing
+  settings::Union{Nothing, PormGSettings} = nothing
   try
     settings = Configuration.get_settings(db)
   catch e

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -270,7 +270,7 @@ function _add_new_field(conn::Union{PormGPostgres, PormGSQLite}, migration_plan:
   _add_new_field(conn, migration_plan, model_name, model, field_name |> string, temporary_default_value=temporary_default_value)
 end
 
-function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, model::PormGModel, current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, settings::SQLConn; interactive::Bool = true)::Nothing
+function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::OrderedDict{Symbol, OrderedDict{String, String}}, model_name::Symbol, model::PormGModel, current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, settings::PormGSettings; interactive::Bool = true)::Nothing
   # @pormg_debug model_name == :new_join_position
   if Models.are_model_fields_equal(current_schema[model_name][:model], model)
     # println("Model $model_name are equal")
@@ -406,7 +406,7 @@ function _resolve_table_fields(
                                 colect_deletion::Vector{Symbol}, 
                                 colect_addition::Vector{Symbol}, 
                                 migration_plan::OrderedDict{Symbol, OrderedDict{String, String}},
-                                settings::SQLConn,
+                                settings::PormGSettings,
                                 model_fields_map::Dict{String, String},
                                 current_fields_map::Dict{String, String};
                                 interactive::Bool = true
@@ -574,7 +574,7 @@ function _colect_numbered_fields(colect::Vector{Symbol})
   end
   return colect_numbered, join([string(index, " - ", colect_numbered[index]) for index in sort(collect(keys(colect_numbered)))], ", ")
 end
-function _get_temporary_default_value(field::PormGField, settings::SQLConn)
+function _get_temporary_default_value(field::PormGField, settings::PormGSettings)
   if field |> typeof == Models.sDateTimeField
     return field.formater(now(), settings.time_zone) |> field.formater
   elseif field |> typeof == Models.sDateField
@@ -590,7 +590,7 @@ end
 # ---
 
 # Compare model definitions to the current database schema
-function get_migration_plan(models::Vector{PormGModel}, current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, conn, settings::SQLConn; interactive::Bool = true)
+function get_migration_plan(models::Vector{PormGModel}, current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, conn, settings::PormGSettings; interactive::Bool = true)
 # models is olds models
 
 migration_plan = OrderedDict{Symbol, OrderedDict{String, String}}()
@@ -697,7 +697,7 @@ return migration_plan
 end
 
 # Main function to simulate makemigrations
-function makemigrations(connection::PormGPostgres, settings::SQLConn; path::String = "db/models.jl", interactive::Bool = true)
+function makemigrations(connection::PormGPostgres, settings::PormGSettings; path::String = "db/models.jl", interactive::Bool = true)
 if !settings.change_db
   @warn("Schema changes are disabled (`change_db: false`). Set `change_db: true` in your db/connection.yml under the active environment to allow migrations.")
   return
@@ -741,7 +741,7 @@ end
 
 end
 
-function makemigrations(connection::PormGSQLite, settings::SQLConn; path::String = "db/models.jl", interactive::Bool = true)
+function makemigrations(connection::PormGSQLite, settings::PormGSettings; path::String = "db/models.jl", interactive::Bool = true)
   if !settings.change_db
     @warn("Schema changes are disabled (`change_db: false`). Set `change_db: true` in your db/connection.yml under the active environment to allow migrations.")
     return
@@ -774,7 +774,7 @@ function makemigrations(connection::PormGSQLite, settings::SQLConn; path::String
   end
 end
 
-function makemigrations(db::String; config::Dict{String,SQLConn} = config, interactive::Bool = true)
+function makemigrations(db::String; config::Dict{String,PormGSettings} = config, interactive::Bool = true)
 settings = Configuration.get_settings(db)
 path = joinpath(db, settings.model_file)
 isfile(path) || error("The file $(path) does not exists")

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -154,11 +154,11 @@ function _ensure_format_version_column(connection::Union{PormGPostgres, PormGSQL
   nothing
 end
 
-function init_migrations(settings::SQLConn)
+function init_migrations(settings::PormGSettings)
   init_migrations(settings.connections)
 end
 
-function init_migrations(db::String; config::Dict{String,SQLConn} = config)
+function init_migrations(db::String; config::Dict{String,PormGSettings} = config)
   settings = config[db]
   init_migrations(settings)
 end
@@ -344,7 +344,7 @@ Report migration status: applied, failed, pending, and drift signals.
 Includes basic drift detection by comparing live database tables against
 the history of applied migrations.
 """
-function status(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn)::MigrationStatus
+function status(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings)::MigrationStatus
   has_table = _migrations_table_exists(connection)
   
   applied = NamedTuple[]
@@ -398,11 +398,11 @@ function status(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn
   return MigrationStatus(applied, failed, has_pending, has_table, drift_signals)
 end
 
-function status(settings::SQLConn)::MigrationStatus
+function status(settings::PormGSettings)::MigrationStatus
   status(settings.connections, settings)
 end
 
-function status(db::String; config::Dict{String,SQLConn} = config)::MigrationStatus
+function status(db::String; config::Dict{String,PormGSettings} = config)::MigrationStatus
   settings = config[db]
   status(settings)
 end
@@ -416,7 +416,7 @@ end
 
 Load and return all OrderedDicts from the pending_migrations.jl file.
 """
-function _load_migration_plan(settings::SQLConn)
+function _load_migration_plan(settings::PormGSettings)
   pending_path = joinpath(settings.db_def_folder, "migrations", "pending_migrations.jl")
   if !isfile(pending_path)
     error("No pending migrations found at: $pending_path")
@@ -523,7 +523,7 @@ Analyze pending migrations without applying them.
 Validates ordering, checksums, destructive actions, and SQL generation.
 Does NOT modify the database or move files.
 """
-function dry_run(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn)::DryRunResult
+function dry_run(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings)::DryRunResult
   migration_plan = _load_migration_plan(settings)
   ordered_statements, all_sql = _order_statements(migration_plan)
   
@@ -537,11 +537,11 @@ function dry_run(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLCon
   )
 end
 
-function dry_run(settings::SQLConn)::DryRunResult
+function dry_run(settings::PormGSettings)::DryRunResult
   dry_run(settings.connections, settings)
 end
 
-function dry_run(db::String; config::Dict{String,SQLConn} = config)::DryRunResult
+function dry_run(db::String; config::Dict{String,PormGSettings} = config)::DryRunResult
   settings = config[db]
   dry_run(settings)
 end
@@ -643,7 +643,7 @@ end
 
 Move pending_migrations.jl to applied_migrations/ and snapshot the models file.
 """
-function _archive_migration_files(settings::SQLConn, date_str::String)
+function _archive_migration_files(settings::PormGSettings, date_str::String)
   path_applied = joinpath(settings.db_def_folder, "migrations", "applied_migrations")
   if !ispath(path_applied)
     mkpath(path_applied)
@@ -689,7 +689,7 @@ Apply pending migrations to a PostgreSQL database.
 - `dry_run_only::Bool=false`: if `true`, only analyze without applying (returns DryRunResult)
 - `name::String="pending_migration"`: name for this migration in the history table
 """
-function migrate(connection::PormGPostgres, settings::SQLConn;
+function migrate(connection::PormGPostgres, settings::PormGSettings;
                  path::String = "db/models/models.jl",
                  interactive::Bool = true,
                  destructive::Bool = false,
@@ -772,7 +772,7 @@ Apply pending migrations to a SQLite database.
 SQLite migrations use BEGIN IMMEDIATE TRANSACTION for safety.
 Advisory locking is not available — single-instance migration safety only.
 """
-function migrate(connection::PormGSQLite, settings::SQLConn; 
+function migrate(connection::PormGSQLite, settings::PormGSettings; 
                  path::String = "db/models/models.jl",
                  interactive::Bool = true, 
                  destructive::Bool = false,
@@ -841,7 +841,7 @@ end
 # Shared execution lifecycle (called within lock for PostgreSQL)
 # ==============================================================================
 
-function _execute_migration_lifecycle(connection::PormGPostgres, settings::SQLConn,
+function _execute_migration_lifecycle(connection::PormGPostgres, settings::PormGSettings,
                                       ordered_statements::Vector{String}, all_sql::String,
                                       version::String, name::String, checksum::String,
                                       has_destructive::Bool)
@@ -916,7 +916,7 @@ function _execute_migration_lifecycle(connection::PormGPostgres, settings::SQLCo
   end
 end
 
-function _execute_migration_lifecycle(connection::PormGSQLite, settings::SQLConn,
+function _execute_migration_lifecycle(connection::PormGSQLite, settings::PormGSettings,
                                       ordered_statements::Vector{String}, all_sql::String,
                                       version::String, name::String, checksum::String,
                                       has_destructive::Bool)
@@ -998,7 +998,7 @@ end
 # String-based entry point
 # ==============================================================================
 
-function migrate(db::String; config::Dict{String,SQLConn} = config, interactive::Bool = true,
+function migrate(db::String; config::Dict{String,PormGSettings} = config, interactive::Bool = true,
                  destructive::Bool = false, dry_run_only::Bool = false, name::String = "pending_migration")
   settings = config[db]
   migrate(settings.connections, settings, interactive=interactive, destructive=destructive, 
@@ -1016,7 +1016,7 @@ Apply pending migrations up to (and including) a specific version.
 Only meaningful when multiple migration files exist in the pending queue.
 For now, this validates the target version against the current history.
 """
-function migrate_to(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn, 
+function migrate_to(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings, 
                     target_version::String; interactive::Bool = true, destructive::Bool = false)
   init_migrations(connection)
   
@@ -1031,7 +1031,7 @@ function migrate_to(connection::Union{PormGPostgres, PormGSQLite}, settings::SQL
   throw(ArgumentError("migrate_to(version) is not implemented for the current single pending_migrations.jl workflow. Generate and apply the pending plan with migrate(), or implement ordered multi-file migration queues first."))
 end
 
-function migrate_to(db::String, target_version::String; config::Dict{String,SQLConn} = config, 
+function migrate_to(db::String, target_version::String; config::Dict{String,PormGSettings} = config, 
                     interactive::Bool = true, destructive::Bool = false)
   settings = config[db]
   migrate_to(settings.connections, settings, target_version; interactive=interactive, destructive=destructive)
@@ -1074,7 +1074,7 @@ verifiable — passing neither is refused rather than fabricated (issue #81). De
 classified from `sql_content` when provided instead of being hard-coded, so a manually-reconciled
 destructive migration is still flagged in history.
 """
-function mark_applied(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn,
+function mark_applied(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings,
                       version::String, name::String;
                       checksum::String = "", sql_content::String = "")
   # Validate arguments before touching the DB so a bad call is a pure ArgumentError.
@@ -1086,7 +1086,7 @@ function mark_applied(connection::Union{PormGPostgres, PormGSQLite}, settings::S
   @info("Marked version $version as applied.")
 end
 
-function mark_applied(db::String, version::String, name::String; config::Dict{String,SQLConn} = config, kwargs...)
+function mark_applied(db::String, version::String, name::String; config::Dict{String,PormGSettings} = config, kwargs...)
   settings = config[db]
   mark_applied(settings.connections, settings, version, name; kwargs...)
 end
@@ -1097,14 +1097,14 @@ end
 Update an existing migration record to 'failed' status.
 Useful after manual investigation of a partially-applied migration.
 """
-function mark_failed(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn,
+function mark_failed(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings,
                      version::String)
   init_migrations(connection)
   _update_migration_status(connection, version, "failed")
   @info("Marked version $version as failed.")
 end
 
-function mark_failed(db::String, version::String; config::Dict{String,SQLConn} = config)
+function mark_failed(db::String, version::String; config::Dict{String,PormGSettings} = config)
   settings = config[db]
   mark_failed(settings.connections, settings, version)
 end
@@ -1116,7 +1116,7 @@ Remove a migration record from the history table entirely.
 Use with caution — this erases history. Intended for cleanup after
 manual rollbacks or test scenarios.
 """
-function remove_migration_record(connection::Union{PormGPostgres, PormGSQLite}, settings::SQLConn,
+function remove_migration_record(connection::Union{PormGPostgres, PormGSQLite}, settings::PormGSettings,
                                  version::String)
   init_migrations(connection)
   
@@ -1130,7 +1130,7 @@ function remove_migration_record(connection::Union{PormGPostgres, PormGSQLite}, 
   @info("Removed migration record for version $version.")
 end
 
-function remove_migration_record(db::String, version::String; config::Dict{String,SQLConn} = config)
+function remove_migration_record(db::String, version::String; config::Dict{String,PormGSettings} = config)
   settings = config[db]
   remove_migration_record(settings.connections, settings, version)
 end
@@ -1155,7 +1155,7 @@ Returns `(discarded=true, path, backup, tables, statements)` describing what was
 or `nothing` when there is no pending migration. Pairs with [`status`](@ref), which reports
 whether a pending file exists.
 """
-function discard_pending_migration(settings::SQLConn; backup::Bool = true)
+function discard_pending_migration(settings::PormGSettings; backup::Bool = true)
   pending_path = joinpath(settings.db_def_folder, "migrations", "pending_migrations.jl")
   if !isfile(pending_path)
     @info(_emsg("\e[32mNo pending migration to discard.\e[0m"))
@@ -1187,7 +1187,7 @@ function discard_pending_migration(settings::SQLConn; backup::Bool = true)
   return (discarded = true, path = pending_path, backup = backup_path, tables = tables, statements = statements)
 end
 
-function discard_pending_migration(db::String; config::Dict{String,SQLConn} = config, backup::Bool = true)
+function discard_pending_migration(db::String; config::Dict{String,PormGSettings} = config, backup::Bool = true)
   settings = config[db]
   discard_pending_migration(settings; backup = backup)
 end

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -6,7 +6,7 @@
     get_settings(obj::Union{SQLObject, SQLObjectHandler}; connection::Union{Nothing, PormGPostgres, PormGSQLite} = nothing)
 
 Resolves the database settings for a query. 
-Returns a tuple of `(settings::SQLConn, connection, conn_key::String)`.
+Returns a tuple of `(settings::PormGSettings, connection, conn_key::String)`.
 
 If a `connection` is provided, it is returned as is. 
 Otherwise, it returns the default connection from the resolved settings.

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -740,7 +740,7 @@ function _get_owned_sequence_name(connection::PormGPostgres, model::PormGModel, 
   return ismissing(sequence_name) || isnothing(sequence_name) ? nothing : sequence_name
 end
 
-function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field::Vector{String}, settings::SQLConn; ignore_tx::Bool = false)
+function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field::Vector{String}, settings::PormGSettings; ignore_tx::Bool = false)
   @pormg_debug true
 
   !(settings.change_db || settings.django_prefix !== nothing) && return nothing
@@ -802,7 +802,7 @@ end
 #     end
 #   end
 # end
-function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::SQLConn)
+function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::PormGSettings)
   for field in pk_field
     safe_field_name = quote_identifier(Models.model_column(model, field), connection)  # db_column (#50)
     safe_table_name = safe_table_identifier(string(model.name), connection)

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -343,7 +343,7 @@ end
 # one isn't already active (#88), and the create() path (execution.jl) reaches here only
 # when get_sqlite_reserved_primary_key_max returned non-nothing, which already implies an
 # open transaction (reservation overlay is a no-op at depth 0).
-function _allocate_sqlite_ids(model::PormGModel, connection::PormGSQLite, pk_field::String, n::Int, settings::SQLConn)
+function _allocate_sqlite_ids(model::PormGModel, connection::PormGSQLite, pk_field::String, n::Int, settings::PormGSettings)
   safe_table = string(model.name |> lowercase)
   safe_table_name = safe_table_identifier(safe_table, connection)
   safe_table_literal = replace(safe_table, "'" => "''")
@@ -1174,7 +1174,7 @@ end
 
 function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGSQLite},
   fields::Vector{String}, rows::Vector{String},
-  pk_exist::Bool, pk_field::Vector{String}, settings::SQLConn,
+  pk_exist::Bool, pk_field::Vector{String}, settings::PormGSettings,
   django_prefix::Bool, show_query::Symbol, parameters:: AbstractPormGParam;
   on_conflict_sql::Union{Nothing, String} = nothing)
 
@@ -1437,7 +1437,7 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
 end
 
 function _bulk_update(model::PormGModel,
-  settings::SQLConn,
+  settings::PormGSettings,
   connection::Union{PormGPostgres, PormGSQLite}, 
   fields::Vector{String}, 
   rows::Vector{String}, 

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -1000,7 +1000,7 @@ end
 
 mutable struct DeletionCollector{T}
   model::PormGModel  # The main model being deleted from
-  settings::SQLConn  # Connection settings
+  settings::PormGSettings  # Connection settings
   connection::Union{PormGPostgres,PormGSQLite}  # Database connection
   objects::Dict{PormGModel,Vector{Dict{Symbol,T}}}  # Models and their objects to delete
   dependencies::Dict{PormGModel,Set{PormGModel}}  # Model dependencies

--- a/test/integration/common_migration_setup.jl
+++ b/test/integration/common_migration_setup.jl
@@ -17,7 +17,7 @@ Destructive reset of the selected integration database.
 After calling this, the database is completely empty — no user tables,
 no pormg_migrations history.
 """
-function reset_database!(settings::PormG.SQLConn)
+function reset_database!(settings::PormG.PormGSettings)
   conn_pool = settings.connections
   if conn_pool isa PormG.PormGSQLite
     _reset_sqlite!(conn_pool)
@@ -86,8 +86,8 @@ is rebuilt via `_build_connection_pool!`.
 `database` is preserved (non-blank in the committed fixture → the loop below skips it), which is
 exactly what keeps the edge DB isolated from the selected integration DB.
 """
-function hydrate_postgres_settings!(edge_settings::PormG.SQLConn,
-                                    source_settings::PormG.SQLConn, folder::String)
+function hydrate_postgres_settings!(edge_settings::PormG.PormGSettings,
+                                    source_settings::PormG.PormGSettings, folder::String)
   edge_cfg = edge_settings.db_config_settings
   source_cfg = source_settings.db_config_settings
 
@@ -123,7 +123,7 @@ _is_safe_pg_ident(name::AbstractString) = occursin(r"^[A-Za-z_][A-Za-z0-9_]*$", 
 
 # Build an ad-hoc pool to the `postgres` maintenance DB using the (already-hydrated) host/port/
 # user/password from the edge settings, so we can CREATE/DROP the disposable DB from outside it.
-function _maintenance_pool(edge_settings::PormG.SQLConn)
+function _maintenance_pool(edge_settings::PormG.PormGSettings)
   cfg = copy(edge_settings.db_config_settings)
   cfg["database"] = "postgres"     # connect to the always-present maintenance DB
   delete!(cfg, "url")              # force param-based DNS so the `database` override takes effect
@@ -139,7 +139,7 @@ end
 Create the disposable `dbname` database if it does not already exist, connecting to the `postgres`
 maintenance DB with the hydrated edge credentials. No-op when the DB is already present.
 """
-function ensure_postgres_database!(edge_settings::PormG.SQLConn, dbname::String)
+function ensure_postgres_database!(edge_settings::PormG.PormGSettings, dbname::String)
   _is_safe_pg_ident(dbname) || error("Refusing unsafe database identifier: $(repr(dbname))")
   maint = _maintenance_pool(edge_settings)
   try
@@ -165,7 +165,7 @@ Best-effort drop of the disposable `dbname` database at teardown (`WITH (FORCE)`
 straggler connections; requires PostgreSQL 13+). Failure only warns — the next run re-creates it.
 Close the edge pool for `dbname` before calling this.
 """
-function drop_postgres_database!(edge_settings::PormG.SQLConn, dbname::String)
+function drop_postgres_database!(edge_settings::PormG.PormGSettings, dbname::String)
   _is_safe_pg_ident(dbname) || return nothing
   maint = _maintenance_pool(edge_settings)
   try

--- a/test/unit/test_commit_failure_release.jl
+++ b/test/unit/test_commit_failure_release.jl
@@ -129,10 +129,10 @@ function PormG.backend_execute(pool::MockSQLitePool139, conn, sql::String, param
   return NamedTuple[]
 end
 
-# ── Minimal concrete SQLConn wrapper (like Configuration.Settings): <: SQLConn but NOT a
-#    PormGPostgres/PormGSQLite, so finalize_transaction_connection!(::SQLConn, ...) dispatches to
+# ── Minimal concrete PormGSettings wrapper (like Configuration.Settings): <: PormGSettings but NOT a
+#    PormGPostgres/PormGSQLite, so finalize_transaction_connection!(::PormGSettings, ...) dispatches to
 #    the delegating overload that delete() relies on (settings is a Settings, not a raw pool). ──
-mutable struct MockSettings139 <: PormG.SQLConn
+mutable struct MockSettings139 <: PormG.PormGSettings
   connections::Any
 end
 
@@ -178,8 +178,8 @@ end
 # ── Drive the REAL PormG.Migrations._execute_migration_lifecycle (not a reproduction) against the
 #    mock, so a future revert of the caller's `release_conn` is caught by CI. The mock returns empty
 #    result tables (so the migration reads the DB as empty → no idempotency skip), no-ops the DDL and
-#    the history INSERTs, and throws on COMMIT. The 2nd arg is `settings::SQLConn`; since #186 a pool is
-#    no longer <: SQLConn, we pass a MockSettings139 (a Settings-like SQLConn wrapping the pool) — it is
+#    the history INSERTs, and throws on COMMIT. The 2nd arg is `settings::PormGSettings`; since #186 a pool is
+#    no longer <: PormGSettings, we pass a MockSettings139 (a Settings-like PormGSettings wrapping the pool) — it is
 #    only touched by archiving, which the COMMIT-failure rethrow never reaches. Returns the error/nothing. ──
 function run_real_migration_lifecycle_139(pool)
   settings = MockSettings139(pool)
@@ -241,20 +241,20 @@ end
   @test pool.next_id == 1                               # no fresh handle created
 end
 
-@testset "finalize_transaction_connection! SQLConn overload delegates to the pool (#139)" begin
-  # delete() passes a Settings (a SQLConn wrapper), not a raw pool, so it dispatches here.
+@testset "finalize_transaction_connection! PormGSettings overload delegates to the pool (#139)" begin
+  # delete() passes a Settings (a PormGSettings wrapper), not a raw pool, so it dispatches here.
   pool = MockPGPool139()
   conn = CP.acquire_connection(pool)
   settings = MockSettings139(pool)
 
-  # #186: a pool and a Settings are now DISTINCT type families — a pool is NOT a SQLConn (it's a
-  # PormGBackend); only the Settings wrapper is a SQLConn. That separation is exactly what makes the
-  # two finalize_transaction_connection! overloads (pool vs SQLConn) dispatch to the right one.
-  @test !(pool isa PormG.SQLConn)
+  # #186: a pool and a Settings are now DISTINCT type families — a pool is NOT a PormGSettings (it's a
+  # PormGBackend); only the Settings wrapper is a PormGSettings. That separation is exactly what makes the
+  # two finalize_transaction_connection! overloads (pool vs PormGSettings) dispatch to the right one.
+  @test !(pool isa PormG.PormGSettings)
   @test pool isa PormG.PormGBackend
-  @test settings isa PormG.SQLConn
+  @test settings isa PormG.PormGSettings
 
-  @test CP.finalize_transaction_connection!(settings, conn) === nothing   # <: SQLConn, not a pool
+  @test CP.finalize_transaction_connection!(settings, conn) === nothing   # <: PormGSettings, not a pool
   @test pool.connections[1] === conn                    # delegated to pool.connections and released
   @test pool.available[1] === true
   # And the renew path still routes through the delegation.

--- a/test/unit/test_self_heal_inference.jl
+++ b/test/unit/test_self_heal_inference.jl
@@ -34,5 +34,5 @@ using PormG.Models: Model, IDField
   @test PormG.Models._infer_self_heal_key(other, [m], Dict("db" => s1)) === nothing
 
   # No connections configured → nothing (length != 1).
-  @test PormG.Models._infer_self_heal_key(m, [m], Dict{String,PormG.SQLConn}()) === nothing
+  @test PormG.Models._infer_self_heal_key(m, [m], Dict{String,PormG.PormGSettings}()) === nothing
 end


### PR DESCRIPTION
Addresses **#188** (rename thread). Does **not** `Closes` — the other two #188 threads are being folded into #60; #188 will be closed with a summary once this merges.

## Why
`SQLConn` is a misnomer: it holds `Configuration.Settings` (config — `app_env`, `db_config_settings`, `connections`, …), **not** a live connection. After #186 moved the pool markers off it, its only real subtype is `Settings`, so the name plainly lied — and it was mis-filed in the `SQL*` family, which is otherwise query-builder internals. Renamed to `PormGSettings`, joining the `PormG*` abstract-type family (`PormGModel`, `PormGField`, `PormGBackend`).

## Change
Pure whole-word rename `SQLConn` → `PormGSettings` across **21 files** (+128/−129): the abstract type, `config::Dict{String,PormGSettings}`, `Settings <: PormGSettings`, ~30 `::PormGSettings` dispatch sites, imports, test mocks, and the docs table. **Internal, unexported type → no public-API impact.** **No deprecation alias** (pre-publish; an alias would defeat the rename).

Also fixes two comments the rename surfaced — including a **latent #186 bug** in `Backend.jl` (a pool is `<: PormGBackend`, not `<: SQLConn`; the blind rename would have made it `<: PormGSettings`, which is doubly wrong).

## Verification
- Whole-word grep confirmed `SQLConn` never appears inside a longer identifier; zero stray references remain (only an intentional "Renamed from `SQLConn`" note in `docs/src/api.md`).
- Unit **4037/4037**; PostgreSQL integration **1748/1748**; SQLite integration **1714 + 1 pre-existing `@test_broken`** (the integration run specifically covers `test/integration/common_migration_setup.jl`, the one renamed file the unit suite can't reach).
- Self-review + independent review (`.github/skills/pormg-changed-code-review`): both ran; between them caught the two corrupted comments and a grammar artifact (`an`→`a PormGSettings`), all fixed. No behavioral change.

## Deferred (folded into #60, per the #188 discussion)
- **Dialect/pool separation** — ~295 dispatch-site rewrite; #60 (MySQL) doesn't get cheaper either way. Not worth it.
- **`Union{PormGPostgres,PormGSQLite}` → `::PormGBackend` collapse** — has a future-backend routing subtlety; best done *selectively* alongside #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)