### PR TITLE
refactor(#202): prune PormG.QueryBuilder exports; With via import, OP internal

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -688,6 +688,17 @@ M.Result.objects.values(              # …or qualify without importing
 `bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Subquery`, `Interval` stay at the top level —
 they are query primitives, not part of the function library.
 
+### Functional CTE constructor: `PormG.QueryBuilder.With`
+
+The `With` (CTE) constructor lives in the `PormG.QueryBuilder` submodule and is **not** part
+of the top-level `using PormG` surface. In everyday code prefer the fluent `.with(...)` method
+(see [Subqueries and CTEs](read/subqueries_and_ctes.md)); reach for the free-function form only
+when you want the functional style. Import it explicitly:
+
+```julia
+using PormG.QueryBuilder: With        # or qualify: PormG.QueryBuilder.With(...)
+```
+
 **Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min`
 **Conditional** — `Case`, `When`
 **Window** — `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -312,7 +312,7 @@ This documentation is organized into the following sections:
 |  [Custom Joins](read/custom_joins.md) | `cjoin()` for runtime join conditions and `on()` for ON-clause predicates. |
 |  [Filters and Aggregates](read/filters_and_aggregates.md) | Lookup operators, grouping, and `HAVING`. |
 |  [Functions and Dates](read/functions_and_dates.md) | SQL functions and date-oriented querying. |
-|  [Subqueries and CTEs](read/subqueries_and_ctes.md) | `IN` subqueries and `With(...)` CTEs. |
+|  [Subqueries and CTEs](read/subqueries_and_ctes.md) | `IN` subqueries and `.with(...)` CTEs. |
 |  [Field Expressions](read/field_expressions.md) | `F()` expressions, column arithmetic, aggregate ratios. |
 |  [Q Objects](read/q_objects.md) | Complex boolean logic with `Q`, `Qor`, and `NOT`. |
 | [Import from Django](import_django.md) | Migrating models and data from Django projects. |

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -11,7 +11,7 @@ This section covers the read side of PormG — querying, filtering, joining, agg
 | [Values and Joins](values_and_joins.md) | Column selection, `__` join traversal, multi-level joins, reverse joins, wildcard `*`, and aliases. |
 | [Filters and Aggregates](filters_and_aggregates.md) | `filter()`, lookup operators (`@gt`, `@in`, `@contains`, …), grouping, and `HAVING` clauses. |
 | [Functions and Dates](functions_and_dates.md) | SQL functions (`Case`, `Coalesce`, `Concat`, …), date extraction, and math transforms. |
-| [Subqueries and CTEs](subqueries_and_ctes.md) | `IN` subqueries, scalar `Subquery`/`Exists` columns, `With(...)` CTEs, deep join paths, and CTE + cjoin combinations. |
+| [Subqueries and CTEs](subqueries_and_ctes.md) | `IN` subqueries, scalar `Subquery`/`Exists` columns, `.with(...)` CTEs, deep join paths, and CTE + cjoin combinations. |
 | [Field Expressions](field_expressions.md) | `F()` for field-to-field comparisons, arithmetic, aggregate ratios, aliasing, and atomic updates. |
 | [Window Functions](window_functions.md) | `Rank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue` — per-row analytics without collapsing rows. |
 | [Q Objects](q_objects.md) | Complex boolean logic with `Q` (AND), `Qor` (OR), nesting, dynamic construction, and `F()` integration. |

--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -252,6 +252,23 @@ The `.with()` method:
 2. Creates a `LEFT JOIN stats ON result.driverid = stats.driverid`.
 3. Makes `stats__total_results` available for selection via `values()`.
 
+!!! note "Functional form: `With(...)`"
+    `.with("name" => subquery; join_field=...)` is the idiomatic fluent form. The same CTE
+    can also be added with the free `With` function, which lives in `PormG.QueryBuilder` (it
+    is **not** part of the top-level `using PormG` surface). Bring it into scope explicitly:
+
+    ```julia
+    using PormG.QueryBuilder: With
+
+    mq = M.Result.objects   # a fresh handler (the CTE is added exactly once)
+    With(mq.object, "stats", driver_stats, join_field="driverid" => "driverid")
+    # …identical to:
+    # mq.with("stats" => driver_stats, join_field="driverid" => "driverid")
+    ```
+
+    Note the functional form takes `mq.object` (the underlying `SQLObject`) as its first
+    argument and returns it, whereas `.with()` operates on the handler directly.
+
 ---
 
 ## Correlating a CTE with `F()` (no `join_field`)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -59,7 +59,10 @@ include("querybuilder/ctes.jl")
 #
 # SQLTypeOper Objects (operators from sql)
 #
-export OP
+# `OP` is intentionally internal (#202): not exported and not documented. The string-lookup
+# form `"field__@op" => value` is the public way to build operator predicates; `OP` is a
+# low-level builder used inside the date-bucketing helpers (QUADRIMESTER/QUARTER). Reach it
+# as `PormG.QueryBuilder.OP` if ever needed — it stays defined, just off the public surface.
 export Q, Qor
 export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Subquery, Case, Cast, Concat, Extract, To_char, Value, Interval
 export WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
@@ -85,10 +88,11 @@ export With
 # end
 
 export object
-export page
-export query
-export update
 export get
+# `page`, `query`, `update` are intentionally NOT exported (#202): they are generic names
+# that pollute scope on a bare `using PormG.QueryBuilder`. The fluent `.page()`/`.update()`
+# methods and explicit `import PormG.QueryBuilder: page`/`query`/`update` are unaffected —
+# export status only governs the bare-`using` dump.
 export PormGRow, pk, DoesNotExist, MultipleObjectsReturned
 # do_count and do_exists are now strictly used as functors (query.count(), query.exists())
 export bulk_insert, bulk_update, bulk_copy, allocate_primary_keys

--- a/src/documentation/querybuilder.jl
+++ b/src/documentation/querybuilder.jl
@@ -1,7 +1,11 @@
 @doc """
 Add a Common Table Expression (CTE) to the query object.
 
-CTEs can be joined like regular tables using their field names.
+CTEs can be joined like regular tables using their field names. The idiomatic form is the
+fluent `.with` method — `q.with("name" => subquery; join_field=...)`. The free `With`
+function shown below is the equivalent functional style; it lives in `PormG.QueryBuilder`
+(not the top-level `using PormG` surface), so bring it into scope with
+`using PormG.QueryBuilder: With` or qualify it as `PormG.QueryBuilder.With`.
 
 # Arguments
 - `q::SQLObject`: The SQL object to add the CTE to (available as `query.object`)
@@ -17,7 +21,9 @@ CTEs can be joined like regular tables using their field names.
 
 # Examples
 ```julia
-import PormG.models as M
+using PormG.QueryBuilder: With   # functional CTE form (or use the `.with()` method)
+using PormG.Functions: Count     # SQL function constructors live in PormG.Functions
+# `M` is your loaded models module (see `@import_models`).
 
 # Example 1: Basic CTE with JOIN (Finding total results per driver)
 drivers_stats = M.Result.objects
@@ -25,6 +31,8 @@ drivers_stats.values("driverid", "total_races" => Count("resultid"))
 
 main_query = M.Result.objects
 With(main_query.object, "stats", drivers_stats, join_field="driverid" => "driverid")
+# Idiomatic equivalent:
+# main_query.with("stats" => drivers_stats, join_field="driverid" => "driverid")
 
 # Filter and select using CTE fields with "cte_name__" prefix
 main_query.filter("resultid__@lte" => 100)
@@ -34,15 +42,18 @@ df = main_query |> DataFrame
 ```
 
 ```julia
+using PormG.QueryBuilder: With
+using PormG.Functions: Sum
+
 # Example 2: CTE with INNER JOIN and Multiple Aggregations
 high_scorers = M.Result.objects
 high_scorers.filter("points__@gte" => 10)
-high_scorers.values("driverid", "max_points" => Sum("points"))
+high_scorers.values("driverid", "total_points" => Sum("points"))
 
 query = M.Driver.objects
 With(query.object, "hs", high_scorers, join_field="driverid" => "driverid", join_type="INNER")
 
-query.values("driverid", "surname", "hs_points" => "hs__max_points")
+query.values("driverid", "surname", "hs_points" => "hs__total_points")
 query.filter("driverid__@lte" => 50)
 
 df = query |> DataFrame

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -121,4 +121,36 @@ const EXPECTED_FUNCTIONS = Set([
         # Still accepts a db-name String (the convenience the public version adds).
         @test hasmethod(PormG.close_pool!, Tuple{String})
     end
+
+    # #202 — the `PormG.QueryBuilder` submodule surface.
+    #
+    # Decision: `With` (CTE) is documented-via-import — it stays EXPORTED by `PormG.QueryBuilder`
+    # (reach it with `using PormG.QueryBuilder: With`) but is NOT promoted onto the top-level
+    # `using PormG` surface. `OP` (operator) is INTERNAL — unexported and undocumented; the public
+    # way to build operator predicates is the `"field__@op"` string lookup. The generic names
+    # `query`/`update`/`page` were also un-exported so a bare `using PormG.QueryBuilder` stops
+    # dumping them into scope.
+    #
+    # Note: `names(M)` lists a module's EXPORTED symbols; `isdefined(M, s)` is true for any
+    # binding whether exported or not. So a name staying defined-but-unexported is exactly the
+    # prune we want — explicit `import PormG.QueryBuilder: name` still works.
+    @testset "QueryBuilder submodule surface (#202)" begin
+        qb_exports = Set(filter(n -> n !== :QueryBuilder, names(PormG.QueryBuilder)))
+
+        # Un-exported from the submodule (still defined, just not dumped by a bare
+        # `using PormG.QueryBuilder`): the generic names + the internal `OP` builder.
+        for n in (:query, :update, :page, :OP)
+            @test !(n in qb_exports)                # no longer exported
+            @test isdefined(PormG.QueryBuilder, n)  # …but still reachable by explicit import
+        end
+
+        # `With` stays exported by the submodule (the documented functional CTE form).
+        @test :With in qb_exports
+        @test isdefined(PormG.QueryBuilder, :With)
+
+        # Neither is promoted onto the top-level surface (kept off `using PormG`). These are the
+        # load-bearing guards: they fail the moment `With`/`OP` are re-homed at top level.
+        @test !isdefined(PormG, :With)
+        @test !isdefined(PormG, :OP)
+    end
 end


### PR DESCRIPTION
Closes #202. Follow-up to the #35 export curation — settles the two residual export-surface problems it flagged.

## What & why

**1. Un-export generic names from `PormG.QueryBuilder`.**
A bare `using PormG.QueryBuilder` was dumping the generic names `query`, `update`, `page` into scope — exactly the collision class the #35 top-level curation removed. They're now un-exported. They stay **defined**, so explicit `import PormG.QueryBuilder: page` and the fluent `.page()`/`.update()` methods are unaffected — export status only governs the bare-`using` dump.

**2. `With` / `OP` reachability (they were documented but unreachable under `using PormG`).**
- **`With`** stays a *documented* functional CTE form, reached via `using PormG.QueryBuilder: With` (or qualified). The fluent `.with()` method remains the primary, idiomatic API.
- **`OP`** becomes **fully internal** — un-exported and un-documented. The public way to build operator predicates is the `"field__@op"` string lookup; `OP` is a low-level builder the internal date-bucketing helpers (`QUADRIMESTER`/`QUARTER`) use from inside the module. Reachable as `PormG.QueryBuilder.OP` in the rare case it's needed.

**3. Docs fixed to match reality.**
- Repaired the stale `With` docstring (wrong unqualified `Count`/`Sum`, bogus `import PormG.models`).
- Index prose `With(...)` → `.with(...)`; added a "Functional form" note to the CTE page and a `With`-only note to api.md's Exported Symbols.

**4. Pinned the decision** in `test/unit/test_public_exports.jl` (new `#202` testset): `query`/`update`/`page`/`OP` are un-exported-but-defined, `With` stays exported, neither `With` nor `OP` is on the top-level `using PormG` surface.

## Versioning
No `Project.toml` bump and no `UPGRADING.md` entry — this rides within the already-unreleased `0.3.0` as an internal export-surface cleanup with no consuming-app action (no app relies on the bare submodule dump; the idiomatic `.with()` / `"__@op"` forms are unchanged).

## Verification
- `test/unit/test_public_exports.jl`: **72/72 pass** (runs without a DB).
- Doc examples verified against live F1 SQLite: fluent `.with()` and functional `With(...)` return identical 100-row results.
- Reviewed: export prune is safe (kept names still defined; top-level never re-exported them); `With` doc signature matches source; api.md anchor valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)