### PR TITLE
feat(#216): agent-consumable upgrade emitter — PormG.upgrade_guide over UPGRADING.md

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -630,7 +630,7 @@ scope — the SQL function constructors are *not* among them (see
 `pool_stats`, `PoolTimeoutError`, `PoolConnectError`
 
 ### Utilities & lifecycle
-`setup`, `install_ai_skills`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
+`setup`, `install_ai_skills`, `upgrade_guide`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
 
 !!! note "`fetch` extends `Base.fetch`"
     The low-level `fetch(settings, sql; params=…)` escape hatch is a method of

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -175,7 +175,7 @@ export PoolTimeoutError  # thrown by acquire_connection when the pool is saturat
 export PoolConnectError  # thrown by acquire_connection when a connection can't be opened (#72)
 export pool_stats  # connection-pool health snapshot (#127)
 export with_tx_context, in_transaction_context  # Transaction context helpers
-export setup, install_ai_skills
+export setup, install_ai_skills, upgrade_guide  # upgrade_guide: version-scoped UPGRADING.md emitter (#216)
 
 # Fallback stub for the Tachikoma TUI extension.
 # When `using Tachikoma`, PormGTachikomaExt overrides this with the real implementation.

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -142,3 +142,113 @@ function install_ai_skills(target_dir::String = pwd())
         @error "Failed to install AI skills" exception=e
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# upgrade_guide — version-scoped emitter over UPGRADING.md (issue #216)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Unstamped ("pre-0.2 history") UPGRADING.md entries sort just below 0.2.0: under any
+# 0.2.x release, but above every 0.1.x. So a consumer coming from before the versioning
+# policy still sees them, while one already on ≥ 0.2.0 does not.
+const _UNSTAMPED_VERSION = v"0.2.0-"
+
+const _UpgradeEntry = @NamedTuple{version::VersionNumber, title::String, body::String}
+
+_asver(v::VersionNumber) = v
+_asver(v::AbstractString) = VersionNumber(v)
+
+"""
+    _read_upgrading_entries() -> Vector{_UpgradeEntry}
+
+Parse the `UPGRADING.md` bundled with the resolved PormG install into change entries,
+newest-first. `body` is the entry's markdown with its PormG-internal `### Per-app rollout`
+table trimmed off. Unstamped pre-0.2 entries get `version = _UNSTAMPED_VERSION`.
+"""
+function _read_upgrading_entries()
+    path = joinpath(Base.pkgdir(@__MODULE__), "UPGRADING.md")
+    isfile(path) || throw(ArgumentError(
+        "UPGRADING.md not found next to the installed PormG (looked in $(dirname(path)))."))
+    text = read(path, String)
+
+    # Drop the "## Template for new entries" section: its body is an HTML comment holding a
+    # fake `## …` heading and a `- **Version**:` placeholder that would parse as a bogus entry.
+    tmpl = findfirst("## Template for new entries", text)
+    tmpl === nothing || (text = text[1:prevind(text, first(tmpl))])
+
+    entries = _UpgradeEntry[]
+    for block in split(text, r"(?m)^---[ \t]*$")
+        # A real change entry has a `## ` heading AND a `- **Recorded**:` bullet — this rejects
+        # the header/recipe prose and any stray section, regardless of `---` placement.
+        title_m = match(r"(?m)^##[ \t]+(.+)$", block)
+        (title_m === nothing || !occursin(r"(?m)^-[ \t]+\*\*Recorded\*\*:", block)) && continue
+
+        ver_m = match(r"(?m)^-[ \t]+\*\*Version\*\*:[ \t]*(\S+)", block)
+        version = ver_m === nothing ? _UNSTAMPED_VERSION : VersionNumber(ver_m[1])
+
+        # Trim the internal per-app rollout table (which of PormG's own apps adopted it) —
+        # noise for a consuming app, which only needs the porting work.
+        body = block
+        roll = findfirst("### Per-app rollout", body)
+        roll === nothing || (body = body[1:prevind(body, first(roll))])
+
+        push!(entries, (version = version,
+                        title = String(strip(title_m[1])),
+                        body = String(strip(body))))
+    end
+    return entries
+end
+
+"""
+    upgrade_guide([io::IO = stdout]; from, to = pkgversion(PormG), structured = false)
+
+Print the `UPGRADING.md` entries a consuming app must work through to move from PormG
+version `from` up to `to` (default: the installed version). Reads the `UPGRADING.md`
+shipped with the *resolved* PormG install, so the scope is accurate against the version
+your app actually depends on — not a latest-on-GitHub copy that may not match.
+
+Entries print newest-first; each keeps its "How to find the calls to migrate" grep and its
+`before → after`, with the PormG-internal per-app rollout table trimmed off.
+
+`from` is required — pass the PormG version your app currently depends on. Both `from` and
+`to` accept a `VersionNumber` or a version string (`v"0.2"` or `"0.2"`).
+
+Pass `structured = true` to get the entries back as data instead of printing — a `Vector`
+of `(; version, title, body)` named tuples, newest-first — for programmatic consumers.
+
+# Examples
+```julia
+julia> using PormG
+
+julia> PormG.upgrade_guide(from = v"0.1")            # everything up to the installed version
+
+julia> PormG.upgrade_guide(from = "0.2", to = "0.3")
+
+julia> entries = PormG.upgrade_guide(from = v"0.1", structured = true);
+```
+"""
+function upgrade_guide(io::IO = stdout; from = nothing, to = pkgversion(@__MODULE__),
+                       structured::Bool = false)
+    from === nothing && throw(ArgumentError(
+        "upgrade_guide requires `from` — the PormG version your app currently depends on, " *
+        "e.g. `upgrade_guide(from = v\"0.2\")`."))
+    from_v = _asver(from)
+    to_v   = _asver(to)
+
+    entries = filter(e -> from_v < e.version <= to_v, _read_upgrading_entries())
+
+    structured && return entries
+
+    if isempty(entries)
+        println(io, "# PormG: nothing to port between $from_v and $to_v.")
+        return nothing
+    end
+
+    println(io, "# Porting a PormG consumer from $from_v → $to_v")
+    println(io, "# Work newest-first; for each entry run its \"How to find the calls to migrate\"")
+    println(io, "# grep, apply before → after, then run your app's tests.")
+    for e in entries
+        println(io)
+        println(io, e.body)
+    end
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ end
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")
+    @testset "Upgrade Guide Emitter (#216)" include("unit/test_upgrade_guide.jl")
     # include("unit/test_migration_planner.jl")
 end
 

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -29,7 +29,7 @@ const EXPECTED_TOPLEVEL = Set([
     # Locking
     :with_advisory_lock,
     # Utilities & lifecycle
-    :setup, :install_ai_skills, :tui, :register_ignore_tables!,
+    :setup, :install_ai_skills, :upgrade_guide, :tui, :register_ignore_tables!,
     Symbol("@import_models"), Symbol("@models_module"), Symbol("@pormg_debug"),
 ])
 

--- a/test/unit/test_upgrade_guide.jl
+++ b/test/unit/test_upgrade_guide.jl
@@ -1,0 +1,102 @@
+# ==============================================================================
+# UNIT TESTS: upgrade_guide — version-scoped UPGRADING.md emitter (issue #216)
+#
+# `PormG.upgrade_guide(; from, to)` reads the UPGRADING.md shipped with the resolved
+# install and renders only the entries a consuming app must port across a version jump.
+# These tests pin the scoping math and the parser's robustness against UPGRADING.md's
+# two hazards: unstamped "pre-0.2 history" entries, and the commented-out "Template for
+# new entries" block (which carries a fake `## …` heading + `- **Version**:` placeholder
+# that must NEVER surface as a real entry).
+#
+# The function parses the *real* repo UPGRADING.md (via `pkgdir`, which resolves to the
+# repo root here), so assertions key on frozen historical facts — the 0.1.0 → 0.2.0
+# window and the #197 entry — never on the total entry count, which grows over time.
+#
+# Runs WITHOUT a live database — it only parses a bundled markdown file.
+# ==============================================================================
+
+using Test
+using PormG
+
+@testset "upgrade_guide over UPGRADING.md (#216)" begin
+
+    # ── structured scope: the historical 0.1.0 → 0.2.0 window is frozen ─────────
+    # Upgrading from before the versioning policy up to the first stamped release must
+    # surface BOTH the version-stamped 0.2.0 entry (#197) and the unstamped pre-0.2
+    # entries (which sort just below 0.2.0).
+    @testset "structured scope: 0.1.0 → 0.2.0" begin
+        entries = PormG.upgrade_guide(from = v"0.1.0", to = v"0.2.0", structured = true)
+
+        @test entries isa AbstractVector
+        @test !isempty(entries)
+
+        # The one stamped entry in this window is the typed-exceptions change (#197 @ 0.2.0).
+        i197 = findfirst(e -> occursin("(#197)", e.title), entries)
+        @test i197 !== nothing
+        @test entries[i197].version == v"0.2.0"
+
+        # The unstamped pre-0.2 history is included and sorts below 0.2.0.
+        @test any(e -> e.version < v"0.2.0", entries)
+
+        # Every returned entry falls inside the requested (from, to] window.
+        @test all(e -> v"0.1.0" < e.version <= v"0.2.0", entries)
+
+        # Rendered newest-first: the 0.2.0 entry precedes the pre-0.2 ones.
+        @test i197 < findfirst(e -> e.version < v"0.2.0", entries)
+    end
+
+    # ── nothing newer than where you already are ───────────────────────────────
+    @testset "empty scope when from == to" begin
+        @test isempty(PormG.upgrade_guide(from = v"0.2.0", to = v"0.2.0", structured = true))
+    end
+
+    # ── parser hygiene: the template block must never leak as an entry ──────────
+    @testset "no bogus entries from the template block" begin
+        all_entries = PormG.upgrade_guide(from = v"0.0.0", to = v"999.0.0", structured = true)
+        @test !isempty(all_entries)
+        @test !any(e -> occursin("Template", e.title), all_entries)  # template heading dropped
+        @test !any(e -> occursin("<api>", e.title), all_entries)     # placeholder never parsed
+        # Titles are single-line headings; every body kept some prose after trimming.
+        @test all(e -> !occursin('\n', e.title) && !isempty(e.body), all_entries)
+    end
+
+    # ── human output: header + entry, internal rollout table trimmed off ────────
+    @testset "printed guide: header, entry, no per-app rollout" begin
+        out = sprint(io -> PormG.upgrade_guide(io; from = v"0.1.0", to = v"0.2.0"))
+        @test occursin("Porting a PormG consumer from", out)     # scope header
+        @test occursin("(#197)", out)                            # the entry itself
+        @test occursin("How to find the calls to migrate", out)  # grep recipe survives
+        @test !occursin("### Per-app rollout", out)              # PormG-internal table trimmed
+    end
+
+    @testset "printed guide: empty range says so, no throw" begin
+        out = sprint(io -> PormG.upgrade_guide(io; from = v"0.2.0", to = v"0.2.0"))
+        @test occursin("nothing to port", out)
+    end
+
+    # ── argument handling ──────────────────────────────────────────────────────
+    @testset "from is required" begin
+        @test_throws ArgumentError PormG.upgrade_guide()
+    end
+
+    @testset "string versions coerce like VersionNumbers" begin
+        as_str = PormG.upgrade_guide(from = "0.1.0", to = "0.2.0", structured = true)
+        as_ver = PormG.upgrade_guide(from = v"0.1.0", to = v"0.2.0", structured = true)
+        @test [e.title for e in as_str] == [e.title for e in as_ver]
+    end
+
+    @testset "from > to yields an empty scope, not an error" begin
+        @test isempty(PormG.upgrade_guide(from = v"9.9.9", to = v"0.2.0", structured = true))
+    end
+
+    # ── default `to` resolves to the installed version (no `nothing` path) ──────
+    @testset "default to = installed version" begin
+        installed = pkgversion(PormG)
+        @test installed isa VersionNumber                           # resolves, not `nothing`
+        scoped = PormG.upgrade_guide(from = v"0.1.0", structured = true)  # to defaults to installed
+        @test !isempty(scoped)
+        @test all(e -> e.version <= installed, scoped)
+        # From the installed version itself there is nothing newer to port.
+        @test isempty(PormG.upgrade_guide(from = installed, structured = true))
+    end
+end


### PR DESCRIPTION
Closes #216.

## What

Adds `PormG.upgrade_guide([io]; from, to = pkgversion(PormG), structured = false)` — a REPL emitter that reads the `UPGRADING.md` shipped with the **resolved** install and prints only the entries in the `from → to` range, so a consuming dev/agent gets exactly the porting work for its version jump. `UPGRADING.md` stays the single source of truth; the function renders from it and holds no copy.

```julia
julia> using PormG; PormG.upgrade_guide(from = v"0.1")   # everything up to the installed version
julia> PormG.upgrade_guide(from = v"0.2.0")              # "nothing to port between 0.2.0 and 0.2.1"
julia> entries = PormG.upgrade_guide(from = v"0.1", structured = true);  # entries as data
```

## How

- **Version scoping** — parses each entry's `- **Version**: 0.y.z` stamp. Unstamped "pre-0.2 history" entries get a `v"0.2.0-"` sentinel that sorts *below* `0.2.0` but *above* any `0.1.x`, so a consumer coming from before the versioning policy still sees the 21 pre-0.2 entries, while one already on `≥ 0.2.0` does not. Keeps entries with `from < version ≤ to`, newest-first.
- **Parser hardening** — drops the `## Template for new entries` block (its commented body carries a fake `## …` heading + `- **Version**:` placeholder) and keeps a block only if it has both a `## ` heading and a `- **Recorded**:` bullet. Verified: no `Template`/`<api>` leakage.
- **Output** — human text trims each entry's PormG-internal `### Per-app rollout` table (noise for a consumer, keeps the grep recipe + before→after); `structured = true` returns `Vector{@NamedTuple{version, title, body}}`.
- **No new dependency** — `pkgdir` / `pkgversion` / `VersionNumber` are all `Base`.
- Additive/non-breaking → **z-bump `0.2.0 → 0.2.1`**, no `UPGRADING.md` entry required.

## Files

| File | Change |
|------|--------|
| `src/tools.jl` | `upgrade_guide` + private `_read_upgrading_entries` / `_asver` helpers |
| `src/PormG.jl` | export `upgrade_guide` |
| `Project.toml` | `0.2.0 → 0.2.1` |
| `test/unit/test_upgrade_guide.jl` | new pure unit test |
| `test/runtests.jl`, `test/unit/test_public_exports.jl` | register test; add to the frozen export set |
| `docs/src/api.md` | list under Utilities & lifecycle (docstring auto-included via `@autodocs`) |

## Verification

- New test file: **24/24**. Export-surface test: **58/58**. Full unit suite: **4159/4159**.
- REPL smoke: `pkgversion(PormG)` → `0.2.1`; `from=v"0.1.0"→v"0.2.0"` → 22 entries newest-first (0.2.0 first, then the `0.2.0-` sentinels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)