### PR TITLE
fix(#87): migrate() non-interactive-safe; unify PG/SQLite pre-flight

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,6 @@
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-- [#87](https://github.com/PingoLee/PormG.jl/issues/87) — `migrate()` defaults `interactive=true` and blocks on `readline()` in non-interactive/CI contexts
 - [#92](https://github.com/PingoLee/PormG.jl/issues/92) — Design: explicit correlated-subquery aggregates (no auto-magic) — the supported fix for #74 fan-out
 
 ---

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,80 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `migrate()` is non-interactive-safe — throws `DestructiveMigrationError` in CI instead of hanging (#87)
+
+- **PormG ref**: issue #87 ; `src/migrations/runner.jl`, `src/Migrations.jl`
+- **Recorded**: 2026-07-21
+- **Severity**: **behavior change (automation only)** — new exported `DestructiveMigrationError`. Affects
+  only code that calls `migrate()` in a **non-interactive** context (CI, `Pkg.test`, deploy/cron script,
+  piped stdin). Interactive `migrate()` at a real terminal is unchanged.
+
+### What changed
+
+`migrate()` defaulted `interactive=true` and called a bare `readline()` to confirm — with **no TTY
+detection**. In a non-interactive process that either **hung** on stdin or read EOF and **silently applied
+nothing** ("Migrations were not applied"). The safe-looking workaround `migrate(...; interactive=false,
+destructive=true)` disabled *both* guardrails at once.
+
+Now:
+
+- The confirmation prompt shows **only when stdin is a real terminal** (`interactive && stdin isa
+  Base.TTY`). `migrate()` never blocks on `readline()` in CI / `Pkg.test` / a deploy script.
+- A **non-destructive** plan applies directly in a non-interactive context (previously a silent no-op).
+- A **destructive** plan in a non-interactive context now **throws `DestructiveMigrationError`** (exported)
+  unless `destructive=true` is passed — instead of silently returning `nothing`. Automation fails loudly
+  with an actionable message.
+- **Piped stdin** (`echo yes | julia … migrate("db")`) counts as non-interactive — it no longer bypasses
+  the destructive gate; pass `destructive=true`.
+
+Interactive terminal behavior is unchanged: you still get the yes/no prompt, and a destructive plan without
+`destructive=true` still prints a red `@error` and aborts.
+
+### How to find the calls to migrate
+
+Grep each app for `migrate(` in automated contexts — CI steps, deploy/bootstrap scripts, anything run
+without a TTY:
+
+```
+rg -n "migrate\(" <app>                 # focus on CI / deploy / cron entry points
+rg -n "interactive\s*=\s*false" <app>
+```
+
+Two things to check at each non-interactive call site:
+
+1. A `catch` / return-value check that assumed a destructive plan **silently returns `nothing`** — it now
+   throws `DestructiveMigrationError`.
+2. A call that passed `interactive=false` only to avoid a hang — that is now optional (auto-detected), but
+   harmless to keep.
+
+### Migrate your app
+
+- Automated apply of a plan that *may* be destructive: pass the explicit opt-in —
+  `migrate("db"; destructive=true)`. CI no longer hangs, and a missing opt-in is now a loud error, not a
+  silent skip.
+- If a script must tolerate "destructive plan present → skip, don't fail", catch it:
+  ```julia
+  try
+      migrate("db")
+  catch e
+      e isa PormG.Migrations.DestructiveMigrationError || rethrow()
+      @warn "Destructive migration skipped; apply manually with destructive=true" exception=e
+  end
+  ```
+- Non-destructive automated migrations need no change — `migrate("db")` now applies them instead of
+  silently no-op'ing.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | check CI/deploy scripts calling `migrate()`; destructive plans now throw `DestructiveMigrationError` |
+| app-2 | ⏳ | as above |
+| app-3 | ⏳ | as above |
+| app-4 | ⏳ | as above |
+
+---
+
 ## Connect fast-fail (`PoolConnectError`, `fail_fast_on_connect`)
 
 - **PormG ref**: issue #72 (AC2; follow-up to #37/#124) ; `src/ConnectionPool.jl`, `src/Configuration.jl`,

--- a/docs/src/migrations/advanced.md
+++ b/docs/src/migrations/advanced.md
@@ -70,4 +70,4 @@ end
 - **Review Plans:** Use `dry_run()` before applying to catch any accidental drops.
 - **Version Control:** Commit your `applied_migrations/` folder.
 - **Backups:** Always back up production databases before running schema changes.
-- **Destructive Guard:** Never bypass the destructive guard in CI/CD without manual approval of the migration plan.
+- **Destructive Guard:** Never bypass the destructive guard in CI/CD without manual approval of the migration plan. In a non-interactive context a destructive plan throws `DestructiveMigrationError` unless you pass `destructive=true`; catch it (or set the flag) deliberately rather than blanket-suppressing it.

--- a/docs/src/migrations/workflow.md
+++ b/docs/src/migrations/workflow.md
@@ -113,14 +113,31 @@ PormG blocks destructive SQL (DROP TABLE, DROP COLUMN) by default. To apply them
 PormG.Migrations.migrate("db", destructive=true)
 ```
 
+At an interactive terminal, a destructive plan without `destructive=true` prints a warning and aborts so you
+can re-run with the opt-in. In a **non-interactive** context (CI, `Pkg.test`, a deploy script, or piped
+stdin) the same plan throws a `DestructiveMigrationError` instead — automation fails loudly rather than
+hanging on a prompt or silently skipping the migration.
+
 ---
 
 ## Automation & CI/CD
-In non-interactive environments, use `interactive=false`:
+`migrate()` detects a non-interactive process automatically: when stdin is not a terminal it shows no
+confirmation prompt and never blocks on `readline()`. You do not need `interactive=false` for that (it is
+auto-detected), though passing it is still allowed and harmless.
 ```julia
-# Safe migrations only
-PormG.Migrations.migrate("my_db", interactive=false)
+# Non-destructive plans apply directly — no prompt, no hang:
+PormG.Migrations.migrate("my_db")
 
-# Destructive migrations allowed
-PormG.Migrations.migrate("my_db", interactive=false, destructive=true)
+# A destructive plan must opt in explicitly, or it throws DestructiveMigrationError:
+PormG.Migrations.migrate("my_db", destructive=true)
+```
+
+To tolerate "a destructive plan is present — skip it rather than fail", catch the error:
+```julia
+try
+    PormG.Migrations.migrate("my_db")
+catch e
+    e isa PormG.Migrations.DestructiveMigrationError || rethrow()
+    @warn "Destructive migration skipped; apply manually with destructive=true" exception=e
+end
 ```

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -25,7 +25,7 @@ import PormG: _emsg  # shared TTY-aware error/log-message strip helper (tools.jl
 import PormG: Models, Migration, Dialect
 import PormG.Models: format_model_name
 import PormG: connection, config, get_constraints_pk, get_constraints_unique, get_constraints_check
-import PormG: PormGModel, PormGField, PormGSettings, PormGPostgres, PormGSQLite
+import PormG: PormGModel, PormGField, PormGSettings, PormGBackend, PormGPostgres, PormGSQLite
 import PormG: sqlite_type_map, postgres_type_map, sqlite_ignore_schema, postgres_ignore_table, _EXTRA_IGNORE_TABLES
 import PormG: MODEL_PATH, PormGSettings, DB_PATH
 import PormG.AdvisoryLock
@@ -51,5 +51,6 @@ export init_migrations, status, dry_run
 export migrate_to, mark_applied, mark_failed, remove_migration_record, discard_pending_migration
 export MigrationStatus, DryRunResult
 export compute_checksum, is_destructive, total_statements, detect_destructive_actions
+export DestructiveMigrationError
 
 end # module Migrations

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -97,6 +97,78 @@ function detect_destructive_actions(statements::Vector{String})::Vector{String}
   return filter(is_destructive, statements)
 end
 
+# ==============================================================================
+# Migration confirmation gate (destructive guard + interactive prompt)
+# ==============================================================================
+
+"""
+    DestructiveMigrationError(msg, statements)
+
+Raised when a migration containing destructive operations (DROP TABLE, DROP COLUMN, …) is applied in a
+**non-interactive** context (no TTY, or `interactive=false`) without `destructive=true`. Failing loudly
+here means CI, `Pkg.test`, and deploy scripts break with an actionable message instead of hanging on
+`readline()` or silently skipping the migration.
+"""
+struct DestructiveMigrationError <: Exception
+  msg::String
+  statements::Vector{String}
+end
+
+function Base.showerror(io::IO, e::DestructiveMigrationError)
+  print(io, "DestructiveMigrationError: ", e.msg)
+  for s in e.statements
+    print(io, "\n  → ", length(s) > 120 ? first(s, 120) * "..." : s)
+  end
+end
+
+"""
+    _confirm_migration(has_destructive, destructive, destructive_stmts; interactive) -> Bool
+
+Resolve the destructive guard and interactive confirmation for `migrate`. A prompt is only possible on a
+real terminal, so `can_prompt = interactive && (stdin isa Base.TTY)` — this is what keeps `migrate()` from
+ever blocking on `readline()` in CI, `Pkg.test`, or a deploy script (even when `interactive=true`, the
+default).
+
+Returns `true` to proceed, `false` to abort quietly (the caller then `return nothing`). Throws
+[`DestructiveMigrationError`](@ref) when a destructive plan is refused in a non-interactive context, so
+automation fails loudly instead of hanging or silently skipping.
+"""
+function _confirm_migration(has_destructive::Bool, destructive::Bool,
+                            destructive_stmts::Vector{String}; interactive::Bool)::Bool
+  can_prompt = interactive && (stdin isa Base.TTY)
+
+  # Destructive guard: a destructive plan requires an explicit `destructive=true` opt-in.
+  if has_destructive && !destructive
+    msg = "Migration contains $(length(destructive_stmts)) destructive operation(s). " *
+          "Pass `destructive=true` to confirm."
+    # Non-interactive (CI / no TTY / interactive=false): fail loudly so automation cannot
+    # silently skip — and never reach the blocking readline() below.
+    can_prompt || throw(DestructiveMigrationError(msg, destructive_stmts))
+    @error(_emsg("\e[31m$msg\e[0m"))
+    for s in destructive_stmts
+      display_s = length(s) > 120 ? first(s, 120) * "..." : s
+      @error("  → $display_s")
+    end
+    return false
+  end
+
+  # Interactive confirmation — only when a human can actually answer (real TTY).
+  if can_prompt
+    if has_destructive
+      @info(_emsg("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m"))
+    end
+    @info(_emsg("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m"))
+    print(_emsg("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m"))
+    response = strip(lowercase(readline()))
+    if !(response in ["yes", "y"])
+      @info("Migrations were not applied.")
+      return false
+    end
+  end
+
+  return true
+end
+
 # Frozen format-v1 primitive (see test/unit/test_migration_format_v1.jl). Retained for format
 # stability, but no longer auto-invoked: `mark_applied` used to call this to *fabricate* a checksum
 # when the caller supplied neither `sql_content` nor `checksum`. A fabricated digest can never be
@@ -672,24 +744,29 @@ end
 # ==============================================================================
 
 """
-    migrate(connection::PormGPostgres, settings; interactive, destructive, dry_run_only, name)
+    migrate(connection::PormGBackend, settings; interactive, destructive, dry_run_only, name)
 
-Apply pending migrations to a PostgreSQL database.
+Apply pending migrations to a database (PostgreSQL or SQLite). This is the shared pre-flight for every
+backend; the backend-specific execution step is dispatched to `_run_locked_lifecycle` (advisory lock on
+PostgreSQL, direct on SQLite).
 
 # Lifecycle
-1. Validate: check change_db, load plan, detect destructive ops
-2. Lock: acquire advisory lock to prevent concurrent migrations
-3. Execute: run SQL in a transaction
+1. Validate: check change_db, install configured extensions, load plan, detect destructive ops
+2. Confirm: destructive guard + interactive confirmation (TTY-aware — see `_confirm_migration`)
+3. Execute: run SQL in a transaction (under an advisory lock on PostgreSQL)
 4. Record: insert history into pormg_migrations
 5. Archive: move files to applied_migrations/
 
 # Keywords
-- `interactive::Bool=true`: prompt for confirmation before applying
-- `destructive::Bool=false`: must be `true` to allow DROP TABLE / DROP COLUMN operations
+- `interactive::Bool=true`: prompt for confirmation before applying — **only when stdin is a real
+  terminal**. In a non-interactive process (CI, `Pkg.test`, deploy script) no prompt is shown and
+  `migrate()` never blocks on `readline()`.
+- `destructive::Bool=false`: must be `true` to allow DROP TABLE / DROP COLUMN operations. A destructive
+  plan in a non-interactive context throws `DestructiveMigrationError` unless this is set.
 - `dry_run_only::Bool=false`: if `true`, only analyze without applying (returns DryRunResult)
 - `name::String="pending_migration"`: name for this migration in the history table
 """
-function migrate(connection::PormGPostgres, settings::PormGSettings;
+function migrate(connection::PormGBackend, settings::PormGSettings;
                  path::String = "db/models/models.jl",
                  interactive::Bool = true,
                  destructive::Bool = false,
@@ -729,110 +806,33 @@ function migrate(connection::PormGPostgres, settings::PormGSettings;
     return DryRunResult(checksum, ordered_statements, destructive_stmts)
   end
   
-  # Destructive guard
-  if has_destructive && !destructive
-    @error(_emsg("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
-           "Pass `destructive=true` to confirm.\e[0m"))
-    for s in destructive_stmts
-      display_s = length(s) > 120 ? s[1:120] * "..." : s
-      @error("  → $display_s")
-    end
-    return nothing
-  end
-  
-  # Interactive confirmation
-  if interactive
-    if has_destructive
-      @info(_emsg("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m"))
-    end
-    @info(_emsg("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m"))
-    print(_emsg("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m"))
-    response = readline()
-    response = strip(lowercase(response))
-    if !(response in ["yes", "y"])
-      @info("Migrations were not applied.")
-      return nothing
-    end
-  end
-  
-  # --- Phase 2: Lock (PostgreSQL advisory lock) ---
+  # Destructive guard + interactive confirmation.
+  # TTY-aware: never blocks on readline() without a terminal, and throws in the non-interactive
+  # destructive case so automation fails loudly (see `_confirm_migration`).
+  _confirm_migration(has_destructive, destructive, destructive_stmts; interactive=interactive) || return nothing
+
+  # --- Phase 2: Execute (backend-specific: advisory lock on PostgreSQL, direct on SQLite) ---
+  _run_locked_lifecycle(connection, settings, ordered_statements, all_sql,
+                        version, name, checksum, has_destructive)
+end
+
+# ==============================================================================
+# Backend-specific execution wrapper. PostgreSQL serializes migrations with an advisory
+# lock; SQLite is single-instance only (no lock). `_execute_migration_lifecycle` is itself
+# already dialect-dispatched — this hook only decides whether to wrap it in a lock.
+# ==============================================================================
+
+function _run_locked_lifecycle(connection::PormGPostgres, settings::PormGSettings,
+                               ordered_statements, all_sql, version, name, checksum, has_destructive)
   lock_key = "pormg_migrations_$(settings.db_def_folder)"
-  
   AdvisoryLock.with_advisory_lock(connection, lock_key; wait=true, timeout_ms=30_000) do
     _execute_migration_lifecycle(connection, settings, ordered_statements, all_sql,
                                  version, name, checksum, has_destructive)
   end
 end
 
-"""
-    migrate(connection::PormGSQLite, settings; interactive, destructive, dry_run_only, name)
-
-Apply pending migrations to a SQLite database.
-
-SQLite migrations use BEGIN IMMEDIATE TRANSACTION for safety.
-Advisory locking is not available — single-instance migration safety only.
-"""
-function migrate(connection::PormGSQLite, settings::PormGSettings; 
-                 path::String = "db/models/models.jl",
-                 interactive::Bool = true, 
-                 destructive::Bool = false,
-                 dry_run_only::Bool = false,
-                 name::String = "pending_migration")
-  # --- Phase 1: Validate ---
-  if !settings.change_db
-    @warn("The database is not set to change_db, so the migration plan will not be applied.")
-    return nothing
-  end
-  
-  # Bootstrap history table
-  init_migrations(connection)
-  
-  # Load and order the plan
-  migration_plan = _load_migration_plan(settings)
-  ordered_statements, all_sql = _order_statements(migration_plan)
-  
-  if isempty(ordered_statements)
-    @info(_emsg("\e[32mNo SQL statements to execute.\e[0m"))
-    return nothing
-  end
-  
-  version = generate_version()
-  checksum = compute_checksum(all_sql)
-  destructive_stmts = detect_destructive_actions(ordered_statements)
-  has_destructive = !isempty(destructive_stmts)
-  
-  # Dry run mode
-  if dry_run_only
-    return DryRunResult(checksum, ordered_statements, destructive_stmts)
-  end
-  
-  # Destructive guard
-  if has_destructive && !destructive
-    @error(_emsg("\e[31mMigration contains $(length(destructive_stmts)) destructive operation(s). " *
-           "Pass `destructive=true` to confirm.\e[0m"))
-    for s in destructive_stmts
-      display_s = length(s) > 120 ? s[1:120] * "..." : s
-      @error("  → $display_s")
-    end
-    return nothing
-  end
-  
-  # Interactive confirmation
-  if interactive
-    if has_destructive
-      @info(_emsg("\e[31m⚠ This migration contains DESTRUCTIVE operations (DROP TABLE, DROP COLUMN, etc.).\e[0m"))
-    end
-    @info(_emsg("\e[33mBefore applying the migrations, make sure to back up your database.\e[0m"))
-    print(_emsg("\e[31mAre you sure you want to apply the migrations? (yes/no): \e[0m"))
-    response = readline()
-    response = strip(lowercase(response))
-    if !(response in ["yes", "y"])
-      @info("Migrations were not applied.")
-      return nothing
-    end
-  end
-  
-  # --- Phase 2: No advisory lock for SQLite (single-instance only) ---
+function _run_locked_lifecycle(connection::PormGSQLite, settings::PormGSettings,
+                               ordered_statements, all_sql, version, name, checksum, has_destructive)
   _execute_migration_lifecycle(connection, settings, ordered_statements, all_sql,
                                version, name, checksum, has_destructive)
 end

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1432,7 +1432,10 @@ end
     # dry_run must not consume the pending file
     @test isfile(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"))
 
-    migrate(joinpath(@__DIR__, edge_db_name), interactive=false)
+    # Apply the plan so DryRunTable actually exists for Phase 12 to drop. This plan is destructive
+    # (it also drops leftover tables from earlier phases), so it needs the explicit destructive=true.
+    # (Pre-#87 this call silently skipped without the flag — a latent no-op the new gate surfaces.)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
   end
 
   # ── Phase 12: Destructive guard ───────────────────────────────────
@@ -1452,9 +1455,17 @@ end
     @test Migrations.is_destructive(result) == true
     @test !isempty(result.destructive_statements)
 
-    # migrate without destructive=true must refuse
-    ret = migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=false)
-    @test ret === nothing
+    # migrate without destructive=true must refuse. In a non-interactive context (#87) this is a
+    # hard error — it THROWS DestructiveMigrationError instead of silently returning nothing, so
+    # CI/automation fails loudly. The pending file must remain (the guard fires before execution).
+    @test_throws Migrations.DestructiveMigrationError migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=false)
+    @test isfile(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"))
+
+    # Anti-hang guarantee (#87): even with interactive=true, a non-TTY process (stdin redirected to a
+    # non-terminal) must NOT block on readline() — it throws immediately rather than waiting on input.
+    redirect_stdin(devnull) do
+      @test_throws Migrations.DestructiveMigrationError migrate(joinpath(@__DIR__, edge_db_name), interactive=true, destructive=false)
+    end
     @test isfile(joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl"))
 
     # With destructive=true it should succeed

--- a/test/unit/test_migrations_runner.jl
+++ b/test/unit/test_migrations_runner.jl
@@ -104,6 +104,72 @@ using Dates
     end
 
     # ==============================================================================
+    # SECTION 2b: Non-interactive confirmation gate (#87)
+    #
+    # `_confirm_migration` is the DB-free core of the migrate() safety gate. It must:
+    #   - NEVER block on readline() without a real terminal, even when interactive=true;
+    #   - THROW DestructiveMigrationError for a destructive plan in a non-interactive
+    #     context (so CI/deploy scripts fail loudly instead of hanging or silently
+    #     skipping) unless destructive=true is passed;
+    #   - return `true` (proceed) for a safe plan, or a destructive plan opted-in.
+    #
+    # Every call is wrapped in `redirect_stdin(devnull)` so `stdin isa Base.TTY` is
+    # deterministically `false` regardless of how the suite is launched (a dev running
+    # `Pkg.test` from a terminal would otherwise have a real TTY and hit the prompt).
+    # ==============================================================================
+
+    @testset "Non-interactive confirmation gate (#87)" begin
+        drop = ["""DROP TABLE "drivers" CASCADE;"""]
+
+        redirect_stdin(devnull) do
+            # A destructive plan with NO opt-in must throw — even with interactive=true,
+            # because there is no TTY to prompt on (this is the anti-hang guarantee).
+            @test_throws Migrations.DestructiveMigrationError Migrations._confirm_migration(
+                true, false, drop; interactive=true)
+
+            # Same with the explicit non-interactive flag.
+            @test_throws Migrations.DestructiveMigrationError Migrations._confirm_migration(
+                true, false, drop; interactive=false)
+
+            # Opting in with destructive=true proceeds (returns true), no prompt.
+            @test Migrations._confirm_migration(true, true, drop; interactive=true) == true
+
+            # A non-destructive plan proceeds directly in a non-interactive context —
+            # previously this path read EOF and silently no-op'd.
+            @test Migrations._confirm_migration(false, false, String[]; interactive=true) == true
+            @test Migrations._confirm_migration(false, false, String[]; interactive=false) == true
+        end
+
+        # The thrown error is actionable: it names the count, carries the offending
+        # statements, and renders them via showerror.
+        err = try
+            redirect_stdin(devnull) do
+                Migrations._confirm_migration(true, false, drop; interactive=false)
+            end
+        catch e
+            e
+        end
+        @test err isa Migrations.DestructiveMigrationError
+        @test occursin("destructive operation", err.msg)
+        @test occursin("destructive=true", err.msg)
+        @test err.statements == drop
+        buf = IOBuffer()
+        showerror(buf, err)
+        rendered = String(take!(buf))
+        @test occursin("DestructiveMigrationError", rendered)
+        @test occursin("DROP TABLE", rendered)
+
+        # showerror truncates a long statement safely, even across a multibyte UTF-8 boundary
+        # (regression guard: byte-slicing `s[1:120]` throws StringIndexError when byte 120 lands
+        # mid-character; `first(s, 120)` is character-safe).
+        long_unicode = "DROP TABLE " * ("π"^200) * ";"   # >120 chars, multibyte
+        long_err = Migrations.DestructiveMigrationError("boom", [long_unicode])
+        buf2 = IOBuffer()
+        showerror(buf2, long_err)                        # must not throw
+        @test occursin("...", String(take!(buf2)))       # and it truncated
+    end
+
+    # ==============================================================================
     # SECTION 3: Statement Ordering
     #
     # Migration statements are ordered for safety:


### PR DESCRIPTION
## Summary

`migrate()` defaulted `interactive=true` and called a bare `readline()` with **no TTY detection**, so in a non-interactive process (CI, `Pkg.test`, a deploy/cron script) it **hung** on stdin or read EOF and **silently applied nothing**. The safe-looking workaround `migrate(...; interactive=false, destructive=true)` disabled *both* guardrails at once.

This gates the confirmation prompt on a real terminal (`interactive && stdin isa Base.TTY`):

- `migrate()` **never blocks on `readline()`** without a TTY — even with `interactive=true` (the default).
- A **non-destructive** plan applies directly in a non-interactive context (previously a silent no-op).
- A **destructive** plan in a non-interactive context throws **`DestructiveMigrationError`** (new, exported) unless `destructive=true` — automation fails loudly instead of hanging or silently skipping.
- Interactive terminal UX is unchanged (yes/no prompt; red `@error` + abort on destructive-without-flag).

The near-identical PostgreSQL/SQLite `migrate()` methods are unified into one shared `migrate(::PormGBackend, …)` pre-flight; the only real difference (advisory lock on PostgreSQL vs direct on SQLite) is dispatched to a small `_run_locked_lifecycle` hook. `_execute_migration_lifecycle` is unchanged.

**Prior art:** raise-with-explicit-override on destructive ops matches Rails `strong_migrations` (`safety_assured{}`), Flyway (`cleanDisabled`), Rails core (`DISABLE_DATABASE_ENVIRONMENT_CHECK`), and Prisma-in-CI; TTY detect-and-branch mirrors Django's interactive/non-interactive questioner split and Prisma's `isTTY` check.

## Changes
- `src/migrations/runner.jl` — `DestructiveMigrationError` + TTY-aware `_confirm_migration`; unified `migrate` + `_run_locked_lifecycle`; char-safe (`first(s, 120)`) truncation.
- `src/Migrations.jl` — import `PormGBackend`, export `DestructiveMigrationError`.
- `test/unit/test_migrations_runner.jl` — non-TTY gate test (`redirect_stdin`), incl. multibyte-truncation regression.
- `test/integration/test_migration_bootstrap.jl` — Phase 12 throw assertions; fix a latent Phase 11 silent no-op (destructive plan was never applied).
- `docs/src/migrations/{workflow,advanced}.md` — non-interactive behavior.
- `UPGRADING.md` — consumer-app rollout entry for #87.
- `TODO.md` — drop #87 from the pre-publish gating list.

## Verification
- Unit: **4049/4049** (incl. Aqua + public-exports)
- Integration: SQLite (`db_sl`) ✅, PostgreSQL (`db_2`) ✅
- Docs build (`checkdocs=:exports`) ✅

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)