### PR TITLE
feat(#92): scalar correlated subqueries — Subquery(...) and Exists(...) projectable in values()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,12 +23,13 @@
 > isolated PG migration fixture (#36) · pool-exhaustion investigation (#37 → follow-ups
 > #124–#128) · `ORDER BY` NULL placement (#75) · `.copy()` state aliasing (#43 → #112) ·
 > bulk mapping contract, `columns=` as the single df→model border (#107) · non-mutating
-> zero-copy bulk pipeline, `copy=` kwarg removed (#132).
+> zero-copy bulk pipeline, `copy=` kwarg removed (#132) · explicit scalar correlated-subquery
+> aggregates, `Subquery`/`OuterRef` surface (#92).
 >
 > **Remaining gating work** — the `pre-publish` label is the source of truth, so this list is exactly
 > [`gh issue list --label pre-publish`](https://github.com/PingoLee/PormG.jl/issues?q=is%3Aopen+label%3Apre-publish):
 
-- [#92](https://github.com/PingoLee/PormG.jl/issues/92) — Design: explicit correlated-subquery aggregates (no auto-magic) — the supported fix for #74 fan-out
+*(none open — the gating list is empty)*
 
 ---
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,6 +43,65 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Scalar correlated subqueries: `Subquery(...)` in `values()`; unsupported `values()` pairs now throw (#92)
+
+- **PormG ref**: issue #92 (the supported fix for the #74 fan-out guard) ; `src/querybuilder/types.jl`,
+  `src/querybuilder/object_manager.jl`, `src/querybuilder/build_query.jl`, `src/querybuilder/build_helpers.jl`,
+  `src/QueryBuilder.jl`, `src/PormG.jl`
+- **Recorded**: 2026-07-22
+- **Severity**: **additive feature + one latent-bug fix to check.** New top-level export `Subquery`;
+  `Exists(...)` is now also projectable in `values()`. The check: `values()` used to **silently drop** an
+  unsupported `"alias" => <value>` pair — that column just vanished from the result. It now throws an
+  `ArgumentError`. Only code that was already getting a wrong/missing column is affected.
+
+### What changed
+
+- **New:** `"alias" => Subquery(inner)` inside `values()` projects a scalar correlated subquery as a
+  column. The inner query correlates via `OuterRef(...)` and must project exactly **one** column; an
+  aggregate (`Count`, `Sum`, …) or a plain column with `order_by` + `limit(1)` both work. This is the
+  fan-out-safe way to attach related-set aggregates — the construct the #74 guard's error message points
+  to. Multiple independent `Subquery` columns compose in one query with no fan-out interaction.
+- **New:** `"alias" => Exists(inner)` inside `values()` projects a per-row boolean column (SQLite `0`/`1`,
+  PostgreSQL booleans). Previously `Exists` was filter-only.
+- **Fail-loud fix:** an unsupported right side in a `values()` pair (e.g. `"x" => 42`, or any type the
+  projection doesn't handle) now raises `ArgumentError` at `values()` time instead of being silently
+  dropped from the SELECT list. Likewise, a **function pair that fails validation** (e.g.
+  `"x" => Concat("surname", 42)` — constructs, but `_check_function` rejects the `Int`) used to be
+  logged and silently dropped; it now propagates the original error (typically a `MethodError`) after
+  logging the failing alias.
+- Guard rails: the inner query must project exactly one column (else `ArgumentError`); the alias is
+  mandatory (bare `Subquery(...)` throws); a `Subquery`/`Exists` projected *inside another subquery*
+  throws (`OuterRef` resolves one level only); a non-aggregate inner with no `LIMIT` emits a build-time
+  `@warn` (possible multi-row scalar).
+
+### How to find the calls to migrate
+
+Nothing to migrate for the new feature (additive). For the silent-drop fix, look for `values()` pairs whose
+right side is not a field name, SQL function, `Value(x)`, `Subquery(...)`, or `Exists(...)`:
+
+```
+rg -n 'values\(' <app> | rg '=>'      # then eyeball non-standard right-hand sides
+```
+
+An affected call site was already broken (the column silently missing from results) — the throw makes it
+visible.
+
+### Migrate your app
+
+- Nothing required. Optionally adopt `Subquery` where an app worked around the #74 guard with a
+  CTE-aggregate join that only needed one scalar per row.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | additive; check for `values()` pairs relying on the old silent drop (unlikely) |
+| app-2 | ⏳ | as above |
+| app-3 | ⏳ | as above |
+| app-4 | ⏳ | as above |
+
+---
+
 ## `migrate()` is non-interactive-safe — throws `DestructiveMigrationError` in CI instead of hanging (#87)
 
 - **PormG ref**: issue #87 ; `src/migrations/runner.jl`, `src/Migrations.jl`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -609,7 +609,7 @@ scope — the SQL function constructors are *not* among them (see
 [SQL function library](#sql-function-library-pormgfunctions)).
 
 ### Query Builder
-`object`, `get`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Interval`, `show_query`, `inspect_query`
+`object`, `get`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Subquery`, `Interval`, `show_query`, `inspect_query`
 
 ### Rows & exceptions
 `PormGRow`, `pk`, `DoesNotExist`, `MultipleObjectsReturned`
@@ -653,8 +653,8 @@ M.Result.objects.values(              # …or qualify without importing
     "n" => PormG.Functions.Count("resultid"))
 ```
 
-`bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Interval` stay at the top level — they are
-query primitives, not part of the function library.
+`bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Subquery`, `Interval` stay at the top level —
+they are query primitives, not part of the function library.
 
 **Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min`
 **Conditional** — `Case`, `When`

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -646,7 +646,7 @@ df = query |> DataFrame
 
 1. **Aggregate the related table's own column** — count/sum the related rows directly, as above.
 2. **Pass `distinct=true`** if de-duplicated counting is what you want: `Count("driverid", distinct=true)` renders `COUNT(DISTINCT …)`.
-3. **Compute the aggregate in a correlated subquery** so the base rows are never multiplied.
+3. **Compute the aggregate in a correlated `Subquery(...)`** projected in `values()` so the base rows are never multiplied — see [Scalar correlated subqueries](subqueries_and_ctes.md#Scalar-correlated-subqueries) for the full pattern.
 
 **Not affected.** Ordinary forward (to-one) `ForeignKey` traversals never trip the guard — only *to-many* joins (reverse FK / many-to-many) multiply rows. Aggregating across a normal FK is always fine:
 
@@ -661,7 +661,7 @@ df = query |> DataFrame
 **Exemptions.** `Max` and `Min` are immune to row duplication and are never blocked; an aggregate built with `distinct=true` is treated as an explicit opt-in.
 
 !!! note
-    The guard is deliberately fail-loud: an aggregate it cannot prove safe (for example one wrapping a multi-column expression) raises rather than risk a silent wrong number. A first-class, explicit correlated-subquery construct for pattern 3 is under design discussion ([#92](https://github.com/PingoLee/PormG.jl/issues/92)).
+    The guard is deliberately fail-loud: an aggregate it cannot prove safe (for example one wrapping a multi-column expression) raises rather than risk a silent wrong number. The first-class fix for pattern 3 is the explicit [`Subquery` scalar column](subqueries_and_ctes.md#Scalar-correlated-subqueries) — the aggregate runs in its own correlated subquery, so the outer rows are never row-multiplied.
 
 ---
 

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -11,7 +11,7 @@ This section covers the read side of PormG — querying, filtering, joining, agg
 | [Values and Joins](values_and_joins.md) | Column selection, `__` join traversal, multi-level joins, reverse joins, wildcard `*`, and aliases. |
 | [Filters and Aggregates](filters_and_aggregates.md) | `filter()`, lookup operators (`@gt`, `@in`, `@contains`, …), grouping, and `HAVING` clauses. |
 | [Functions and Dates](functions_and_dates.md) | SQL functions (`Case`, `Coalesce`, `Concat`, …), date extraction, and math transforms. |
-| [Subqueries and CTEs](subqueries_and_ctes.md) | `IN` subqueries, `With(...)` CTEs, deep join paths, and CTE + cjoin combinations. |
+| [Subqueries and CTEs](subqueries_and_ctes.md) | `IN` subqueries, scalar `Subquery`/`Exists` columns, `With(...)` CTEs, deep join paths, and CTE + cjoin combinations. |
 | [Field Expressions](field_expressions.md) | `F()` for field-to-field comparisons, arithmetic, aggregate ratios, aliasing, and atomic updates. |
 | [Window Functions](window_functions.md) | `Rank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue` — per-row analytics without collapsing rows. |
 | [Q Objects](q_objects.md) | Complex boolean logic with `Q` (AND), `Qor` (OR), nesting, dynamic construction, and `F()` integration. |

--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -1,6 +1,6 @@
 # Subqueries and CTEs
 
-This page covers nested queries with `IN (SELECT ...)`, Common Table Expressions (`WITH`), CTE join types, deep join paths, and mixing CTEs with custom joins.
+This page covers nested queries with `IN (SELECT ...)`, scalar correlated subqueries projected as columns (`Subquery` / `Exists`), Common Table Expressions (`WITH`), CTE join types, deep join paths, and mixing CTEs with custom joins.
 
 ---
 
@@ -100,6 +100,117 @@ query.values(
 query.order_by("raceid__date__quarter")
 df = query |> DataFrame
 ```
+
+---
+
+## Scalar correlated subqueries
+
+A **scalar correlated subquery** computes one value per outer row — "each driver's standings count", "each driver's latest position" — inside its own sub-`SELECT`, correlated to the outer query with `OuterRef`. Project it as a column with `"alias" => Subquery(inner)` inside `values()`:
+
+```julia
+# Inner query: correlated via OuterRef, projects exactly ONE column
+standings = M.Driver_standings.objects
+standings.filter("driverid" => OuterRef("driverid"))
+standings.values("t" => Count("driverstandingsid"))
+
+query = M.Driver.objects
+query.values(
+    "surname",
+    "total_standings" => Subquery(standings),   # scalar subquery column
+    "has_standings"   => Exists(standings),     # boolean subquery column
+)
+df = query |> DataFrame
+```
+
+Generated SQL (PostgreSQL; SQLite renders `?` placeholders):
+
+```sql
+SELECT
+    "Tb"."surname" as "surname",
+  (SELECT
+    COUNT("R1"."driverstandingsid") as "t"
+FROM "driver_standings" as "R1"
+WHERE "R1"."driverid" = "Tb"."driverid"
+) as "total_standings",
+  EXISTS (SELECT 1
+FROM "driver_standings" as "R2"
+WHERE "R2"."driverid" = "Tb"."driverid"
+LIMIT 1) as "has_standings"
+FROM "driver" as "Tb"
+```
+
+`OuterRef("driverid")` binds the inner query's filter to the **outer** query's column — that is the correlation. `Exists(...)` (already familiar from [filters](filters_and_aggregates.md)) can likewise be projected as a per-row boolean column (SQLite returns `0`/`1` integers, PostgreSQL booleans).
+
+### Why: the fan-out-safe aggregate
+
+This is the supported fix the [aggregate fan-out guard](filters_and_aggregates.md#Aggregating-Across-To-Many-Relations-(Fan-Out-Guard)) points to. A to-many join repeats each outer row once per related row, so a naive join aggregate over a base column is silently multiplied — PormG raises instead. Moving the aggregate into a correlated `Subquery` dissolves the fan-out entirely: the aggregate runs in its own scalar subquery and the outer rows are never row-multiplied.
+
+It also **composes** — multiple independent aggregates in one query, something a join-based rewrite cannot do without multiplying the counts against each other:
+
+```julia
+standings = M.Driver_standings.objects
+standings.filter("driverid" => OuterRef("driverid"))
+standings.values("t" => Count("driverstandingsid"))
+
+results = M.Result.objects
+results.filter("driverid" => OuterRef("driverid"))
+results.values("t" => Count("resultid"))
+
+query = M.Driver.objects
+query.values(
+    "surname",
+    "n_standings" => Subquery(standings),   # each count stays exact —
+    "n_results"   => Subquery(results),     # no interaction between the two relations
+)
+df = query |> DataFrame
+```
+
+### Latest-value scalars (non-aggregate)
+
+The inner projection does not have to be an aggregate — any one-column query works. Use the inner query's own `order_by` + `limit(1)` for the "latest related value per row" pattern:
+
+```julia
+# Each driver's most recent standings position
+latest = M.Driver_standings.objects
+latest.filter("driverid" => OuterRef("driverid"))
+latest.values("position")
+latest.order_by("-driverstandingsid")
+latest.limit(1)
+
+query = M.Driver.objects
+query.values("surname", "latest_position" => Subquery(latest))
+df = query |> DataFrame
+```
+
+For an outer row with **no** related rows, an aggregate scalar returns its natural value (`Count` → `0`), while a plain-column scalar is SQL `NULL` → `missing` in the DataFrame.
+
+### Rules and limitations
+
+- **Exactly one column.** The inner query must project exactly one column via `.values(...)` (the inner alias is cosmetic). Zero or several columns raise an `ArgumentError` at build time — the same one-column rule as `@in` subqueries.
+- **The alias is mandatory.** Always project as a pair: `"alias" => Subquery(...)`. A bare `Subquery(...)` inside `values()` raises.
+- **At most one row.** The database requires a scalar subquery to return ≤ 1 row ("more than one row returned by a subquery used as an expression" at execution otherwise). An aggregate always satisfies this; for a plain column add `order_by` + `limit(1)` — PormG emits a build-time warning for the non-aggregate/no-limit case but does not block it.
+- **One level of correlation.** `OuterRef` resolves against the immediately enclosing query only, so a `Subquery`/`Exists` projected *inside another subquery* raises rather than risk silently correlating to the wrong level. Multi-level correlation is a possible future extension.
+- **Correlate on base columns.** `OuterRef("driverid")` against a plain outer column is the canonical, supported case. A joined-path `OuterRef` (e.g. `OuterRef("constructorid__name")`) adds a join to the outer query and is not part of the validated #92 surface.
+- **Outer `GROUP BY` — backend divergence, be careful.** Combining a correlated `Subquery` with an outer aggregate/`GROUP BY` is only well-defined when the correlated column is itself grouped (e.g. group by `driverid` and correlate on `OuterRef("driverid")` — this works on both backends). If the correlated column is **not** grouped, PostgreSQL fails loud (`subquery uses ungrouped column … from outer query`), but **SQLite silently evaluates the subquery against an arbitrary row of each group** — a plausible-looking wrong number. PormG emits a build-time warning whenever a projected `Subquery`/`Exists` coexists with a grouped projection; the warning is a false positive when the correlated column is in the group. A precise fail-loud guard is tracked in [#194](https://github.com/PingoLee/PormG.jl/issues/194).
+- **Untested SQL edges.** A CTE *inside* a subquery is not blocked, but not validated by the test suite either.
+
+### CTE-aggregate vs scalar `Subquery`
+
+Both are explicit, fan-out-safe ways to attach related aggregates. Pick by shape:
+
+| | CTE aggregate + `join_field` | Scalar `Subquery` column |
+|---|---|---|
+| Result shape | one pre-aggregated table, joined once | one scalar per outer row |
+| Multiple independent aggregates | one CTE each + join-key management per CTE | just add another `values()` pair |
+| Reusing the aggregated set (filter/order on it) | ✓ natural (`HAVING`-style via the CTE) | ✗ recompute per use |
+| Join-key bookkeeping | explicit `join_field` | none — correlation via `OuterRef` |
+| Latest-value (non-aggregate) per row | awkward (needs window functions) | ✓ `order_by` + `limit(1)` |
+
+**Performance.** A correlated subquery is evaluated once **per outer row** (SQLite in particular never decorrelates it). For a filtered outer set — one driver, a season's entrants — it is ideal. For a full-table scan projecting several aggregates over large related tables, the CTE aggregate (computed once, joined once) usually wins; measure before choosing at scale.
+
+### Positioning: explicit, not magic
+
+Django offers two paths for related-set aggregates: the implicit `annotate(Count("relation"))` — which silently row-multiplies when two annotations are combined (the documented "Cartesian product trap") — and the explicit `Subquery()` + `OuterRef()` its own docs recommend as the fix. PormG ships **only** the explicit path (with the same recognizable names) and goes one step further: the [#74 guard](filters_and_aggregates.md#Aggregating-Across-To-Many-Relations-(Fan-Out-Guard)) turns the silent-fan-out form into a hard error. This is the same explicit-subquery camp as jOOQ (`DSL.field(select …)`) and SQLAlchemy (`.scalar_subquery()`), with correlation always spelled out via `OuterRef` — never inferred.
 
 ---
 
@@ -366,6 +477,8 @@ See [Custom Joins](custom_joins.md) for the full `.cjoin()` and `.on()` document
 | Feature | Syntax | Use Case |
 | :--- | :--- | :--- |
 | Subquery `IN` | `"field__@in" => subquery` | Filter by a set computed on the server. |
+| Scalar subquery column | `values("n" => Subquery(inner))` | Fan-out-safe per-row aggregate / latest value. |
+| Boolean subquery column | `values("has_x" => Exists(inner))` | Per-row existence flag. |
 | CTE with JOIN | `.with("name" => subq, join_field=...)` | Pre-aggregate data and join it. |
 | CTE without JOIN | `.with("name" => subq)` | Declare for use in filters only. |
 | CTE INNER JOIN | `join_type="INNER"` | Only keep matching rows. |

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -136,7 +136,7 @@ include("QueryBuilder.jl")
 # Query primitives only. The SQL function constructors are NOT imported into PormG — they
 # live solely in `PormG.Functions` (below). There is intentionally no `PormG.Sum`: the
 # function library has exactly one home, reached via `using PormG.Functions` / `PormG.Functions.X`.
-import .QueryBuilder: object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+import .QueryBuilder: object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Subquery, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 
 """
     PormG.Functions
@@ -168,7 +168,7 @@ end
 
 # Curated top-level surface: query primitives only. The SQL function constructors above
 # live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
-export object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+export object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Subquery, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -61,7 +61,7 @@ include("querybuilder/ctes.jl")
 #
 export OP
 export Q, Qor
-export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Case, Cast, Concat, Extract, To_char, Value, Interval
+export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Subquery, Case, Cast, Concat, Extract, To_char, Value, Interval
 export WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
 export Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim
 export Floor, Ceil, Sqrt, Exp, Ln, Power, Mod

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -805,11 +805,66 @@ function _get_select_query(q::SQLTypeQ, instruc::SQLInstruction; _as::Union{Noth
   end
   return "(" * join(resp, " AND ") * ")"
 end
+# #92: fail loud rather than silently mis-correlate a projected subquery nested inside another one —
+# OuterRef resolves only one level, so nesting could bind to the wrong outer query and return a wrong
+# value. `instruc.outer !== nothing` means the current build is itself a subquery.
+function _guard_no_nested_projection(instruc::SQLInstruction, what::AbstractString)
+  instruc.outer === nothing || throw(_argerr(
+    "$what(...) projected inside another subquery is not supported yet: OuterRef resolves one level " *
+    "only, so a nested projected subquery could correlate to the wrong level. Keep projected subqueries " *
+    "to a single level of correlation."))
+  return nothing
+end
+
+_projection_is_aggregate(v)::Bool =
+  v isa SQLTypeField && v.field isa SQLTypeFunction &&
+  hasproperty(v.field, :agregate) && getproperty(v.field, :agregate) === true
+
+# Soft heads-up: a non-aggregate scalar subquery with no LIMIT may match >1 row and error at the DB.
+function _warn_if_possible_multirow(handler::SQLObjectHandler)
+  vals = handler.object.values
+  length(vals) == 1 || return nothing
+  is_agg = _projection_is_aggregate(vals[1])
+  has_limit = handler.object.limit != 0
+  (!is_agg && !has_limit) && @warn(_emsg(
+    "Subquery(...) projects a non-aggregate column with no LIMIT; if the correlation matches more than " *
+    "one row the database raises \"more than one row returned by a subquery used as an expression\". " *
+    "Use an aggregate, or add order_by + a limit of 1."))
+  return nothing
+end
+
 function _get_select_query(v::ExistsObject, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
+  _guard_no_nested_projection(instruc, "Exists")   # #92
   return _get_filter_query(v, instruc)
 end
 function _get_select_query(v::OuterRefObject, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
   return _get_filter_query(v, instruc)
+end
+function _get_select_query(v::SubqueryObject, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
+  # #92: scalar single-column correlated subquery projected as a SELECT-list column.
+  _guard_no_nested_projection(instruc, "Subquery")
+
+  # query() mutates the handler's parameters, and SQLField deepcopy is shallow on `.field`, so the same
+  # SubqueryObject can be shared across list()/count() deepcopies — copy before rendering.
+  handler = deepcopy(v.query)
+
+  # Exactly one projected column (reuse the @in one-column rule).
+  labels = _subquery_projection_labels(handler)
+  length(labels) == 1 || throw(_argerr(
+    "Subquery(...) must project exactly one column; it currently projects $(length(labels)): " *
+    "$(_summarize_projection_labels(labels)). Call .values(\"alias\" => <expr>) on the inner query."))
+
+  _warn_if_possible_multirow(handler)
+
+  # Passing the shared `parameters` makes query() treat this as a subquery: it inherits the ambient
+  # :select bucket (set by build()) and restores the context afterward, so the inner params flatten in
+  # :select — textually correct (the SELECT list precedes FROM/JOIN/WHERE). Correlate via outer=instruc.
+  inner_sql = query(handler,
+                    table_alias=instruc.table_alias,
+                    connection=instruc.connection,
+                    parameters=instruc.parameters,
+                    outer=instruc)
+  return string("(", inner_sql, ")")
 end
 function _get_select_query(q::SQLTypeF, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
   return _set_update_query(q, instruc)

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -36,12 +36,17 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
       else
         instruc.agregate = true
       end
+    elseif isa(v_copy.field, Union{SubqueryObject, ExistsObject})
+      # #92: a projected scalar subquery / EXISTS is a per-row expression — neither a groupable
+      # column nor an outer aggregate. It must NOT be pushed into GROUP BY (in a mixed projection
+      # with a real aggregate, that would otherwise emit the subquery's positional index into GROUP BY).
+      nothing
     else
       push!(instruc.group, i |> string)
     end
 
     if haskey(instruc.cache, v_copy._as)
-      instruc.select[i] = instruc.cache[v_copy._as]  # TODO That is necessary in get_select_query    
+      instruc.select[i] = instruc.cache[v_copy._as]  # TODO That is necessary in get_select_query
     else
       @pormg_debug false
       v_copy.field = _get_select_query(v_copy.field, instruc, _as=v_copy._as)
@@ -51,6 +56,22 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
       end
       instruc.cache[v_copy._as] = instruc.select[i]
     end
+  end
+
+  # #194 (interim, coarse): a projected correlated Subquery/Exists alongside a grouped projection is
+  # dangerous when the OuterRef column is not in the GROUP BY — PostgreSQL raises a GroupingError, but
+  # SQLite silently evaluates the subquery against an ARBITRARY row of each group (a plausible-looking
+  # wrong number). We cannot yet resolve which outer columns the inner OuterRefs reference (tracked in
+  # #194 for a precise fail-loud guard), so warn on the combination itself. False positive when the
+  # correlation column IS grouped — the message says so. `values` holds the originals (the loop deep-
+  # copies), so the SubqueryObject/ExistsObject fields are still inspectable here.
+  if instruc.agregate && !isempty(instruc.group) &&
+     any(v -> v isa SQLTypeField && isa(v.field, Union{SubqueryObject,ExistsObject}), values)
+    @warn(_emsg(
+      "Subquery/Exists projected alongside a grouped aggregate: if the inner OuterRef column is not " *
+      "in the GROUP BY, SQLite silently returns an arbitrary row's value per group and PostgreSQL " *
+      "raises a GroupingError. Ensure the correlated column is part of the grouped projection " *
+      "(then this warning is a false positive — precise guard tracked in #194)."))
   end
 end
 
@@ -468,5 +489,6 @@ function _fanout_error_msg(a, many, ambiguous::Bool)
     "  Fix one of:\n",
     "    \e[32m1.\e[0m Aggregate the RELATED table's own column instead (e.g. count related rows: Count(\"reverse_relation__id\")).\n",
     "    \e[32m2.\e[0m Pass \e[32mdistinct=true\e[0m to the aggregate if de-duplicated counting is what you want.\n",
-    "    \e[32m3.\e[0m Compute the aggregate in a correlated subquery so the base rows are not multiplied.\n")
+    "    \e[32m3.\e[0m Compute the aggregate in a correlated \e[32mSubquery(...)\e[0m projected in values() " *
+    "(correlate the inner query with \e[32mOuterRef(...)\e[0m) so the base rows are not multiplied.\n")
 end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -33,9 +33,18 @@ function up_values!(q::SQLObject, values)
         try
           push!(q.values, SQLField(_check_function(v.second), v.first))
         catch e
-          @pormg_debug false
-          @error "Error processing values pair: $e" exception = (e, catch_backtrace())
+          # #92: this used to swallow the error and continue — the column silently vanished from
+          # the result while values() returned normally. Log the failing alias for context (the
+          # underlying error may not name it), then propagate: an invalid projection must surface
+          # at values() time, consistent with the fail-loud branches below.
+          @error "Invalid values pair" alias = v.first exception = (e, catch_backtrace())
+          rethrow()
         end
+      elseif isa(v.second, Union{SubqueryObject,ExistsObject})
+        # #92: project a scalar subquery / EXISTS as an aliased column, e.g.
+        # "total" => Subquery(inner)  or  "has_x" => Exists(inner). The alias goes in _as; the
+        # subquery is rendered by _get_select_query(::SubqueryObject/::ExistsObject) during build.
+        push!(q.values, SQLField(v.second, v.first))
       elseif isa(v.second, SQLTypeText)
         # Support Value(x) as an aliased pair: "label" => Value("hello")
         v.second.custom_as = v.first
@@ -44,11 +53,15 @@ function up_values!(q::SQLObject, values)
         z = _up_values(v.second)
         z.custom_as = v.first
         push!(q.values, z)
+      else
+        # #92: previously an unhandled pair value was silently dropped — the column just vanished from
+        # the result. Fail loud instead so a wrong projection surfaces at build time.
+        throw(_argerr("Invalid values pair \"$(v.first)\" => ::$(typeof(v.second)): the right side must be a field name, a function (Count, Sum, …), Value(x), Subquery(inner), or Exists(inner)."))
       end
     elseif isa(v, String)
       push!(q.values, _up_values(v))
     else
-      throw("Invalid argument: $(v) (::$(typeof(v)))); please use a string or a function (Mounth, Year, Day, Y_M ...)")
+      throw(_argerr("Invalid argument: $(v) (::$(typeof(v)))); use a string field name, a function (Count, Sum, Day, …), or an aliased pair \"alias\" => expr (e.g. \"total\" => Subquery(inner))."))
     end
   end
 

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -9,14 +9,28 @@ end
 Exists(query::SQLObjectHandler) = ExistsObject(query=query)
 Base.deepcopy(x::ExistsObject) = ExistsObject(query=deepcopy(x.query))
 
+# SubqueryObject is a scalar single-column subquery projected as a SELECT-list column (#92).
+# Like ExistsObject it inherits SQLType directly. It is rendered via query() and correlated with the
+# enclosing query through OuterRef. It is defined before FieldPart (below), which is widened to admit
+# it so an SQLField.field can carry it until get_select_query resolves it to SQL text.
+@kwdef mutable struct SubqueryObject <: SQLType
+  query::SQLObjectHandler
+end
+Subquery(query::SQLObjectHandler) = SubqueryObject(query=query)
+Base.deepcopy(x::SubqueryObject) = SubqueryObject(query=deepcopy(x.query))
+# Defensive backstop: a SubqueryObject is always resolved to a string by get_select_query before any
+# string()/show consumer sees it (audited). If one ever leaked, this keeps it legible rather than dumping
+# the whole struct into a SQL string.
+Base.show(io::IO, ::SubqueryObject) = print(io, "Subquery(…)")
+
 #
 # Type Aliases for Heavy Unions
 #
 """Filter components: Operator objects, Q (AND), Qor (OR), F expressions, and EXISTS predicates."""
 const FilterType = Union{SQLTypeQ,SQLTypeQor,SQLTypeOper,SQLTypeF,ExistsObject}
 
-"""Field references in SQL: text, functions, or string names."""
-const FieldPart = Union{SQLTypeText,SQLTypeFunction,String,SQLTypeF}
+"""Field references in SQL: text, functions, string names, or projected subqueries (Subquery/Exists, #92)."""
+const FieldPart = Union{SQLTypeText,SQLTypeFunction,String,SQLTypeF,SubqueryObject,ExistsObject}
 
 """Column references: fields, functions, strings, or vectors of operations."""
 const ColumnPart = Union{SQLTypeField,SQLTypeFunction,String,SQLTypeF,Vector{Union{String,SQLTypeF}}}

--- a/test/integration/test_subqueries.jl
+++ b/test/integration/test_subqueries.jl
@@ -80,3 +80,299 @@ end
     @test length(rows) == 1
     @test rows[1][:resultid] == expected_max
 end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Scalar correlated subqueries (#92): "alias" => Subquery(inner) projected in
+# values(), correlated with OuterRef — the supported fix the #74 fan-out guard
+# points users to. Subquery/Exists/OuterRef are used through the top-level
+# `using PormG` exports (from common_setup) — deliberately, to pin the public
+# surface. Every aggregate value below is recomputed independently and asserted
+# for equality — a query that executes can still be wrong.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): the fan-out proof — the before/after that motivates #92.
+# The naive reverse-FK join aggregate is refused by the #74 guard (cause-checked);
+# the same question asked through a correlated Subquery returns the exact
+# per-driver value because the aggregate runs in its own scalar subquery and the
+# outer Driver rows are never row-multiplied.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - fan-out proof: naive join raises, Subquery is exact" begin
+    # Naive form: COUNT over a base column under a to-many join → #74 guard raises.
+    naive = M.Driver.objects
+    naive.values("surname", "n" => Count("driverid"))
+    naive.filter("driver_standings__position__@gte" => 1)
+    err = try; naive |> DataFrame; nothing; catch e; e; end
+    @test err isa ArgumentError && occursin("fan-out", err.msg)
+
+    # #92 form: the aggregate moves into a correlated scalar subquery.
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects.
+        filter("driverid" => 1).
+        values("surname", "n_standings" => Subquery(standings))
+    df = q |> DataFrame
+
+    # Independent recomputation — the fan-out factor must be real (>1 related row).
+    expected = M.Driver_standings.objects.filter("driverid" => 1).count()
+    @test expected > 1
+    @test nrow(df) == 1
+    @test df[1, :n_standings] == expected
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): reverse-FK per-row correctness across multiple outer rows.
+# Each driver's scalar must equal an independently computed count() — the
+# correlation binds per outer row, not once per query.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - reverse FK counts are exact per outer row" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    df = M.Driver.objects.
+        filter("driverid__@lte" => 5).
+        values("driverid", "n_standings" => Subquery(standings)) |> DataFrame
+
+    @test nrow(df) == 5
+    for row in eachrow(df)
+        # Independent per-driver recomputation through the manager.
+        indep = M.Driver_standings.objects.filter("driverid" => row.driverid).count()
+        @test row.n_standings == indep
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): multiple independent aggregates in ONE query — the key
+# ergonomic win over a CTE join. Two correlated subqueries over two different
+# to-many relations must each stay exact, with no fan-out interaction (this is
+# precisely the case where a naive double join multiplies both counts).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - multiple independent aggregates in one query" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    # Lap_times, NOT Result: standings and results are both one-per-race, so their
+    # counts are structurally EQUAL for every driver — a bug projecting the same
+    # subquery into both columns would pass undetected. Lap counts differ by orders
+    # of magnitude, so the two expected values discriminate.
+    laps = M.Lap_times.objects
+    laps.filter("driverid" => OuterRef("driverid"))
+    laps.values("t" => Count("lap"))
+
+    df = M.Driver.objects.
+        filter("driverid" => 1).
+        values("surname",
+               "n_standings" => Subquery(standings),
+               "n_laps"      => Subquery(laps)) |> DataFrame
+
+    exp_standings = M.Driver_standings.objects.filter("driverid" => 1).count()
+    exp_laps      = M.Lap_times.objects.filter("driverid" => 1).count()
+    # Both relations must have >1 row, or the no-interaction claim is vacuous —
+    # and the two expected values must DIFFER, or a same-subquery-twice bug hides.
+    @test exp_standings > 1 && exp_laps > 1
+    @test exp_standings != exp_laps
+    @test nrow(df) == 1
+    @test df[1, :n_standings] == exp_standings   # NOT n_standings × n_laps
+    @test df[1, :n_laps]      == exp_laps
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): latest-value (non-aggregate) scalar — the inner query's own
+# ORDER BY + LIMIT 1 select a single related value per outer row ("the driver's
+# most recent standings position"). An aggregate is not required; the one-column
+# rule is the only structural constraint.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - latest-value non-aggregate scalar" begin
+    latest = M.Driver_standings.objects
+    latest.filter("driverid" => OuterRef("driverid"))
+    latest.values("position")
+    latest.order_by("-driverstandingsid")
+    latest.limit(1)
+
+    df = M.Driver.objects.
+        filter("driverid" => 1).
+        values("latest_position" => Subquery(latest)) |> DataFrame
+
+    # Independent recomputation: same ordering, directly against the related table.
+    indep = M.Driver_standings.objects.
+        filter("driverid" => 1).
+        order_by("-driverstandingsid").
+        limit(1).
+        values("position") |> DataFrame
+
+    @test nrow(df) == 1 && nrow(indep) == 1
+    @test df[1, :latest_position] == indep[1, :position]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): empty related set — a COUNT scalar must be 0 (COUNT of an
+# empty set), while a non-aggregate scalar must be missing (SQL NULL). The F1
+# dataset contains drivers with no driver_standings rows; find one dynamically
+# so reseeding can't break the fixture.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - empty related set: Count is 0, plain scalar is missing" begin
+    with_standings = Set((M.Driver_standings.objects.values("driverid") |> DataFrame).driverid)
+    all_ids = (M.Driver.objects.values("driverid") |> DataFrame).driverid
+    lonely = [id for id in all_ids if !(id in with_standings)]
+    @test !isempty(lonely)              # dataset invariant: some drivers never scored standings
+    lonely_id = minimum(lonely)
+
+    count_sub = M.Driver_standings.objects
+    count_sub.filter("driverid" => OuterRef("driverid"))
+    count_sub.values("t" => Count("driverstandingsid"))
+
+    latest_sub = M.Driver_standings.objects
+    latest_sub.filter("driverid" => OuterRef("driverid"))
+    latest_sub.values("position")
+    latest_sub.order_by("-driverstandingsid")
+    latest_sub.limit(1)
+
+    df = M.Driver.objects.
+        filter("driverid" => lonely_id).
+        values("n_standings"     => Subquery(count_sub),
+               "latest_position" => Subquery(latest_sub)) |> DataFrame
+
+    @test nrow(df) == 1
+    @test df[1, :n_standings] == 0             # COUNT over the empty set
+    @test ismissing(df[1, :latest_position])   # scalar over the empty set is NULL
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exists-as-column (#92): Exists(...) projected in values() returns a boolean
+# per outer row (SQLite renders 0/1 integers, PostgreSQL booleans — normalize
+# via Bool()). Cross-checked against a driver with and a driver without
+# related rows.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Exists projection (#92) - boolean column per outer row" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    # A driver with standings (1 = Hamilton) → true.
+    df_has = M.Driver.objects.
+        filter("driverid" => 1).
+        values("has_standings" => Exists(standings)) |> DataFrame
+    @test Bool(df_has[1, :has_standings]) == true
+
+    # A driver without standings → false (found dynamically, as above).
+    with_standings = Set((M.Driver_standings.objects.values("driverid") |> DataFrame).driverid)
+    all_ids = (M.Driver.objects.values("driverid") |> DataFrame).driverid
+    lonely_id = minimum([id for id in all_ids if !(id in with_standings)])
+    df_not = M.Driver.objects.
+        filter("driverid" => lonely_id).
+        values("has_standings" => Exists(standings)) |> DataFrame
+    @test Bool(df_not[1, :has_standings]) == false
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): M2M through-table counts. The naive M2M-join aggregate raises
+# the #74 guard; counting the explicit through model's rows in a correlated
+# Subquery returns the exact per-driver team count. Self-seeded scratch rows
+# (explicit through: M2m_link_plain_scratch) with idempotent cleanup.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - M2M through-table count" begin
+    slug = "subq92"
+
+    # Idempotent cleanup of any prior run (links first: FK references).
+    for d in M.M2m_driver_plain_scratch.objects.filter("driverref__@contains" => slug).list()
+        M.M2m_link_plain_scratch.objects.filter("driver" => d[:id]).delete()
+    end
+    M.M2m_driver_plain_scratch.objects.filter("driverref__@contains" => slug).delete()
+    M.M2m_team_plain_scratch.objects.filter("name__@contains" => slug).delete()
+
+    # Seed: one driver on TWO teams (fan-out factor > 1), one teamless control driver.
+    driver   = M.M2m_driver_plain_scratch.objects.create("driverref" => "$(slug)-senna")
+    loner    = M.M2m_driver_plain_scratch.objects.create("driverref" => "$(slug)-lone")
+    team_a   = M.M2m_team_plain_scratch.objects.create("name" => "$(slug)-mclaren")
+    team_b   = M.M2m_team_plain_scratch.objects.create("name" => "$(slug)-lotus")
+    M.M2m_link_plain_scratch.objects.create("driver" => driver[:id], "team" => team_a[:id])
+    M.M2m_link_plain_scratch.objects.create("driver" => driver[:id], "team" => team_b[:id])
+
+    # Naive form: base-column COUNT under the M2M join → #74 guard raises.
+    naive = M.M2m_driver_plain_scratch.objects
+    naive.values("driverref", "n" => Count("id"))
+    naive.filter("teams__name__@contains" => slug)
+    err = try; naive |> DataFrame; nothing; catch e; e; end
+    @test err isa ArgumentError && occursin("fan-out", err.msg)
+
+    # #92 form: count the through-table rows in a correlated scalar subquery.
+    links = M.M2m_link_plain_scratch.objects
+    links.filter("driver" => OuterRef("id"))
+    links.values("t" => Count("id"))
+
+    df = M.M2m_driver_plain_scratch.objects.
+        filter("driverref__@contains" => slug).
+        values("driverref", "n_teams" => Subquery(links)) |> DataFrame
+
+    @test nrow(df) == 2
+    by_ref = Dict(row.driverref => row.n_teams for row in eachrow(df))
+    @test by_ref["$(slug)-senna"] == 2   # exact — not inflated by any other relation
+    @test by_ref["$(slug)-lone"]  == 0   # COUNT over the empty set
+
+    # Teardown (links first: FK references).
+    M.M2m_link_plain_scratch.objects.filter("driver" => driver[:id]).delete()
+    M.M2m_driver_plain_scratch.objects.filter("driverref__@contains" => slug).delete()
+    M.M2m_team_plain_scratch.objects.filter("name__@contains" => slug).delete()
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): reuse-safety. query() renders an internal deepcopy of the
+# wrapped handler, so the SAME Subquery object projected in two different outer
+# queries — and a count() then list() on one of them — yields correct,
+# uncorrupted results (mirrors the Exists "immutability across two usages" test).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - reuse across outer queries and terminals" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+    shared = Subquery(standings)
+
+    q1 = M.Driver.objects.
+        filter("driverid" => 1).
+        values("n_standings" => shared)
+    first_val = (q1 |> DataFrame)[1, :n_standings]
+    @test first_val == M.Driver_standings.objects.filter("driverid" => 1).count()
+
+    # count() clears values internally (COUNT(*) of the outer rows) — it must not
+    # corrupt the shared Subquery for later renders.
+    @test q1.count() == 1
+    @test (q1 |> DataFrame)[1, :n_standings] == first_val
+
+    # The same Subquery object in a second outer query correlates independently.
+    q2 = M.Driver.objects.
+        filter("driverid" => 2).
+        values("n_standings" => shared)
+    @test (q2 |> DataFrame)[1, :n_standings] ==
+        M.Driver_standings.objects.filter("driverid" => 2).count()
+
+    # And q1 still renders correctly after q2 ran.
+    @test (q1 |> DataFrame)[1, :n_standings] == first_val
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92): fail-loud nesting boundary. A Subquery projected inside
+# another subquery raises — OuterRef resolves one level only, so a nested
+# projection could silently correlate to the wrong outer query. Locks in the
+# error rather than a wrong number (the #74 philosophy).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery (#92) - nested projected subquery raises" begin
+    innermost = M.Driver_standings.objects
+    innermost.filter("driverid" => OuterRef("driverid"))
+    innermost.values("t" => Count("driverstandingsid"))
+
+    middle = M.Driver_standings.objects
+    middle.filter("driverid" => OuterRef("driverid"))
+    middle.values("nested" => Subquery(innermost))
+    middle.limit(1)                       # single column + LIMIT: passes every other check
+
+    q = M.Driver.objects.
+        filter("driverid" => 1).
+        values("x" => Subquery(middle))
+
+    err = try; q |> DataFrame; nothing; catch e; e; end
+    @test err isa ArgumentError && occursin("one level", err.msg)
+end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -5,6 +5,9 @@ using Dates
 
 # Mock SQLite Settings
 struct MockSQLite <: PormG.PormGSQLite end
+# ORDER BY renders NULL placement via a library-version probe (#75); pin a modern version on the
+# mock so order_by works without a live driver (same pattern as test_order_by_nulls.jl).
+PormG.backend_sqlite_version(::MockSQLite) = 3045000
 # Use a dummy path and key to prevent cross-test contamination in runtests.jl
 MockSettings = PormG.Configuration.Settings(
     connections=MockSQLite(),
@@ -17,7 +20,7 @@ PormG.config["mock_sl_key"] = MockSettings
 include("../integration/db_sl/models.jl")
 import .models as M
 PormG.Models.set_models(M, "mock_sl_path")
-import PormG.QueryBuilder: Q, Qor, F, Exists, OuterRef, inspect_query, Case, When, Sum, Avg, Value, Round, With
+import PormG.QueryBuilder: Q, Qor, F, Exists, OuterRef, Subquery, Count, Concat, inspect_query, Case, When, Sum, Avg, Value, Round, With
 
 @testset "SQLite Parameter Alignment Verification (Real Models)" begin
     # 1. Positional Cross-Check with Real Schema
@@ -2129,3 +2132,327 @@ end
 end
 
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scalar correlated Subquery (#92): "alias" => Subquery(inner) projected in
+# values(), correlated via OuterRef. Verifies the SELECT-list SQL shape: the
+# paren-wrapped aliased scalar, the correlation predicate binding the inner
+# alias to the OUTER query alias ("Tb"), and Exists(...) rendering as an
+# aliased boolean column — the supported fix the #74 fan-out guard points to.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - scalar + Exists column SQL shape" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects
+    q.values("surname",
+             "n_standings" => Subquery(standings),
+             "has_standings" => Exists(standings))
+
+    sql = (q |> inspect_query)[:sql_text]
+
+    # Scalar subquery: paren-wrapped, aggregate inside, correlated against "Tb", aliased.
+    @test contains(sql, "(SELECT")
+    @test contains(sql, "COUNT(\"R1\".\"driverstandingsid\")")
+    @test contains(sql, "\"R1\".\"driverid\" = \"Tb\".\"driverid\"")
+    @test contains(sql, ") as \"n_standings\"")
+    # Exists column: the EXISTS(SELECT 1 … LIMIT 1) template, aliased as a column.
+    @test contains(sql, "EXISTS (SELECT 1")
+    @test contains(sql, "LIMIT 1) as \"has_standings\"")
+    # No outer aggregate here, so projecting subqueries must NOT force a GROUP BY.
+    @test !contains(sql, "GROUP BY")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - mixed projection GROUP BY isolation: when the outer query
+# mixes a plain column, a real aggregate, and a projected subquery, GROUP BY
+# must reference only the plain column's positional index — a projected
+# subquery is a per-row expression, neither groupable nor an outer aggregate.
+# Regression: get_select_query used to push every non-aggregate value's index.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - mixed projection keeps subquery out of GROUP BY" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects
+    q.values("nationality",                          # index 1 — groupable plain column
+             "n_drivers" => Count("driverid"),       # index 2 — outer aggregate (forces GROUP BY)
+             "n_standings" => Subquery(standings))   # index 3 — must NOT appear in GROUP BY
+
+    # #194 interim warn: grouped projection + projected subquery is the SQLite arbitrary-row trap
+    # (the correlation column `driverid` is NOT grouped here) — the coarse warn must fire.
+    insp = @test_logs (:warn, r"grouped aggregate.*#194"s) match_mode=:any (q |> inspect_query)
+    sql = insp[:sql_text]
+
+    m = match(r"GROUP BY\s+([0-9,\s]+)", sql)
+    @test m !== nothing                      # the outer aggregate forces a GROUP BY
+    @test strip(m.captures[1]) == "1"        # …that references ONLY the plain column
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Interim GROUP BY warn (#194) - negative case: a projected Subquery WITHOUT an
+# outer aggregate produces no GROUP BY and therefore must build silently. Locks
+# the warn to the dangerous combination only, so every plain #92 usage stays
+# noise-free.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92/#194) - no grouped aggregate, no warn" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"))
+    standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects
+    q.values("surname", "n_standings" => Subquery(standings))
+
+    insp = @test_logs min_level=Logging.Warn (q |> inspect_query)   # must be silent
+    @test !contains(insp[:sql_text], "GROUP BY")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - SQLite parameter bucket routing: the inner subquery's own
+# filter parameter must land in the :select bucket (the SELECT list precedes
+# FROM/JOIN/WHERE in the rendered text), flattening BEFORE the outer :where
+# parameter. This is the positional-placeholder correctness core of #92.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - inner params in :select bucket, before :where" begin
+    p1_standings = M.Driver_standings.objects
+    p1_standings.filter("driverid" => OuterRef("driverid"), "position" => 1)
+    p1_standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects
+    q.filter("surname" => "Senna")
+    q.values("surname", "n_p1" => Subquery(p1_standings))
+
+    insp = q |> inspect_query
+    buckets = insp[:parameter_buckets]
+
+    @test buckets[:select] == [1]              # inner filter param (position => 1)
+    @test buckets[:where] == ["Senna"]         # outer filter param
+    @test insp[:parameters] == [1, "Senna"]    # flatten order: :select before :where
+    @test count(==('?'), insp[:sql_text]) == 2 # marker count matches parameter count
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exists-as-column (#92) - bucket routing: Exists projected in values() renders
+# via _build_exists_query in the :select context (a path never exercised before
+# #92 — Exists was filter-only). Its inner filter parameter must also land in
+# the :select bucket and flatten before the outer :where parameter.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Exists projection (#92) - inner params in :select bucket" begin
+    winners = M.Driver_standings.objects
+    winners.filter("driverid" => OuterRef("driverid"), "wins__@gt" => 3)
+    winners.values("driverstandingsid")
+
+    q = M.Driver.objects
+    q.filter("driverid__@lte" => 100)
+    q.values("surname", "won_gt3" => Exists(winners))
+
+    insp = q |> inspect_query
+    buckets = insp[:parameter_buckets]
+
+    @test buckets[:select] == [3]              # inner Exists filter param (wins > 3)
+    @test buckets[:where] == [100]             # outer filter param
+    @test insp[:parameters] == [3, 100]        # :select flattens before :where
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) + CTE - full bucket interplay: a With CTE param, an inner
+# subquery param, and an outer WHERE param must flatten in SQL-clause order
+# :cte → :select → :where, matching the rendered text order of a query that
+# opens with WITH, then the SELECT list, then WHERE.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - CTE + subquery + where flatten cte→select→where" begin
+    races_91 = M.Race.objects.filter("year" => 1991).values("raceid")
+
+    p1_standings = M.Driver_standings.objects
+    p1_standings.filter("driverid" => OuterRef("driverid"), "position" => 1)
+    p1_standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Result.objects
+    With(q, "r91", races_91, join_field="raceid" => "raceid")
+    q.filter("positionorder" => 1)
+    q.values("driverid", "n_p1" => Subquery(p1_standings))
+
+    insp = q |> inspect_query
+    buckets = insp[:parameter_buckets]
+
+    @test buckets[:cte] == [1991]              # CTE body param
+    @test buckets[:select] == [1]              # inner subquery param (position => 1)
+    @test buckets[:where] == [1]               # outer filter param (positionorder => 1)
+    @test insp[:parameters] == [1991, 1, 1]    # :cte → :select → :where
+    @test count(==('?'), insp[:sql_text]) == 3
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - latest-value (non-aggregate) scalar: the inner query's own
+# ORDER BY + LIMIT 1 must survive into the rendered subquery — the canonical
+# "latest related value per outer row" pattern. With the LIMIT present, no
+# multi-row warning may fire.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - latest-value keeps ORDER BY + LIMIT, no warn" begin
+    latest_pos = M.Driver_standings.objects
+    latest_pos.filter("driverid" => OuterRef("driverid"))
+    latest_pos.values("position")
+    latest_pos.order_by("-driverstandingsid")
+    latest_pos.limit(1)
+
+    q = M.Driver.objects
+    q.values("surname", "latest_position" => Subquery(latest_pos))
+
+    # A limit-1 non-aggregate scalar is the supported pattern — assert NO warning fires.
+    insp = @test_logs min_level=Logging.Warn (q |> inspect_query)
+    sql = insp[:sql_text]
+
+    @test contains(sql, "\"R1\".\"position\"")                       # plain column projection
+    @test contains(sql, "ORDER BY \"R1\".\"driverstandingsid\" DESC") # inner ORDER BY preserved
+    @test occursin(r"LIMIT 1\s*\n?\) as \"latest_position\""s, sql)   # inner LIMIT inside the paren wrap
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - soft multi-row warning: a NON-aggregate single-column
+# subquery with NO LIMIT may match >1 row and would fail at execution with
+# "more than one row returned by a subquery used as an expression" — PormG
+# warns at build time (mirrors the CTE Cartesian-product warning philosophy).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - non-aggregate without LIMIT warns" begin
+    unlimited = M.Driver_standings.objects
+    unlimited.filter("driverid" => OuterRef("driverid"))
+    unlimited.values("position")                 # plain column, no order_by/limit
+
+    q = M.Driver.objects
+    q.values("surname", "some_position" => Subquery(unlimited))
+
+    @test_logs (:warn, r"non-aggregate column with no LIMIT") match_mode=:any (q |> inspect_query)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - error paths: the one-column contract (0 or ≥2 projected
+# columns throw), alias is mandatory (bare Subquery in values throws), and the
+# up_values! silent-drop fix (an unsupported "alias" => value pair now throws
+# instead of silently vanishing from the projection).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - error paths" begin
+    # ≥2 projected columns → build-time ArgumentError naming the contract.
+    two_cols = M.Driver_standings.objects
+    two_cols.filter("driverid" => OuterRef("driverid"))
+    two_cols.values("points", "wins")
+    q_two = M.Driver.objects
+    q_two.values("x" => Subquery(two_cols))
+    err_two = try q_two |> inspect_query; nothing catch e; e end
+    @test err_two isa ArgumentError && occursin("exactly one column", err_two.msg)
+
+    # No values() on the inner → implicit all-columns projection → same contract error.
+    all_cols = M.Driver_standings.objects
+    all_cols.filter("driverid" => OuterRef("driverid"))
+    q_all = M.Driver.objects
+    q_all.values("x" => Subquery(all_cols))
+    err_all = try q_all |> inspect_query; nothing catch e; e end
+    @test err_all isa ArgumentError && occursin("exactly one column", err_all.msg)
+
+    # Bare Subquery(...) without an alias pair → rejected at values() time.
+    one_col = M.Driver_standings.objects
+    one_col.filter("driverid" => OuterRef("driverid"))
+    one_col.values("t" => Count("driverstandingsid"))
+    err_bare = try M.Driver.objects.values("surname", Subquery(one_col)); nothing catch e; e end
+    @test err_bare isa ArgumentError && occursin("Subquery", err_bare.msg)
+
+    # Silent-drop fix: an unsupported pair value now throws instead of vanishing.
+    err_pair = try M.Driver.objects.values("x" => 42); nothing catch e; e end
+    @test err_pair isa ArgumentError && occursin("Invalid values pair", err_pair.msg)
+
+    # Silent-drop fix, function-pair branch: a function that constructs but fails
+    # _check_function validation (Concat accepts the Int; validation rejects it) used to be
+    # logged + silently dropped — values() returned normally minus the column. It must now
+    # propagate the original error. The @error context log still fires first — silence it.
+    q_fn = M.Driver.objects
+    err_fn = Logging.with_logger(Logging.NullLogger()) do
+        try q_fn.values("driverid", "broken" => Concat("surname", 42)); nothing catch e; e end
+    end
+    @test err_fn isa MethodError                 # propagated, not swallowed
+    @test length(q_fn.object.values) == 1        # the failing column was never half-pushed
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - fail-loud nesting boundary: a Subquery/Exists projected
+# INSIDE another subquery must raise, because OuterRef resolves one level only —
+# a nested projection could silently correlate to the wrong outer query and
+# return a wrong number (the exact failure mode the #74 guard exists to stop).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - nested projected subquery raises" begin
+    innermost = M.Driver_standings.objects
+    innermost.filter("driverid" => OuterRef("driverid"))
+    innermost.values("t" => Count("driverstandingsid"))
+
+    middle = M.Driver_standings.objects
+    middle.filter("driverid" => OuterRef("driverid"))
+    middle.values("nested" => Subquery(innermost))    # one column — passes the column check
+
+    q = M.Driver.objects
+    q.values("x" => Subquery(middle))
+
+    # The nested projection is detected while rendering `middle` as a subquery. `middle` also
+    # triggers the incidental non-aggregate/no-LIMIT soft warn first — silence it; the throw is
+    # what this testset locks in.
+    err = Logging.with_logger(Logging.NullLogger()) do
+        try q |> inspect_query; nothing catch e; e end
+    end
+    @test err isa ArgumentError && occursin("one level", err.msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - render-isolation: rendering a query holding a Subquery must
+# not corrupt the wrapped handler (query() runs on an internal deepcopy), so
+# the same Subquery object renders identically across repeated inspections and
+# across two different outer queries.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - repeated renders are stable (internal deepcopy)" begin
+    standings = M.Driver_standings.objects
+    standings.filter("driverid" => OuterRef("driverid"), "position" => 1)
+    standings.values("t" => Count("driverstandingsid"))
+    shared = Subquery(standings)
+
+    q1 = M.Driver.objects
+    q1.values("surname", "n" => shared)
+    first_sql = (q1 |> inspect_query)[:sql_text]
+    first_params = (q1 |> inspect_query)[:parameters]
+
+    # Same outer query re-rendered: identical SQL and parameters (no accumulated state).
+    @test (q1 |> inspect_query)[:sql_text] == first_sql
+    @test (q1 |> inspect_query)[:parameters] == first_params
+
+    # A different outer query reusing the SAME Subquery object still renders the
+    # correlation correctly and keeps its own parameter list uncorrupted.
+    q2 = M.Driver.objects
+    q2.filter("nationality" => "Brazilian")
+    q2.values("surname", "n" => shared)
+    insp2 = q2 |> inspect_query
+    @test contains(insp2[:sql_text], "\"R1\".\"driverid\" = \"Tb\".\"driverid\"")
+    @test insp2[:parameters] == [1, "Brazilian"]   # :select (inner) before :where (outer)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Subquery (#92) - order_by on a projected subquery alias: ORDER BY must
+# reference the quoted ALIAS, not re-render the subquery. A re-render would
+# duplicate the inner bind parameter into the ORDER BY clause — which has no
+# parameter bucket — silently misaligning every SQLite placeholder after it.
+# The exact parameter list proves the subquery rendered exactly once.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Subquery projection (#92) - order_by on subquery alias renders alias only" begin
+    p1_standings = M.Driver_standings.objects
+    p1_standings.filter("driverid" => OuterRef("driverid"), "position" => 1)
+    p1_standings.values("t" => Count("driverstandingsid"))
+
+    q = M.Driver.objects
+    q.filter("driverid__@lte" => 5)
+    q.values("driverid", "n" => Subquery(p1_standings))
+    q.order_by("-n")
+
+    insp = q |> inspect_query
+    sql = insp[:sql_text]
+
+    @test contains(sql, "ORDER BY \"n\" DESC")      # alias reference…
+    @test length(collect(eachmatch(r"\(SELECT", sql))) == 1  # …not a second rendered subquery
+    @test insp[:parameters] == [1, 5]               # inner param once, outer param once
+    @test count(==('?'), sql) == 2                  # marker count matches — no orphan placeholder
+end

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -11,7 +11,7 @@ All tests use mock PostgreSQL connections (no live database required).
 using Test
 using PormG
 using PormG.Models: Model, CharField, IDField, IntegerField, DateTimeField
-using PormG.QueryBuilder: Q, Qor, F, Exists, OuterRef, inspect_query, list, update, delete, bulk_insert, bulk_update
+using PormG.QueryBuilder: Q, Qor, F, Exists, OuterRef, Subquery, Count, inspect_query, list, update, delete, bulk_insert, bulk_update
 import DataFrames
 
 # Initialize test models
@@ -548,6 +548,47 @@ PormG.config["default"] = MockSettings
     @test contains(sql, "\"R1\".\"body\" ILIKE \$2")
     @test contains(sql, "LIMIT 1)")
     @test res[:parameters] == ["British", "%wet%"]
+    @test res[:dialect] == :postgresql
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scalar correlated Subquery projection (#92) on PostgreSQL: the linear $N
+  # collector must number parameters in SQL-text order — inner subquery ($1),
+  # projected EXISTS ($2), then the outer WHERE ($3) — with the scalar wrapped
+  # in parens, aliased, and correlated against the outer alias "Tb".
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "Subquery projection (#92) - PostgreSQL scalar + Exists column" begin
+    note_query = DriverNoteModel.objects.filter(
+      "driver_id" => OuterRef("id"),
+      "body__@icontains" => "rain",
+    )
+    note_query.values("n" => Count("id"))
+
+    q = DriverModel.objects
+    q.filter("nationality" => "British")
+    q.values("surname",
+             "n_rain_notes" => Subquery(note_query),
+             "has_rain" => Exists(note_query))
+
+    res = inspect_query(q)
+    sql = res[:sql_text]
+
+    # Scalar subquery column: paren-wrapped aggregate, correlated, aliased.
+    @test contains(sql, "(SELECT")
+    @test contains(sql, "COUNT(\"R1\".\"id\")")
+    @test contains(sql, "\"R1\".\"driver_id\" = \"Tb\".\"id\"")
+    @test contains(sql, ") as \"n_rain_notes\"")
+    # EXISTS column reuses the EXISTS(SELECT 1 … LIMIT 1) template with its own alias (R2).
+    @test contains(sql, "EXISTS (SELECT 1")
+    @test contains(sql, "\"R2\".\"driver_id\" = \"Tb\".\"id\"")
+    @test contains(sql, "LIMIT 1) as \"has_rain\"")
+    # Linear $N numbering follows SQL-text order: subquery, EXISTS, outer WHERE.
+    @test contains(sql, "\"R1\".\"body\" ILIKE \$1")
+    @test contains(sql, "\"R2\".\"body\" ILIKE \$2")
+    @test contains(sql, "\"Tb\".\"nationality\" = \$3")
+    @test res[:parameters] == ["%rain%", "%rain%", "British"]
+    # A projected subquery is a per-row expression — it must not force a GROUP BY.
+    @test !contains(sql, "GROUP BY")
     @test res[:dialect] == :postgresql
   end
 

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -17,7 +17,7 @@ using PormG
 # The frozen top-level surface of `using PormG` (must match docs/src/api.md exactly).
 const EXPECTED_TOPLEVEL = Set([
     # Query builder
-    :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Interval, :show_query, :inspect_query,
+    :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Subquery, :Interval, :show_query, :inspect_query,
     # Rows & exceptions
     :PormGRow, :pk, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :PoolConnectError, :pool_stats,
     # Bulk operations


### PR DESCRIPTION
Closes #92

## What

The supported fix the #74 fan-out guard points users to: **scalar correlated subqueries projected as columns**. The aggregate runs in its own correlated sub-`SELECT`, so outer rows are never row-multiplied — and multiple independent aggregates compose in one query.

```julia
standings = M.Driver_standings.objects.
    filter("driverid" => OuterRef("driverid")).
    values("t" => Count("driverstandingsid"))

M.Driver.objects.values(
    "surname",
    "total_standings" => Subquery(standings),   # scalar subquery column
    "has_standings"   => Exists(standings),     # boolean subquery column
)
```

## Surface (pins the pre-publish API — #92's remit)

- New top-level export **`Subquery(queryset)`**, projected via `values("alias" => Subquery(inner))`, correlated with the existing `OuterRef` — Django-recognizable names, no auto-rewrite magic
- **`Exists(...)`** now also projectable in `values()` as a per-row boolean column (was filter-only)
- Inner query projects exactly **one column**: an aggregate, or a plain column with `order_by` + `limit(1)` (latest-value pattern); alias is mandatory

## Guard rails (fail-loud, #74 philosophy)

- Nested projected subqueries **raise** — `OuterRef` resolves one level only; better a loud refusal than a silently mis-correlated number
- `up_values!` silent-drop fixes: an unsupported `"alias" => value` pair now throws `ArgumentError`; a function pair failing `_check_function` validation now rethrows after logging the alias (both previously vanished the column while `values()` returned normally)
- Soft `@warn` for a non-aggregate inner with no `LIMIT` (multi-row scalar risk)
- **Interim coarse `@warn`** when a projected `Subquery`/`Exists` coexists with a grouped aggregate: live-probing showed PostgreSQL raises a `GroupingError` for an ungrouped correlation column, but **SQLite silently evaluates the subquery against an arbitrary row per group**. Precise guard tracked in #194.

## Implementation

Rendering reuses the membership-`IN` template (`query()` with shared collector/alias/`outer`); inner params land in the `:select` bucket, flattening `cte → select → where` on SQLite (PostgreSQL is linear `$N`). Projected subqueries are excluded from `GROUP BY`. `FieldPart` widened to admit `SubqueryObject`/`ExistsObject` (pre-build readers audited; defensive `Base.show` backstop). Internal `deepcopy` before render keeps a shared `Subquery` object reusable across outer queries and terminals.

## Tests

- **Unit** (13 testsets + PG coverage): SQL shape both dialects, `:select`-bucket routing and flatten order, GROUP BY isolation, `order_by`-on-alias single-render (exact param list), latest-value, warn/error paths (cause-checked), nested guard, deepcopy stability
- **Integration** (9 testsets, both backends, independently recomputed expected values): the #74→#92 fan-out proof (naive join raises, `Subquery` exact), per-row reverse-FK cross-checks, multiple independent aggregates (discriminating relations), latest-value, empty set (`Count`→0, scalar→`missing`), `Exists` booleans, M2M through-table, reuse safety, nested guard

## Docs

New "Scalar correlated subqueries" section in `subqueries_and_ctes.md` (examples verified against live `db_sl` with value cross-checks), CTE-vs-`Subquery` chooser table + per-outer-row perf note, per-backend GROUP BY divergence documented, fan-out guard cross-links, `api.md` export list, `UPGRADING.md` entry (additive feature + the silent-drop fix heads-up). `TODO.md`: #92 moves to the settled list — the release-gating index is now empty.

## Verification

| Suite | Result |
|---|---|
| Unit | 4118/4118 |
| Integration SQLite (`db_sl`) | 1749 pass (+1 pre-existing broken) |
| Integration PostgreSQL (`db_2`) | 1783/1783 |
| Docs build (`--project=docs`) | green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
