### PR TITLE
feat(#197): typed exceptions across the query surface

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -493,7 +493,7 @@ end
 function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{String,Any}
   db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME) 
 
-  endswith(db_settings_file, ".yml") || throw("Unknow configuration file type - expecting .yml")
+  endswith(db_settings_file, ".yml") || throw(ArgumentError("Unknown configuration file type at $(db_settings_file) — expecting a .yml file"))
   db_conn_data::Dict = open(db_settings_file) do io
     YAML.load(io)
   end

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -437,8 +437,7 @@ function _resolve_table_fields(
           response_idx = parse(Int, response)
           old_field_sym = colect_numbered[response_idx]          
         catch e
-          throw("Invalid number, please try makemigrations again")
-          return
+          throw(ArgumentError("Invalid choice \"$(response)\" — enter one of the listed option numbers; please try makemigrations again"))
         end
         old_field_name = old_field_sym |> string
         new_field = current_model.fields[current_fields_map[field_name]]
@@ -659,16 +658,19 @@ for (model_name, model) in current_schema
           if response in ["no", "n"]
             _add_new_table(conn, migration_plan, model_name, model[:model])
           else
+            # Only the input parse/lookup is guarded (mirrors the field-rename prompt above) — a
+            # genuine planner failure below must propagate as itself, not as "invalid choice" (#197).
+            local old_model_name
             try
               res_idx = parse(Int, response)
               old_model_name = dict_rename[res_idx]
-              # first i need to alter the fields from old table named in postgres
-              _alter_table_fields(conn, migration_plan, old_model_name, futher_processing[:drop_table][old_model_name]["model"], current_schema, settings, interactive=interactive)
-              _configure_order_dict_migration_plan(migration_plan, model_name, "Rename table", Dialect.rename_table(conn, model_name, old_model_name |> string))
-              futher_processing[:drop_table][old_model_name]["exist"] = true
-            catch e
-              throw("Invalid number, please try makemigrations again")
+            catch
+              throw(ArgumentError("Invalid choice \"$(response)\" — enter one of the listed option numbers; please try makemigrations again"))
             end
+            # first i need to alter the fields from old table named in postgres
+            _alter_table_fields(conn, migration_plan, old_model_name, futher_processing[:drop_table][old_model_name]["model"], current_schema, settings, interactive=interactive)
+            _configure_order_dict_migration_plan(migration_plan, model_name, "Rename table", Dialect.rename_table(conn, model_name, old_model_name |> string))
+            futher_processing[:drop_table][old_model_name]["exist"] = true
           end
         end         
       end    

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -374,7 +374,7 @@ function _check_filter(x::Pair)
       rethrow(e)
     end
   else
-    throw("Error in filter: '$(x.first) => ...' must be a String, got $(typeof(x.first))")
+    throw(_argerr("Error in filter: '$(x.first) => ...' must use a String key, got $(typeof(x.first))"))
   end
 end
 
@@ -463,7 +463,10 @@ function _insert_join(
       return row["alias_b"]
     else
       if size(check, 1) > 1
-        throw("Error in join")
+        # #197: was `throw("Error in join")` — a raw String with zero context. This branch means
+        # the dedup filter matched the same (a, b, key_a, key_b, alias_a) join row more than once,
+        # which the dedup invariant forbids.
+        error(_emsg("PormG internal error in _insert_join: duplicate deduplicated join rows for $(row["a"]) → $(row["b"]) (alias $(row["alias_a"])) — please report this."))
       end
       return check[1]["alias_b"]
     end
@@ -534,19 +537,8 @@ _solve_field(field::String, _module::Module, model_name::String, instruct::SQLIn
 _solve_field(field::String, _module::Module, model_name::PormGModel, instruct::SQLInstruction) = _solve_field(field, model_name, instruct)
 
 
-
-# outher functions
-function _df_to_dic(df::DataFrames.DataFrame, column::String, filter::String)
-  column = Symbol(column)
-  loc = DataFrames.subset(df, DataFrames.AsTable([column]) => (@. x -> x[column] == filtro))
-  if size(loc, 1) == 0
-    throw("Error in _df_to_dic, $(filter) not found in $(column)")
-  elseif size(loc, 1) > 1
-    throw("Error in _df_to_dic, $(filter) found more than one time in $(column)")
-  else
-    return loc[1, :]
-  end
-end
+# `_df_to_dic` used to live here — deleted in #197: it had zero callers and referenced an
+# undefined variable (`filtro`), so it was both dead and broken.
 
 # ---
 # Build the SQLInstruction object
@@ -1129,7 +1121,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     # Subqueries - these are safe since they're built through PormG.jl
     if !(v.operator in ["IN", "NOT IN"])
       @pormg_debug
-      throw("Error in values, $(v.column.field) in filter is not a object")
+      throw(_argerr("Invalid subquery filter on \"$(v.column.field)\": a queryset value requires a membership operator — use \"$(v.column.field)__@in\" => subquery or __@nin."))
     end
     _validate_membership_subquery(v)
     placeholders = query(v.values, table_alias=instruc.table_alias, connection=instruc.connection, parameters=instruc.parameters, outer=instruc)
@@ -1188,7 +1180,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       placeholders = add_parameter!(instruc, v.values, contains=is_like_op, operator=v.operator)
     else
       @pormg_debug false
-      throw("Error in values, $(v.column.field) not found in $(instruc.object.model.name)")
+      throw(_argerr("Field \"$(v.column.field)\" not found in model $(instruc.object.model.name)"))
     end
   end
 
@@ -1209,13 +1201,14 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     elseif isa(placeholders, AbstractArray)
       return string(column, " ", v.operator, " (", join(placeholders, ", "), ")")
     else
-      throw("Error in operator: $(v.operator), the value must be a String or a Vector of Strings")
+      # Internal invariant: add_parameter! only ever returns a String or a Vector of placeholders.
+      error(_emsg("PormG internal error rendering $(v.operator): parameter placeholders must be a String or a Vector, got $(typeof(placeholders))."))
     end
   elseif v.operator in ["contains", "icontains", "iunaccent_contains", "iunaccent_exact", "startswith", "endswith"]
     @pormg_debug false
     return getfield(Dialect, Symbol(v.operator))(instruc.connection, column, placeholders)
   else
-    throw("Error in operator, $(v.operator) is not a valid operator")
+    throw(_argerr("Invalid filter operator: $(v.operator) is not a supported operator."))
   end
 end
 function _get_filter_query(q::SQLTypeQ, instruc::SQLInstruction)

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -192,7 +192,7 @@ function _apply_many_to_many_branch(
   foreign_model = _resolve_many_to_many_related_model(foreing_table_module, relation)
   if length(vector) == 1
     msg = reverse ? "many-to-many reverse field" : "many-to-many field"
-    throw("Error in _build_row_join, the column $(vector[1]) is a $(msg), you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")")
+    throw(_argerr("Invalid field path: $(vector[1]) is a $(msg), you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
   end
   last_field = size(vector, 1) == 2 ? foreign_model.fields[vector[2]] : nothing
   tb_alias = _insert_many_to_many_joins(relation, instruct, parent_table, parent_alias, join_path, previus_how=previus_how)
@@ -266,7 +266,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     end
     cte_model = cte_dict["model"]::PormGModel
     
-    length(vector) == 1 && throw("Error, CTE reference '$(cte_name)' must include a field name. Example: '$(cte_name)__field_name'")
+    length(vector) == 1 && throw(_argerr("CTE reference '$(cte_name)' must include a field name. Example: '$(cte_name)__field_name'"))
 
     # Get the join field configuration from the CTE
     jf = cte_dict["join_field"]
@@ -355,7 +355,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     row_join["how"] = _determine_join_type(first_field, second_fild_name= size(vector, 1) > 1 ? vector[2] : nothing)
     foreign_table_name = first_field.to
     if foreign_table_name === nothing
-      throw("Error in _build_row_join, the column $(first_column) does not have a foreign key")
+      throw(_argerr("Invalid field path: the column $(first_column) does not have a foreign key"))
     elseif isa(foreign_table_name, PormGModel)
       row_join["b"] = foreign_table_name.name
       size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
@@ -381,21 +381,17 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     # @pormg_debug false
     s_model = Symbol(uppercasefirst(string(instruct.object.model.related_objects[vector[1]][3])))
     reverse_model = getfield(foreing_table_module, s_model)
-    length(vector) == 1 && throw("Error in _build_row_join, the column $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")")
+    length(vector) == 1 && throw(_argerr("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
     # !(vector[2] in reverse_model.field_names) && throw("Error in _build_row_join, the column $(vector[2]) not found in $(reverse_model.name)")
     row_join["a"] = instruct.object.model.name
     row_join["alias_a"] = instruct.alias
     join_field = reverse_model.fields[instruct.object.model.related_objects[vector[1]][1] |> String]
     row_join["how"] = _determine_join_type(join_field, second_fild_name= vector[2])
     size(vector, 1) == 2 && (last_field = reverse_model.fields[vector[2]])
+    # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
+    # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
     foreign_table_name = instruct.object.model.related_objects[vector[1]][3] |> String
-    if foreign_table_name === nothing
-      throw("Error in _build_row_join, the column $(foreign_table_name) does not have a foreign key")
-    elseif isa(foreign_table_name, PormGModel)
-      row_join["b"] = foreign_table_name.name
-    else
-      row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
-    end
+    row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
 
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
     # Reverse join: key_a is the parent's referenced column, key_b the child's FK
@@ -461,13 +457,14 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       _m2m_inserted = true
     elseif first_column in new_object.field_names
       first_field = new_object.fields[first_column]
-      !hasfield(typeof(first_field), :to) && throw("Error in _build_row_join, the column $(first_column) is a field from $(new_object.name), but this field has not a foreign key")
+      !hasfield(typeof(first_field), :to) && throw(_argerr("Invalid field path: the column $(first_column) is a field from $(new_object.name), but it does not have a foreign key"))
       row_join["a"] = prev_b
       row_join["alias_a"] = tb_alias      
       row_join["how"] = _determine_join_type(new_object.fields[first_column], previus_how=prev_how, second_fild_name= size(vector, 1) > 1 ? vector[2] : nothing)
       foreign_table_name = new_object.fields[first_column].to
       if foreign_table_name === nothing
-        throw("Error in _build_row_join, the column $(vector[2]) does not have a foreign key")
+        # #197: this used to blame `vector[2]`, but the FK-less column is `first_column`.
+        throw(_argerr("Invalid field path: the column $(first_column) in $(new_object.name) does not have a foreign key target"))
       elseif isa(foreign_table_name, PormGModel)
         row_join["b"] = foreign_table_name.name
         size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
@@ -491,21 +488,17 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       else
       s_model = Symbol(uppercasefirst(string(new_object.related_objects[vector[1]][3])))
       reverse_model = getfield(foreing_table_module, s_model)
-      length(vector) == 1 && throw("Error in _build_row_join, the column $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")")
-      !(vector[2] in reverse_model.field_names) && throw("Error in _build_row_join, the column $(vector[2]) not found in $(reverse_model.name)")
+      length(vector) == 1 && throw(_argerr("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
+      !(vector[2] in reverse_model.field_names) && throw(_argerr("Invalid field path: the column $(vector[2]) not found in $(reverse_model.name)"))
       row_join["a"] = prev_b
       row_join["alias_a"] = tb_alias
       join_field = reverse_model.fields[new_object.related_objects[vector[1]][1] |> String]
       row_join["how"] = _determine_join_type(join_field, previus_how=prev_how, second_fild_name= vector[2])
       size(vector, 1) == 2 && (last_field = reverse_model.fields[vector[2]])
+      # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
+      # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
       foreign_table_name = new_object.related_objects[vector[1]][3] |> String
-      if foreign_table_name === nothing
-        throw("Error in _build_row_join, the column $(foreign_table_name) does not have a foreign key")
-      elseif isa(foreign_table_name, PormGModel)
-        row_join["b"] =  foreign_table_name.name
-      else
-        row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
-      end
+      row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
 
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
       # Reverse join: key_a is the parent's referenced column, key_b the child's FK
@@ -520,7 +513,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       end
 
     else
-      throw("Error in _build_row_join, the column $(vector[1]) not found in $(new_object.name)")
+      throw(_argerr("Invalid field path: the column $(vector[1]) not found in $(new_object.name)"))
     end
 
     @pormg_debug false   

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -267,7 +267,7 @@ function get_filter_query(object::SQLObject, instruc::SQLInstruction)::Nothing
     elseif isa(v, Union{SQLTypeQor,SQLTypeQ,SQLTypeF})
       push!(instruc._where, _get_filter_query(v, instruc))
     else
-      throw("Error in values, $(v) is not a SQLTypeQor, SQLTypeQ or SQLTypeOper")
+      throw(_argerr("Invalid filter entry: $(v) (::$(typeof(v))) is not a Q, Qor, or operator expression."))
     end
   end
   return nothing

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -25,7 +25,7 @@ function With(q::SQLObject, name::String, query::SQLObjectHandler;
   join_type::String="LEFT")
   cte_fields = _preset_cte_fields(name, query, join_field=join_field, join_type=join_type)
   if haskey(q.ctes, name)
-    throw("CTE with name $(name) already exists in the query; please use a different name")
+    throw(_argerr("CTE with name \"$(name)\" already exists in the query; please use a different name."))
   end
   @pormg_debug false
   q.ctes[name] = cte_fields

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -485,7 +485,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     sql = "DELETE FROM $(model.name |> lowercase) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   end
 
-  sql == "" && throw("Error in delete, the SQL query is empty, this should not happen")
+  sql == "" && error(_emsg("PormG internal error in delete(): the generated SQL is empty — this should not happen; please report it."))
       
   if show_query !== :execute
     return _show_query_result(show_query, sql, connection, model, :delete, parameters=parameters)

--- a/src/querybuilder/exceptions.jl
+++ b/src/querybuilder/exceptions.jl
@@ -22,3 +22,10 @@ Base.showerror(io::IO, e::MultipleObjectsReturned) =
 # non-TTY sink (CI output, file logs, `sprint(showerror, e)`). `_argerr` wraps the
 # common case so a call site only changes `ArgumentError(` → `_argerr(`.
 _argerr(msg::AbstractString) = ArgumentError(_emsg(msg))
+
+# Internal dispatch fallback (#197): a connection object that is neither a PostgreSQL nor a
+# SQLite pool reached an execution path. Typed (ErrorException) so downstream
+# `catch e; e isa Exception` works — these sites previously threw raw Strings, which are not
+# Exceptions and escape every typed catch.
+_unsupported_conn(op::AbstractString, conn) = error(_emsg(
+  "PormG internal error in $(op): unsupported connection type $(typeof(conn)) — expected a PostgreSQL or SQLite connection pool."))

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -615,7 +615,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     pk_exist && _update_sequence(model, connection, pk_field, settings)
     return PormGRow(result_dict, model)
   else
-    throw("Unsupported connection type")
+    _unsupported_conn("insert()", connection)
   end
 
 end
@@ -721,7 +721,7 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
     pk_exist && _update_sequence(model, connection, pk_field, settings)
     return (PormGRow(dict, model), created)
   else
-    throw("Unsupported connection type")
+    _unsupported_conn("update_or_create()", connection)
   end
 end
 
@@ -775,16 +775,15 @@ end
 
 function _fix_sequence_name(connection::PormGPostgres, model::PormGModel; ignore_tx::Bool = false) # TODO maby i need use Migration get_sequence_name aproach
   pk_field = [field for field in keys(model.fields) if model.fields[field].primary_key]
+  # #197 review: guard BEFORE anything indexes pk_field[1] — the empty-PK check used to sit
+  # after an indexing condition, so BoundsError always won and the guard could never fire.
+  length(pk_field) == 0 && throw(_argerr("Cannot fix the PK sequence for model $(model.name): the model does not define a primary key."))
+  length(pk_field) > 1 && throw(_argerr("Cannot fix the PK sequence for model $(model.name): composite primary keys are not supported here."))
   sequences = fetch(connection, """SELECT *
       FROM pg_sequences
-      WHERE sequencename LIKE '$(model.name |> lowercase)%';"""; ignore_tx=ignore_tx) |> DataFrames.DataFrame  
+      WHERE sequencename LIKE '$(model.name |> lowercase)%';"""; ignore_tx=ignore_tx) |> DataFrames.DataFrame
   for (index, row) in enumerate(eachrow(sequences))
     if index == 1 && row.sequencename != "$(model.name |> lowercase)_$(pk_field[1])_seq"
-      if length(pk_field) == 0
-        throw("Error in _fix_sequence_name, the model $(model.name) does not have a primary key")
-      elseif length(pk_field) > 1
-        throw("Error in _fix_sequence_name, the model $(model.name) has more than one primary key")
-      end
       fetch(connection, "ALTER SEQUENCE $(row.sequencename) RENAME TO $(model.name |> lowercase)_$(pk_field[1])_seq;"; ignore_tx=ignore_tx)
     else
       fetch(connection, "DROP SEQUENCE $(row.sequencename);"; ignore_tx=ignore_tx)
@@ -973,7 +972,7 @@ function _render_date_period_arithmetic(v::FExpression, instruc::SQLInstruction)
     isempty(mods) && return left_side
     return "$wrapper($(left_side), $(join(mods, ", ")))"
   else
-    throw("Unsupported connection type")
+    _unsupported_conn("date/interval arithmetic", instruc.connection)
   end
 end
 
@@ -1058,7 +1057,7 @@ function _set_update_query(v::FExpression, instruc::SQLInstruction)
 
       return "((($(left_side1)) | ($(right_side1))) - (($(left_side2)) & ($(right_side2))))"
     else
-      throw("Unsupported connection type")
+      _unsupported_conn("xor update expression", instruc.connection)
     end
   elseif v.operation in ("+", "-") && v.operand isa Union{Dates.Period, Dates.CompoundPeriod, Interval}
     # Date arithmetic with an explicit Julia duration type (#25). Handled ahead of the generic
@@ -1225,7 +1224,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   instruction = build(real_obj, table_alias=table_alias, connection=connection) 
 
   # Don't allow to update a field without filter
-  instruction._where |> isempty && throw("Error in update, the update must have a filter")
+  instruction._where |> isempty && throw(_argerr("update() requires a filter — refusing to update every row. Add .filter(...) before .update(...)."))
   
   parameters = instruction.parameters
   fields = model.field_names
@@ -1303,7 +1302,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
       end
     else
       @error "Error in update: Unsupported database type for JOIN operations" connection_type=typeof(connection)
-      throw("Error in update: Unsupported database type for JOIN operations")
+      _unsupported_conn("update() with JOINs", connection)
     end
   else
     # No joins - simple UPDATE
@@ -1351,7 +1350,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
         end
       end
     else
-      throw("Unsupported connection type")
+      _unsupported_conn("update()", connection)
     end
   catch e
     @error "Error executing UPDATE query" exception=(e, catch_backtrace()) sql=sql

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -1224,12 +1224,17 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
             _update_sequence(model, connection, pk_field, settings)
             fetch(settings, sql, parameters)
           else
-            throw("Error in bulk_insert, the row has a duplicate key value and no primary key sequence can be synchronized")
+            # #197: keep the original driver exception (it carries the constraint detail and is a
+            # real Exception type); the String throw this replaces destroyed both. The diagnostic
+            # hint moves to the log.
+            @error "bulk_insert: duplicate key and no primary-key sequence to resync — the conflicting values came from the DataFrame" model=model.name exception=e
+            rethrow()
           end
         elseif occursin("violates foreign key constraint", e |> string)
-          throw("Error in bulk_insert, the row has a foreign key constraint")
+          @error "bulk_insert: foreign key constraint violated — a referenced row is missing" model=model.name exception=e
+          rethrow()
         else
-          throw(e)
+          rethrow()
         end
       end
     elseif connection isa PormGSQLite
@@ -1237,7 +1242,7 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
       # and pass the parameterized query with correct bucket ordering
       fetch(settings, sql, parameters)
     else
-      throw("Unsupported connection type")
+      _unsupported_conn("bulk_insert()", connection)
     end
 
     pk_exist && _update_sequence(model, connection, pk_field, settings)
@@ -1448,7 +1453,7 @@ function _bulk_update(model::PormGModel,
 
   @pormg_debug false
   if instruction !== nothing && instruction.join |> length > 0
-    throw("Error in bulk_update, the join is not allowed in bulk_update")
+    throw(_argerr("bulk_update() does not allow joined field paths (\"__\") — restrict filters and update columns to the model's own fields."))
   end
 
   # Security: Quote table name and field names

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -14,7 +14,7 @@
 
 """
 function Q(x...)
-  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw("Invalid argument: $(v); please use a pair (key => value)") for v in x]
+  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
   return QObject(filters = colect)
 end
 
@@ -35,7 +35,7 @@ end
 
 """
 function Qor(x...)
-  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw("Invalid argument: $(v); please use a pair (key => value)") for v in x]
+  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
   return QorObject(or = colect)
 end
 
@@ -480,7 +480,7 @@ end
 
 function ISNULL(v::String , value::Bool)
   if contains(v, "(")
-    throw("Error in ISNULL, the column $(v) can't be a function")
+    throw(_argerr("Error in ISNULL: the column $(v) cannot be a function expression."))
   end
   if value
     return string(v, " IS NULL")

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -9,7 +9,7 @@ function _up_values(str::String)
   if size(check, 1) == 1
     return SQLField(str, str)
   elseif haskey(PormGsuffix, check[end])
-    throw("Invalid argument: $(str) does not must contain operators (lte, gte, contains ...)")
+    throw(_argerr("Invalid values() field \"$(str)\": operator suffixes (__@lte, __@gte, __@contains, …) are not allowed in a projection — use them in filter() instead."))
   else
     @pormg_debug false
     return SQLField(_check_function(check), join(check, "__"))
@@ -27,7 +27,7 @@ function up_values!(q::SQLObject, values)
       push!(q.values, SQLField(_check_function(v), v._as))
     elseif isa(v, Pair)
       if !isa(v.first, String)
-        throw("Invalid argument: $(v.first) (::$(typeof(v.first)))); please use a string as key in the pair (key => value)")
+        throw(_argerr("Invalid values() pair key: $(v.first) (::$(typeof(v.first))) — use a String alias as the key in \"alias\" => expr."))
       end
       if isa(v.second, Union{SQLTypeFunction,SQLTypeF})
         try
@@ -86,7 +86,7 @@ function up_update!(q::SQLObject, values; kwargs...)
       if k == :show_query
         show_query = v
       else
-        throw("Invalid keyword argument: $(k); please use :show_query")
+        throw(_argerr("Invalid keyword argument for update(): $(k) — the only supported keyword is show_query."))
       end
     end
   end
@@ -178,7 +178,9 @@ function up_filter!(q::SQLObject, filter)
     elseif isa(v, Pair)
       push!(q.filter, _check_filter(v))
     else
-      error("Invalid argument: $(v) (::$(typeof(v)))); please use a pair (key => value) or a Q(key => value...) or a Qor(key => value...)")
+      # ArgumentError (not ErrorException) so filter() misuse matches the values()/order_by()
+      # siblings — this call site was the two-era inconsistency #197 calls out explicitly.
+      throw(_argerr("Invalid filter argument: $(v) (::$(typeof(v))) — use a \"field\" => value pair, a Q(key => value, …), or a Qor(key => value, …)."))
     end
   end
   return q
@@ -199,7 +201,7 @@ end
 distinct!(q::SQLObject, value::Tuple{}) = distinct!(q, true) # if no value is passed, distinct is true
 distinct!(q::SQLObject, value::Tuple{Bool}) = distinct!(q, value[1]) # if a value is passed, distinct is the value
 function distinct!(q::SQLObject, value)
-  throw("Invalid argument: $(value) (::$(typeof(value))); please use a boolean value (true or false)")
+  throw(_argerr("Invalid distinct() argument: $(value) (::$(typeof(value))) — use a Bool (true or false)."))
 end
 
 # #26: mark the query for row-level locking. Renders `FOR [NO KEY] UPDATE [NOWAIT|SKIP LOCKED]`
@@ -259,7 +261,7 @@ function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} wh
       if size(check, 1) == 1
         push!(q.order, SQLOrder(SQLField(v, v), orientation=orientation))
       elseif haskey(PormGsuffix, check[end])
-        throw("Invalid argument: $(v) does not must contain operators (lte, gte, contains ...)")
+        throw(_argerr("Invalid order_by() field \"$(v)\": operator suffixes (__@lte, __@gte, __@contains, …) are not allowed in ordering."))
       else
         push!(q.order, SQLOrder(SQLField(_check_function(check), join(check, "__")), orientation=orientation))
       end
@@ -270,7 +272,7 @@ function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} wh
   return q
 end
 function order_by!(q::SQLObject, values)
-  throw("Invalid argument: $(values) (::$(typeof(values))); please use a string or a SQLTypeOrder)")
+  throw(_argerr("Invalid order_by() argument: $(values) (::$(typeof(values))) — use field-name Strings (\"-field\" for DESC) or SQLTypeOrder values."))
 end
 
 

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -339,7 +339,7 @@ function Base.push!(q::SQLTypeQ, x...)
     elseif isa(v, FilterType)
       push!(q.filters, v)
     else
-      throw("Invalid argument: $(v); please use a pair (key => value) or Q/Qor/OP object")
+      throw(_argerr("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
     end
   end
   return q
@@ -352,7 +352,7 @@ function Base.push!(q::SQLTypeQor, x...)
     elseif isa(v, FilterType)
       push!(q.or, v)
     else
-      throw("Invalid argument: $(v); please use a pair (key => value) or Q/Qor/OP object")
+      throw(_argerr("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
     end
   end
   return q

--- a/test/integration/test_cte.jl
+++ b/test/integration/test_cte.jl
@@ -339,7 +339,9 @@ end
         q = M.Result.objects
         sub = M.Driver.objects.filter("driverid__@lte" => 5).values("driverid")
         q.with("dup" => sub, join_field="driverid" => "driverid")
-        @test_throws String q.with("dup" => sub, join_field="driverid" => "driverid")
+        # #197: With() now throws a typed ArgumentError (was a raw String, which no
+        # `catch e; e isa Exception` could see).
+        @test_throws ArgumentError q.with("dup" => sub, join_field="driverid" => "driverid")
     end
 
 end

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -235,7 +235,9 @@ end
         e
     end
     @test err !== nothing
-    @test occursin("must have a filter", lowercase(string(err)))
+    # #197: the guard is now a typed ArgumentError with reworded message — assert both.
+    @test err isa ArgumentError
+    @test occursin("requires a filter", lowercase(string(err)))
 
     row_after_unfiltered_attempt = M.Just_a_test_deletion.objects.filter("name" => "valid").list() |> first
     @test row_after_unfiltered_attempt[:name] == "valid"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,7 @@ end
     @testset "JSON Path Lookups (#27)" include("unit/test_json_lookups.jl")
     @testset "JSON Containment Operators (#27)" include("unit/test_json_operators.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
+    @testset "Typed Exceptions on Query Surface (#197)" include("unit/test_typed_exceptions.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")
     @testset "Configuration API" include("unit/test_configuration_api.jl")

--- a/test/unit/test_typed_exceptions.jl
+++ b/test/unit/test_typed_exceptions.jl
@@ -1,0 +1,145 @@
+"""
+Typed-exception contract tests for the public query surface (#197).
+
+This file tests:
+- Representative fluent-surface misuse (filter, values, order_by, distinct, update kwargs,
+  With/CTE names, Q/Qor construction) throws a typed `ArgumentError` — previously many of
+  these sites threw raw Strings, which are NOT `Exception`s and escape every
+  `catch e; e isa Exception` handler a package user can write
+- Internal dispatch fallbacks throw `ErrorException` (via `_unsupported_conn`)
+
+No database is required: every assertion fires at query-build/validation time.
+"""
+# julia -t auto --project=. test/unit/test_typed_exceptions.jl
+
+using Test
+using PormG
+using PormG.Models
+using PormG.QueryBuilder: object, Q, Qor, With
+
+const QB = PormG.QueryBuilder
+
+# Minimal in-memory model — mirrors the mock-model pattern from
+# test_field_validation_and_operations.jl. No connection, no settings needed:
+# all the misuse below is rejected before any DB work.
+typed_errs_model = Models.Model_Type(
+    name = "typed_errs_test",
+    fields = Dict(
+        "id" => Models.IDField(),
+        "points" => Models.IntegerField(),
+    ),
+    field_names = ["id", "points"]
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: filter() misuse
+# A non-Pair/non-Q filter argument must raise ArgumentError. This site was the
+# #197 poster child: filter() threw ErrorException while its values()/order_by()
+# siblings threw ArgumentError — same surface, different types.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "filter() misuse is ArgumentError" begin
+    q = object(typed_errs_model)
+    # An Int is neither a Pair nor a Q/Qor/operator object.
+    @test_throws ArgumentError q.filter(123)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: values() misuse
+# Three rejection paths in up_values!/_up_values, all previously raw-String throws:
+# a non-String pair key, an operator suffix inside a projection, and (pre-typed
+# since #92, pinned here) a value of an unsupported type.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "values() misuse is ArgumentError" begin
+    q = object(typed_errs_model)
+    # Pair key must be a String alias.
+    @test_throws ArgumentError q.values(1 => "points")
+    # Operator suffixes belong in filter(), never in a projection.
+    @test_throws ArgumentError q.values("points__@gte")
+    # Unsupported bare value type (already typed by #92 — regression pin).
+    @test_throws ArgumentError q.values(3.14)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: order_by() misuse
+# Both order_by! rejection paths: an operator suffix inside an ordering field,
+# and an argument that is neither String nor SQLTypeOrder.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() misuse is ArgumentError" begin
+    q = object(typed_errs_model)
+    # Operator suffixes are meaningless in ORDER BY.
+    @test_throws ArgumentError q.order_by("points__@gte")
+    # An Int can't name an ordering column (hits the generic fallback method).
+    @test_throws ArgumentError q.order_by(1)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: distinct() misuse
+# distinct() accepts only Bool (or no argument); anything else hits the typed
+# fallback method.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "distinct() misuse is ArgumentError" begin
+    q = object(typed_errs_model)
+    @test_throws ArgumentError q.distinct("yes")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: update() keyword misuse
+# up_update! validates keywords BEFORE any build/DB work, so a typo'd kwarg
+# (only :show_query is supported) is a pure ArgumentError — no settings needed.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "update() bad keyword is ArgumentError" begin
+    q = object(typed_errs_model)
+    @test_throws ArgumentError q.update("points" => 1, show_querys = :sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: Q / Qor construction and push!
+# The Q/Qor constructors and Base.push! on Q objects validate their arguments;
+# all four rejection paths were raw-String throws before #197.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Q/Qor misuse is ArgumentError" begin
+    @test_throws ArgumentError Q(123)
+    @test_throws ArgumentError Qor(123)
+    # push! onto an existing Q/Qor rejects non-Pair/non-filter entries too.
+    @test_throws ArgumentError push!(Q("points" => 1), 123)
+    @test_throws ArgumentError push!(Qor("points" => 1, "points" => 2), 123)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: duplicate CTE name via With()
+# Registering two CTEs under one alias would render invalid SQL; With() rejects
+# the second registration at the call site (integration twin lives in
+# test/integration/test_cte.jl "With() duplicate CTE name is rejected").
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "With() duplicate CTE name is ArgumentError" begin
+    q = object(typed_errs_model)
+    sub = object(typed_errs_model)
+    With(q, "dup", sub)
+    @test_throws ArgumentError With(q, "dup", sub)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: ISNULL guard
+# ISNULL refuses a function expression as its column operand.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ISNULL on function expression is ArgumentError" begin
+    @test_throws ArgumentError QB.ISNULL("lower(points)", true)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed exceptions: internal dispatch fallback helper
+# _unsupported_conn is the shared fallback for execution paths reached with a
+# connection that is neither PostgreSQL nor SQLite. It must throw a REAL
+# exception (ErrorException) naming the operation and the offending type —
+# these sites were raw "Unsupported connection type" String throws before #197.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_unsupported_conn is ErrorException with context" begin
+    err = try
+        QB._unsupported_conn("unit-test-op", nothing)
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test occursin("unit-test-op", err.msg)     # names the operation
+    @test occursin("Nothing", err.msg)          # names the offending type
+end


### PR DESCRIPTION
Closes #197.

## What

Every raw-string `throw("...")` on the query surface is now a typed exception. Raw Strings are not `Exception`s — they escaped every `catch e; e isa Exception` a package user could write, so no reliable error handling was possible around filters, joins, projections, or CTEs.

**The contract** (settled pre-publish, per the issue):

| Path | Type |
|---|---|
| User misuse (bad filter/values/order_by args, invalid field paths, bad operators, duplicate CTE names…) | `ArgumentError` via `_argerr` (TTY-aware) |
| Internal invariants / dispatch fallbacks | `ErrorException` — "Unsupported connection type" sites now share the new `_unsupported_conn(op, conn)` helper with operation + type context |
| `bulk_insert` catch-site diagnostics | `@error … exception=e` + `rethrow()` — the original driver exception survives instead of being flattened into a String |

**Decision recorded:** no new exported domain exception types — `ArgumentError`/`ErrorException` plus the existing `DoesNotExist`/`MultipleObjectsReturned`/`PoolTimeoutError`/`PoolConnectError` cover the surface.

## Riding along with the sweep

- Three wrong interpolations fixed in `build_joins.jl` messages (one printed `nothing`, one blamed the wrong column)
- Context-free messages rewritten (`throw("Error in join")` → named invariant with join context)
- Dead code removed: `_df_to_dic` (zero callers + undefined `filtro` reference) and two type-impossible reverse-relation branches
- `_fix_sequence_name` PK guards hoisted above the indexing that made the empty-PK guard unreachable
- `makemigrations` rename-choice catch narrowed to input parsing only — genuine planner failures now propagate as themselves

## Tests

- New `test/unit/test_typed_exceptions.jl` — 17 deterministic assertions, one representative misuse per public method, no DB needed
- `test_cte.jl` (`@test_throws String` → `ArgumentError`) and `test_updates.jl` (filter-guard message/type) updated to the typed contract
- Adversarial review pass ran over the diff; its one blocking finding (stale `test_updates.jl` assertion) and all advisories are addressed

## Verification

| Suite | Result |
|---|---|
| Full unit suite incl. Aqua | 4135/4135, exit 0 |
| SQLite integration (`db_sl`) | 1750 pass / 1 pre-existing broken / 0 fail |
| PG slices (`test_cte.jl`, `test_updates.jl`) | green (standalone `test_updates` harness-helper gap is pre-existing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
