### PR TITLE
fix(#200): remove Base.first type piracy — nullary first(; kwargs...) curried method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,62 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Removed `Base.first` type piracy — curried `first(; kwargs…)` form (#200)
+
+- **Version**: 0.3.0
+- **PormG ref**: issue #200 ; `src/querybuilder/execution.jl`
+- **Recorded**: 2026-07-24
+- **Severity**: **breaking (method removal)** — but the removed form was undocumented, unexported, and
+  used nowhere in-repo, so real impact is expected to be nil. Bumped `y` anyway because the method was
+  globally reachable, so `compat = "0.2"` should reject it.
+
+### What changed
+
+The convenience method
+
+```julia
+first(; kwargs...) = (objct) -> first(objct; kwargs...)   # removed
+```
+
+was **type piracy**: a zero-positional method on `Base.first` with no PormG type in its signature, so
+after `using PormG` it claimed the global `Base.first(; kwargs…)` call for every module in the process.
+There is no piracy-free version (a nullary method on someone else's function has no owned type to
+anchor it), so it was removed. The normal ergonomics are unaffected — only passing keywords *inside a
+pipe* is gone, and it has a direct equivalent:
+
+```julia
+# ✗ before — curried, kwargs-in-a-pipe (the only removed form):
+sql = M.Driver.objects.filter("nationality" => "British") |> first(show_query = :sql)
+
+# ✓ after — pass the handler explicitly (or use the method form):
+sql = first(M.Driver.objects.filter("nationality" => "British"); show_query = :sql)
+sql = M.Driver.objects.filter("nationality" => "British").first(show_query = :sql)
+```
+
+Still valid, untouched: `q.first()`, `first(q)`, `q.first(show_query=:sql)`, the bare pipe
+`q |> first` (that's `first(q)`), and `list() |> first` (that's `Base.first(::Vector)`). The sibling
+curried forms `delete(; kwargs…)` / `inspect_query(; kwargs…)` are **not** affected — those functions
+are package-owned, so a kwargs-only method on them is not piracy.
+
+### How to find the calls to migrate
+
+Grep each app for a `first` that is piped **with keyword arguments** (bare `|> first` is fine):
+
+```
+rg -n '\|>\s*first\(' <app>/src        # curried first(...) in a pipe — the only form to change
+```
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | optional — likely — (form used nowhere); rewrite any `\|> first(kw)` to `first(q; kw)` |
+| app-2 | ⏳ | optional / likely — |
+| app-3 | ⏳ | optional / likely — |
+| app-4 | ⏳ | optional / likely — |
+
+---
+
 ## `first()` / `get()` no longer mutate the handler (#199)
 
 - **Version**: 0.2.3

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -1548,7 +1548,11 @@ function first(objct::SQLObjectHandler; show_query::Symbol = :execute)
   end
   return isempty(res) ? nothing : res[1]
 end
-first(; kwargs...) = (objct) -> first(objct; kwargs...)
+# NOTE (#200): the curried `first(; kwargs...) = (objct) -> first(objct; kwargs...)` form
+# was removed — a zero-positional method on Base.first with no PormG type is type piracy.
+# `q.first(...)`, `first(q; kw...)` and `q |> first` are unaffected. See the piracy guard in
+# test/unit/test_public_exports.jl. (`delete`/`inspect_query` keep their curried forms — those
+# functions are package-owned, so a kwargs-only method on them is not piracy.)
 
 function _get_filter_repr(filter::SQLTypeOper)::String
   column = filter.column isa SQLTypeField ? filter.column.field : filter.column

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -91,6 +91,27 @@ const EXPECTED_FUNCTIONS = Set([
         @test PormG.ConnectionPool.fetch === Base.fetch
     end
 
+    # No type piracy on Base.first (#200). PormG extends Base.first only through the typed
+    # `first(::SQLObjectHandler; …)` method (nargs==2 — the function slot plus a PormG-owned
+    # positional arg). A PormG-defined method on Base.first with NO positional argument
+    # (nargs==1, only the function slot) has no PormG type to anchor it → global type piracy.
+    # The curried `first(; kwargs…)` form was exactly that and was removed.
+    #
+    # Why Aqua's piracies check didn't catch it (verified against Aqua 0.8): `Aqua.Piracy.is_pirate`
+    # DOES flag the nullary method, but `hunt(PormG)`/`test_piracies(PormG)` filter methods by
+    # `method.module === PormG` and never recurse into submodules — the method lived in
+    # `PormG.QueryBuilder`, so it was dropped before is_pirate saw it. This explicit guard closes
+    # that submodule blind spot without depending on Aqua internals.
+    @testset "no Base.first type piracy — nullary kwargs method (#200)" begin
+        pormg_nullary_first = filter(methods(first)) do m
+            occursin("PormG", string(parentmodule(m))) && m.nargs == 1
+        end
+        @test isempty(pormg_nullary_first)
+        # …and the legitimate, non-pirating extension is still there (this is the ONLY way
+        # PormG may touch Base.first): a typed method with a PormG positional argument.
+        @test hasmethod(first, Tuple{PormG.QueryBuilder.SQLObjectHandler})
+    end
+
     # `close_pool!` was exported by BOTH Configuration and ConnectionPool as *different*
     # functions, which made `PormG.close_pool!` ambiguous (undefined). The dedup leaves
     # Configuration's full-featured version (pool OR db-name String) as the single one.

--- a/test/unit/test_shared_state_readpath.jl
+++ b/test/unit/test_shared_state_readpath.jl
@@ -165,21 +165,23 @@ end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # AC1 names .first() explicitly. It intentionally mutates the caller's limit (documented
-  # last-call semantics) but must NOT leak parameters or the CTE "model" — the two must
-  # coexist. .first() funnels through query_list, so the read-path copy covers it.
+  # AC1 names .first() explicitly. Post-#199 it is copy-first like every read terminal:
+  # limit(1) is applied to an internal copy only, so the caller's limit / parameters /
+  # CTE "model" are all left untouched. .first() funnels through query_list, so the
+  # read-path copy covers it.
   # ─────────────────────────────────────────────────────────────────────────────
-  @testset "first() mutates only its documented limit(1), nothing else" begin
+  @testset "first() does not mutate the caller (copy-first, #199)" begin
     q = _cte_query()
     @test q.object.parameters === nothing
     @test !haskey(q.object.ctes["agg"], "model")
 
+    limit_before = q.object.limit
     sql = q.first(show_query = :sql)
     @test sql isa String && occursin("WITH", sql)
-    @test occursin("LIMIT 1", sql)                 # first() applied limit(1) to the build
-    @test q.object.limit == 1                       # documented: limit(1) persists on the caller
-    @test q.object.parameters === nothing           # but parameters did NOT leak (fixed)
-    @test !haskey(q.object.ctes["agg"], "model")    # and the CTE "model" did NOT leak (fixed)
+    @test occursin("LIMIT 1", sql)                 # first() applied limit(1) to its internal copy
+    @test q.object.limit == limit_before            # #199: copy-first — caller's limit is untouched
+    @test q.object.parameters === nothing           # parameters did NOT leak
+    @test !haskey(q.object.ctes["agg"], "model")    # and the CTE "model" did NOT leak
   end
 
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #200.

## What & why

The curried convenience method in `src/querybuilder/execution.jl`

```julia
first(; kwargs...) = (objct) -> first(objct; kwargs...)   # removed
```

was **type piracy**: a zero-positional method on `Base.first` with no PormG type in its signature, so after `using PormG` it claimed the global `Base.first(; kwargs...)` call for every module in the process. There is no piracy-free version (a nullary method on someone else's function has no owned type to anchor it), so it is removed.

**Ergonomics are unaffected** — only the used-nowhere kwargs-in-a-pipe form is gone:

| form | after |
|------|-------|
| `q.first()`, `first(q)`, `q.first(show_query=:sql)` | ✅ unchanged |
| `q \|> first` (that's `first(q)`), `list() \|> first` (`Base.first(::Vector)`) | ✅ unchanged |
| `q \|> first(show_query=:sql)` (curried-with-kwargs) | ❌ removed — use `first(q; show_query=:sql)` |

A repo-wide grep confirms the curried form was used nowhere.

## Regression guard

Adds a self-proving guard to `test/unit/test_public_exports.jl` (next to the `fetch === Base.fetch` check): no PormG-owned **nullary** method may exist on `Base.first`, **and** the legit typed `first(::SQLObjectHandler)` must remain.

**Why Aqua's `piracies` check missed it** (recorded in the test comment, verified against Aqua 0.8): `is_pirate` *does* flag the nullary method, but `hunt(PormG)`/`test_piracies(PormG)` filter by `method.module === PormG` and never recurse into submodules — the method lived in `PormG.QueryBuilder`, so it was dropped before `is_pirate` saw it. The guard is `methods()`-based, so it doesn't depend on Aqua internals.

## Versioning

Breaking (a globally-reachable `Base` method is removed) → **y-bump `0.2.3 → 0.3.0`** with a version-stamped `UPGRADING.md` entry.

## Drive-by: corrects a #199 unit-test oversight

Rebasing onto the latest `main` (which now includes #199 / PR #222, "first()/get() copy-first") surfaced that #199 left `test/unit/test_shared_state_readpath.jl` asserting the **old** mutating contract (`q.object.limit == 1`), so `main`'s unit suite was red independent of this change. Second commit updates that testset to #199's copy-first contract (assert the caller's `limit` is unchanged after `.first()`). Called out here since it touches #199's area.

## Verification

- Unit suite (`Pkg.test()`): **4171/4171 pass** — includes Aqua and the new guard.
- SQLite integration (`db_sl`): 1777 pass, 1 pre-existing `@test_broken`, 0 fail (run pre-rebase; change is dialect-agnostic).
- Sanity: `Base.first(; foo=1)` now `MethodError`s (piracy gone); `first(q)`, `q.first(...)`, `q \|> first`, `Base.first(::Vector)` all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)