### PR TITLE
refactor(#201): settle public naming before publish — ToChar, formatter, aggregate, M2M bang removal, setup unexported

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,53 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## Public naming settled — ToChar, formatter, aggregate, M2M `add`/`remove`/`clear`/`set`, setup unexported (#201)
+
+- **Version**: 0.3.0
+- **PormG ref**: issue #201 ; `src/querybuilder/{functions,types,many_to_many}.jl`, `src/models/fields.jl`,
+  `src/PormG.jl` exports, `docs/src/{api,many_to_many,import_django}.md`
+- **Recorded**: 2026-07-24
+- **Severity**: **breaking (renames)** — pre-publish naming pass; every rename is old-name-gone, no aliases.
+  `0.3.0` is the shared stamp for the current pre-publish wave: roll an app forward by applying **all**
+  `0.3.0` entries together.
+
+### What changed
+
+| Old | New | Surface |
+|-----|-----|---------|
+| `To_char(x, fmt; formater=…)` | `ToChar(x, fmt; formatter=…)` | `PormG.Functions` export (only non-PascalCase name in the library) |
+| `formater` (kwarg + struct field) | `formatter` | `Extract`/`ToChar`/math-function kwarg; fields on `FObject`/`WindowFunction` **and** all model-field structs |
+| `agregate` (struct field) | `aggregate` | `InstructionObject`/`FExpression`/`FObject`/`WindowFunction` internals |
+| `manager.add!/remove!/clear!/set!` | `manager.add/remove/clear/set` | M2M manager mutators (Django parity; bang implied "mutates a Julia arg", which these don't — they mutate the DB; see the rationale note in `docs/src/many_to_many.md`) |
+| `setup` / `install_ai_skills` (exported) | `PormG.setup()` / `PormG.install_ai_skills()` (qualified-only) | top-level exports removed; behavior unchanged |
+| `InstrucObject` | `InstructionObject` | internal QB struct (public-adjacent docstrings) |
+
+**Deliberate non-change:** `bulk_insert` keeps its name (Django's `bulk_create` is a different API —
+DataFrame-first, `on_conflict=` kwarg; documented in `docs/src/import_django.md`, "API Naming
+Differences from Django").
+
+### How to find the calls to migrate
+
+```
+rg -n 'To_char|formater|agregate|InstrucObject'        # renames: mechanical old → new
+rg -n '\.(add|remove|clear|set)!\('                    # M2M mutators: drop the !
+rg -n '(^|[^.\w])(setup|install_ai_skills)\('           # bare calls → prefix with PormG.
+```
+
+The first two are safe find-and-replace (whole-word). For the third, only *unqualified* calls need
+the `PormG.` prefix — `PormG.setup()` calls keep working as-is.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | run the three greps; mechanical replace |
+| app-2 | ⏳ | same |
+| app-3 | ⏳ | same |
+| app-4 | ⏳ | same |
+
+---
+
 ## Removed `Base.first` type piracy — curried `first(; kwargs…)` form (#200)
 
 - **Version**: 0.3.0

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -310,7 +310,7 @@ df = M.Result.objects.values(
 | `Least(args...)` | Minimum of values | `Least("points", Value(100))` |
 | `Cast("field", type)` | Type casting | `Cast("points", "INTEGER")` |
 | `Extract("field", "part")` | Extract date/time part | `Extract("dob", "year")` |
-| `To_char("field", fmt)` | Format to string | `To_char("dob", "YYYY-MM")` |
+| `ToChar("field", fmt)` | Format to string | `ToChar("dob", "YYYY-MM")` |
 
 ### Case Expressions
 
@@ -661,7 +661,13 @@ scope — the SQL function constructors are *not* among them (see
 `pool_stats`, `PoolTimeoutError`, `PoolConnectError`
 
 ### Utilities & lifecycle
-`setup`, `install_ai_skills`, `upgrade_guide`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
+`upgrade_guide`, `tui`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
+
+!!! note "`setup` and `install_ai_skills` are qualified-call-only"
+    The one-off lifecycle helpers `PormG.setup()` (interactive project wizard) and
+    `PormG.install_ai_skills()` are deliberately **not exported** — their generic names
+    would otherwise land in every `using PormG` namespace. Call them qualified, exactly
+    as shown throughout these docs.
 
 !!! note "`fetch` extends `Base.fetch`"
     The low-level `fetch(settings, sql; params=[...])` escape hatch (values bound with
@@ -704,7 +710,7 @@ using PormG.QueryBuilder: With        # or qualify: PormG.QueryBuilder.With(...)
 **Window** — `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`
 **String** — `Concat`, `Lower`, `Upper`, `Length`, `Replace`, `Trim`, `LTrim`, `RTrim`
 **Math** — `Abs`, `Round`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`
-**Type / value** — `Cast`, `Extract`, `To_char`, `Value`, `Coalesce`, `Greatest`, `Least`, `NullIf`
+**Type / value** — `Cast`, `Extract`, `ToChar`, `Value`, `Coalesce`, `Greatest`, `Least`, `NullIf`
 
 ### Result-shape contract for `list()`
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -6,7 +6,7 @@ point at the real definitions so you can jump in and read the body.
 !!! note "Type naming"
     The **abstract** types are `SQLObject`, `SQLObjectHandler`, `SQLInstruction`; the **concrete**
     ones you actually hold are `SQLObjectQuery` (the query state), `ObjectHandler` (the chainable
-    wrapper), and `InstrucObject` (the per-query SQL builder).
+    wrapper), and `InstructionObject` (the per-query SQL builder).
 
 ## Layers (who depends on whom)
 
@@ -21,7 +21,7 @@ flowchart TD
 
   subgraph QB["QueryBuilder — src/querybuilder/"]
     Q["query() — execution.jl"]
-    B["build() → InstrucObject<br/>build_query.jl"]
+    B["build() → InstructionObject<br/>build_query.jl"]
     J["_build_row_join (joins)<br/>build_joins.jl"]
     P["parameters.jl<br/>$1.. (PG) / ? buckets (SQLite)"]
     F["functions.jl / operators.jl / ctes.jl"]
@@ -75,7 +75,7 @@ sequenceDiagram
   EX->>EX: query() — resolve settings + param collector
   EX->>BQ: build(object)
   BQ->>BQ: get_select_query / get_filter_query<br/>_build_row_join / order / build_cte_clause
-  Note over BQ: fills an InstrucObject:<br/>SQL text + ordered parameters
+  Note over BQ: fills an InstructionObject:<br/>SQL text + ordered parameters
   BQ-->>EX: SQL string + parameters
   EX->>CP: fetch(conn, sql, params)
   CP->>CP: fetch_async() → acquire_connection (under lock)

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -905,16 +905,16 @@ senna_id = 102
 prost_id = 117
 
 manager = Driver_collection.drivers(collection_id)
-manager.add!(senna_id, prost_id)  # returns nothing
-manager.remove!(prost_id)         # returns nothing
-manager.set!([senna_id])          # returns (added=X, removed=Y)
+manager.add(senna_id, prost_id)  # returns nothing
+manager.remove(prost_id)         # returns nothing
+manager.set([senna_id])          # returns (added=X, removed=Y)
 driver_rows = manager.all().values("surname", "nationality").list()
 ```
 
 Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table.
 
 !!! warning
-    **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add!`, `remove!`, `clear!`, and `set!`) will raise an `ArgumentError`. Create or delete custom through model objects directly using the through model's objects manager instead.
+    **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add`, `remove`, `clear`, and `set`) will raise an `ArgumentError`. Create or delete custom through model objects directly using the through model's objects manager instead.
 
 ---
 

--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -238,6 +238,16 @@ user_type = models.CharField(
 4. **Metaclass Options**: Model Meta options are not converted
 5. **Methods**: Model methods are not converted (only fields)
 
+## API Naming Differences from Django
+
+PormG is **inspired by** Django, not a port — where an API is genuinely different, it also gets its own name rather than borrowing Django's. The one you will notice first when migrating:
+
+| Django | PormG | Why it's not just a rename |
+| :--- | :--- | :--- |
+| `Model.objects.bulk_create(objs, batch_size=…, ignore_conflicts=…)` | `bulk_insert(query, df; chunk_size=…, on_conflict=…)` | PormG's bulk API is **DataFrame-first**: it inserts rows from a `DataFrame` (with optional `"df_col" => "model_field"` mapping) instead of a list of model instances, and it does not materialize/return created instances. Conflict handling is the explicit `on_conflict=` kwarg (`:nothing`, or `(action = :update, target = […], set = […])` for upserts) rather than Django's `ignore_conflicts`/`update_conflicts` booleans. |
+
+`bulk_insert` sits beside its siblings `bulk_update` and `bulk_copy` — see [Bulk Operations](write/bulk.md) for the full API.
+
 ## Datetime Interoperability Contract
 
 When PormG writes into tables that are also managed by Django, timezone semantics need to be explicit.

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -85,7 +85,7 @@ This pattern matches Django exactly and keeps your model definitions clean and r
 ### Relationship Mutator Limitations on Custom Through Tables
 
 !!! warning
-    **Django-Style Strict Mutators**: If your custom intermediate `through` model contains *any extra fields* beyond the two relationship foreign keys (like the `joined_year` field in `M2m_membership_scratch` above), all direct manager mutators (`add!`, `remove!`, `clear!`, and `set!`) are disabled and will raise an `ArgumentError`.
+    **Django-Style Strict Mutators**: If your custom intermediate `through` model contains *any extra fields* beyond the two relationship foreign keys (like the `joined_year` field in `M2m_membership_scratch` above), all direct manager mutators (`add`, `remove`, `clear`, and `set`) are disabled and will raise an `ArgumentError`.
 
 This constraint prevents silent failures or incomplete rows, as PormG cannot determine appropriate values to insert for your custom fields. 
 
@@ -106,13 +106,21 @@ M2m_membership_scratch.objects.filter(
 ).delete()
 ```
 
-If the custom intermediate model *only* contains the two foreign keys (and no extra columns), mutator methods like `add!` and `remove!` are fully supported.
+If the custom intermediate model *only* contains the two foreign keys (and no extra columns), mutator methods like `add` and `remove` are fully supported.
 
 ---
 
 ## The ManyToMany Manager API
 
 When you access a `ManyToManyField` on a fetched `PormGRow`, PormG returns a **ManyToManyManager**. This manager provides methods to query, add, remove, and sync relationships.
+
+!!! note "Why `add`/`remove`/`clear`/`set` carry no `!`"
+    Julia's `!` suffix conventionally marks a function that mutates a **Julia argument**.
+    The manager mutators mutate the database through-table instead — and they are only ever
+    reached as manager methods (`driver.sponsors.add(...)`), never as free functions in your
+    namespace. That makes them the same kind of surface as the bang-free fluent terminals
+    (`q.update(...)`, `q.delete()`), and matches Django's `add`/`remove`/`clear`/`set`.
+    (Renamed from `add!`/`remove!`/`clear!`/`set!` in 0.3.0 — see `UPGRADING.md`.)
 
 ### Model-level vs instance-level access
 
@@ -149,49 +157,49 @@ sponsors_df = driver.sponsors.all() |> DataFrame
 brazilian_sponsors = driver.sponsors.all().filter("country__name" => "Brazil") |> DataFrame
 ```
 
-### `.add!(targets...)` — Adding relationships
+### `.add(targets...)` — Adding relationships
 
-You can link new items to the relationship using `.add!`. It accepts integers (primary keys), dictionaries, named tuples, or actual model instances.
+You can link new items to the relationship using `.add`. It accepts integers (primary keys), dictionaries, named tuples, or actual model instances.
 
 ```julia
 # By primary key
-driver.sponsors.add!(1)
+driver.sponsors.add(1)
 
 # Multiple at once
-driver.sponsors.add!(2, 3)
+driver.sponsors.add(2, 3)
 
 # By dictionary (must contain the primary key)
-driver.sponsors.add!(Dict(:id => 4))
+driver.sponsors.add(Dict(:id => 4))
 ```
 
-### `.remove!(targets...)` — Removing relationships
+### `.remove(targets...)` — Removing relationships
 
-Unlink specific items from the relationship. It takes the exact same arguments as `.add!`.
+Unlink specific items from the relationship. It takes the exact same arguments as `.add`.
 
 ```julia
 # Remove sponsor with ID 2
-driver.sponsors.remove!(2)
+driver.sponsors.remove(2)
 ```
 
-### `.set!(targets...)` — Syncing relationships
+### `.set(targets...)` — Syncing relationships
 
-`.set!` compares the IDs you provide with the IDs currently in the database. It will automatically `add!` any missing ones and `remove!` any extra ones, all wrapped in a **transaction**.
+`.set` compares the IDs you provide with the IDs currently in the database. It will automatically `add` any missing ones and `remove` any extra ones, all wrapped in a **transaction**.
 
 ```julia
 # Ensure the driver is linked ONLY to sponsors 1, 4, and 5.
 # If they were linked to 2, it will be removed.
 # If they weren't linked to 4, it will be added.
-changes = driver.sponsors.set!(1, 4, 5)
+changes = driver.sponsors.set(1, 4, 5)
 
 println("Added: $(changes.added), Removed: $(changes.removed)")
 ```
 
-### `.clear!()` — Removing all relationships
+### `.clear()` — Removing all relationships
 
 Unlinks everything.
 
 ```julia
-driver.sponsors.clear!()
+driver.sponsors.clear()
 ```
 
 ---

--- a/docs/src/read/functions_and_dates.md
+++ b/docs/src/read/functions_and_dates.md
@@ -265,14 +265,14 @@ query.values(
 )
 ```
 
-### `To_char` — Format as String
+### `ToChar` — Format as String
 
 ```julia
-using PormG.Functions: To_char
+using PormG.Functions: ToChar
 
 query = M.Race.objects
 query.values(
-    "formatted_date" => To_char("date", "YYYY-MM")
+    "formatted_date" => ToChar("date", "YYYY-MM")
 )
 ```
 

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -157,11 +157,11 @@ M.Result.objects.values("n" => PormG.Functions.Count("resultid"))
 """
 module Functions
   import ..QueryBuilder: Sum, Avg, Count, Max, Min, Case, When, Cast, Concat, Extract,
-    To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
+    ToChar, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
     Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver,
     WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
   export Sum, Avg, Count, Max, Min, Case, When, Cast, Concat, Extract,
-    To_char, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
+    ToChar, Value, Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf,
     Replace, Trim, LTrim, RTrim, Floor, Ceil, Sqrt, Exp, Ln, Power, Mod, WindowOver,
     WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
 end
@@ -175,7 +175,10 @@ export PoolTimeoutError  # thrown by acquire_connection when the pool is saturat
 export PoolConnectError  # thrown by acquire_connection when a connection can't be opened (#72)
 export pool_stats  # connection-pool health snapshot (#127)
 export with_tx_context, in_transaction_context  # Transaction context helpers
-export setup, install_ai_skills, upgrade_guide  # upgrade_guide: version-scoped UPGRADING.md emitter (#216)
+# setup / install_ai_skills are deliberately NOT exported (#201): maximally generic names for
+# one-off lifecycle helpers — call them qualified (`PormG.setup()`, `PormG.install_ai_skills()`),
+# which is how every doc and README example already shows them.
+export upgrade_guide  # version-scoped UPGRADING.md emitter (#216)
 
 # Fallback stub for the Tachikoma TUI extension.
 # When `using Tachikoma`, PormGTachikomaExt overrides this with the real implementation.

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -64,7 +64,7 @@ include("querybuilder/ctes.jl")
 # low-level builder used inside the date-bucketing helpers (QUADRIMESTER/QUARTER). Reach it
 # as `PormG.QueryBuilder.OP` if ever needed — it stays defined, just off the public surface.
 export Q, Qor
-export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Subquery, Case, Cast, Concat, Extract, To_char, Value, Interval
+export Sum, Avg, Count, Max, Min, When, F, Exists, OuterRef, Subquery, Case, Cast, Concat, Extract, ToChar, Value, Interval
 export WindowOver, WindowSpec, Rank, DenseRank, RowNumber, Lag, Lead, FirstValue, LastValue, NthValue
 export Coalesce, Greatest, Least, Lower, Upper, Length, Abs, Round, NullIf, Replace, Trim, LTrim, RTrim
 export Floor, Ceil, Sqrt, Exp, Ln, Power, Mod

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -332,7 +332,7 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
               # :db_column never alters the live schema by itself — the column identity is
               # already proven equal by the matched (column-keyed) field, and the introspected
               # side carries db_column=nothing (#50).
-              attr in [:blank, :on_delete, :related_name, :verbose_name, :editable, :how, :formater, :db_column] && continue
+              attr in [:blank, :on_delete, :related_name, :verbose_name, :editable, :how, :formatter, :db_column] && continue
               push!(colect_not_equal, attr)
             end
           end
@@ -575,9 +575,9 @@ function _colect_numbered_fields(colect::Vector{Symbol})
 end
 function _get_temporary_default_value(field::PormGField, settings::PormGSettings)
   if field |> typeof == Models.sDateTimeField
-    return field.formater(now(), settings.time_zone) |> field.formater
+    return field.formatter(now(), settings.time_zone) |> field.formatter
   elseif field |> typeof == Models.sDateField
-    return field.formater(today())    
+    return field.formatter(today())    
   else
     return nothing
   end

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -11,7 +11,7 @@ struct sIDField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
   generated::Bool  # New field to indicate GENERATED ... AS IDENTITY
   generated_always::Bool # New field to indicate GENERATED ALWAYS AS IDENTITY
 end
@@ -138,7 +138,7 @@ mutable struct sForeignKey <: PormGField
   how::Union{String, Nothing}  # INNER JOIN, LEFT JOIN, RIGHT JOIN, FULL JOIN used in _build_row_join
   related_name::Union{String, Nothing}
   type::String
-  formater::Function
+  formatter::Function
   db_constraint::Bool
   initially_deferred::Bool
 end
@@ -378,7 +378,7 @@ mutable struct sManyToManyField <: PormGField
   source_field::Union{String, Nothing}
   target_field::Union{String, Nothing}
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -454,7 +454,7 @@ mutable struct sOneToOneField <: PormGField
   how::Union{String, Nothing}  # INNER JOIN, LEFT JOIN, RIGHT JOIN, FULL JOIN used in _build_row_join
   related_name::Union{String, Nothing}
   type::String
-  formater::Function
+  formatter::Function
   db_constraint::Bool
   initially_deferred::Bool
 end
@@ -686,7 +686,7 @@ mutable struct sAutoField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -792,7 +792,7 @@ mutable struct sCharField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
   choices::Union{NTuple{N, Tuple{AbstractString, AbstractString}}, Nothing} where N
 end
 
@@ -1055,7 +1055,7 @@ mutable struct sIntegerField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -1180,7 +1180,7 @@ mutable struct sPositiveSmallIntegerField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 # Upper bound of a signed 2-byte integer; matches Django's PositiveSmallIntegerField range (0..32767).
@@ -1289,7 +1289,7 @@ mutable struct sPositiveIntegerField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 # Upper bound of a signed 4-byte integer; matches Django's PositiveIntegerField range (0..2147483647).
@@ -1398,7 +1398,7 @@ mutable struct sBigIntegerField <: PormGField
   default::Union{Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -1532,7 +1532,7 @@ mutable struct sBooleanField <: PormGField
   default::Union{Bool, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 
@@ -1633,7 +1633,7 @@ mutable struct sDateField <: PormGField
   auto_now::Bool
   auto_now_add::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -1781,7 +1781,7 @@ mutable struct sDateTimeField <: PormGField
   auto_now::Bool
   auto_now_add::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -1918,7 +1918,7 @@ mutable struct sDecimalField <: PormGField
   max_digits::Int
   decimal_places::Int
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -2043,7 +2043,7 @@ mutable struct sEmailField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -2146,7 +2146,7 @@ mutable struct sPasswordField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
   max_length::Int  # Length of stored hash (Django uses VARCHAR(128))
   auto_hash::Bool  # Accepted for Django compat; PormG performs no hashing
 end
@@ -2270,7 +2270,7 @@ mutable struct sFloatField <: PormGField
   default::Union{Float64, String, Int64, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -2366,7 +2366,7 @@ mutable struct sImageField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -2512,7 +2512,7 @@ mutable struct sTextField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -2606,7 +2606,7 @@ mutable struct sTimeField <: PormGField
   default::Union{Time, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 function TimeField(; kwargs...)
@@ -2668,7 +2668,7 @@ mutable struct sBinaryField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
   max_length::Union{Int, Nothing}
 end
 
@@ -2745,7 +2745,7 @@ mutable struct sDurationField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 function DurationField(; kwargs...)
@@ -2811,7 +2811,7 @@ mutable struct sUUIDField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
   auto_add::Bool
 end
 
@@ -2919,7 +2919,7 @@ mutable struct sURLField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -3017,7 +3017,7 @@ mutable struct sSlugField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """
@@ -3116,7 +3116,7 @@ mutable struct sJSONField <: PormGField
   default::Union{String, Nothing}
   editable::Bool
   type::String
-  formater::Function
+  formatter::Function
 end
 
 """

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -155,7 +155,7 @@ if ccall(:jl_generating_output, Cint, ()) == 1
       Base.precompile(Tuple{getfield(QB, Symbol("#100#101"))})                    # 0.12 s
     isdefined(QB, Symbol("#9#10")) &&
       Base.precompile(Tuple{getfield(QB, Symbol("#9#10")), QB.SQLTypeQ})          # 0.09 s
-    Base.precompile(Tuple{typeof(QB._get_filter_query), QB.QorObject, QB.InstrucObject})  # 0.11 s
+    Base.precompile(Tuple{typeof(QB._get_filter_query), QB.QorObject, QB.InstructionObject})  # 0.11 s
     Base.precompile(Tuple{typeof(QB.deepcopy), QB.QObject})                       # 0.08 s
     Base.precompile(Tuple{QB.ChainCaller{typeof(QB.order_by!), QB.ObjectHandler}, String, Vararg{String}})  # 0.04 s
     Base.precompile(Tuple{typeof(QB.F), String})                                  # 0.01 s
@@ -163,8 +163,8 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     Base.precompile(Tuple{typeof(QB._get_join_filters), QB.SQLObjectQuery, String})       # 0.005 s
     Base.precompile(Tuple{typeof(QB._get_join_type_override), QB.SQLObjectQuery, String}) # 0.005 s
     # add_parameter! bodyfunction forms (snoop run 2 — 0.05s combined)
-    let fbody = try Base.bodyfunction(which(QB.add_parameter!, (QB.InstrucObject, Int64,))) catch; missing end
-      ismissing(fbody) || precompile(fbody, (Bool, String, Nothing, typeof(QB.add_parameter!), QB.InstrucObject, Int64,))
+    let fbody = try Base.bodyfunction(which(QB.add_parameter!, (QB.InstructionObject, Int64,))) catch; missing end
+      ismissing(fbody) || precompile(fbody, (Bool, String, Nothing, typeof(QB.add_parameter!), QB.InstructionObject, Int64,))
     end
     let fbody = try Base.bodyfunction(which(QB.add_parameter!, (QB.SQLiteParameterizedQuery, Float64,))) catch; missing end
       ismissing(fbody) || precompile(fbody, (Bool, String, Nothing, typeof(QB.add_parameter!), QB.SQLiteParameterizedQuery, Float64,))

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -810,7 +810,7 @@ end
 
 _projection_is_aggregate(v)::Bool =
   v isa SQLTypeField && v.field isa SQLTypeFunction &&
-  hasproperty(v.field, :agregate) && getproperty(v.field, :agregate) === true
+  hasproperty(v.field, :aggregate) && getproperty(v.field, :aggregate) === true
 
 # Soft heads-up: a non-aggregate scalar subquery with no LIMIT may match >1 row and error at the DB.
 function _warn_if_possible_multirow(handler::SQLObjectHandler)
@@ -911,7 +911,7 @@ function _build_exists_query(subquery::SQLObjectHandler, instruc::SQLInstruction
     print(io, "\n")
   end
 
-  if instruction.agregate && !isempty(instruction.group)
+  if instruction.aggregate && !isempty(instruction.group)
     print(io, "GROUP BY ", join(instruction.group, ", "), " \n")
   end
 
@@ -1023,7 +1023,7 @@ function _json_numeric_rhs(value)
 end
 
 # #27: render a comparison against a JSON path lookup (e.g. `payload__driver`). The RHS binds
-# dialect-aware — NOT through the JSON field's formater (which would reject a plain string like
+# dialect-aware — NOT through the JSON field's formatter (which would reject a plain string like
 # "hamilton"):
 #   - PostgreSQL `#>>` always yields TEXT, so equality binds text and `<`/`>` cast the LHS
 #     `::numeric`.
@@ -1094,7 +1094,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
   end
   # #27: comparison against a JSON path lookup (payload__key). Resolving `column` above populated
   # json_lookup_cache; the dedicated branch binds the RHS as plain text (the generic path would run
-  # the JSON formater on the RHS and throw on plain strings) and applies the PG numeric cast for </>.
+  # the JSON formatter on the RHS and throw on plain strings) and applies the PG numeric cast for </>.
   if isa(v.column, SQLTypeField) && v.column._as !== nothing && haskey(instruc.json_lookup_cache, v.column._as)
     return _render_json_lookup_comparison(v, column, instruc)
   end
@@ -1107,14 +1107,14 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     # Case/When and other SQL function expressions as filter RHS
     placeholders = _get_filter_query(v.values, instruc)
     return string(column, " ", v.operator, " ", placeholders)
-  elseif isa(v.column, SQLTypeField) && isa(v.column.field, SQLTypeFunction) && v.column.field.formater !== nothing
+  elseif isa(v.column, SQLTypeField) && isa(v.column.field, SQLTypeFunction) && v.column.field.formatter !== nothing
     @pormg_debug false
-    placeholders = add_parameter!(instruc, v.column.field.formater(v.values))
+    placeholders = add_parameter!(instruc, v.column.field.formatter(v.values))
   elseif isa(v.column, SQLTypeField) && isa(v.column.field, SQLTypeFunction) && haskey(PormGTypeField, v.column.field.function_name)
     placeholders = add_parameter!(instruc, getfield(Models, PormGTypeField[v.column.field.function_name])(v.values))
     # value = getfield(Models, PormGTypeField[v.column.field.function_name])(v.values)
   elseif isa(v.column, SQLTypeFunction) && haskey(PormGTypeField, v.column.function_name)
-    # Function with formater
+    # Function with formatter
     @pormg_debug false
     placeholders = add_parameter!(instruc, getfield(Models, PormGTypeField[v.column.function_name])(v.values))
   elseif isa(v.values, SQLObjectHandler)
@@ -1147,9 +1147,9 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       end
 
       if field_name != "" && haskey(instruc.object.model.fields, field_name)
-        formater = instruc.object.model.fields[field_name].formater
-        p1 = add_parameter!(instruc, formater(v.values[1]))
-        p2 = add_parameter!(instruc, formater(v.values[2]))
+        formatter = instruc.object.model.fields[field_name].formatter
+        p1 = add_parameter!(instruc, formatter(v.values[1]))
+        p2 = add_parameter!(instruc, formatter(v.values[2]))
         return string(column_sql, " BETWEEN ", p1, " AND ", p2)
       else
         p1 = add_parameter!(instruc, v.values[1])
@@ -1161,7 +1161,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       try
         # Determine if this is a LIKE-based operator and which wildcard pattern to use
         is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]
-        placeholders = add_parameter!(instruc, instruc.object.model.fields[v.column.field].formater(v.values), contains=is_like_op, operator=v.operator)
+        placeholders = add_parameter!(instruc, instruc.object.model.fields[v.column.field].formatter(v.values), contains=is_like_op, operator=v.operator)
       catch e
         @pormg_debug false
         if contains(string(e), "The date") && contains(string(e), "is invalid")
@@ -1173,7 +1173,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     elseif haskey(instruc.tab_field_cache, v.column._as) # Check cache first
       @pormg_debug false
       is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]
-      placeholders = add_parameter!(instruc, instruc.tab_field_cache[v.column._as].formater(v.values), contains=is_like_op, operator=v.operator)
+      placeholders = add_parameter!(instruc, instruc.tab_field_cache[v.column._as].formatter(v.values), contains=is_like_op, operator=v.operator)
     elseif isa(v.column, SQLTypeField)
       @pormg_debug false
       is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -31,10 +31,10 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
     if isa(v_copy.field, Union{SQLTypeFunction, SQLTypeF})
       if _is_window_expr(v_copy.field)
         nothing
-      elseif v_copy.field.agregate == false
+      elseif v_copy.field.aggregate == false
         push!(instruc.group, i |> string)
       else
-        instruc.agregate = true
+        instruc.aggregate = true
       end
     elseif isa(v_copy.field, Union{SubqueryObject, ExistsObject})
       # #92: a projected scalar subquery / EXISTS is a per-row expression — neither a groupable
@@ -65,7 +65,7 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
   # #194 for a precise fail-loud guard), so warn on the combination itself. False positive when the
   # correlation column IS grouped — the message says so. `values` holds the originals (the loop deep-
   # copies), so the SubqueryObject/ExistsObject fields are still inspectable here.
-  if instruc.agregate && !isempty(instruc.group) &&
+  if instruc.aggregate && !isempty(instruc.group) &&
      any(v -> v isa SQLTypeField && isa(v.field, Union{SubqueryObject,ExistsObject}), values)
     @warn(_emsg(
       "Subquery/Exists projected alongside a grouped aggregate: if the inner OuterRef column is not " *
@@ -117,7 +117,7 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # referenced directly in ORDER BY. Cached join paths created while resolving CTE join_field
     # entries must reuse their resolved SQL selector instead of quoting the raw lookup string.
     for value in object.values
-      if isa(value, SQLTypeFunction) && value.field.agregate == true
+      if isa(value, SQLTypeFunction) && value.field.aggregate == true
         continue
       end
 
@@ -194,7 +194,7 @@ end
 
 function _resolve_having_filter_value(alias::String, raw_value, instruc::SQLInstruction)
   if haskey(instruc.tab_field_cache, alias)
-    formatted_value = instruc.tab_field_cache[alias].formater(raw_value)
+    formatted_value = instruc.tab_field_cache[alias].formatter(raw_value)
     return _sqlite_preserve_native_parameter(raw_value, formatted_value, instruc)
   end
 
@@ -205,8 +205,8 @@ function _resolve_having_filter_value(alias::String, raw_value, instruc::SQLInst
     if isa(selected_value, SQLTypeField) && isa(selected_value.field, SQLTypeFunction)
       sql_function = selected_value.field
 
-      if sql_function.formater !== nothing
-        formatted_value = sql_function.formater(raw_value)
+      if sql_function.formatter !== nothing
+        formatted_value = sql_function.formatter(raw_value)
         return _sqlite_preserve_native_parameter(raw_value, formatted_value, instruc)
       elseif sql_function.function_name == "AVG"
         formatted_value = Models.format_number_sql(raw_value)
@@ -218,13 +218,13 @@ function _resolve_having_filter_value(alias::String, raw_value, instruc::SQLInst
         formatted_value = Models.format_number_sql(raw_value)
         return _sqlite_preserve_native_parameter(raw_value, formatted_value, instruc)
       elseif sql_function.function_name in ["MAX", "MIN"] && sql_function.column isa String && haskey(instruc.object.model.fields, sql_function.column)
-        formatted_value = instruc.object.model.fields[sql_function.column].formater(raw_value)
+        formatted_value = instruc.object.model.fields[sql_function.column].formatter(raw_value)
         return _sqlite_preserve_native_parameter(raw_value, formatted_value, instruc)
       end
     end
   end
 
-  formatted_value = IntegerField().formater(raw_value)
+  formatted_value = IntegerField().formatter(raw_value)
   return _sqlite_preserve_native_parameter(raw_value, formatted_value, instruc)
 end
 
@@ -400,7 +400,7 @@ function build(object::SQLObject;
   table_alias === nothing && (table_alias = SQLTbAlias())
   parameters === nothing && (parameters = get_parameter(connection))
   @pormg_debug false
-  instruct = InstrucObject(text="",
+  instruct = InstructionObject(text="",
     object=object,
     table_alias=table_alias === nothing ? SQLTbAlias() : table_alias,
     alias=get_alias(table_alias),

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -78,7 +78,7 @@ function delete(objct::SQLObjectHandler;
     ))
   end
 
-  if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.agregate, objct.object.values)
+  if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.aggregate, objct.object.values)
     throw(ArgumentError(
       "Cannot call delete() on a query with group_by() / annotate aggregations. " *
       "GROUP BY collapses rows, making cascade counting and constraint handling " *
@@ -502,7 +502,7 @@ function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::Porm
   pk_field == DIRECT_DELETE_KEY_SENTINEL && throw(ArgumentError("Cannot update field on keyless model $(model.name); define a primary key"))
   _query = keys[:objct]
   parameters = get_parameter(connection)
-  value_sql = value === nothing ? "NULL" : model.fields[field].formater(value)
+  value_sql = value === nothing ? "NULL" : model.fields[field].formatter(value)
   # SET column and outer WHERE key both target the physical column (db_column) — #50.
   sql = "UPDATE $(model.name |> lowercase) SET \"$(Models.model_column(model, field))\" = $(value_sql) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   if show_query !== :execute

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -229,7 +229,7 @@ function query(q::SQLObjectHandler;
     print(io, "\n")
   end
   
-  if instruction.agregate && !isempty(instruction.group)
+  if instruction.aggregate && !isempty(instruction.group)
     print(io, "GROUP BY ")
     for (i, g) in enumerate(instruction.group)
       i > 1 && print(io, ", ")
@@ -366,7 +366,7 @@ function do_count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} =
   body = """FROM $safe_table_name as $safe_alias
     $(join(instruction.join, "\n"))
     $(instruction._where |> length > 0 ? "WHERE" : "") $(join(instruction._where, " AND \n   "))
-    $(instruction.agregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "")
+    $(instruction.aggregate ? "GROUP BY $(join(instruction.group, ", ")) \n" : "")
     """
   if distinct || q.object.distinct
     # COUNT(DISTINCT *) is invalid SQL in both PostgreSQL and SQLite. To count the rows a
@@ -433,7 +433,7 @@ function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAli
     FROM $safe_table_name as $safe_alias
     $(join(instruction.join, "\n"))
     $(isempty(instruction._where) ? "" : "WHERE " * join(instruction._where, " AND \n   "))
-    $(instruction.agregate && !isempty(instruction.group) ? "GROUP BY $(join(instruction.group, ", "))" : "")
+    $(instruction.aggregate && !isempty(instruction.group) ? "GROUP BY $(join(instruction.group, ", "))" : "")
     $limit_clause
     $offset_clause
     """
@@ -485,11 +485,11 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
       if model.fields[field].default !== nothing
         real_obj.insert[field] = model.fields[field].default
       elseif model.fields[field].type == "TIMESTAMPTZ" && (model.fields[field].auto_now_add || model.fields[field].auto_now)
-        real_obj.insert[field] = model.fields[field].formater(now(TimeZone(settings.time_zone)))
+        real_obj.insert[field] = model.fields[field].formatter(now(TimeZone(settings.time_zone)))
       elseif model.fields[field].type == "DATE" && (model.fields[field].auto_now_add || model.fields[field].auto_now)
-        real_obj.insert[field] = model.fields[field].formater(today())
+        real_obj.insert[field] = model.fields[field].formatter(today())
       elseif model.fields[field].type == "UUID" && model.fields[field].auto_add
-        real_obj.insert[field] = model.fields[field].formater(UUIDs.uuid4())
+        real_obj.insert[field] = model.fields[field].formatter(UUIDs.uuid4())
       elseif model.fields[field].null || model.fields[field].primary_key
         continue
       else
@@ -519,7 +519,7 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
   for field in keys(real_obj.insert)
     # Validation checks
     validate_field_data(model, field, real_obj.insert[field], "insert"; allow_primary_key = true)
-    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in create(); use $(model.name).$(field)(source_id).add!(target_id) after creating the source row"))
+    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in create(); use $(model.name).$(field)(source_id).add(target_id) after creating the source row"))
 
     # check if the field is a primary key
     model.fields[field].primary_key && (pk_exist = true; push!(pk_field, field))
@@ -528,7 +528,7 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
     push!(quoted_field_columns, quote_identifier(Models.field_db_column(model.fields[field], field), connection))
 
     # Format and add value to parameters
-    push!(param_values, add_parameter!(parameters, real_obj.insert[field] |> model.fields[field].formater))
+    push!(param_values, add_parameter!(parameters, real_obj.insert[field] |> model.fields[field].formatter))
 
   end
 
@@ -699,7 +699,7 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
       tp = get_parameter(connection)
       set_context!(tp, :where)
       for f in target_fields
-        add_parameter!(tp, real_obj.insert[f] |> model.fields[f].formater)
+        add_parameter!(tp, real_obj.insert[f] |> model.fields[f].formatter)
       end
       tp
     end
@@ -1159,7 +1159,7 @@ function _build_update_target_pk_subquery(instruction::SQLInstruction)::Union{St
     print(io, "\n")
   end
 
-  if instruction.agregate && !isempty(instruction.group)
+  if instruction.aggregate && !isempty(instruction.group)
     print(io, "GROUP BY ")
     for (i, g) in enumerate(instruction.group)
       i > 1 && print(io, ", ")
@@ -1213,7 +1213,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
     ))
   end
 
-  if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.agregate, real_obj.values)
+  if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.aggregate, real_obj.values)
     throw(ArgumentError(
       "Cannot call update() on a query with group_by() / annotate aggregations. " *
       "GROUP BY collapses rows, making the UPDATE target ambiguous. " *
@@ -1233,9 +1233,9 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   for field in fields
     if !haskey(objct.insert, field)
       if model.fields[field].type == "TIMESTAMPTZ" && (model.fields[field].auto_now)
-        objct.insert[field] = model.fields[field].formater(now(TimeZone(settings.time_zone)))
+        objct.insert[field] = model.fields[field].formatter(now(TimeZone(settings.time_zone)))
       elseif model.fields[field].type == "DATE" && (model.fields[field].auto_now)
-        objct.insert[field] = model.fields[field].formater(today())
+        objct.insert[field] = model.fields[field].formatter(today())
       end
     end
   end
@@ -1247,7 +1247,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   for field in keys(objct.insert)    
     # Validation checks
     validate_field_data(model, field, objct.insert[field], "update"; allow_primary_key = false)
-    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add!, remove!, clear!, or set! methods"))
+    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add, remove, clear, or set methods"))
     
     quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)  # db_column (#50)
 
@@ -1255,7 +1255,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
       f_value = _set_update_query(objct.insert[field], instruction)
       push!(set_clause_parts, "$(quoted_field) = $(f_value)")
     else
-      formatted_value = objct.insert[field] |> model.fields[field].formater
+      formatted_value = objct.insert[field] |> model.fields[field].formatter
       placeholder = add_parameter!(parameters, formatted_value)
       push!(set_clause_parts, "$(quoted_field) = $(placeholder)")
     end

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -413,16 +413,16 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       return true, f_meta.default
     elseif f_meta.type == "TIMESTAMPTZ"
       if operation in [:insert, :copy] && (f_meta.auto_now_add || f_meta.auto_now)
-        value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formater(now(TimeZone(settings.time_zone)))
+        value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formatter(now(TimeZone(settings.time_zone)))
         return true, value
       elseif operation == :update && f_meta.auto_now
-        value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formater(now(TimeZone(settings.time_zone)))
+        value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formatter(now(TimeZone(settings.time_zone)))
         return true, value
       end
     elseif f_meta.type == "DATE"
       if operation in [:insert, :copy] && (f_meta.auto_now_add || f_meta.auto_now)
         # NOTE: `today()` is returned as a bare `Date` object without calling
-        # `f_meta.formater` here. The DATE formatter (`format_date_sql`) only
+        # `f_meta.formatter` here. The DATE formatter (`format_date_sql`) only
         # converts Date → String and does not transform the value (no time_zone
         # argument), unlike the TIMESTAMPTZ formatter which returns a ZonedDateTime.
         # Sanitization handles both `Date` objects and date strings correctly, so
@@ -904,7 +904,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
           validate_field_data(model, field, row[mapping[field]], "bulk_insert"; allow_primary_key = true)
         end
 
-        param_placeholders = [add_parameter!(parameters, model.fields[field].formater(row[mapping[field]])) for field in fields_df]
+        param_placeholders = [add_parameter!(parameters, model.fields[field].formatter(row[mapping[field]])) for field in fields_df]
         # param_placeholders = add_parameter!(parameters, values)
       catch e
         _depuration_values_bulk_insert(fields_df, mapping, model, row, index, django_prefix)
@@ -1033,7 +1033,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
           row_index = i + offset - 1
           try
             validate_field_data(model, field, value, "bulk_copy"; allow_primary_key = true)
-            model.fields[field].formater(value)
+            model.fields[field].formatter(value)
           catch e
             throw(ErrorException("Error in bulk_copy, row $(row_index) for model $(model.name) failed validation or formatting: $(e)"))
           end
@@ -1078,7 +1078,7 @@ function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{St
       continue
     end
     try
-      model.fields[field].formater(row[col_name])
+      model.fields[field].formatter(row[col_name])
     catch e
       throw(_argerr("Error in bulk processing, the field \e[4m\e[31m$(field)\e[0m (col: $(col_name)) in row \e[4m\e[31m$(index)\e[0m has a value that can't be formatted: \e[4m\e[31m$(row[col_name])\e[0m"))
     end
@@ -1401,7 +1401,7 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
             validate_field_data(model, field, row[mapping[field]], "bulk_update"; allow_primary_key = false)
         end
 
-        param_placeholders = [add_parameter!(instruction.parameters, model.fields[field].formater(row[mapping[field]])) for field in joined_columns]
+        param_placeholders = [add_parameter!(instruction.parameters, model.fields[field].formatter(row[mapping[field]])) for field in joined_columns]
       catch e
         _depuration_values_bulk_insert(fields_df, mapping, model, row, index, settings.django_prefix !== nothing)
         throw(ErrorException("Error in bulk_update, row $(index) for model $(model.name) failed validation or formatting: $(e)"))

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -1,17 +1,17 @@
 
 """
-  Q(x...)
+    Q(x...)
 
-  Create a `QObject` with the given filters.
-  Ex.:
-  ```julia
-  a = object("tb_user")
-  a.filter(Q("name" => "John", Qor("age" => 18, "age" => 19)))
-  ```
+Create a `QObject` with the given filters.
 
-  Arguments:
-  - `x`: A list of key-value pairs or Qor(x...) or Q(x...) objects.
+# Arguments
+- `x...`: key-value pairs, `Qor(x...)`, or `Q(x...)` objects.
 
+# Example
+```julia
+a = object("tb_user")
+a.filter(Q("name" => "John", Qor("age" => 18, "age" => 19)))
+```
 """
 function Q(x...)
   colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
@@ -20,19 +20,18 @@ end
 
 
 """
-  Qor(x...)
+    Qor(x...)
 
-  Create a `QorObject` from the given arguments. The `QorObject` represents a disjunction of `SQLTypeQ` or `SQLTypeQor` objects.
+Create a `QorObject` from the given arguments. The `QorObject` represents a disjunction of `SQLTypeQ` or `SQLTypeQor` objects.
 
-  Ex.:
-  ```julia
-  a = object("tb_user")
-  a.filter(Qor("name" => "John", Q("age__gte" => 18, "age__lte" => 19)))
-  ```
+# Arguments
+- `x...`: A variable number of arguments. Each argument can be either a `SQLTypeQ` or `SQLTypeQor` object, or a `Pair` object.
 
-  # Arguments
-  - `x...`: A variable number of arguments. Each argument can be either a `SQLTypeQ` or `SQLTypeQor` object, or a `Pair` object.
-
+# Example
+```julia
+a = object("tb_user")
+a.filter(Qor("name" => "John", Q("age__gte" => 18, "age__lte" => 19)))
+```
 """
 function Qor(x...)
   colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
@@ -50,10 +49,10 @@ end
 Computes the sum of all values in the column.
 """
 function Sum(x; distinct::Bool = false)
-  return FObject(function_name = "SUM", column = x, agregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
+  return FObject(function_name = "SUM", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
 end  
 function Avg(x; distinct::Bool = false)
-  return FObject(function_name = "AVG", column = x, agregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
+  return FObject(function_name = "AVG", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
 end
 """
   Count(x; distinct::Bool = false)
@@ -74,13 +73,13 @@ df = query |> DataFrame
 ```
 """
 function Count(x; distinct::Bool = false)
-  return FObject(function_name = "COUNT", column = x, agregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
+  return FObject(function_name = "COUNT", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
 end
 function Max(x)
-  return FObject(function_name = "MAX", column = x, agregate = true)
+  return FObject(function_name = "MAX", column = x, aggregate = true)
 end
 function Min(x)
-  return FObject(function_name = "MIN", column = x, agregate = true)
+  return FObject(function_name = "MIN", column = x, aggregate = true)
 end
 
 function _window_part_vector(value, part_name::String)::Vector{WindowPartitionPart}
@@ -186,14 +185,14 @@ Concat(args...; kwargs...) = Concat(collect(args); kwargs...)
 
 Extracts a component (YEAR, MONTH, DAY, etc.) from a date/time column.
 """
-function Extract(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, part::String; formater::Union{Nothing, Function, PormGField} = nothing)
-  isa(formater, PormGField) && (formater = formater.formater)
-  return FObject(function_name = "EXTRACT", column = x, formater = formater, kwargs = Dict{String, Any}("part" => part))
+function Extract(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, part::String; formatter::Union{Nothing, Function, PormGField} = nothing)
+  isa(formatter, PormGField) && (formatter = formatter.formatter)
+  return FObject(function_name = "EXTRACT", column = x, formatter = formatter, kwargs = Dict{String, Any}("part" => part))
 end
 
-function Extract(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, part::String, format::String; formater::Union{Nothing, Function, PormGField} = nothing)
-  isa(formater, PormGField) && (formater = formater.formater)
-  return FObject(function_name = "EXTRACT", column = x, formater = formater, kwargs = Dict{String, Any}("part" => part, "format" => format))
+function Extract(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, part::String, format::String; formatter::Union{Nothing, Function, PormGField} = nothing)
+  isa(formatter, PormGField) && (formatter = formatter.formatter)
+  return FObject(function_name = "EXTRACT", column = x, formatter = formatter, kwargs = Dict{String, Any}("part" => part, "format" => format))
 end
 # Build a WHEN fragment. When `otherwise` is provided, wrap it in a CASE automatically so
 # When(..., otherwise=x) is a complete standalone expression. When used inside Case([...]),
@@ -228,9 +227,9 @@ function Case(conditions::SQLTypeFunction; default::Any = "NULL", output_field::
   end  
   return FObject(function_name = "CASE", column = conditions, kwargs = Dict{String, Any}("else" => default, "output_field" => output_field)) 
 end
-function To_char(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, format::String; formater::Union{Nothing, Function, PormGField} = nothing)
-  isa(formater, PormGField) && (formater = formater.formater)
-  return FObject(function_name = "EXTRACT_DATE", column = x, formater = formater, kwargs = Dict{String, Any}("format" => format))
+function ToChar(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, format::String; formatter::Union{Nothing, Function, PormGField} = nothing)
+  isa(formatter, PormGField) && (formatter = formatter.formatter)
+  return FObject(function_name = "EXTRACT_DATE", column = x, formatter = formatter, kwargs = Dict{String, Any}("format" => format))
 end
 
 
@@ -299,7 +298,7 @@ end
 Returns the length of a string.
 """
 function Length(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "LENGTH", column = x, formater = Models.format_number_sql)
+  return FObject(function_name = "LENGTH", column = x, formatter = Models.format_number_sql)
 end
 
 """
@@ -308,7 +307,7 @@ end
 Returns the absolute value of a number.
 """
 function Abs(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "ABS", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "ABS", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 """
@@ -317,7 +316,7 @@ end
 Rounds a number to the specified precision.
 """
 function Round(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF}, precision::Integer = 0)
-  return FObject(function_name = "ROUND", column = x, agregate = _is_agg(x), kwargs = Dict{String, Any}("precision" => precision), formater = Models.format_number_sql)
+  return FObject(function_name = "ROUND", column = x, aggregate = _is_agg(x), kwargs = Dict{String, Any}("precision" => precision), formatter = Models.format_number_sql)
 end
 
 """
@@ -376,7 +375,7 @@ end
 Returns the largest integer less than or equal to a number.
 """
 function Floor(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "FLOOR", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "FLOOR", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 """
@@ -385,7 +384,7 @@ end
 Returns the smallest integer greater than or equal to a number.
 """
 function Ceil(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "CEIL", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "CEIL", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 
@@ -396,7 +395,7 @@ end
 Returns the square root of a number.
 """
 function Sqrt(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "SQRT", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "SQRT", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 """
@@ -405,7 +404,7 @@ end
 Returns the exponential value (e^x) of a number.
 """
 function Exp(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "EXP", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "EXP", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 """
@@ -414,7 +413,7 @@ end
 Returns the natural logarithm of a number.
 """
 function Ln(x::Union{String, SQLTypeField, SQLTypeText, SQLTypeFunction, SQLTypeF})
-  return FObject(function_name = "LN", column = x, agregate = _is_agg(x), formater = Models.format_number_sql)
+  return FObject(function_name = "LN", column = x, aggregate = _is_agg(x), formatter = Models.format_number_sql)
 end
 
 """
@@ -423,7 +422,7 @@ end
 Returns `base` raised to the power of `exponent`.
 """
 function Power(x, y)
-  return FObject(function_name = "POWER", column = [isa(x, String) ? SQLField(x) : x, isa(y, String) ? SQLField(y) : y], formater = Models.format_number_sql)
+  return FObject(function_name = "POWER", column = [isa(x, String) ? SQLField(x) : x, isa(y, String) ? SQLField(y) : y], formatter = Models.format_number_sql)
 end
 
 """
@@ -432,15 +431,15 @@ end
 Returns the remainder (modulo) of a division.
 """
 function Mod(x, y)
-  return FObject(function_name = "MOD", column = [isa(x, String) ? SQLField(x) : x, isa(y, String) ? SQLField(y) : y], formater = Models.format_number_sql)
+  return FObject(function_name = "MOD", column = [isa(x, String) ? SQLField(x) : x, isa(y, String) ? SQLField(y) : y], formatter = Models.format_number_sql)
 end
 
 
-MONTH(x) = Extract(x, "MONTH", formater = Models.format_number_sql)
-YEAR(x) = Extract(x, "YEAR", formater = Models.format_number_sql)
-DAY(x) = Extract(x, "DAY", formater = Models.format_number_sql)
-Y_M(x) = To_char(x, "YYYY-MM", formater = Models.format_yyyy_mm)
-DATE(x) = To_char(x, "YYYY-MM-DD", formater = Models.format_date_sql)
+MONTH(x) = Extract(x, "MONTH", formatter = Models.format_number_sql)
+YEAR(x) = Extract(x, "YEAR", formatter = Models.format_number_sql)
+DAY(x) = Extract(x, "DAY", formatter = Models.format_number_sql)
+Y_M(x) = ToChar(x, "YYYY-MM", formatter = Models.format_yyyy_mm)
+DATE(x) = ToChar(x, "YYYY-MM-DD", formatter = Models.format_date_sql)
 # Same that function CAST in django ORM
 # # relatorio = relatorio.annotate(quarter=functions.Concat(functions.Cast(f'{data}__year', CharField()), Value('-Q'), Case(
 # # 					When(**{ f'{data}__month__lte': 4 }, then=Value('1')),

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -61,11 +61,11 @@ function _m2m_settings(manager::ManyToManyManager)
 end
 
 function _m2m_format_owner(manager::ManyToManyManager)
-  return manager.owner_model.fields[manager.relation.owner_pk].formater(manager.owner_id)
+  return manager.owner_model.fields[manager.relation.owner_pk].formatter(manager.owner_id)
 end
 
 function _m2m_format_related(manager::ManyToManyManager, related_id)
-  return manager.related_model.fields[manager.relation.related_pk].formater(related_id)
+  return manager.related_model.fields[manager.relation.related_pk].formatter(related_id)
 end
 
 function _m2m_target_ids(manager::ManyToManyManager, targets)::Vector{Any}
@@ -119,13 +119,13 @@ function _m2m_query(manager::ManyToManyManager)
   return q
 end
 
-function add!(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add!, remove!, clear!, set!) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+function add(manager::ManyToManyManager, targets...)
+  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   target_ids = _m2m_target_ids(manager, targets)
   isempty(target_ids) && return nothing
 
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many add!, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to insert"))
+  !settings.change_data && throw(_argerr("Error in many-to-many add, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to insert"))
 
   table_name = safe_table_identifier(manager.relation.through_model, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
@@ -165,19 +165,19 @@ function add!(manager::ManyToManyManager, targets...)
     sql = "INSERT OR IGNORE INTO $table_name ($owner_column, $related_column) VALUES $(join(groups, ", "));"
     fetch(settings, sql, parameters)
   else
-    throw(ArgumentError("Unsupported connection type $(typeof(connection)) for many-to-many add!"))
+    throw(ArgumentError("Unsupported connection type $(typeof(connection)) for many-to-many add"))
   end
 
   return nothing
 end
 
-function remove!(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add!, remove!, clear!, set!) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+function remove(manager::ManyToManyManager, targets...)
+  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   target_ids = _m2m_target_ids(manager, targets)
   isempty(target_ids) && return nothing
 
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many remove!, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
+  !settings.change_data && throw(_argerr("Error in many-to-many remove, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
 
   table_name = safe_table_identifier(manager.relation.through_model, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
@@ -199,10 +199,10 @@ function remove!(manager::ManyToManyManager, targets...)
   return nothing
 end
 
-function clear!(manager::ManyToManyManager)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add!, remove!, clear!, set!) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+function clear(manager::ManyToManyManager)
+  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many clear!, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
+  !settings.change_data && throw(_argerr("Error in many-to-many clear, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
 
   parameters = get_parameter(connection)
   set_context!(parameters, :where)
@@ -227,8 +227,8 @@ function _m2m_current_ids(manager::ManyToManyManager)::Vector{Any}
   return Any[row[Symbol(manager.relation.related_column)] for row in DataFrames.eachrow(df)]
 end
 
-function set!(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add!, remove!, clear!, set!) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+function set(manager::ManyToManyManager, targets...)
+  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   desired_ids = Set(_m2m_target_ids(manager, targets))
   settings, _, _ = _m2m_settings(manager)
 
@@ -237,8 +237,8 @@ function set!(manager::ManyToManyManager, targets...)
     to_remove = collect(setdiff(current_ids, desired_ids))
     to_add = collect(setdiff(desired_ids, current_ids))
 
-    !isempty(to_remove) && remove!(manager, to_remove)
-    !isempty(to_add) && add!(manager, to_add)
+    !isempty(to_remove) && remove(manager, to_remove)
+    !isempty(to_add) && add(manager, to_add)
     return (added=length(to_add), removed=length(to_remove))
   end
 end
@@ -246,14 +246,14 @@ end
 function Base.getproperty(manager::ManyToManyManager, sym::Symbol)
   if sym === :all
     return () -> _m2m_query(manager)
-  elseif sym === :add!
-    return (targets...) -> add!(manager, targets...)
-  elseif sym === :remove!
-    return (targets...) -> remove!(manager, targets...)
-  elseif sym === :clear!
-    return () -> clear!(manager)
-  elseif sym === :set!
-    return (targets...) -> set!(manager, targets...)
+  elseif sym === :add
+    return (targets...) -> add(manager, targets...)
+  elseif sym === :remove
+    return (targets...) -> remove(manager, targets...)
+  elseif sym === :clear
+    return () -> clear(manager)
+  elseif sym === :set
+    return (targets...) -> set(manager, targets...)
   else
     return getfield(manager, sym)
   end

--- a/src/querybuilder/sanitization.jl
+++ b/src/querybuilder/sanitization.jl
@@ -351,7 +351,7 @@ end
 
 function validate_field_data(model::PormGModel, field::String, value::Any, operation::String; allow_primary_key::Bool = true)
     if haskey(model.fields, field) && Models.is_many_to_many_field(model.fields[field])
-        _validation_error(operation, model, field, "many-to-many relations are not physical columns"; suggestion="use the many-to-many manager add!, remove!, clear!, or set! methods")
+        _validation_error(operation, model, field, "many-to-many relations are not physical columns"; suggestion="use the many-to-many manager add, remove, clear, or set methods")
     end
 
     # 1. Field existence

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -68,7 +68,7 @@ end
 #
 # SQLInstruction Objects (instructions to build a query)
 #
-@kwdef mutable struct InstrucObject <: SQLInstruction
+@kwdef mutable struct InstructionObject <: SQLInstruction
   text::String # text to be used in the query
   table_alias::SQLTableAlias
   alias::String
@@ -76,7 +76,7 @@ end
   select::Vector{SQLTypeField} = Array{SQLTypeField,1}(undef, 60)
   join::Vector{String} = []  # values to be used in join query
   _where::Vector{String} = []  # values to be used in where query
-  agregate::Bool = false
+  aggregate::Bool = false
   group::Vector{String} = []  # values to be used in group query
   having::Vector{String} = [] # values to be used in having query
   order::Vector{String} = [] # values to be used in order query  
@@ -87,7 +87,7 @@ end
   tab_field_cache::Dict{String,PormGField} = sizehint!(Dict{String,PormGField}(), 12) # cache to be used in join query
   # #27: records each resolved JSON-lookup path (e.g. "payload__driver") → (JSON base field,
   # validated key segments). Set when the JSON-path gate renders an extraction; read by the
-  # filter-render branch to bind the RHS as plain text (not through the JSON formater) and to
+  # filter-render branch to bind the RHS as plain text (not through the JSON formatter) and to
   # reject containment operators on a nested key path.
   json_lookup_cache::Dict{String,Tuple{PormGField,Vector{String}}} = Dict{String,Tuple{PormGField,Vector{String}}}()
   connection::ConnType = nothing
@@ -435,7 +435,7 @@ query.values("price", "discounted_price" => F("price") * 0.9)
   operand::Union{String,Integer,Float64,SQLTypeF,SQLTypeFunction,Dates.Period,Dates.CompoundPeriod,Interval,Nothing} = nothing
   function_name::String = "F"
   column::Union{String,SQLTypeField,Vector{String}} = ""
-  agregate::Bool = false
+  aggregate::Bool = false
   _as::OptionalString = nothing
   kwargs::Dict{String,Any} = Dict{String,Any}()
 end
@@ -456,7 +456,7 @@ function Base.deepcopy(f::FExpression)
       operand=deepcopy(f.operand),
       function_name=f.function_name,
       column=deepcopy(f.column),
-      agregate=f.agregate,
+      aggregate=f.aggregate,
       _as=f._as,
       kwargs=deepcopy(f.kwargs)
     )
@@ -468,8 +468,8 @@ end
 
 # Arithmetic operations for F expressions
 # Aggregate propagation helper: result is aggregate if any operand is aggregate
-_is_agg(f::FExpression) = f.agregate
-_is_agg(f::SQLTypeFunction) = f.agregate
+_is_agg(f::FExpression) = f.aggregate
+_is_agg(f::SQLTypeFunction) = f.aggregate
 _is_agg(::Any) = false
 
 function Base.:+(f::FExpression, operand::Union{Integer,Float64,String,FExpression,SQLTypeFunction})
@@ -479,7 +479,7 @@ function Base.:+(f::FExpression, operand::Union{Integer,Float64,String,FExpressi
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate || _is_agg(operand)
+    aggregate=f.aggregate || _is_agg(operand)
   )
 end
 
@@ -490,7 +490,7 @@ function Base.:-(f::FExpression, operand::Union{Integer,Float64,String,FExpressi
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate || _is_agg(operand)
+    aggregate=f.aggregate || _is_agg(operand)
   )
 end
 
@@ -501,7 +501,7 @@ function Base.:*(f::FExpression, operand::Union{Integer,Float64,String,FExpressi
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate || _is_agg(operand)
+    aggregate=f.aggregate || _is_agg(operand)
   )
 end
 
@@ -512,7 +512,7 @@ function Base.:/(f::FExpression, operand::Union{Integer,Float64,String,FExpressi
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate || _is_agg(operand)
+    aggregate=f.aggregate || _is_agg(operand)
   )
 end
 
@@ -520,7 +520,7 @@ end
 # + (Month(1) + Day(15)), + Interval("01:30:00"), etc. Only + and - are meaningful — multiplying
 # or dividing a date field by a duration is nonsense (`Day(30) * 2` is resolved by Julia's own
 # Period arithmetic before it ever reaches an FExpression). A duration is never an aggregate, so
-# `agregate` propagates from `f` unchanged.
+# `aggregate` propagates from `f` unchanged.
 function Base.:+(f::FExpression, operand::_DurationOperand)
   return FExpression(
     field_name=f.operation === nothing ? f.field_name : f,
@@ -528,7 +528,7 @@ function Base.:+(f::FExpression, operand::_DurationOperand)
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate
+    aggregate=f.aggregate
   )
 end
 
@@ -539,7 +539,7 @@ function Base.:-(f::FExpression, operand::_DurationOperand)
     operand=operand,
     function_name="F",
     column=f.operation === nothing ? (f.field_name isa String ? f.field_name : "") : "",
-    agregate=f.agregate
+    aggregate=f.aggregate
   )
 end
 
@@ -554,7 +554,7 @@ function Base.:(==)(f::FExpression, operand::Union{Integer,Float64,String,Dates.
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation="=", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation="=", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 function Base.:(!=)(f::FExpression, operand::Union{Integer,Float64,String,Dates.Date,Dates.DateTime,FExpression})
@@ -563,7 +563,7 @@ function Base.:(!=)(f::FExpression, operand::Union{Integer,Float64,String,Dates.
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation="!=", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation="!=", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 function Base.:>(f::FExpression, operand::Union{Integer,Float64,String,Dates.Date,Dates.DateTime,FExpression})
@@ -572,7 +572,7 @@ function Base.:>(f::FExpression, operand::Union{Integer,Float64,String,Dates.Dat
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation=">", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation=">", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 
@@ -582,7 +582,7 @@ function Base.:<(f::FExpression, operand::Union{Integer,Float64,String,Dates.Dat
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation="<", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation="<", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 
@@ -592,7 +592,7 @@ function Base.:>=(f::FExpression, operand::Union{Integer,Float64,String,Dates.Da
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation=">=", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation=">=", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 
@@ -602,7 +602,7 @@ function Base.:<=(f::FExpression, operand::Union{Integer,Float64,String,Dates.Da
     f.operand = operand
     return f
   else
-    return FExpression(field_name=f, operation="<=", operand=operand, function_name="F", column="", agregate=f.agregate)
+    return FExpression(field_name=f, operation="<=", operand=operand, function_name="F", column="", aggregate=f.aggregate)
   end
 end
 # function Base.:>(f::FExpression, operand::Union{Integer, Float64, String, Dates.Date, Dates.DateTime, FExpression})
@@ -629,7 +629,7 @@ function Base.:+(operand::Union{Integer,Float64}, f::FExpression)
     operand=operand,
     function_name="F",
     column=f.field_name,
-    agregate=f.agregate
+    aggregate=f.aggregate
   )
 end
 
@@ -640,7 +640,7 @@ function Base.:*(operand::Union{Integer,Float64}, f::FExpression)
     operand=operand,
     function_name="F",
     column=f.field_name,
-    agregate=f.agregate
+    aggregate=f.aggregate
   )
 end
 
@@ -661,8 +661,8 @@ Base.deepcopy(x::OuterRefObject) = OuterRefObject(field_name=x.field_name)
 @kwdef mutable struct FObject <: SQLTypeFunction
   function_name::String
   column::Union{String,SQLTypeField,SQLTypeText,N,Vector{N},Vector{T},SQLTypeOper,SQLTypeQ,SQLTypeQor,SQLTypeF} where {N<:SQLTypeFunction,T}
-  agregate::Bool = false
-  formater::Union{Nothing,Function} = nothing # function to format the value
+  aggregate::Bool = false
+  formatter::Union{Nothing,Function} = nothing # function to format the value
   _as::OptionalString = nothing
   kwargs::Dict{String,Any} = Dict{String,Any}()
 end
@@ -670,8 +670,8 @@ function Base.deepcopy(f::FObject)
   return FObject(
     function_name=f.function_name,
     column=deepcopy(f.column),
-    agregate=f.agregate,
-    formater=f.formater,
+    aggregate=f.aggregate,
+    formatter=f.formatter,
     _as=f._as,
     kwargs=deepcopy(f.kwargs)
   )
@@ -694,8 +694,8 @@ end
   function_name::String
   column::WindowColumnPart = nothing
   over::WindowSpec
-  agregate::Bool = false
-  formater::Union{Nothing,Function} = nothing
+  aggregate::Bool = false
+  formatter::Union{Nothing,Function} = nothing
   _as::OptionalString = nothing
   kwargs::Dict{String,Any} = Dict{String,Any}()
 end
@@ -704,8 +704,8 @@ function Base.deepcopy(f::WindowFunction)
     function_name=f.function_name,
     column=deepcopy(f.column),
     over=deepcopy(f.over),
-    agregate=f.agregate,
-    formater=f.formater,
+    aggregate=f.aggregate,
+    formatter=f.formatter,
     _as=f._as,
     kwargs=deepcopy(f.kwargs)
   )
@@ -719,49 +719,49 @@ _is_window_expr(values::Vector) = any(_is_window_expr, values)
 _is_window_expr(::Any) = false
 
 function Base.:+(f::WindowFunction, operand::Union{Integer,Float64,String,FExpression,SQLTypeFunction})
-  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", agregate=_is_agg(operand))
+  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", aggregate=_is_agg(operand))
 end
 function Base.:-(f::WindowFunction, operand::Union{Integer,Float64,String,FExpression,SQLTypeFunction})
-  return FExpression(field_name=f, operation="-", operand=operand, function_name="F", column="", agregate=_is_agg(operand))
+  return FExpression(field_name=f, operation="-", operand=operand, function_name="F", column="", aggregate=_is_agg(operand))
 end
 function Base.:*(f::WindowFunction, operand::Union{Integer,Float64,String,FExpression,SQLTypeFunction})
-  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", agregate=_is_agg(operand))
+  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", aggregate=_is_agg(operand))
 end
 function Base.:/(f::WindowFunction, operand::Union{Integer,Float64,String,FExpression,SQLTypeFunction})
-  return FExpression(field_name=f, operation="/", operand=operand, function_name="F", column="", agregate=_is_agg(operand))
+  return FExpression(field_name=f, operation="/", operand=operand, function_name="F", column="", aggregate=_is_agg(operand))
 end
 
 function Base.:+(operand::Union{Integer,Float64}, f::WindowFunction)
-  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", agregate=false)
+  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", aggregate=false)
 end
 
 function Base.:*(operand::Union{Integer,Float64}, f::WindowFunction)
-  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", agregate=false)
+  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", aggregate=false)
 end
 
 # Arithmetic operations for FObject (aggregate functions like Sum, Count, Avg)
 # Enable expressions like Sum("points") / Count("resultid")
 function Base.:+(f::FObject, operand::Union{Integer,Float64,String,FExpression,FObject})
-  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", agregate=f.agregate || _is_agg(operand))
+  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", aggregate=f.aggregate || _is_agg(operand))
 end
 function Base.:-(f::FObject, operand::Union{Integer,Float64,String,FExpression,FObject})
-  return FExpression(field_name=f, operation="-", operand=operand, function_name="F", column="", agregate=f.agregate || _is_agg(operand))
+  return FExpression(field_name=f, operation="-", operand=operand, function_name="F", column="", aggregate=f.aggregate || _is_agg(operand))
 end
 function Base.:*(f::FObject, operand::Union{Integer,Float64,String,FExpression,FObject})
-  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", agregate=f.agregate || _is_agg(operand))
+  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", aggregate=f.aggregate || _is_agg(operand))
 end
 function Base.:/(f::FObject, operand::Union{Integer,Float64,String,FExpression,FObject})
-  return FExpression(field_name=f, operation="/", operand=operand, function_name="F", column="", agregate=f.agregate || _is_agg(operand))
+  return FExpression(field_name=f, operation="/", operand=operand, function_name="F", column="", aggregate=f.aggregate || _is_agg(operand))
 end
 
 
 # Commutative: scalar op FObject
 function Base.:+(operand::Union{Integer,Float64}, f::FObject)
-  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", agregate=f.agregate)
+  return FExpression(field_name=f, operation="+", operand=operand, function_name="F", column="", aggregate=f.aggregate)
 end
 
 function Base.:*(operand::Union{Integer,Float64}, f::FObject)
-  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", agregate=f.agregate)
+  return FExpression(field_name=f, operation="*", operand=operand, function_name="F", column="", aggregate=f.aggregate)
 end
 
 
@@ -771,7 +771,7 @@ end
 const BitwiseExpression = Union{FExpression,WindowFunction,FObject}
 const BitwiseOperand = Union{Integer,FExpression,WindowFunction,FObject}
 
-_bitwise_is_agg(f::BitwiseExpression) = f.agregate
+_bitwise_is_agg(f::BitwiseExpression) = f.aggregate
 _bitwise_is_agg(::Integer) = false
 
 function _build_bitwise_expr(left, op::String, right)
@@ -781,7 +781,7 @@ function _build_bitwise_expr(left, op::String, right)
     operand=right,
     function_name="F",
     column=left isa FExpression && left.operation === nothing ? (left.field_name isa String ? left.field_name : "") : "",
-    agregate=_bitwise_is_agg(left) || _bitwise_is_agg(right)
+    aggregate=_bitwise_is_agg(left) || _bitwise_is_agg(right)
   )
 end
 
@@ -792,7 +792,7 @@ function _build_bitwise_unary(expr, op::String)
     operand=nothing,
     function_name="F",
     column="",
-    agregate=_bitwise_is_agg(expr)
+    aggregate=_bitwise_is_agg(expr)
   )
 end
 
@@ -825,7 +825,7 @@ function Base.:<<(a::Integer, b::BitwiseExpression)
     operand=b,
     function_name="F",
     column="",
-    agregate=_bitwise_is_agg(b)
+    aggregate=_bitwise_is_agg(b)
   )
 end
 
@@ -839,7 +839,7 @@ function Base.:>>(a::Integer, b::BitwiseExpression)
     operand=b,
     function_name="F",
     column="",
-    agregate=_bitwise_is_agg(b)
+    aggregate=_bitwise_is_agg(b)
   )
 end
 

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -256,7 +256,7 @@ end
 end
 
 # #64: an M2M where BOTH participating models' PKs are renamed via db_column. The through-table
-# join must target the physical PK columns ("driver_pk"/"sponsor_pk"). `add!` writes the through
+# join must target the physical PK columns ("driver_pk"/"sponsor_pk"). `add` writes the through
 # table regardless of the fix (it uses through-table columns), so the discriminator is the READ:
 # forward/reverse filters join on the parent PK columns and would target a non-existent "code"
 # column without the fix.
@@ -269,7 +269,7 @@ end
         driver_x  = M.M2m_rpk_driver_scratch.objects.create("driverref" => "ham44")
 
         manager = M.M2m_rpk_driver_scratch.sponsors(driver_x)
-        @test manager.add!(sponsor_a, sponsor_b) === nothing
+        @test manager.add(sponsor_a, sponsor_b) === nothing
         @test length(manager.all().list()) == 2            # all() routes through the fixed join
 
         # Forward: driver → sponsors (through-join on "driver_pk", related-join on "sponsor_pk").

--- a/test/integration/test_having.jl
+++ b/test/integration/test_having.jl
@@ -130,7 +130,7 @@ end
     @testset "HAVING with Aggregate Arithmetic (Sum/Count)" begin
         # Logic: Find constructors where (Sum of points / Count of results) > 5.
         # Why: Validates that FObject arithmetic (Sum / Count) produces a valid
-        # FExpression with agregate=true, correctly promoted to HAVING.
+        # FExpression with aggregate=true, correctly promoted to HAVING.
 
         q = M.Result.objects.values(
             "constructorid__name",

--- a/test/integration/test_internals.jl
+++ b/test/integration/test_internals.jl
@@ -106,7 +106,7 @@ end
   query.filter("date" => test_date)
   instruc = PormG.QueryBuilder.build(query.object)
 
-  # The formater should have converted Date to String for the DB driver if needed,
+  # The formatter should have converted Date to String for the DB driver if needed,
   # or kept it as Date if the driver handles it. Check ISO-like output.
   @test string(instruc.parameters.parameters[1]) == "2023-10-22"
 

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -6,16 +6,16 @@ Exercises ManyToManyField end-to-end against the selected integration database
 
   • Auto-generated through table is created during migration bootstrap
     (see test_migration_bootstrap.jl Phase B).
-  • ManyToManyManager `add!`, `remove!`, `clear!`, `set!` against the
+  • ManyToManyManager `add`, `remove`, `clear`, `set` against the
     through table with parameterized SQL on both backends.
   • Forward-direction filter traversal (`endorsement.sponsors__name`).
   • Reverse-direction filter traversal (`sponsor.drivers__driverref`)
     using the `related_name="drivers"` declared on the field.
   • `manager.all()` returning a fluent query restricted to the related rows.
-  • Empty/no-op mutators, `set!` rollback on FK failure, parent-delete cascade,
+  • Empty/no-op mutators, `set` rollback on FK failure, parent-delete cascade,
     and explicit through tables without extra fields.
   • Query surface: `__@in`, `__@nin`, `Q`/`Qor`, `distinct`, `count`/`exists` on
-    `manager.all()`, vector `remove!`, default reverse accessor, short multi-hop reverse.
+    `manager.all()`, vector `remove`, default reverse accessor, short multi-hop reverse.
 
 Run with:
   julia -t auto --project=. test/integration/runtests.jl
@@ -87,18 +87,18 @@ _ensure_m2m_scratch_schema!()
     @test sponsor_a[:id] isa Integer
     @test driver_x[:id] isa Integer
 
-    # --- ManyToManyManager.add! ----------------------------------------------
+    # --- ManyToManyManager.add ----------------------------------------------
     manager_x = M.M2m_driver_endorsement_scratch.sponsors(driver_x)
     manager_y = M.M2m_driver_endorsement_scratch.sponsors(driver_y)
 
-    @test manager_x.add!(sponsor_a, sponsor_b) === nothing
+    @test manager_x.add(sponsor_a, sponsor_b) === nothing
     # Re-adding the same pair must be idempotent (PostgreSQL: WHERE NOT EXISTS; SQLite: INSERT OR IGNORE).
-    @test manager_x.add!(sponsor_a) === nothing
+    @test manager_x.add(sponsor_a) === nothing
     listed_x = manager_x.all().list()
     @test length(listed_x) == 2
     @test Set([row[:name] for row in listed_x]) == Set(["Petrolux", "AeroFuel"])
 
-    @test manager_y.add!([sponsor_b, sponsor_c]) === nothing
+    @test manager_y.add([sponsor_b, sponsor_c]) === nothing
     @test length(manager_y.all().list()) == 2
 
     # --- Forward filter traversal --------------------------------------------
@@ -116,37 +116,37 @@ _ensure_m2m_scratch_schema!()
     reverse_rows = reverse_q.list()
     @test Set([row[:name] for row in reverse_rows]) == Set(["AeroFuel", "Stratostream"])
 
-    # --- ManyToManyManager.remove! -------------------------------------------
-    @test manager_x.remove!(sponsor_a) === nothing
+    # --- ManyToManyManager.remove -------------------------------------------
+    @test manager_x.remove(sponsor_a) === nothing
     remaining_x = manager_x.all().list()
     @test length(remaining_x) == 1
     @test remaining_x[1][:name] == "AeroFuel"
 
     # Removing an entry that no longer exists must be a no-op (no SQL error).
-    @test manager_x.remove!(sponsor_a) === nothing   # returns nothing
+    @test manager_x.remove(sponsor_a) === nothing   # returns nothing
 
-    # --- ManyToManyManager.set! ----------------------------------------------
-    diff = manager_x.set!(sponsor_b, sponsor_c)
+    # --- ManyToManyManager.set ----------------------------------------------
+    diff = manager_x.set(sponsor_b, sponsor_c)
     @test diff.added == 1            # sponsor_c added
     @test diff.removed == 0
     after_set = Set([row[:name] for row in manager_x.all().list()])
     @test after_set == Set(["AeroFuel", "Stratostream"])
 
     new_team = M.M2m_sponsor_scratch.objects.create("name" => "NewTeam")
-    diff_partial = manager_x.set!(sponsor_c, new_team)
+    diff_partial = manager_x.set(sponsor_c, new_team)
     @test diff_partial.removed == 1
     @test diff_partial.added == 1
     final_set = Set([row[:name] for row in manager_x.all().list()])
     @test final_set == Set(["Stratostream", "NewTeam"])
 
-    # set! to an empty target list removes everything.
-    diff_empty = manager_x.set!(Any[])
+    # set to an empty target list removes everything.
+    diff_empty = manager_x.set(Any[])
     @test diff_empty.removed == 2
     @test diff_empty.added == 0
     @test isempty(manager_x.all().list())
 
-    # --- ManyToManyManager.clear! --------------------------------------------
-    @test manager_y.clear!() === nothing
+    # --- ManyToManyManager.clear --------------------------------------------
+    @test manager_y.clear() === nothing
     @test isempty(manager_y.all().list())
 
     # Final cleanup so subsequent test files start from a known-empty M2M state.
@@ -169,8 +169,8 @@ end
     driver_a = M.M2m_driver_multi_hop_scratch.objects.create("driverref" => "lec")
     driver_b = M.M2m_driver_multi_hop_scratch.objects.create("driverref" => "massa")
 
-    M.M2m_driver_multi_hop_scratch.sponsors(driver_a).add!(ferrari)
-    M.M2m_driver_multi_hop_scratch.sponsors(driver_b).add!(petrobras)
+    M.M2m_driver_multi_hop_scratch.sponsors(driver_a).add(ferrari)
+    M.M2m_driver_multi_hop_scratch.sponsors(driver_b).add(petrobras)
 
     # Multi-hop filter: Driver -> Sponsor -> Country
     q = M.M2m_driver_multi_hop_scratch.objects
@@ -206,17 +206,17 @@ end
     team_a = M.M2m_team_scratch.objects.create("name" => "Renault")
     team_b = M.M2m_team_scratch.objects.create("name" => "McLaren")
 
-    # When using explicit through, we can still use add! if the through model
+    # When using explicit through, we can still use add if the through model
     # only has the two foreign keys, OR we can use direct objects.
     # Here we verify that the ManyToManyManager still works with explicit through.
     manager = M.M2m_driver_explicit_scratch.teams(driver)
     
     # Since the explicit through model has an extra field (`joined_year`),
-    # all direct mutators (add!, remove!, clear!, set!) must raise an ArgumentError (Django behavior).
-    @test_throws ArgumentError manager.add!(team_a)
-    @test_throws ArgumentError manager.remove!(team_a)
-    @test_throws ArgumentError manager.clear!()
-    @test_throws ArgumentError manager.set!(team_a)
+    # all direct mutators (add, remove, clear, set) must raise an ArgumentError (Django behavior).
+    @test_throws ArgumentError manager.add(team_a)
+    @test_throws ArgumentError manager.remove(team_a)
+    @test_throws ArgumentError manager.clear()
+    @test_throws ArgumentError manager.set(team_a)
     
     # Instead, we create the intermediate record directly using the objects manager:
     M.M2m_membership_scratch.objects.create("driver" => driver[:id], "team" => team_a[:id])
@@ -245,13 +245,13 @@ end
 
     # Test Raw ID support
     manager = M.M2m_driver_endorsement_scratch.sponsors(driver[:id])
-    manager.add!(sponsor_a[:id], sponsor_b[:id])
+    manager.add(sponsor_a[:id], sponsor_b[:id])
     @test length(manager.all().list()) == 2
 
     # Test Transaction Rollback
     err = try
         PormG.run_in_transaction(PORMG_DB_FOLDER) do
-            manager.clear!()
+            manager.clear()
             @test isempty(manager.all().list())
             throw(ErrorException("Simulated Failure"))
         end
@@ -276,14 +276,14 @@ end
     driver = M.M2m_driver_endorsement_scratch.objects.create("driverref" => "noop1")
 
     manager = M.M2m_driver_endorsement_scratch.sponsors(driver)
-    manager.add!(sponsor_a, sponsor_b)
+    manager.add(sponsor_a, sponsor_b)
     before = Set([row[:name] for row in manager.all().list()])
 
-    @test manager.add!() === nothing   # empty-args: consistent Nothing return
-    @test manager.remove!() === nothing
+    @test manager.add() === nothing   # empty-args: consistent Nothing return
+    @test manager.remove() === nothing
     @test Set([row[:name] for row in manager.all().list()]) == before
 
-    diff_noop = manager.set!(sponsor_a, sponsor_b)
+    diff_noop = manager.set(sponsor_a, sponsor_b)
     @test diff_noop.added == 0
     @test diff_noop.removed == 0
     @test Set([row[:name] for row in manager.all().list()]) == before
@@ -292,7 +292,7 @@ end
     M.M2m_sponsor_scratch.objects.delete(allow_delete_all=true)
 end
 
-@testset "Many-to-Many: set! rolls back on failure" begin
+@testset "Many-to-Many: set rolls back on failure" begin
     M.M2m_driver_endorsement_scratch.objects.delete(allow_delete_all=true)
     M.M2m_sponsor_scratch.objects.delete(allow_delete_all=true)
 
@@ -302,16 +302,16 @@ end
     driver = M.M2m_driver_endorsement_scratch.objects.create("driverref" => "rb1")
 
     manager = M.M2m_driver_endorsement_scratch.sponsors(driver)
-    manager.add!(sponsor_a, sponsor_b, sponsor_c)
+    manager.add(sponsor_a, sponsor_b, sponsor_c)
     expected = Set(["RollbackA", "RollbackB", "RollbackC"])
 
-    # Force remove! to fail inside set!'s run_in_transaction (SQLite does not enforce
+    # Force remove to fail inside set's run_in_transaction (SQLite does not enforce
     # FK at runtime unless PRAGMA foreign_keys=ON, so bogus IDs are not reliable).
     orig_change_data = PormG.config[PORMG_DB_FOLDER].change_data
     try
         PormG.config[PORMG_DB_FOLDER].change_data = false
         err = try
-            manager.set!(sponsor_a, sponsor_b)
+            manager.set(sponsor_a, sponsor_b)
             nothing
         catch e
             e
@@ -337,7 +337,7 @@ end
     # Auto-generated through table (FK ON DELETE CASCADE on both sides).
     sponsor = M.M2m_sponsor_scratch.objects.create("name" => "CascadeSponsor")
     driver = M.M2m_driver_endorsement_scratch.objects.create("driverref" => "cascade_auto")
-    M.M2m_driver_endorsement_scratch.sponsors(driver).add!(sponsor)
+    M.M2m_driver_endorsement_scratch.sponsors(driver).add(sponsor)
     @test length(M.M2m_sponsor_scratch.drivers(sponsor).all().list()) == 1
 
     M.M2m_driver_endorsement_scratch.objects.filter("id" => driver[:id]).delete()
@@ -369,10 +369,10 @@ end
     team_b = M.M2m_team_plain_scratch.objects.create("name" => "PlainB")
 
     manager = M.M2m_driver_plain_scratch.teams(driver)
-    @test manager.add!(team_a, team_b) === nothing
+    @test manager.add(team_a, team_b) === nothing
     @test Set([row[:name] for row in manager.all().list()]) == Set(["PlainA", "PlainB"])
 
-    diff = manager.set!(team_b)
+    diff = manager.set(team_b)
     @test diff.added == 0
     @test diff.removed == 1
     @test Set([row[:name] for row in manager.all().list()]) == Set(["PlainB"])
@@ -401,14 +401,14 @@ end
     ham_mgr = M.M2m_driver_endorsement_scratch.sponsors(ham)
     ver_mgr = M.M2m_driver_endorsement_scratch.sponsors(ver)
     rus_mgr = M.M2m_driver_endorsement_scratch.sponsors(rus)
-    ham_mgr.add!(petrolux, aerofuel)
-    ver_mgr.add!(stratostream)
-    rus_mgr.add!(petrolux)
+    ham_mgr.add(petrolux, aerofuel)
+    ver_mgr.add(stratostream)
+    rus_mgr.add(petrolux)
 
-    # Vector remove!
-    @test ham_mgr.remove!([petrolux, aerofuel]) === nothing
+    # Vector remove
+    @test ham_mgr.remove([petrolux, aerofuel]) === nothing
     @test isempty(ham_mgr.all().list())
-    ham_mgr.add!(petrolux, aerofuel)
+    ham_mgr.add(petrolux, aerofuel)
 
     # manager.all() terminals
     @test ham_mgr.all().count() == 2
@@ -456,7 +456,7 @@ end
     brand_b = M.M2m_brand_scratch.objects.create("name" => "FutureBrand")
     default_driver = M.M2m_driver_default_reverse_scratch.objects.create("driverref" => "def_rev1")
     default_mgr = M.M2m_driver_default_reverse_scratch.partners(default_driver)
-    default_mgr.add!(brand_a, brand_b)
+    default_mgr.add(brand_a, brand_b)
 
     reverse_default_q = M.M2m_brand_scratch.objects
     reverse_default_q.filter("m2m_driver_default_reverse_scratch__driverref" => "def_rev1")
@@ -486,10 +486,10 @@ end
 
         PormG.config[PORMG_DB_FOLDER].change_data = false
         try
-            @test_throws ArgumentError readonly_manager.add!(1)
-            @test_throws ArgumentError readonly_manager.remove!(1)
-            @test_throws ArgumentError readonly_manager.clear!()
-            @test_throws ArgumentError readonly_manager.set!([1])
+            @test_throws ArgumentError readonly_manager.add(1)
+            @test_throws ArgumentError readonly_manager.remove(1)
+            @test_throws ArgumentError readonly_manager.clear()
+            @test_throws ArgumentError readonly_manager.set([1])
         finally
             PormG.config[PORMG_DB_FOLDER].change_data = orig_change_data
         end

--- a/test/integration/test_row_and_get.jl
+++ b/test/integration/test_row_and_get.jl
@@ -93,7 +93,7 @@ end
         sponsor_row = M.M2m_sponsor_scratch.objects.get("id" => sponsor[:id])
 
         @test manager.all() isa PormG.QueryBuilder.ObjectHandler
-        @test manager.add!(sponsor_row) === nothing
+        @test manager.add(sponsor_row) === nothing
 
         related = manager.all().list()
         @test length(related) == 1

--- a/test/integration/test_sql_functions.jl
+++ b/test/integration/test_sql_functions.jl
@@ -175,13 +175,13 @@ end
     @test df[1, :full_info] == "Lewis Hamilton (1)"
 end
 
-@testset "Extraction & To_char" begin
-    # Logic: Test explicit Extract and To_char functions.
+@testset "Extraction & ToChar" begin
+    # Logic: Test explicit Extract and ToChar functions.
     # Why: Provides more control over date/time formatting than standard modifiers.
     q = M.Driver.objects
     q.values(
         "extracted_year"  => Extract("dob", "YEAR"),
-        "formatted_date" => To_char("dob", "DD/MM/YYYY")
+        "formatted_date" => ToChar("dob", "DD/MM/YYYY")
     )
     q.filter("driverid" => 1)
     df = q |> DataFrame
@@ -1048,17 +1048,17 @@ end
         end
     end
 
-    @testset "Extract and To_char accept SQLField and F inputs" begin
-        # Scenario: Extract/To_char should be consistent with the other helper constructors
+    @testset "Extract and ToChar accept SQLField and F inputs" begin
+        # Scenario: Extract/ToChar should be consistent with the other helper constructors
         # and accept both SQLField(joined path) and F(date_field) inputs.
         q = M.Result.objects
         q.values(
             "resultid",
             "race_date_raw" => "raceid__date",
             "race_year_from_field" => Extract(PormG.QueryBuilder.SQLField("raceid__date"), "YEAR"),
-            "race_date_fmt_field" => To_char(PormG.QueryBuilder.SQLField("raceid__date"), "YYYY-MM-DD"),
+            "race_date_fmt_field" => ToChar(PormG.QueryBuilder.SQLField("raceid__date"), "YYYY-MM-DD"),
             "race_year_from_f" => Extract(F("raceid__date"), "YEAR"),
-            "race_date_fmt_f" => To_char(F("raceid__date"), "YYYY-MM-DD")
+            "race_date_fmt_f" => ToChar(F("raceid__date"), "YYYY-MM-DD")
         )
         q.order_by("resultid")
         q.limit(10)

--- a/test/unit/test_date_bucket_operator.jl
+++ b/test/unit/test_date_bucket_operator.jl
@@ -4,7 +4,7 @@ Unit tests for the `__@yyyy_mm` date-bucket filter operator.
 `field__@yyyy_mm` is the month-bucket operator: it renders the column through
 `to_char(col, 'YYYY-MM')` and binds the comparison value after normalising it via
 `Models.format_yyyy_mm` (constants.jl: "yyyy_mm" => "Y_M";
-functions.jl: `Y_M(x) = To_char(x, "YYYY-MM", formater = Models.format_yyyy_mm)`).
+functions.jl: `Y_M(x) = ToChar(x, "YYYY-MM", formatter = Models.format_yyyy_mm)`).
 
 Why a dedicated file?
   - `test_operators.jl` covers the comparison / string / null suffixes but not the

--- a/test/unit/test_datetime_canonicalization.jl
+++ b/test/unit/test_datetime_canonicalization.jl
@@ -6,7 +6,7 @@ instant comparison.
 
 Root cause: SQLite stores datetimes as TEXT and compares them byte-for-byte, but
 PormG's shared formatter (`Models.format_timezone_sql`, wired as the `DateTimeField`
-`.formater`) previously returned any offset-bearing string verbatim. Equivalent
+`.formatter`) previously returned any offset-bearing string verbatim. Equivalent
 instants in different spellings (`Z` vs `+00:00`, `.0`/`.000`/no-subsecond, non-UTC
 offsets) therefore produced *distinct* TEXT that neither compared equal nor ordered
 chronologically on SQLite — while PostgreSQL saw them as the same `timestamptz`.

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -2097,16 +2097,16 @@ end
         @test 1 in insp[:parameters]
 
         wrapped_avg = QB.Round(QB.Sum("points") / QB.Count("id"), 1)
-        @test wrapped_avg.agregate === true
+        @test wrapped_avg.aggregate === true
     end
 
-    @testset "Extract and To_char preserve helper surface consistency" begin
+    @testset "Extract and ToChar preserve helper surface consistency" begin
         # These helpers should accept the same advanced field wrappers as the rest of the
         # SQL helper family: direct SQLField objects and F expressions.
         @test hasmethod(QB.Extract, Tuple{QB.SQLField, String})
         @test hasmethod(QB.Extract, Tuple{QB.FExpression, String})
-        @test hasmethod(QB.To_char, Tuple{QB.SQLField, String})
-        @test hasmethod(QB.To_char, Tuple{QB.FExpression, String})
+        @test hasmethod(QB.ToChar, Tuple{QB.SQLField, String})
+        @test hasmethod(QB.ToChar, Tuple{QB.FExpression, String})
 
         DateHelperModel = Models.Model_Type(
             name = "date_helper_model",
@@ -2122,8 +2122,8 @@ end
         q.values(
             "year_from_sqlfield" => QB.Extract(QB.SQLField("created_at"), "YEAR"),
             "year_from_f" => QB.Extract(QB.F("created_at"), "YEAR"),
-            "text_from_sqlfield" => QB.To_char(QB.SQLField("created_at"), "YYYY-MM-DD"),
-            "text_from_f" => QB.To_char(QB.F("created_at"), "YYYY-MM-DD")
+            "text_from_sqlfield" => QB.ToChar(QB.SQLField("created_at"), "YYYY-MM-DD"),
+            "text_from_f" => QB.ToChar(QB.F("created_at"), "YYYY-MM-DD")
         )
 
         insp = inspect_query(q)

--- a/test/unit/test_json_lookups.jl
+++ b/test/unit/test_json_lookups.jl
@@ -53,7 +53,7 @@ _sql(q; conn = nothing) = (conn === nothing ? inspect_query(q) : inspect_query(q
   # ─────────────────────────────────────────────────────────────────────────────
   # Equality lookup — the core `payload__key => value` shape on both dialects
   # PG extracts via `#>>` (text[] path), SQLite via `json_extract` (JSONPath); the RHS binds as a
-  # single plain-text parameter (NOT through the JSON formater, which would reject "hamilton").
+  # single plain-text parameter (NOT through the JSON formatter, which would reject "hamilton").
   # ─────────────────────────────────────────────────────────────────────────────
   @testset "equality: payload__nome => value (both dialects)" begin
     mkq() = (q = JL.Json_scratch.objects; q.filter("payload__nome" => "hamilton"); q.values("id"); q)

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -114,10 +114,10 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BUG-2 regression: add! must return `nothing` consistently regardless of whether
+# BUG-2 regression: add must return `nothing` consistently regardless of whether
 # the targets list is empty or non-empty.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "add! return type consistency (BUG-2)" begin
+@testset "add return type consistency (BUG-2)" begin
   # Construct a mock manager for Driver_championship (auto-through, no extra fields)
   rel = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
   manager = PormG.QueryBuilder.ManyToManyManager(
@@ -127,15 +127,15 @@ end
     1,
   )
 
-  # Empty add! must return nothing (was returning 0 before the fix)
-  result_empty = PormG.QueryBuilder.add!(manager)
+  # Empty add must return nothing (was returning 0 before the fix)
+  result_empty = PormG.QueryBuilder.add(manager)
   @test result_empty === nothing
   @test result_empty isa Nothing
 
-  # A non-empty add! also returns nothing (consistent return type).
+  # A non-empty add also returns nothing (consistent return type).
   # We cannot actually execute the INSERT on a mock connection, but we verify the
   # early-return path of the empty branch so both branches share the same type.
-  result_empty_vec = PormG.QueryBuilder.add!(manager, Integer[])
+  result_empty_vec = PormG.QueryBuilder.add(manager, Integer[])
   @test result_empty_vec === nothing
 end
 

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -28,8 +28,8 @@ const EXPECTED_TOPLEVEL = Set([
     :run_in_transaction, :atomic, :with_savepoint, :with_tx_context, :in_transaction_context,
     # Locking
     :with_advisory_lock,
-    # Utilities & lifecycle
-    :setup, :install_ai_skills, :upgrade_guide, :tui, :register_ignore_tables!,
+    # Utilities & lifecycle (#201: setup / install_ai_skills are qualified-call-only, not exported)
+    :upgrade_guide, :tui, :register_ignore_tables!,
     Symbol("@import_models"), Symbol("@models_module"), Symbol("@pormg_debug"),
 ])
 
@@ -40,7 +40,7 @@ const EXPECTED_FUNCTIONS = Set([
     :WindowOver, :WindowSpec, :Rank, :DenseRank, :RowNumber, :Lag, :Lead, :FirstValue, :LastValue, :NthValue,
     :Concat, :Lower, :Upper, :Length, :Replace, :Trim, :LTrim, :RTrim,
     :Abs, :Round, :Floor, :Ceil, :Sqrt, :Exp, :Ln, :Power, :Mod,
-    :Cast, :Extract, :To_char, :Value, :Coalesce, :Greatest, :Least, :NullIf,
+    :Cast, :Extract, :ToChar, :Value, :Coalesce, :Greatest, :Least, :NullIf,
 ])
 
 @testset "Public export surface (#35)" begin

--- a/test/unit/test_window_functions.jl
+++ b/test/unit/test_window_functions.jl
@@ -221,9 +221,9 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 # Window-only with plain fields: GROUP BY must NOT be emitted
 #
-# When there is no aggregate (instruc.agregate stays false), GROUP BY must be
+# When there is no aggregate (instruc.aggregate stays false), GROUP BY must be
 # suppressed entirely — even if instruc.group has entries from plain fields.
-# This verifies the guard condition `agregate && !isempty(group)`.
+# This verifies the guard condition `aggregate && !isempty(group)`.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "Window-only with multiple plain fields: no GROUP BY" begin
   q = WindowPgResult.objects.values(


### PR DESCRIPTION
Closes #201.

Pre-publish naming pass. Renames are breaking after publish and free now (no external users), so this settles them in one sweep. All naming decisions confirmed with the maintainer.

## Renames (no aliases — old name gone)

| Old | New | Notes |
|-----|-----|-------|
| `To_char` | `ToChar` | The only non-PascalCase name in the `PormG.Functions` library. Rendering still dispatches on the `"EXTRACT_DATE"` string, so `Dialect.jl` is untouched. |
| `formater` | `formatter` | Misspelling. Renamed on **both** clusters: the QueryBuilder function kwarg/fields *and* all 26 model-field structs. The migrations serializer skip-list symbol was renamed to match. |
| `agregate` | `aggregate` | Misspelling on struct fields + `FExpression` propagation. |
| `InstrucObject` | `InstructionObject` | Truncated internal struct name. |
| `add!`/`remove!`/`clear!`/`set!` | `add`/`remove`/`clear`/`set` | M2M manager mutators. Julia's `!` means "mutates a Julia argument"; these mutate the DB and are only reached as manager methods (`driver.sponsors.add(...)`), so they read like the bang-free fluent terminals and match Django. Rationale note added to `docs/src/many_to_many.md`. |

## Export surface

`setup` / `install_ai_skills` are **unexported** — maximally generic names that every doc already calls qualified (`PormG.setup()`). `api.md` gains a note.

## Deliberate non-change

`bulk_insert` keeps its name. Django's `bulk_create` is a *genuinely different* API (DataFrame-first, `on_conflict=` kwarg, no returned instances), not just a rename — documented in `docs/src/import_django.md` under a new "API Naming Differences from Django" section.

Also: `Q`/`Qor` docstrings reindented so signatures render as code blocks.

## Versioning

`0.3.0` — the shared stamp for the current pre-publish wave (alongside #200/#202), so consuming apps pinned to `0.2.x` find everything to fix by scanning `0.3.0` entries. `UPGRADING.md` gains a `0.3.0` entry with the old→new table and three per-rename grep recipes.

## Verification

- PostgreSQL (db_2): **1833 / 1833**
- SQLite (db_sl): **1799 passed, 0 failed** (1 pre-existing `@test_broken`)
- Export-surface test: **72/72** (co-exists with #202's submodule-surface guards)
- Docs build clean; `ToChar`/`formatter=` doc examples verified against live F1 data
- Rebased cleanly onto current `main` (post #200 + #202); zero rename leftovers, no name collisions with #202
- Reviewed by a parallel agent (one finding — stale bang-form error messages — fixed)

## Post-merge chore

Regenerate the gitignored `test/performance/snoop_out/` snoop artifact to clear a stale `InstrucObject` reference (does not affect the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)