### PR TITLE
feat(#218): raw-SQL manual params — fetch/fetch_async accept a values array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,57 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Raw-SQL manual params: `fetch` / `fetch_async` accept a values array (#218)
+
+- **Version**: 0.2.2
+- **PormG ref**: issue #218 (follow-up to #198) ; `src/ConnectionPool.jl` (`fetch` / `fetch_async`),
+  `docs/src/async.md`
+- **Recorded**: 2026-07-23
+- **Severity**: new feature — **additive, non-breaking**. Existing collector / `nothing` / no-param
+  calls are unchanged; a plain array that previously raised `MethodError` now binds.
+
+### What changed
+
+The low-level raw-SQL escape hatch (`fetch` / `fetch_async(settings, sql; params=…)`) now accepts a
+plain values **array or tuple** — the previously internal-only `params` slot was typed
+`Union{Nothing, AbstractPormGParam}` (an ORM collector a user could not construct), so raw SQL had no
+public value-binding path. You write the placeholder your backend uses — `$1, $2, …` on PostgreSQL,
+`?` on SQLite — and PormG performs **no** placeholder translation (the Go `database/sql` / Python
+DB-API / Julia `DBInterface` convention: raw means native). A NULL is `missing`; a bare `nothing` is
+normalized to it. The array bypasses the ORM field formatters (datetime/float/bool coercion), which is
+expected for a raw hatch. Portable queries still belong on the ORM surface.
+
+```julia
+# ✗ before — a user value in raw SQL could only be string-interpolated (a SQL-injection hole)…
+fetch(settings, "SELECT count(*) FROM driver WHERE nationality = '$(nat)'")
+# …or expressed through the ORM surface:
+M.Driver.objects.filter("nationality" => nat).count()
+
+# ✓ after — bind it, with the backend-native placeholder:
+fetch(settings, "SELECT count(*) FROM driver WHERE nationality = \$1", [nat])   # PostgreSQL
+fetch(settings, "SELECT count(*) FROM driver WHERE nationality = ?",  [nat])    # SQLite
+```
+
+### How to find the calls to migrate
+
+Nothing to migrate — additive. **Optional adoption:** grep each app for a raw `fetch` / `fetch_async`
+whose SQL string interpolates a value (a SQL-injection risk) and move the value into the array:
+
+```
+rg -n 'fetch(_async)?\(' <app>/src | rg '\$\('     # raw fetch with $(...) interpolation
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | optional — replace interpolated raw `fetch`/`fetch_async` SQL with the values array |
+| app-2 | ⏳ | optional |
+| app-3 | ⏳ | optional |
+| app-4 | ⏳ | optional |
+
+---
+
 ## Typed exceptions across the query surface — raw-`String` throws are now `ArgumentError`/`ErrorException` (#197)
 
 - **Version**: 0.2.0

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -526,6 +526,16 @@ task = fetch_async(settings, "SELECT count(*) FROM driver")
 result = await_result(task)   # returns rows and releases the pooled connection
 ```
 
+Bind user values with a plain array — write the backend-native placeholder (`$1, $2` on
+PostgreSQL, `?` on SQLite); PormG does no translation, and a NULL is `missing`:
+
+```julia
+# PostgreSQL
+task = fetch_async(settings, "SELECT count(*) FROM driver WHERE nationality = \$1", ["Brazilian"])
+n    = await_result(task)
+# SQLite: the same call with "... = ?" and the same ["Brazilian"] array
+```
+
 !!! warning "An un-awaited `FetchTask` leaks its pool connection"
     `fetch_async` checks its connection out synchronously; only `await_result` returns it.
     Always await every task you start.
@@ -654,7 +664,8 @@ scope — the SQL function constructors are *not* among them (see
 `setup`, `install_ai_skills`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
 
 !!! note "`fetch` extends `Base.fetch`"
-    The low-level `fetch(settings, sql; params=…)` escape hatch is a method of
+    The low-level `fetch(settings, sql; params=[...])` escape hatch (values bound with
+    backend-native placeholders — see [Async & Concurrency](async.md)) is a method of
     `Base.fetch`, so it is always in scope (no import, no qualification) and does not
     shadow Base. Prefer the fluent terminals (`list()`, `DataFrame`, `count()`) for
     application code.

--- a/docs/src/async.md
+++ b/docs/src/async.md
@@ -80,10 +80,28 @@ result = await_result(task)                                   # rows; releases t
 
 `await_result` is idempotent — a second call returns the cached result without touching the pool.
 
-This hatch runs the SQL string **as you supply it**, so reserve it for static, trusted statements — schema introspection, a fixed `COUNT(*)`, a maintenance command. It is not a parameterized-query path: the `params` keyword takes a parameter collector the ORM builds internally, not a plain vector of values you pass in. Any query that carries user-supplied values belongs on the ORM surface — wrap `list()` / `count()` / `filter(...)` in a task as shown above — which binds parameters, post-processes rows, and manages the connection for you.
+### Binding values — a manual-params array
+
+The hatch **does** bind parameters: pass a plain values array (or tuple) and write the placeholder your backend uses. PormG performs **no** placeholder translation — you write `$1, $2, …` on PostgreSQL and `?` on SQLite — the same low-level convention as Go's `database/sql`, Python's DB-API, and Julia's `DBInterface`:
+
+```julia
+# PostgreSQL — numbered placeholders
+task = fetch_async(settings, "SELECT count(*) FROM driver WHERE nationality = \$1", ["Brazilian"])
+n    = await_result(task)
+
+# SQLite — positional placeholders (same values array, backend-native marker)
+rows = fetch(settings, "SELECT * FROM driver WHERE nationality = ?", ["Brazilian"])
+```
+
+The driver binds each value as **data**, so a user value can never change the statement's structure. Write a NULL as `missing` (a bare `nothing` is normalized to it). The array bypasses the ORM's field formatters (datetime canonicalization, float precision, `bool`→`int`), which is expected for a raw hatch — pre-format any such values yourself.
+
+Because the placeholder style is backend-native, a manual-params string is **not portable** across backends. For portable queries — and for row post-processing and connection management — prefer the ORM surface (`list()` / `count()` / `filter(...)` wrapped in a task, as above). Reach for the values-array hatch only for static SQL you own that the ORM can't express.
 
 !!! danger "Never interpolate user input into the SQL string"
-    `fetch_async(settings, "... $uservalue ...")` is a SQL-injection hole. The raw-SQL hatch has no value-binding on the public surface by design; if you need user values, use the ORM query surface, which parameterizes every value.
+    `fetch_async(settings, "... $uservalue ...")` is a SQL-injection hole. Pass user values as the
+    `params` **array** instead — `fetch_async(settings, "... = \$1", [uservalue])` on PostgreSQL,
+    `"... = ?"` with `[uservalue]` on SQLite — so the driver binds them as data. Never build the SQL
+    string from user input, even with the values-array path available.
 
 !!! warning "An un-awaited `FetchTask` holds a pool connection"
     `fetch_async` checks its connection out *synchronously*; only `await_result` (or the owning transaction's cleanup) returns it. Always await every task you start — including fire-and-forget writes. The opt-in [`leak_detection_threshold`](configuration/advanced.md) logs a warning when a connection is held suspiciously long, which almost always means an un-awaited `FetchTask`.

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -105,7 +105,7 @@ PormG keeps the two backends aligned wherever it can and documents the differenc
 
 Notes:
 
-- **Placeholders.** The generated SQL uses `$1`/`$2` on PostgreSQL and `?` on SQLite. Doc SQL blocks conventionally show the PostgreSQL form; the shape is otherwise identical. You never write placeholders yourself — parameters are always bound, never interpolated.
+- **Placeholders.** The generated SQL uses `$1`/`$2` on PostgreSQL and `?` on SQLite. Doc SQL blocks conventionally show the PostgreSQL form; the shape is otherwise identical. You never write placeholders yourself — parameters are always bound, never interpolated. The one exception is the raw-SQL manual-params escape hatch (`fetch`/`fetch_async` with a values array), where you write the backend-native placeholder yourself and PormG binds the values — see [Async & Concurrency](async.md).
 - **DateTime is canonicalized to UTC.** `DateTimeField` values are stored as a single UTC ISO-8601 string on both backends (see the `#79` entry in `UPGRADING.md`); prefer `ZonedDateTime` when the source has a real civil timezone.
 - **Primary-key allocation** (`allocate_primary_keys`) presents one API over both backends; PostgreSQL reserves ids via the column sequence, SQLite emulates the same reservation. See [Bulk Insert, Copy, and Update](write/bulk.md).
 - **Sequence resync.** After inserting rows with *explicit* primary keys, PostgreSQL's sequence can fall behind, so a later auto-id insert collides. PormG resynchronizes the sequence for you on the write path (and retries a duplicate-key insert once by resyncing) — a class of "duplicate key" surprise that doesn't exist on SQLite's `AUTOINCREMENT`.

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -27,6 +27,20 @@ import PormG.Configuration: get_tx_connection, get_tx_pool, with_tx_context, tra
 
 const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
 
+# #218: a raw-SQL manual-params array/tuple the caller binds with backend-native placeholders
+# ($1,$2 on PostgreSQL, ? on SQLite). PormG performs NO placeholder translation — the caller
+# writes the dialect's own marker. Disjoint from AbstractPormGParam (the ORM's internal collector),
+# so admitting it in the fetch/fetch_async param slot never collides with the collector methods.
+# `String <: AbstractString`, not `AbstractVector`, so the SQL argument is never swallowed.
+const ManualParams = Union{AbstractVector, Tuple}
+
+# Normalize a manual-params array before binding. A raw array bypasses every ORM `format_*_sql`
+# formatter by design, so a bare `nothing` would reach the driver un-normalized (LibPQ/SQLite treat
+# it differently from `missing`). Map `nothing`→`missing` so a NULL binds predictably on both
+# backends; every non-null value is passed through byte-for-byte (this is a RAW hatch — no coercion).
+# Returns a fresh `Any[]` (never mutates the caller's array) and is idempotent under the fetch retry.
+_normalize_manual_params(params::ManualParams) = Any[v === nothing ? missing : v for v in params]
+
 # A pool starts at `pool_size` connections and may grow lazily (on demand) up to
 # `pool_size * POOL_EXPANSION_FACTOR` before acquisition fails with a PoolTimeoutError (#37).
 # The base stays small (idle footprint) while the ceiling gives async fan-out real headroom.
@@ -1298,8 +1312,16 @@ orders = await_result(task2)
 """
 function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
   conn = nothing,
-  params::Union{Nothing, AbstractPormGParam} = nothing,
+  params::Union{Nothing, AbstractPormGParam, ManualParams} = nothing,
   ignore_tx::Bool = false)
+
+  # #218: this is the single funnel every fetch/fetch_async path reaches (delegates and the
+  # sync `fetch` — including its reconnect retry — all land here), so normalize manual-params
+  # NULLs once, here. Guarded to ManualParams: ORM collectors (AbstractPormGParam) and the
+  # `nothing` sentinel are untouched (collectors already ran nothing→missing via format_*_sql).
+  if params isa ManualParams
+    params = _normalize_manual_params(params)
+  end
 
   # Check for transaction context first
   tx_conn = ignore_tx ? nothing : get_tx_connection()
@@ -1344,9 +1366,9 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     end
   end
 end
-fetch_async(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch_async(settings::PormGSettings, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam, ManualParams} = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::PormGSettings, sql::String, params::Union{AbstractPormGParam, ManualParams}; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch_async(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::Union{AbstractPormGParam, ManualParams}; conn = nothing, ignore_tx::Bool = false) = fetch_async(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
     fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String; params=nothing, ignore_tx=false) -> Tables.rowtable
@@ -1356,9 +1378,11 @@ Internally uses async execution but immediately awaits the result.
 """
 function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
   conn = nothing,
-  params::Union{Nothing, AbstractPormGParam} = nothing,
+  params::Union{Nothing, AbstractPormGParam, ManualParams} = nothing,
   ignore_tx::Bool = false)
   @pormg_debug false
+  # Manual-params NULL normalization happens in the fetch_async funnel this delegates to (#218) —
+  # `fetch` only forwards params, never inspects their values.
 
   # Use async-first approach: start async query then await
   fetch_task = fetch_async(connection, sql; conn=conn, params=params, ignore_tx=ignore_tx)
@@ -1387,9 +1411,9 @@ function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     throw(root)
   end
 end
-fetch(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch(settings::PormGSettings, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
-fetch(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::AbstractPormGParam; conn = nothing, ignore_tx::Bool = false) = fetch(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::PormGSettings, sql::String; conn = nothing, params::Union{Nothing, AbstractPormGParam, ManualParams} = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::PormGSettings, sql::String, params::Union{AbstractPormGParam, ManualParams}; conn = nothing, ignore_tx::Bool = false) = fetch(settings.connections, sql; conn=conn, params=params, ignore_tx=ignore_tx)
+fetch(settings::Union{PormGPostgres, PormGSQLite}, sql::String, params::Union{AbstractPormGParam, ManualParams}; conn = nothing, ignore_tx::Bool = false) = fetch(settings, sql; conn=conn, params=params, ignore_tx=ignore_tx)
 
 """
     fetch_copy(connection::PormGPostgres, sql::String, data_itr)

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -50,6 +50,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Transactions"                 begin include("test_transactions.jl")       end
     @testset "Async Task Concurrency (#198)" begin include("test_async_tasks.jl")       end
     @testset "Connection Pool (#37)"        begin include("test_connection_pool.jl")    end
+    @testset "Manual Params raw SQL (#218)" begin include("test_manual_params.jl")       end
     @testset "Advisory Locks"               begin include("test_advisorylock.jl")       end
     @testset "Having (Aggregates)"          begin include("test_having.jl")             end
     @testset "Field Validation DB Tests"    begin include("test_field_validation_db_roundtrip.jl") end

--- a/test/integration/test_manual_params.jl
+++ b/test/integration/test_manual_params.jl
@@ -1,0 +1,117 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Manual-params raw SQL (#218): fetch / fetch_async accept a plain values array
+# The raw-SQL escape hatch now binds a user-supplied Vector/Tuple of values. The
+# caller writes the placeholder native to their backend — $1,$2 on PostgreSQL,
+# ? on SQLite — and PormG performs NO placeholder translation (the low-level-driver
+# convention: Go database/sql, Python DB-API, Julia DBInterface). These tests pin
+# that the array-bound raw query returns the same value as the ORM equivalent on
+# both backends, that positional binding order is honored, that a hostile value
+# stays bound (never interpreted as SQL), and that NULL binds from both `missing`
+# and `nothing` (the latter via the #218 nothing→missing normalization).
+# ─────────────────────────────────────────────────────────────────────────────
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+using Test
+
+settings = PormG.config[PORMG_DB_FOLDER]
+pool     = settings.connections
+
+# Backend-native placeholder: PostgreSQL numbers them ($1,$2…), SQLite is positional (?).
+# PormG does no translation (#218) — the caller writes the dialect's own marker. This helper
+# is the entire "portability" surface of these tests.
+ph(i) = pool isa PormG.PormGPostgres ? "\$$(i)" : "?"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A — fetch parity vs ORM (single param)
+# The array-bound raw count must equal the ORM's own count. Cross-checked against an
+# independent ORM computation (not "it ran"); reverting the widening makes fetch(...; params=[...])
+# a MethodError, so this errors rather than silently passing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "fetch parity vs ORM (single param)" begin
+    n_orm = M.Driver.objects.filter("nationality" => "Brazilian").count()
+    @test n_orm > 0   # guard: a vacuous 0 == 0 would prove nothing
+
+    sql = "SELECT count(*) AS c FROM driver WHERE nationality = $(ph(1))"
+    df  = DataFrame(fetch(settings, sql; params = ["Brazilian"]))
+    @test df[1, :c] == n_orm
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B — fetch_async + await_result parity (positional ManualParams overload)
+# Same value via the positional array form `fetch_async(settings, sql, [...])`, which exercises
+# the widened positional overload (distinct from the keyword path in A).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "fetch_async positional-array parity" begin
+    n_orm = M.Driver.objects.filter("nationality" => "Brazilian").count()
+    sql   = "SELECT count(*) AS c FROM driver WHERE nationality = $(ph(1))"
+
+    task = fetch_async(settings, sql, ["Brazilian"])
+    df   = DataFrame(await_result(task))
+    @test df[1, :c] == n_orm
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C — multiple params + positional ordering
+# Two placeholders: the values must bind in array order. The swapped-order call returns 0 rows
+# (a real driver/name never equals a nationality), which can only happen if positional binding is
+# honored end to end — the ordering proof.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "multiple params bind in positional order" begin
+    d        = M.Driver.objects.filter("nationality" => "Brazilian").order_by("surname").list()[1]
+    nat, sur = d.nationality, d.surname
+    n_orm    = M.Driver.objects.filter("nationality" => nat, "surname" => sur).count()
+    @test n_orm > 0
+
+    sql = "SELECT count(*) AS c FROM driver WHERE nationality = $(ph(1)) AND surname = $(ph(2))"
+    @test DataFrame(fetch(settings, sql; params = [nat, sur]))[1, :c] == n_orm   # correct order
+    @test DataFrame(fetch(settings, sql; params = [sur, nat]))[1, :c] == 0       # swapped → empty
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D — injection value stays bound (0 rows + table intact)
+# A value containing SQL syntax is bound as data, never parsed. If it were interpolated, the
+# first query would match every row (== total) and the second would drop the table.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "hostile value stays bound, not interpreted" begin
+    total = M.Driver.objects.count()
+    sql   = "SELECT count(*) AS c FROM driver WHERE nationality = $(ph(1))"
+
+    @test DataFrame(fetch(settings, sql; params = ["' OR '1'='1"]))[1, :c] == 0
+    @test DataFrame(fetch(settings, sql; params = ["x'; DROP TABLE driver; --"]))[1, :c] == 0
+    @test M.Driver.objects.count() == total   # table intact — value never executed as SQL
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E — NULL binds from both `missing` and `nothing`
+# A bound NULL is observed via `<param> IS NULL` (a `col = NULL` filter can't — NULL is never
+# =-true). PostgreSQL needs an explicit cast to type an all-NULL parameter; SQLite does not.
+# The `nothing` case is exactly what the #218 nothing→missing normalization exists to make pass;
+# the non-null control makes the assertion non-vacuous.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "NULL binds from missing and nothing" begin
+    # Alias is `is_null`, not `isnull` — SQLite reserves ISNULL as a postfix operator keyword.
+    sql = pool isa PormG.PormGPostgres ?
+        "SELECT ($(ph(1))::text IS NULL) AS is_null" :
+        "SELECT ($(ph(1)) IS NULL) AS is_null"
+
+    for nullish in (missing, nothing)
+        got = DataFrame(fetch(settings, sql; params = [nullish]))[1, :is_null]
+        @test got in (true, 1)    # PG returns Bool, SQLite returns Int 1
+    end
+    ctrl = DataFrame(fetch(settings, sql; params = ["x"]))[1, :is_null]
+    @test ctrl in (false, 0)      # control: a non-null value is not NULL
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F — Tuple params
+# The ManualParams union is Union{AbstractVector, Tuple}; a Tuple binds identically to a Vector.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Tuple params bind like a Vector" begin
+    n_orm = M.Driver.objects.filter("nationality" => "Brazilian").count()
+    sql   = "SELECT count(*) AS c FROM driver WHERE nationality = $(ph(1))"
+
+    df = DataFrame(fetch(settings, sql; params = ("Brazilian",)))
+    @test df[1, :c] == n_orm
+end


### PR DESCRIPTION
Closes #218.

## What & why

The raw-SQL escape hatch (`fetch`/`fetch_async(settings, sql; params)`) typed `params` as `Union{Nothing, AbstractPormGParam}` — an internal ORM collector with **no public constructor** — so raw SQL had no user-reachable value-binding path. The only options were the ORM surface or unsafe string interpolation (which the #198 async guide warns against). This admits a plain **values array/tuple**.

## Decision: backend-native placeholders, no translation

The caller writes the placeholder their backend uses — `$1,$2` on PostgreSQL, `?` on SQLite — and PormG binds through the driver unchanged. This follows the low-level-driver convention (Go `database/sql`, Python DB-API, Julia `DBInterface`, Rust sqlx: "raw means native"); portability stays on the ORM surface.

Rejected **neutral-placeholder rewriting**: it needs a new SQL-string parser, and a bare-`?` rewriter would corrupt PostgreSQL's JSONB `?`/`?|`/`?&` operators. Frameworks that *do* translate (SQLAlchemy `text()`, Django) use **named** params precisely to dodge this.

## Changes

- **`src/ConnectionPool.jl`** — `const ManualParams = Union{AbstractVector, Tuple}` (disjoint from `AbstractPormGParam`, so no dispatch ambiguity — confirmed by Aqua). All 8 `fetch`/`fetch_async` methods widened (4 keyword unions + 4 positional overloads); **no new methods, no extension changes** — the driver layer already forwarded a plain array verbatim.
- **NULL handling** — `nothing`→`missing` normalized once at the `fetch_async` funnel so a NULL binds predictably on both backends; every non-null value passes byte-for-byte (raw hatch — no formatter coercion). Guarded so ORM collectors are untouched.
- **New `test/integration/test_manual_params.jl`** (Phase 3) — ORM parity, positional-array `fetch_async`, multi-param ordering, injection-value-stays-bound + table intact, NULL via `missing` AND `nothing`, `Tuple` params. Backend-branched placeholders, mutation-disciplined.
- **Docs** — async.md §"Raw SQL" inverted (values-array path + reframed injection `!!! danger`); api.md example; postgres.md cross-reference.
- **`Project.toml`** — 0.2.1 → 0.2.2 (additive z-bump) + `UPGRADING.md` optional-adoption entry.

## Verification

- New test standalone: **SQLite 13/13, PostgreSQL 13/13**.
- Unit + Aqua (ambiguity check): **4135/4135**.
- Full integration: **PostgreSQL 1811/1811**, **SQLite exit 0** (1777 pass, 1 pre-existing unrelated broken).
- Docs build: exit 0, no cross-reference errors.
- One bug caught in test: SQLite reserves `ISNULL` as a keyword, so the NULL-probe alias is `is_null`.

## Out of scope (deferred)

Named params (`:name`), `Dict`/`NamedTuple` params, placeholder translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
