### PR TITLE
docs(#198): async & concurrency guide + regression tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -65,6 +65,7 @@ makedocs(
         "Import from Django" => "import_django.md",
 
         "PostgreSQL Guide" => "postgres.md",
+        "Async & Concurrency" => "async.md",
         "Architecture" => "architecture.md",
         "Advisory Locks" => "advisory_lock.md",
         "Extending PormG" => "extending.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -503,15 +503,36 @@ end
 
 ## Async Execution
 
-### `fetch_async`
-
-Execute a query asynchronously, returning a `FetchTask`:
+PormG is async-first *internally*: every terminal (`list()`, `count()`, `create()`, …) already
+yields to the Julia scheduler while the database round-trip is in flight. There is no separate
+async query API — wrap the ordinary call in a task:
 
 ```julia
-task = fetch_async(M.Driver.objects.filter("nationality" => "Brazilian"))
-# ... do other work ...
-result = await_result(task)
+t = Threads.@spawn M.Driver.objects.filter("nationality" => "Brazilian").list()
+# ... other work overlaps the database round-trip ...
+rows = fetch(t)   # Base.fetch on the Task — same rows as calling list() directly
 ```
+
+### `fetch_async` / `await_result` (raw SQL)
+
+The lower-level escape hatch accepts **raw SQL only** — not query-builder objects — and returns
+a `FetchTask`:
+
+```julia
+settings = PormG.Configuration.get_settings("db")
+
+task = fetch_async(settings, "SELECT count(*) FROM driver")
+# ... do other work ...
+result = await_result(task)   # returns rows and releases the pooled connection
+```
+
+!!! warning "An un-awaited `FetchTask` leaks its pool connection"
+    `fetch_async` checks its connection out synchronously; only `await_result` returns it.
+    Always await every task you start.
+
+See the [Async & Concurrency guide](async.md) for fan-out patterns, `@async` vs
+`Threads.@spawn`, connection-pool sizing, and why you must not fan out queries *inside* a
+transaction.
 
 ---
 
@@ -618,7 +639,7 @@ scope — the SQL function constructors are *not* among them (see
 `bulk_insert`, `bulk_update`, `bulk_copy`, `allocate_primary_keys`
 
 ### Async API
-`fetch_async`, `await_result`, `FetchTask`
+`fetch_async`, `await_result`, `FetchTask` — see [Async & Concurrency](async.md)
 
 ### Transactions
 `run_in_transaction`, `atomic`, `with_savepoint`, `with_tx_context`, `in_transaction_context`

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -191,6 +191,7 @@ characterizations worth stating plainly.
     **SQLite**, every statement is funnelled through a single global worker (serialized), with write
     transactions further pinned behind a process-wide lock — pool size buys no query-level
     concurrency. "Async-first" is a real PostgreSQL capability, not a blanket ORM property.
+    Usage patterns live in the [Async & Concurrency guide](async.md).
 
 ## Where to look next
 

--- a/docs/src/async.md
+++ b/docs/src/async.md
@@ -1,0 +1,116 @@
+# Async & Concurrency
+
+PormG is **async-first internally**: every terminal — `list()`, `count()`, `create()`, a `DataFrame` pipe — runs through the asynchronous core (`fetch_async` → `await_result`) and **yields to the Julia scheduler** while the database round-trip is in flight. The "synchronous" API parks the *task*, never the thread.
+
+That has a powerful consequence: **there is no separate async query API to learn.** Julia functions are not colored — any query can be made concurrent by wrapping the ordinary call in a task:
+
+```julia
+t = Threads.@spawn M.Driver.objects.filter("nationality" => "Brazilian").list()
+# ... other work overlaps the database round-trip ...
+rows = fetch(t)          # Base.fetch on a Task — same Vector{PormGRow} as calling list() directly
+```
+
+This is the same contract Elixir's Ecto (`Task.async`) and Go's `database/sql` (goroutines) chose, and it is guaranteed by regression tests on both PostgreSQL and SQLite: a task-wrapped query returns exactly what the sync call returns.
+
+!!! note "Two `fetch`es"
+    `fetch(t)` above is `Base.fetch` on a `Task`. PormG's low-level `fetch(settings, sql)` escape hatch is *also* a method of `Base.fetch` — same name, different arguments. Application code rarely needs the latter; prefer the fluent terminals.
+
+## How it works
+
+`list()` → `fetch()` → `fetch_async()` → `await_result()`. On PostgreSQL the round-trip is real non-blocking I/O (`LibPQ.async_execute`); on SQLite every statement is funnelled through one serialized worker task. Both paths *yield* while waiting, so concurrency is always safe — but only PostgreSQL executes queries in parallel across connections. See the [Architecture](architecture.md) guide's *"Async-first" is backend-specific* note for the full picture.
+
+## `@async` vs `Threads.@spawn`
+
+Both overlap database waits, because the wait is a scheduler yield either way:
+
+- **`Threads.@spawn`** (recommended default) — the task may run on any thread, so CPU-bound work after the query (row processing, aggregation) also parallelizes when Julia has threads (`julia -t auto`). Under `julia -t 1` it simply schedules on the sole thread and still overlaps I/O.
+- **`@async`** — pins the task to the current thread. Fine for pure I/O overlap; no CPU parallelism.
+
+!!! warning "Collect results from tasks, don't mutate shared state"
+    With `Threads.@spawn`, tasks run in parallel. A shared counter like `hits[] += 1` on a `Ref` is a data race that silently loses updates. Return values from the task and collect them with `fetch` (as in every example on this page), or use `Base.Threads.Atomic` / a lock when you genuinely need shared state.
+
+## Fan-out patterns
+
+Run independent queries concurrently and collect results in input order:
+
+```julia
+years = 2010:2019
+
+# One task per season — all round-trips in flight together
+tasks = [Threads.@spawn M.Race.objects.filter("year" => y).count() for y in years]
+counts = fetch.(tasks)   # [19, 19, 20, 19, 19, 19, 21, 20, 21, 21]
+```
+
+The same shape as a one-liner with `asyncmap`:
+
+```julia
+counts = asyncmap(y -> M.Race.objects.filter("year" => y).count(), collect(years))
+```
+
+For side-effecting fan-out where you only need completion, use a `@sync` block:
+
+```julia
+@sync for y in years
+    Threads.@spawn begin
+        n = M.Race.objects.filter("year" => y).count()
+        @info "season loaded" year = y races = n
+    end
+end
+```
+
+Results arrive in *input* order with `fetch.(tasks)` / `asyncmap` — tasks may *complete* in any order.
+
+## Connection-pool interplay
+
+Each in-flight query leases one pooled connection for its duration; a 10-way fan-out briefly holds up to 10 connections. The pool starts at `pool_size` and grows lazily to a `pool_size × 10` ceiling; beyond that, callers park until a connection frees, and a genuine saturation raises a catchable `PoolTimeoutError` (tune with `pool_timeout`). Diagnose with `pool_stats("db")`. Details and YAML examples live in [Advanced Configuration](configuration/advanced.md).
+
+A task-wrapped terminal **cannot leak** a connection: the query acquires and releases its connection inside the task, even if you never `fetch` the task.
+
+## Raw SQL: `fetch_async`, `await_result`, `FetchTask`
+
+The only PormG-specific async API is the low-level escape hatch, and it takes **raw SQL only** — not query-builder objects:
+
+```julia
+settings = PormG.Configuration.get_settings("db")
+
+task = fetch_async(settings, "SELECT count(*) FROM driver")   # returns a FetchTask
+# ... do other work ...
+result = await_result(task)                                   # rows; releases the pooled connection
+```
+
+`await_result` is idempotent — a second call returns the cached result without touching the pool.
+
+This hatch runs the SQL string **as you supply it**, so reserve it for static, trusted statements — schema introspection, a fixed `COUNT(*)`, a maintenance command. It is not a parameterized-query path: the `params` keyword takes a parameter collector the ORM builds internally, not a plain vector of values you pass in. Any query that carries user-supplied values belongs on the ORM surface — wrap `list()` / `count()` / `filter(...)` in a task as shown above — which binds parameters, post-processes rows, and manages the connection for you.
+
+!!! danger "Never interpolate user input into the SQL string"
+    `fetch_async(settings, "... $uservalue ...")` is a SQL-injection hole. The raw-SQL hatch has no value-binding on the public surface by design; if you need user values, use the ORM query surface, which parameterizes every value.
+
+!!! warning "An un-awaited `FetchTask` holds a pool connection"
+    `fetch_async` checks its connection out *synchronously*; only `await_result` (or the owning transaction's cleanup) returns it. Always await every task you start — including fire-and-forget writes. The opt-in [`leak_detection_threshold`](configuration/advanced.md) logs a warning when a connection is held suspiciously long, which almost always means an un-awaited `FetchTask`.
+
+## Transactions and concurrency
+
+The transaction context is a `ScopedValue`, so tasks spawned **inside** `run_in_transaction` inherit it — every query they run targets the transaction's **single pinned connection** (see [Async Context Propagation](write/transaction.md#Async-Context-Propagation)). That is exactly what you want for *correctness*: child tasks participate in the same transaction.
+
+It is **not** a way to speed anything up:
+
+- All statements on one connection execute one at a time — fan-out inside a transaction **serializes** and buys zero concurrency.
+- The serialization currently relies on driver-internal locking (LibPQ's per-connection lock, SQLite's global worker). It is safe today on both backends, but it is a property of the drivers, not a PormG contract — concurrent statements on one connection are a driver error class (e.g. PostgreSQL's *"another command is already in progress"*) that PormG does not promise to absorb.
+
+!!! warning "Fan out transactions, not queries inside one"
+    For concurrent transactional work, spawn the *whole transaction* — each task pins its own pooled connection:
+
+    ```julia
+    # Recompute each season's driver standings in its own transaction. The seasons
+    # are independent, so the transactions run concurrently — each on its own pooled
+    # connection with its own BEGIN/COMMIT.
+    @sync for year in 2010:2019
+        Threads.@spawn PormG.run_in_transaction(settings) do
+            new_standings = compute_driver_standings(year)   # your domain logic → DataFrame
+            M.Driver_standings.objects.filter("raceid__year" => year).delete()
+            bulk_insert(M.Driver_standings.objects, new_standings)
+        end
+    end
+    ```
+
+Also remember the retry rule from [Transactions](write/transaction.md): a connection error inside a transaction propagates — retry the whole transaction, never a single statement.

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -4,7 +4,7 @@ PormG is designed for Julia's asynchronous task scheduling. This section covers 
 
 ## Connection Pooling & Async-First Design
 
-- **Async-First API:** The synchronous `fetch()` API is a wrapper around the asynchronous `fetch_async()` core. This wrapper yields to the Julia scheduler while waiting for the database, ensuring compatibility with async frameworks.
+- **Async-First API:** The synchronous `fetch()` API is a wrapper around the asynchronous `fetch_async()` core. This wrapper yields to the Julia scheduler while waiting for the database, ensuring compatibility with async frameworks. See the [Async & Concurrency guide](../async.md) for usage patterns.
 - **Pooling Strategy:** The default strategy is `:poll`, which retries at configured intervals. Use `:block` for PostgreSQL to let the server-side manage the wait, often combined with a `statement_timeout`.
 - **Sizing & capacity:** A pool starts at `pool_size` connections (default `3`) and grows **lazily, on demand,** up to `pool_size × 10` under concurrent load — so the idle footprint stays small while async fan-out still gets headroom. If every connection is busy and none frees within the retry/timeout budget, `acquire_connection` raises a catchable `PoolTimeoutError` (exported by PormG). Raise `pool_size` in your `connection.yml` to add capacity for genuinely high-concurrency workloads:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -316,6 +316,7 @@ This documentation is organized into the following sections:
 |  [Field Expressions](read/field_expressions.md) | `F()` expressions, column arithmetic, aggregate ratios. |
 |  [Q Objects](read/q_objects.md) | Complex boolean logic with `Q`, `Qor`, and `NOT`. |
 | [Import from Django](import_django.md) | Migrating models and data from Django projects. |
+| [Async & Concurrency](async.md) | Task-based concurrent queries, fan-out patterns, `fetch_async`, pool interplay. |
 | [Advisory Locks](advisory_lock.md) | Distributed locking with `with_advisory_lock`. |
 | [Contributing](contributing.md) | Development workflow, `@pormg_debug` breakpoints, and testing conventions. |
 | [API Reference](api.md) | Full auto-generated API reference and exported function catalog. |

--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -152,6 +152,8 @@ PormG.bulk_insert(query, df, chunk_size=5)
 
 One of PormG's key strengths is that spawned `@async` tasks automatically inherit the transaction context. This lets you write elegant concurrent code without worrying about connection pools.
 
+Note that inherited context means every child task shares the transaction's **single pinned connection**, so their statements serialize — this propagation is about *correctness* (all work joins the same transaction), not throughput. For concurrent throughput, fan out whole transactions instead; see [Async & Concurrency — Transactions and concurrency](../async.md#Transactions-and-concurrency).
+
 ### Single Async Task
 
 ```julia

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -48,6 +48,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Custom Joins (cjoin)"         begin include("test_cjoin.jl")              end    
     @testset "Cached Joins"                 begin include("test_cache_join.jl")         end
     @testset "Transactions"                 begin include("test_transactions.jl")       end
+    @testset "Async Task Concurrency (#198)" begin include("test_async_tasks.jl")       end
     @testset "Connection Pool (#37)"        begin include("test_connection_pool.jl")    end
     @testset "Advisory Locks"               begin include("test_advisorylock.jl")       end
     @testset "Having (Aggregates)"          begin include("test_having.jl")             end

--- a/test/integration/test_async_tasks.jl
+++ b/test/integration/test_async_tasks.jl
@@ -1,0 +1,134 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Async task concurrency (#198): "tasks are the async API"
+# PormG's contract for per-query async execution is Julia's task system: every
+# terminal (list(), count(), …) already yields to the scheduler while the DB
+# round-trip is in flight (fetch → fetch_async → await_result), so wrapping the
+# ordinary sync call in Threads.@spawn / @async IS the async query API. These
+# tests pin that contract: task-wrapped queries return exactly what the sync
+# path returns (PG + SQLite), fan-out leaks no pool connections, and the
+# ScopedValue transaction context propagates into spawned tasks (the mechanism
+# behind the "don't fan out queries inside a transaction" guidance in
+# docs/src/async.md).
+# ─────────────────────────────────────────────────────────────────────────────
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+using Test
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parity: a task-wrapped list() returns exactly the sync list() rows
+# The issue-#198 regression: the async path is the sync path (same SQL, same
+# post-processing, same Vector{PormGRow}) — only the awaiting differs. Ordered
+# by primary key so the element-wise comparison is deterministic.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Threads.@spawn list() parity with sync list()" begin
+    # Sync baseline. order_by makes row order deterministic on both backends.
+    sync_query = M.Driver.objects
+    sync_query.filter("nationality" => "Brazilian")
+    sync_query.order_by("driverid")
+    sync_rows = sync_query.list()
+    @test !isempty(sync_rows)   # guard: a vacuously-empty comparison proves nothing
+
+    # Async arm: build the handler INSIDE the task (each `.objects` access
+    # returns a fresh handler, and terminals deepcopy before building — no
+    # shared mutable state between the sync and async arms).
+    t = Threads.@spawn M.Driver.objects.filter(
+        "nationality" => "Brazilian"
+    ).order_by("driverid").list()
+    spawn_rows = fetch(t)   # Base.fetch on a Task — this is the whole async API
+
+    @test length(spawn_rows) == length(sync_rows)
+    @test [r[:driverid] for r in spawn_rows] == [r[:driverid] for r in sync_rows]
+    @test [r[:surname] for r in spawn_rows] == [r[:surname] for r in sync_rows]
+
+    # Same contract holds for @async (current-thread task): both spellings are
+    # documented in docs/src/async.md — the DB wait is a scheduler yield either way.
+    t2 = @async M.Driver.objects.filter(
+        "nationality" => "Brazilian"
+    ).order_by("driverid").list()
+    async_rows = fetch(t2)
+    @test [r[:driverid] for r in async_rows] == [r[:driverid] for r in sync_rows]
+    @test [r[:surname] for r in async_rows] == [r[:surname] for r in sync_rows]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fan-out: @sync + @spawn over independent queries matches sync baselines and
+# returns every pooled connection. Unlike an un-awaited fetch_async (which
+# holds its connection until await_result), a task-wrapped terminal acquires
+# AND releases its connection inside the task — so even a forgotten task
+# cannot leak. Busy-count is compared against a pre-fan-out baseline (same
+# robustness pattern as test_connection_pool.jl). No simultaneous-checkout
+# assertion here: SQLite serializes through its shared async worker.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Concurrent fan-out matches sync baselines and leaks nothing" begin
+    settings = PormG.config[PORMG_DB_FOLDER]
+    years = 2010:2019
+
+    # Sync baselines first (sequential, no concurrency in play).
+    expected = [M.Race.objects.filter("year" => y).count() for y in years]
+    @test any(>(0), expected)   # guard: the fixture must actually cover these seasons
+
+    # Baseline of busy (checked-out) pool slots before the fan-out.
+    base_busy = count(!, settings.connections.available)
+
+    # One task per season, all in flight together; fetch preserves input order.
+    tasks = [Threads.@spawn M.Race.objects.filter("year" => y).count() for y in years]
+    got = fetch.(tasks)
+    @test got == expected
+
+    # Every connection the fan-out used was returned to the pool.
+    @test count(!, settings.connections.available) == base_busy
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# asyncmap: the one-liner fan-out spelling documented in docs/src/async.md.
+# Result order matches input order by construction.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "asyncmap parity" begin
+    years = 2010:2019
+    expected = [M.Race.objects.filter("year" => y).count() for y in years]
+    got = asyncmap(y -> M.Race.objects.filter("year" => y).count(), collect(years))
+    @test got == expected
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Raw-SQL escape hatch: fetch_async(settings, sql) → await_result. Anchors the
+# rewritten docs/src/api.md "Async Execution" example: fetch_async takes RAW
+# SQL only (never a query handler — the phantom fetch_async(handler) form from
+# the old docs does not exist). Also pins await_result's documented idempotence
+# (second await returns the cached result, no double-release).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "raw-SQL fetch_async parity with the query path" begin
+    settings = PormG.config[PORMG_DB_FOLDER]
+
+    task = fetch_async(settings, "SELECT count(*) FROM driver")
+    result = await_result(task)
+    df = DataFrame(result)
+    @test df[1, 1] == M.Driver.objects.count()
+
+    # Idempotent await: same object back, connection released exactly once.
+    @test await_result(task) === result
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transaction context propagates into spawned tasks (ScopedValue semantics).
+# This is the mechanism behind the async-guide warning: a task spawned INSIDE
+# run_in_transaction inherits the pinned transaction connection, so fanning
+# out queries inside a transaction gives zero concurrency (they all serialize
+# on one connection) — fan out whole transactions instead. BEGIN/COMMIT only,
+# no writes, so the testset is read-only on both backends.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "tx context propagates into spawned tasks" begin
+    settings = PormG.config[PORMG_DB_FOLDER]
+
+    # Outside any transaction: no pinned connection to inherit.
+    @test fetch(Threads.@spawn get_tx_connection() !== nothing) == false
+
+    # Inside: the spawned task sees the transaction's pinned connection.
+    seen = Ref(false)
+    PormG.run_in_transaction(settings) do
+        seen[] = fetch(Threads.@spawn get_tx_connection() !== nothing)
+    end
+    @test seen[]
+end


### PR DESCRIPTION
Closes #198.

## What & why

The docs promised `fetch_async(M.Driver.objects.filter(...))` — a method that never existed (`MethodError`). PormG is async-first *internally* (sync `fetch` wraps `fetch_async`/`await_result`, parking the task not the thread), and Julia's functions are uncolored — so the per-query async surface is Julia's own task system: `Threads.@spawn query.list()` already overlaps DB I/O correctly on both backends.

This is the pre-publish contract decision for #198: **"tasks are the async API."** No new `src/` surface, so nothing here can ever need a breaking rename.

## Changes

- **New `docs/src/async.md`** — "Async & Concurrency" guide: the task pattern, `@async` vs `Threads.@spawn`, fan-out (`@sync` / `asyncmap`), connection-pool interplay, the raw-SQL `fetch_async`/`await_result`/`FetchTask` escape hatch (with a no-interpolation `!!! danger` and un-awaited-task leak semantics), and the transaction-concurrency pitfall (ScopedValue context propagation → single pinned connection).
- **`docs/src/api.md`** — replaced the phantom "Async Execution" section with the real task pattern + real raw-SQL signature; cross-linked from `make.jl` nav, `index.md`, `configuration/advanced.md`, `write/transaction.md`, `architecture.md`.
- **New `test/integration/test_async_tasks.jl`** (Phase 3) — task-wrapped `list()` parity with sync, concurrent fan-out with no pool leak, `asyncmap` parity, raw-SQL `fetch_async` parity + `await_result` idempotence, and tx-context propagation into spawned tasks.
- **`Project.toml`** — 0.2.0 → 0.2.1 (z-bump; docs+tests, no behavior change, no `UPGRADING.md` entry — the phantom API never worked, so no consumer can break).

## Verification

- Integration: **PostgreSQL 1797/1797**, **SQLite exit 0** (full suites).
- Unit: **4135/4135**.
- Docs build: exit 0, no cross-reference errors.
- Every doc example live-verified against the F1 fixture on both backends (32 Brazilian drivers; per-season race counts; the `raceid__year` join-filtered delete SQL confirmed to render).

## Follow-up

- #218 (manual-params mode for raw-SQL `fetch`/`fetch_async`) — filed from the review discussion; kept out of this docs+tests PR because it adds a new public API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
