### PR TITLE
fix(#199): first()/get() copy-first — unify fluent-surface mutation semantics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,67 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `first()` / `get()` no longer mutate the handler (#199)
+
+- **Version**: 0.2.3
+- **PormG ref**: issue #199 ; `src/querybuilder/execution.jl` (`first`, `get`),
+  `docs/src/read/index.md` (new *Handler Mutation Model* section)
+- **Recorded**: 2026-07-24
+- **Severity**: footgun fix — **no action expected**. Classified non-breaking: the only affected
+  code exploits `first()`'s documented limit-leak workaround or `get()`'s *undocumented*
+  filter-persistence side effect.
+
+### What changed
+
+All read terminals now share one contract: they execute on an internal copy and never mutate the
+handler. Previously `first()` permanently set `limit(1)` on the handler and `get(q, filters...)`
+permanently appended its inline filters to it — `count`/`exists`/`list` already copied. Re-call
+semantics of chain methods are unchanged (and now documented): `filter` accumulates,
+`values`/`order_by` replace their previous call.
+
+```julia
+# ✗ before — handler reuse after first()/get() silently carried leaked state:
+q = M.Driver.objects.filter("nationality" => "British")
+q.first()                                # left limit=1 on q
+q.list()                                 # returned 1 row (leaked limit)
+q.update("nationality" => "English")     # threw: UPDATE with LIMIT is not supported
+
+r = M.Result.objects
+r.get("resultid" => 1)                   # appended the inline filter to r
+r.count()                                # counted WHERE resultid = 1 (leaked filter)
+
+# ✓ after — the handler is untouched; same calls, no leaked state:
+q.first()                                # q unchanged (limit stays 0)
+q.list()                                 # all matching rows
+q.update("nationality" => "English")     # valid on the same handler
+
+r.get("resultid" => 1)                   # r unchanged
+r.count()                                # counts ALL results
+```
+
+### How to find the calls to migrate
+
+Nothing to migrate unless an app **reuses a handler after** `.first()`/`.get()` *and relies on the
+leaked state* (a limit-1 `list()`, or inline `get` filters narrowing later calls). Grep each app for
+a handler variable used again after one of these terminals:
+
+```
+rg -n '\.(first|get)\(' <app>/src        # then eyeball: is that handler variable used again below?
+```
+
+One-handler-per-query code (the documented style) is unaffected.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | grep to confirm no handler reuse relies on leaked state, then mark ✅/— |
+| app-2 | ⏳ | same check |
+| app-3 | ⏳ | same check |
+| app-4 | ⏳ | same check |
+
+---
+
 ## Raw-SQL manual params: `fetch` / `fetch_async` accept a values array (#218)
 
 - **Version**: 0.2.2

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -111,24 +111,73 @@ df = query |> DataFrame
 
 ---
 
+## Handler Mutation Model
+
+Every query handler follows four rules. They are where PormG deliberately differs from
+Django's clone-per-call querysets, so they are worth internalizing once:
+
+1. **`Model.objects` returns a fresh handler on every access.** Two mentions of
+   `M.Driver.objects` are two independent queries — state never leaks between them.
+2. **Chain methods mutate the handler in place** and return that same handler (not a
+   copy). Assigning a chain to a second variable aliases the same query.
+3. **`.copy()` is the branching escape hatch** — deep-copy a base query, then extend
+   each copy independently (example below).
+4. **Terminal methods never mutate the handler.** `count`, `exists`, `list`, `first`,
+   `get`, and the `show_query`/`inspect_query` inspection paths all execute on an
+   internal copy of the handler. A handler stays reusable after any read terminal —
+   `q.first()` does not leave a `limit(1)` behind, inline filters passed to
+   `q.get("field" => v)` do not persist, and `q.update(...)` after `q.first()` is valid.
+
+### Re-call semantics: which methods accumulate
+
+Calling the same chain method twice is not always the same operation. The semantics
+follow Django: `filter` accumulates, while `values`/`order_by` replace their previous
+call (Django documents this as "each `order_by()` call will clear any previous ordering").
+
+```julia
+q = M.Result.objects
+q.filter("raceid__year" => 2019)
+q.filter("positionorder" => 1)           # accumulates: year = 2019 AND positionorder = 1
+
+q.values("driverid__surname")
+q.values("driverid__surname", "points")  # replaces: only surname + points are selected
+
+q.order_by("points")
+q.order_by("-points")                    # replaces: ORDER BY points DESC only
+```
+
+### Branching with `.copy()`
+
+```julia
+base_query = M.Result.objects.filter("positionorder" => 1)
+
+# Reuse for different projections — each copy evolves independently
+winners_by_driver = base_query.copy().values("driverid__surname", "wins" => Count("resultid"))
+winners_by_team   = base_query.copy().values("constructorid__name", "wins" => Count("resultid"))
+```
+
+---
+
 ## Chainable Methods Reference
 
-These methods modify the query builder and return the handler for further chaining:
+These methods modify the query builder and return the handler for further chaining. The
+**On re-call** column states what a second call of the same method does (see the
+[handler mutation model](#Handler-Mutation-Model) above):
 
-| Method | Description |
-| :--- | :--- |
-| `.filter(key => value, ...)` | Add WHERE conditions. Multiple pairs are ANDed. |
-| `.values("field1", "field2", ...)` | Select specific columns. Use `"*"` for all main-table columns. |
-| `.order_by("field", "-field")` | Sort results. Prefix with `-` for descending. |
-| `.limit(n)` | Limit the number of returned rows. |
-| `.offset(n)` | Skip the first `n` rows. |
-| `.page(n)` | Convenience for pagination (requires `.limit()` to be set first). |
-| `.distinct()` | Add `SELECT DISTINCT` to the query. |
-| `.db("key")` | Route the query to a different connection pool. |
-| `.with("name" => subquery)` | Attach a Common Table Expression (CTE). |
-| `.cjoin("field" => "Model")` | Add a custom join at query time. |
-| `.on("path", key => value)` | Add predicates to the ON clause of an existing join. |
-| `.copy()` | Deep-copy the query object for reuse. |
+| Method | Description | On re-call |
+| :--- | :--- | :--- |
+| `.filter(key => value, ...)` | Add WHERE conditions. Multiple pairs are ANDed. | **Accumulates** (ANDed) |
+| `.values("field1", "field2", ...)` | Select specific columns. Use `"*"` for all main-table columns. | **Replaces** previous call |
+| `.order_by("field", "-field")` | Sort results. Prefix with `-` for descending. | **Replaces** previous call |
+| `.limit(n)` | Limit the number of returned rows. | Last value wins |
+| `.offset(n)` | Skip the first `n` rows. | Last value wins |
+| `.page(n)` | Convenience for pagination (requires `.limit()` to be set first). | Last value wins |
+| `.distinct()` | Add `SELECT DISTINCT` to the query. | Last value wins |
+| `.db("key")` | Route the query to a different connection pool. | Last value wins |
+| `.with("name" => subquery)` | Attach a Common Table Expression (CTE). | Adds another CTE |
+| `.cjoin("field" => "Model")` | Add a custom join at query time. | Adds another join |
+| `.on("path", key => value)` | Add predicates to the ON clause of an existing join. | Adds more predicates |
+| `.copy()` | Deep-copy the query object for reuse. | — |
 
 ---
 
@@ -182,16 +231,6 @@ nationalities = M.Driver.objects.values("nationality").distinct().list()
 
     # ✓ … or drop distinct() if you meant "one row per nationality, ordered by an aggregate"
     ```
-
-### Copying a Query for Reuse
-
-```julia
-base_query = M.Result.objects.filter("positionorder" => 1)
-
-# Reuse for different projections
-winners_by_driver = base_query.copy().values("driverid__surname", "wins" => Count("resultid"))
-winners_by_team   = base_query.copy().values("constructorid__name", "wins" => Count("resultid"))
-```
 
 ---
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -1527,32 +1527,22 @@ list(objct::SQLObjectHandler; kwargs...) = list(objct, Val(:row); kwargs...)
 
 Return the first `PormGRow` matching the current query, or `nothing` if no records match.
 
-**Mutates the handler**: calls `objct.limit(1)` on the handler before executing. This is
-permanent — the `limit(1)` persists on the object after the call returns (last-call
-semantics, consistent with all other fluent methods such as `filter`, `order_by`, etc.).
-
-Because the limit is mutated into the handler, chaining `.first()` followed by `.update()`
-on the **same handler** will raise an `ArgumentError` ("UPDATE with LIMIT/OFFSET is not
-supported"). Obtain a fresh handler or call `.update()` before `.first()` if both
-operations are needed.
+Like every read terminal (`count`, `exists`, `list`, `get`), `first` executes on an
+internal copy of the handler — the `limit(1)` it needs is applied to that copy, never
+to `objct`. The handler is reusable afterwards, including for `.update()`:
 
 ```julia
 q = M.Driver.objects
 q.filter("nationality" => "British")
-driver = q.first()           # q now has limit=1
-
-# Wrong — throws because limit=1 was set by first()
-# q.update("nationality" => "English")
-
-# Correct — create a separate handler for the update
-u = M.Driver.objects
-u.filter("nationality" => "British")
-u.update("nationality" => "English")
+driver = q.first()                      # q is unchanged — no limit leaks in
+q.update("nationality" => "English")    # still valid on the same handler
 ```
 """
 function first(objct::SQLObjectHandler; show_query::Symbol = :execute)
-  objct.limit(1)
-  res = list(objct, show_query=show_query)
+  # #199: copy-first like count/exists/list — limit(1) must not leak into the caller's handler
+  q = deepcopy(objct)
+  q.limit(1)
+  res = list(q, show_query=show_query)
   if show_query !== :execute
     return res
   end
@@ -1589,11 +1579,16 @@ driver = M.Driver.objects.filter("driverref" => "hamilton").get()
 
 Raises `DoesNotExist` when no rows match and `MultipleObjectsReturned` when more
 than one row matches.
+
+Like every read terminal, `get` executes on an internal copy of the handler: inline
+filters do **not** persist on `objct`, so the handler can be reused afterwards with
+its original filter list intact.
 """
 function get(objct::SQLObjectHandler, filters...; show_query::Symbol = :execute)
-  !isempty(filters) && up_filter!(objct.object, filters)
-
+  # #199: copy-first — inline filters and the limit(2) probe apply to the copy only,
+  # so they never leak into the caller's handler.
   q = deepcopy(objct)
+  !isempty(filters) && up_filter!(q.object, filters)
   q = q.limit(2)
 
   if show_query !== :execute
@@ -1601,8 +1596,8 @@ function get(objct::SQLObjectHandler, filters...; show_query::Symbol = :execute)
   end
 
   rows = list(q)
-  model_name = objct.object.model.name
-  filter_repr = isempty(objct.object.filter) ? "(none)" : join(_get_filter_repr.(objct.object.filter), ", ")
+  model_name = q.object.model.name
+  filter_repr = isempty(q.object.filter) ? "(none)" : join(_get_filter_repr.(q.object.filter), ", ")
 
   isempty(rows) && throw(DoesNotExist(model_name, filter_repr))
   length(rows) > 1 && throw(MultipleObjectsReturned(model_name, length(rows), filter_repr))

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -16,6 +16,12 @@ function _up_values(str::String)
   end
 end
 
+"""
+  up_values!(q::SQLObject, values)
+
+Set the query projection. Each `.values(...)` call **replaces** the previous one
+(last-call-wins, Django parity, #199) — unlike `.filter(...)`, which accumulates.
+"""
 function up_values!(q::SQLObject, values)
   # every call of values, reset the values
   q.values = []
@@ -251,6 +257,13 @@ function _query_select(array::Vector{SQLTypeField}, connection)
 end
 
 
+"""
+  order_by!(q::SQLObject, values)
+
+Set the query ordering. Each `.order_by(...)` call **replaces** the previous one
+(last-call-wins, matching Django's "each order_by() call clears previous ordering",
+#199) — unlike `.filter(...)`, which accumulates.
+"""
 function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} where N)
   q.order = [] # every call of order_by, reset the order
   for v in values
@@ -403,6 +416,10 @@ end
 Apply filters to the query. Chainable method that returns the query object.
 
 Usage: `query.filter("field" => value)`
+
+Repeated calls **accumulate**: each `.filter(...)` appends its conditions (ANDed) to
+those already on the handler — unlike `.values(...)`/`.order_by(...)`, which replace
+their previous call (Django parity, #199).
 
 See [Read documentation](read/index.md) for detailed filter syntax and examples.
 """ ChainCaller(up_filter!, q)

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -28,6 +28,7 @@ include("common_bulk_scratch_setup.jl")
     # ── Phase 2: Behavioral Tests (reads, filters, expressions) ──────
     @testset "Selection and Filters"        begin include("test_selection.jl")          end # TODO: split this into multiple files (selection, filters, expressions)
     @testset "PormGRow and get()"           begin include("test_row_and_get.jl")        end
+    @testset "Handler Semantics (#199)"     begin include("test_handler_semantics.jl")  end
     @testset "PormGRow Mutation"            begin include("test_row_mutation.jl")       end
     @testset "Field-name Case Preservation" begin include("test_field_name_case_db.jl") end
     @testset "db_column Authoritative"       begin include("test_db_column_db.jl")       end

--- a/test/integration/test_handler_semantics.jl
+++ b/test/integration/test_handler_semantics.jl
@@ -1,0 +1,143 @@
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+# This file pins the fluent-surface mutation semantics settled in #199:
+#   - chain methods mutate the handler in place; filter() ACCUMULATES across calls,
+#     while values()/order_by() REPLACE their previous call (Django parity);
+#   - read terminals (count/exists/list/first/get) NEVER mutate the handler — they
+#     execute on an internal copy, so a handler stays reusable after any of them.
+# Flipping either behavior after publish would be silently breaking, so these tests
+# are the contract.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: filter() re-call accumulates
+# Two successive filter() calls must AND together (narrowing the result), not
+# replace each other — both predicates stay on the handler and in the SQL.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "filter() re-call accumulates" begin
+    q = M.Result.objects
+    q.filter("raceid__year" => 2021)
+    n_year = q.count()
+    @test n_year > 1                       # sanity: 2021 season is seeded
+
+    q.filter("positionorder" => 1)         # second call must narrow, not reset
+    n_both = q.count()
+
+    @test length(q.object.filter) == 2     # both predicates live on the handler
+    @test 0 < n_both < n_year              # ANDed: strictly narrower than year alone
+
+    # SQL shape: both predicates render in the same WHERE clause
+    sql = q.list(show_query=:sql)
+    @test occursin("year", sql)
+    @test occursin("positionorder", sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: values() re-call is last-call-wins
+# A second values() call replaces the projection entirely (Django parity) — the
+# result exposes only the columns of the last call.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "values() re-call replaces the projection" begin
+    q = M.Driver.objects.filter("driverref" => "hamilton")
+    q.values("forename")
+    q.values("surname")                    # replaces the "forename" projection
+
+    @test length(q.object.values) == 1     # only the last projection remains
+
+    row = q.list()[1]
+    @test haskey(row, :surname)            # last call's column is selected …
+    @test !haskey(row, :forename)          # … the first call's column is gone
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: order_by() re-call is last-call-wins
+# A second order_by() call clears the previous ordering (Django: "each order_by()
+# call will clear any previous ordering") — only the last sort key applies.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() re-call replaces the ordering" begin
+    q = M.Driver.objects.filter("nationality" => "British").values("surname")
+    q.order_by("surname")
+    q.order_by("-surname")                 # replaces ASC ordering with DESC
+
+    @test length(q.object.order) == 1      # only the last ordering remains
+
+    surnames = [r[:surname] for r in q.list()]
+    @test length(surnames) > 1             # sanity: enough rows to observe order
+
+    # Behavioral proof that the ASC call was CLEARED (not composed into a secondary
+    # sort key): the re-called handler must return rows in the same order as a fresh
+    # handler ordered only by "-surname". Comparing two DB queries — rather than to
+    # Julia's `sort` — keeps this collation-robust: SQLite (BINARY) and PostgreSQL
+    # (locale collation) order mixed-case names like "di Resta" differently, and only
+    # the database's own ordering is the contract here. Had order_by accumulated, the
+    # composed `surname ASC, surname DESC` would sort ascending and diverge from this.
+    reference = [r[:surname] for r in
+        M.Driver.objects.filter("nationality" => "British").values("surname").
+            order_by("-surname").list()]
+    @test surnames == reference
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: first() does not mutate the handler (#199)
+# first() used to permanently set limit(1) on the handler, breaking reuse (and
+# making a follow-up update() throw "UPDATE with LIMIT"). It now executes on an
+# internal copy: the handler keeps limit=0 and re-executes with all rows.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "first() leaves the handler unchanged" begin
+    q = M.Driver.objects.filter("nationality" => "British")
+    total = q.count()
+    @test total > 1                        # sanity: first() must actually truncate
+
+    d = q.first()
+    @test d isa PormGRow
+
+    @test q.object.limit == 0              # no limit(1) leaked into the handler
+    @test length(q.list()) == total        # re-execution still returns every row
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: first() then update() on the same handler (#199)
+# The old mutate-first behavior made this exact sequence throw ("UPDATE with
+# LIMIT/OFFSET is not supported"). With copy-first terminals it is valid. Uses
+# the scratch model so the F1 fixture data stays untouched; explicit cleanup.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "first() then update() on the same handler" begin
+    row = M.Just_a_test_deletion.objects.create("name" => "handler_semantics_199")
+    try
+        q = M.Just_a_test_deletion.objects.filter("name" => "handler_semantics_199")
+        @test q.first() isa PormGRow
+
+        # The former footgun: this threw because first() had left limit=1 behind
+        q.update("name" => "handler_semantics_199_updated")
+
+        updated = M.Just_a_test_deletion.objects.get("id" => row.id)
+        @test updated.name == "handler_semantics_199_updated"
+    finally
+        M.Just_a_test_deletion.objects.filter("id" => row.id).delete()
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler semantics: get() inline filters do not persist (#199)
+# get(q, filters...) used to append its inline filters to the handler before
+# copying — reusing the handler afterwards silently kept them. Now the filters
+# apply to the internal copy only, while error messages still report them.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "get() inline filters stay off the handler" begin
+    q = M.Driver.objects
+    driver = q.get("driverref" => "hamilton")
+    @test driver.surname == "Hamilton"
+
+    @test isempty(q.object.filter)         # inline filter did not persist
+    @test q.count() > 1                    # handler still matches every driver
+
+    # The typed errors still describe the inline filters (taken from the copy)
+    err = try
+        M.Driver.objects.get("driverref" => "pormg_missing_199")
+    catch e
+        e
+    end
+    @test err isa DoesNotExist
+    @test occursin("driverref", err.filters)
+end


### PR DESCRIPTION
Closes #199.

## What & why

The pre-publish audit (#199) flagged two inconsistencies in the fluent surface. This PR settles both — the pre-publish window is the time to lock them in, since flipping either after publish would be silently breaking.

### 1. Terminal contract — `first`/`get` now copy-first

`count`/`exists`/`list` already deepcopy before executing, but:
- `first()` permanently set `limit(1)` on the handler, and
- `get(q, filters...)` permanently appended its inline filters to the handler before its deepcopy.

Both now deepcopy **first**, so every read terminal executes on an internal copy and leaves the caller's handler untouched:
- `q.first()` followed by `q.update(...)` on the same handler is now valid (the documented footgun is gone).
- Inline filters in `q.get("field" => v)` no longer persist on `q`.
- `get`'s error repr is read from the copy, so `DoesNotExist`/`MultipleObjectsReturned` still name the inline filters.

No internal caller relied on the old side effects.

### 2. Accumulate-vs-reset — keep Django parity, document it

`filter` accumulates; `values`/`order_by` replace the previous call. A survey of Django, SQLAlchemy, Rails, and Ecto found **no cross-framework consensus** on `values`/`order_by`, and PormG already mirrors Django's surface (`__` lookups, `Q`/`Qor`, `get()`+`DoesNotExist`) — so the existing split stays, now documented:
- re-call semantics added to the `filter`/`values`/`order_by` docstrings;
- new **Handler Mutation Model** section in `docs/src/read/index.md` (fresh-handler-per-access, in-place mutation, `.copy()` escape hatch, terminals never mutate);
- an **On re-call** column in the chainable-methods reference table.

## Tests

New `test/integration/test_handler_semantics.jl` pins all six behaviors (filter accumulate; values/order_by replace; first/get non-mutation; the former first-then-update footgun). The `order_by` check compares against a reference DB query rather than Julia's `sort`, keeping it collation-robust — SQLite (BINARY) and PostgreSQL (locale) order mixed-case names like `"di Resta"` differently.

## Verification

- PostgreSQL (db_2): **1833 passed, 0 failed**
- SQLite (db_sl): **1799 passed, 0 failed** (1 pre-existing `@test_broken`)
- Docs build: exit 0
- Doc examples verified against live F1 data

## Versioning

z-bump `0.2.2 → 0.2.3` (footgun fix, not breaking) with a "no action expected" `UPGRADING.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)