### PR TITLE
feat(#207): negated pattern/range lookups (NOT LIKE / NOT BETWEEN)

### DIFF
--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -34,6 +34,29 @@ These work in both `filter()` and `values()`.
 | `@iunaccent_contains` | `immutable_unaccent(col) ILIKE immutable_unaccent('%val%')` | Accent- & case-insensitive substring (PostgreSQL only) | `"surname__@iunaccent_contains" => "raikkonen"` |
 | `@iunaccent_exact` | `LOWER(immutable_unaccent(col)) = LOWER(immutable_unaccent(val))` | Accent- & case-insensitive equality (PostgreSQL only) | `"surname__@iunaccent_exact" => "raikkonen"` |
 
+### Negating Pattern and Range Lookups
+
+The pattern and range lookups each have a **negated twin** — same value handling, the SQL operator
+flipped to `NOT LIKE` / `NOT ILIKE` / `<>` / `NOT BETWEEN`. Use these to express "does **not** match"
+without inverting the logic by hand.
+
+| Operator | SQL | Description | Example |
+| :--- | :--- | :--- | :--- |
+| `@ncontains` | `NOT LIKE '%val%'` | Case-sensitive substring absent | `"name__@ncontains" => "Racing"` |
+| `@nicontains` | `NOT ILIKE '%val%'` | Case-insensitive substring absent | `"name__@nicontains" => "racing"` |
+| `@nstartswith` | `NOT LIKE 'val%'` | Does not start with | `"surname__@nstartswith" => "M"` |
+| `@nendswith` | `NOT LIKE '%val'` | Does not end with | `"surname__@nendswith" => "son"` |
+| `@nrange` | `NOT BETWEEN a AND b` | Outside two bounds | `"laps__@nrange" => [1, 10]` |
+| `@niunaccent_contains` | `immutable_unaccent(col) NOT ILIKE immutable_unaccent('%val%')` | Accent- & case-insensitive substring absent (PostgreSQL only) | `"surname__@niunaccent_contains" => "raikkonen"` |
+| `@niunaccent_exact` | `LOWER(immutable_unaccent(col)) <> LOWER(immutable_unaccent(val))` | Accent- & case-insensitive inequality (PostgreSQL only) | `"surname__@niunaccent_exact" => "raikkonen"` |
+
+!!! note "NULL semantics"
+    `NOT LIKE`, `<>`, and `NOT BETWEEN` follow SQL three-valued logic: when the column is `NULL` the
+    predicate is UNKNOWN, so the **row is excluded** — exactly like `@ne` and `@nin`. If you also want
+    the `NULL` rows, add an explicit `Qor(..., "field__@isnull" => true)`. PormG deliberately keeps
+    negation per-field (there is no `.exclude()` / `~Q` group-negation) so the emitted SQL stays
+    predictable — see [Q Objects](q_objects.md).
+
 ### Transform Functions (Modifiers)
 
 | Transform | Description | Use in `filter()` | Use in `values()` |

--- a/docs/src/read/q_objects.md
+++ b/docs/src/read/q_objects.md
@@ -297,10 +297,14 @@ df = M.Driver.objects.filter("nationality__@in" => nationalities) |> DataFrame
 | Grouped boolean logic | `Q(a, Qor(b, c))` |
 | Dynamic conditions from user input | `Q()` + `push!` |
 | Set membership (`IN`) | `"field__@in" => [values]` |
-| NOT operator | `"field__@ne"` or `"field__@nin"` |
+| NOT equal / NOT in set | `"field__@ne"` or `"field__@nin"` |
+| NOT a pattern / range match | `"field__@ncontains"`, `"field__@nstartswith"`, `"field__@nrange"`, … (see [Filters and Aggregates](filters_and_aggregates.md#Negating-Pattern-and-Range-Lookups)) |
 
 !!! warning
-    PormG does **not** define `|` or `&` operators between Q objects. Use `Qor(...)` for OR logic and `Q(...)` or multiple `filter()` arguments for AND logic.
+    PormG does **not** define `|` or `&` operators between Q objects, nor a `.exclude()` / `~Q`
+    group-negation. Use `Qor(...)` for OR logic and `Q(...)` or multiple `filter()` arguments for AND
+    logic; negate **per field** with the `@ne` / `@nin` / `@n…` pattern-and-range suffixes. This keeps
+    the emitted SQL predictable — PormG is inspired by Django, not a port of it.
 
 ---
 

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -1227,6 +1227,83 @@ function iendswith(conn::PormGAbstractType, column::String, value)
   return nothing
 end
 
+# ------------------------------------------------------------------------------
+# #207: negated pattern lookups — the NOT-LIKE / NOT-ILIKE / <> twins of the
+# renderers above. The value is decorated with the same wildcards by
+# _apply_like_wildcards (parameters.jl); only the operator differs here. `col NOT
+# LIKE …` / `<>` yield UNKNOWN (row excluded) for NULL columns — consistent with
+# @ne / @nin. The unaccent twins stay PostgreSQL-only, mirroring their positive form.
+# ------------------------------------------------------------------------------
+
+function ncontains(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function ncontains(conn::PormGSQLite, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function ncontains(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
+function nicontains(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) NOT ILIKE $(value)$(_like_escape_clause())"
+end
+function nicontains(conn::PormGSQLite, column::String, value::String)::String
+  # pormg_lower = Unicode-aware LOWER UDF (#78); NOT LIKE over folded text mirrors icontains.
+  return "pormg_lower($(column)) NOT LIKE pormg_lower($(value))$(_like_escape_clause())"
+end
+function nicontains(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
+function niunaccent_contains(conn::PormGPostgres, column::String, value::String)::String
+  return "public.immutable_unaccent($(column)) NOT ILIKE public.immutable_unaccent($(value))$(_like_escape_clause())"
+end
+function niunaccent_contains(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The niunaccent_contains lookup requires PostgreSQL and the unaccent extension"))
+  return nothing
+end
+function niunaccent_contains(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
+function niunaccent_exact(conn::PormGPostgres, column::String, value::String)::String
+  return "LOWER(public.immutable_unaccent($(column))) <> LOWER(public.immutable_unaccent($(value)))"
+end
+function niunaccent_exact(conn::PormGSQLite, column::String, value::String)
+  throw(ArgumentError("The niunaccent_exact lookup requires PostgreSQL and the unaccent extension"))
+  return nothing
+end
+function niunaccent_exact(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
+function nstartswith(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function nstartswith(conn::PormGSQLite, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function nstartswith(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
+function nendswith(conn::PormGPostgres, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function nendswith(conn::PormGSQLite, column::String, value::String)::String
+  return "$(column) NOT LIKE $(value)$(_like_escape_clause())"
+end
+function nendswith(conn::PormGAbstractType, column::String, value)
+  throw(ArgumentError("The value must be a String"))
+  return nothing
+end
+
 # ==============================================================================
 # MIGRATION HISTORY TABLE DDL
 # DDL for the pormg_migrations table that tracks applied migrations.

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -53,6 +53,17 @@ const PormGsuffix = Dict{String,Union{Int64, String}}(
   "startswith" => "startswith",
   "endswith" => "endswith",
   "range" => "BETWEEN",
+  # #207: negated twins of the pattern/range lookups above. Each LIKE-family value is the operator
+  # name itself — it doubles as the `Dialect.<name>` dispatch symbol in _get_filter_query(::SQLTypeOper)
+  # (rendered as NOT LIKE / NOT ILIKE / <>). `nrange` renders NOT BETWEEN via the BETWEEN branch.
+  # These negate a match rather than compose a NOT-group (PormG has no .exclude()/~Q by design).
+  "ncontains" => "ncontains",
+  "nicontains" => "nicontains",
+  "niunaccent_contains" => "niunaccent_contains",
+  "niunaccent_exact" => "niunaccent_exact",
+  "nstartswith" => "nstartswith",
+  "nendswith" => "nendswith",
+  "nrange" => "NOT BETWEEN",
   # #27: PostgreSQL JSONB containment/overlap operators. Each maps to a Dialect renderer of the
   # same name (PG emits the operator; SQLite/abstract throw a friendly PG-only error). Distinct
   # from the LIKE `contains` above — a JSON `@>` and a string LIKE are different operations.

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -239,9 +239,9 @@ function _get_pair_to_oper(x::Pair{Vector{String},Vector{T}}) where T<:Union{Mis
   if suffix in ["in", "nin"]
     @pormg_debug false
     return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
-  elseif suffix == "range"
+  elseif suffix in ("range", "nrange")   # #207: nrange = NOT BETWEEN, same 2-value shape
     if length(x.second) != 2
-      throw(_argerr("Error in filter, 'range' operator requires exactly 2 values, got $(length(x.second))"))
+      throw(_argerr("Error in filter, '$(suffix)' operator requires exactly 2 values, got $(length(x.second))"))
     end
     return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   elseif suffix in ("has_any_keys", "has_keys")
@@ -253,7 +253,7 @@ function _get_pair_to_oper(x::Pair{Vector{String},Vector{T}}) where T<:Union{Mis
     # parse time so OperObject.values stays a String (no downstream type-union change).
     return OperObject(operator="jcontains", values=Models.format_json_sql(x.second), column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    _raise_invalid_filter_operator(x.first, "vector", ["in", "nin", "range", "has_any_keys", "has_keys", "jcontains"])
+    _raise_invalid_filter_operator(x.first, "vector", ["in", "nin", "range", "nrange", "has_any_keys", "has_keys", "jcontains"])
   end
 end
 # #27: JSONB document containment (@>) with a Dict / NamedTuple RHS — serialize at parse time so
@@ -267,10 +267,10 @@ function _get_pair_to_oper(x::Pair{Vector{String},<:NamedTuple})
   return OperObject(operator="jcontains", values=Models.format_json_sql(x.second), column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Tuple{T,T}}) where T
-  if x.first[end] == "range"
+  if x.first[end] in ("range", "nrange")   # #207: nrange = NOT BETWEEN, same 2-value shape
     return OperObject(operator=PormGsuffix[x.first[end]], values=[x.second[1], x.second[2]], column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   else
-    _raise_invalid_filter_operator(x.first, "tuple", ["range"])
+    _raise_invalid_filter_operator(x.first, "tuple", ["range", "nrange"])
   end
 end
 function _get_pair_to_oper(x::Pair{Vector{String},Date})
@@ -476,6 +476,7 @@ end
 function _check_if_field_is_a_operator(field::String)
   common_operators = ["exact", "iexact", "contains", "icontains", "iunaccent_contains", "iunaccent_exact", "in", "gt", "gte", "lt", "lte",
     "startswith", "istartswith", "endswith", "iendswith", "range", "date",
+    "ncontains", "nicontains", "niunaccent_contains", "niunaccent_exact", "nstartswith", "nendswith", "nrange",  # #207
     "year", "iso_year", "quarter", "month", "day", "week", "week_day", "iso_week_day",
     "hour", "minute", "second", "isnull", "regex", "iregex"]
   if field in common_operators
@@ -1136,8 +1137,9 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     end
     if v.operator in ["ISNULL"]
       return getfield(QueryBuilder, Symbol(v.operator))(_get_filter_query(v.column, instruc), v.values)
-    elseif v.operator == "BETWEEN"
-      # Handle BETWEEN with two parameters
+    elseif v.operator in ("BETWEEN", "NOT BETWEEN")
+      # Handle (NOT) BETWEEN with two parameters. #207: `nrange` renders NOT BETWEEN — the operator
+      # string carries "BETWEEN"/"NOT BETWEEN" so both branches emit it verbatim.
       column_sql = _get_filter_query(v.column, instruc)
       field_name = ""
       if isa(v.column, SQLTypeField)
@@ -1150,17 +1152,18 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
         formatter = instruc.object.model.fields[field_name].formatter
         p1 = add_parameter!(instruc, formatter(v.values[1]))
         p2 = add_parameter!(instruc, formatter(v.values[2]))
-        return string(column_sql, " BETWEEN ", p1, " AND ", p2)
+        return string(column_sql, " ", v.operator, " ", p1, " AND ", p2)
       else
         p1 = add_parameter!(instruc, v.values[1])
         p2 = add_parameter!(instruc, v.values[2])
-        return string(column_sql, " BETWEEN ", p1, " AND ", p2)
+        return string(column_sql, " ", v.operator, " ", p1, " AND ", p2)
       end
     elseif haskey(instruc.object.model.fields, v.column.field)
       placeholders = nothing
       try
         # Determine if this is a LIKE-based operator and which wildcard pattern to use
-        is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]
+        is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith",
+                                    "ncontains", "nicontains", "niunaccent_contains", "nstartswith", "nendswith"]
         placeholders = add_parameter!(instruc, instruc.object.model.fields[v.column.field].formatter(v.values), contains=is_like_op, operator=v.operator)
       catch e
         @pormg_debug false
@@ -1172,11 +1175,13 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       end
     elseif haskey(instruc.tab_field_cache, v.column._as) # Check cache first
       @pormg_debug false
-      is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]
+      is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith",
+                                  "ncontains", "nicontains", "niunaccent_contains", "nstartswith", "nendswith"]
       placeholders = add_parameter!(instruc, instruc.tab_field_cache[v.column._as].formatter(v.values), contains=is_like_op, operator=v.operator)
     elseif isa(v.column, SQLTypeField)
       @pormg_debug false
-      is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith"]
+      is_like_op = v.operator in ["contains", "icontains", "iunaccent_contains", "startswith", "endswith",
+                                  "ncontains", "nicontains", "niunaccent_contains", "nstartswith", "nendswith"]
       placeholders = add_parameter!(instruc, v.values, contains=is_like_op, operator=v.operator)
     else
       @pormg_debug false
@@ -1204,7 +1209,8 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       # Internal invariant: add_parameter! only ever returns a String or a Vector of placeholders.
       error(_emsg("PormG internal error rendering $(v.operator): parameter placeholders must be a String or a Vector, got $(typeof(placeholders))."))
     end
-  elseif v.operator in ["contains", "icontains", "iunaccent_contains", "iunaccent_exact", "startswith", "endswith"]
+  elseif v.operator in ["contains", "icontains", "iunaccent_contains", "iunaccent_exact", "startswith", "endswith",
+                        "ncontains", "nicontains", "niunaccent_contains", "niunaccent_exact", "nstartswith", "nendswith"]
     @pormg_debug false
     return getfield(Dialect, Symbol(v.operator))(instruc.connection, column, placeholders)
   else

--- a/src/querybuilder/parameters.jl
+++ b/src/querybuilder/parameters.jl
@@ -95,18 +95,22 @@ end
     _apply_like_wildcards(value::Any, operator::String)::Any
 
 Apply appropriate LIKE wildcards based on the operator:
-- contains/icontains/iunaccent_contains: %value%
-- startswith: value%
-- endswith: %value
+- contains/icontains/iunaccent_contains (and their negated n… twins): %value%
+- startswith / nstartswith: value%
+- endswith / nendswith: %value
 - Other operators: no wildcards
+
+The negated pattern operators (#207) decorate the value identically to their positive twin — only
+the Dialect renderer differs (NOT LIKE vs LIKE), so the wildcard placement is the same.
 """
 function _apply_like_wildcards(value::Any, operator::String)::Any
   escaped = escape_like_pattern(string(value))
-  if operator in ["contains", "icontains", "iunaccent_contains"]
+  if operator in ["contains", "icontains", "iunaccent_contains",
+                  "ncontains", "nicontains", "niunaccent_contains"]
     return string("%", escaped, "%")
-  elseif operator == "startswith"
+  elseif operator in ["startswith", "nstartswith"]
     return string(escaped, "%")
-  elseif operator == "endswith"
+  elseif operator in ["endswith", "nendswith"]
     return string("%", escaped)
   else
     return value

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -899,6 +899,53 @@ end
     @test contains(insp[:sql_text], "NOT") || contains(insp[:sql_text], "<>")
 end
 
+@testset "Alignment Verification - Negated Pattern/Range Operators SQLite (#207)" begin
+    # Exercise the SQLite render path for the #207 negated twins (test_operators.jl
+    # gates the PostgreSQL shapes via a PG mock). "NOT LIKE" contains "LIKE" and
+    # "NOT BETWEEN" contains "BETWEEN", so each assertion checks the "NOT " prefix.
+
+    # ncontains → NOT LIKE '%val%'
+    insp_nc = M.Result.objects.filter("driverid__surname__@ncontains" => "Sen") |> inspect_query
+    @test contains(insp_nc[:sql_text], "NOT LIKE")
+    @test "%Sen%" in insp_nc[:parameter_buckets][:where]
+
+    # nicontains → pormg_lower(col) NOT LIKE pormg_lower(?)  (Unicode case-fold UDF, #78)
+    insp_nic = M.Result.objects.filter("driverid__surname__@nicontains" => "sen") |> inspect_query
+    @test contains(insp_nic[:sql_text], "pormg_lower")
+    @test contains(insp_nic[:sql_text], "NOT LIKE")
+    @test "%sen%" in insp_nic[:parameter_buckets][:where]
+
+    # nstartswith → NOT LIKE 'val%'
+    insp_nsw = M.Result.objects.filter("driverid__surname__@nstartswith" => "Ham") |> inspect_query
+    @test contains(insp_nsw[:sql_text], "NOT LIKE")
+    @test "Ham%" in insp_nsw[:parameter_buckets][:where]
+
+    # nendswith → NOT LIKE '%val'
+    insp_new = M.Result.objects.filter("driverid__surname__@nendswith" => "ton") |> inspect_query
+    @test contains(insp_new[:sql_text], "NOT LIKE")
+    @test "%ton" in insp_new[:parameter_buckets][:where]
+
+    # nrange → NOT BETWEEN ? AND ?  (positional params preserved in order)
+    insp_nr = M.Result.objects.filter("positionorder__@nrange" => [1, 3]) |> inspect_query
+    @test contains(insp_nr[:sql_text], "NOT BETWEEN")
+    @test insp_nr[:parameter_buckets][:where] == [1, 3]
+
+    # niunaccent_* are PostgreSQL-only — the SQLite renderer must throw *its* PostgreSQL-required
+    # error, NOT the AbstractType "value must be a String" fallback (which would signal a
+    # mis-dispatch). Assert the cause so a wrong-error regression can't masquerade as a pass.
+    for (path, val) in [("driverid__surname__@niunaccent_contains", "sen"),
+                        ("driverid__surname__@niunaccent_exact", "senna")]
+      err_pg = try
+        M.Result.objects.filter(path => val) |> inspect_query
+        nothing
+      catch e
+        e
+      end
+      @test err_pg !== nothing
+      @test occursin("requires PostgreSQL", sprint(showerror, err_pg))
+    end
+end
+
 @testset "Alignment Verification - Boolean Field Filters" begin
     # Test filtering on an explicit BooleanField
     # Passing true/false to BooleanField demonstrates the parameterisation layer's 

--- a/test/unit/test_operators.jl
+++ b/test/unit/test_operators.jl
@@ -211,6 +211,97 @@ const _E = _OperTestEvent
   end
 
   # =========================================================================
+  # 4b. Negated pattern operators (#207): NOT LIKE / NOT ILIKE / <>
+  # Same wildcard decoration as the positive twin; only the operator flips.
+  # NOTE (as above): the _OperTest models render through a PostgreSQL mock, so
+  # these assert the PG operator SHAPE. Crucially, "NOT LIKE" contains "LIKE"
+  # and "NOT ILIKE" contains "ILIKE", so each test asserts the "NOT " prefix
+  # explicitly — a bare contains(…, "LIKE") would pass on the positive form too.
+  # =========================================================================
+  @testset "Negated pattern operators (ncontains, nstartswith, nendswith, nicontains) — #207" begin
+    # ncontains → NOT LIKE '%val%'
+    q_nc = _D.objects.filter("forename__@ncontains" => "lew")
+    r_nc = q_nc.list(show_query=:dict)
+    @test contains(r_nc[:sql_text], "NOT LIKE")
+    @test contains(r_nc[:sql_text], "ESCAPE")
+    @test r_nc[:parameters] == ["%lew%"]
+
+    # nicontains → NOT ILIKE '%val%' (PostgreSQL) / pormg_lower(col) NOT LIKE … (SQLite, #78)
+    q_nic = _D.objects.filter("forename__@nicontains" => "LEW")
+    r_nic = q_nic.list(show_query=:dict)
+    @test contains(r_nic[:sql_text], "NOT ILIKE") || contains(r_nic[:sql_text], "NOT LIKE")
+    @test contains(r_nic[:sql_text], "ESCAPE")
+    @test r_nic[:parameters] == ["%LEW%"]
+
+    # nstartswith → NOT LIKE 'val%'
+    q_nsw = _D.objects.filter("nationality__@nstartswith" => "Brit")
+    r_nsw = q_nsw.list(show_query=:dict)
+    @test contains(r_nsw[:sql_text], "NOT LIKE")
+    @test contains(r_nsw[:sql_text], "ESCAPE")
+    @test r_nsw[:parameters] == ["Brit%"]
+
+    # nendswith → NOT LIKE '%val'
+    q_new = _D.objects.filter("forename__@nendswith" => "wis")
+    r_new = q_new.list(show_query=:dict)
+    @test contains(r_new[:sql_text], "NOT LIKE")
+    @test contains(r_new[:sql_text], "ESCAPE")
+    @test r_new[:parameters] == ["%wis"]
+  end
+
+  # =========================================================================
+  # 4c. Negated unaccent operators (#207) — PostgreSQL-only, mirror positive twin
+  # =========================================================================
+  @testset "Negated unaccent operators (niunaccent_contains, niunaccent_exact) — #207" begin
+    # niunaccent_contains → immutable_unaccent(col) NOT ILIKE immutable_unaccent('%val%')
+    q_niuc = _D.objects.filter("forename__@niunaccent_contains" => "sao jose")
+    r_niuc = q_niuc.list(show_query=:dict)
+    @test contains(r_niuc[:sql_text], "public.immutable_unaccent")
+    @test contains(r_niuc[:sql_text], "NOT ILIKE")
+    @test contains(r_niuc[:sql_text], "ESCAPE")
+    @test r_niuc[:parameters] == ["%sao jose%"]
+
+    # niunaccent_exact → LOWER(immutable_unaccent(col)) <> LOWER(immutable_unaccent('val'))
+    # No wildcards, no ESCAPE, value passed as-is.
+    q_niue = _D.objects.filter("forename__@niunaccent_exact" => "são josé")
+    r_niue = q_niue.list(show_query=:dict)
+    @test contains(r_niue[:sql_text], "public.immutable_unaccent")
+    @test contains(r_niue[:sql_text], "LOWER")
+    @test contains(r_niue[:sql_text], "<>")
+    @test !contains(r_niue[:sql_text], "ESCAPE")
+    @test r_niue[:parameters] == ["são josé"]
+  end
+
+  # =========================================================================
+  # 4d. Negated range operator (#207): nrange → NOT BETWEEN
+  # =========================================================================
+  @testset "Negated range operator (nrange → NOT BETWEEN) — #207" begin
+    # With Vector — "NOT BETWEEN" contains "BETWEEN", so assert the "NOT " prefix.
+    q_vec = _D.objects.filter("id__@nrange" => [10, 50])
+    res_vec = q_vec.list(show_query=:dict)
+    @test contains(res_vec[:sql_text], "NOT BETWEEN")
+    @test res_vec[:parameters] == [10, 50]
+
+    # With Tuple — both forms must be accepted, same as positive range.
+    q_tup = _D.objects.filter("id__@nrange" => (10, 50))
+    res_tup = q_tup.list(show_query=:dict)
+    @test contains(res_tup[:sql_text], "NOT BETWEEN")
+    @test res_tup[:parameters] == [10, 50]
+
+    # Shape guard: a 3-element vector is rejected, and the error must name the operator and
+    # the 2-value requirement. A bare @test_throws would also pass on an unrelated error
+    # (e.g. if `nrange` were missing from the vector allowed-op list), so assert the cause.
+    err_nr = try
+      _D.objects.filter("id__@nrange" => [1, 2, 3]).list(show_query=:dict)
+      nothing
+    catch e
+      e
+    end
+    @test err_nr !== nothing
+    @test occursin("nrange", sprint(showerror, err_nr))
+    @test occursin("exactly 2 values", sprint(showerror, err_nr))
+  end
+
+  # =========================================================================
   # 5. NULL checks  (isnull)
   # =========================================================================
   @testset "NULL check operator (isnull)" begin


### PR DESCRIPTION
## Summary

Adds the **seven negated twins** of PormG's pattern/range field lookups — the one genuine gap in the
negation surface. Every positive pattern/range suffix now has a negated counterpart:

| Suffix | SQL (PostgreSQL / SQLite) |
|--------|----------------------------|
| `@ncontains` / `@nstartswith` / `@nendswith` | `NOT LIKE` (both) |
| `@nicontains` | `NOT ILIKE` / `pormg_lower(col) NOT LIKE pormg_lower(?)` |
| `@niunaccent_contains` | `immutable_unaccent(col) NOT ILIKE …` — **PostgreSQL-only** (throws on SQLite) |
| `@niunaccent_exact` | `LOWER(immutable_unaccent(col)) <> …` — **PostgreSQL-only** |
| `@nrange` | `NOT BETWEEN a AND b` (both) |

### Why (and why only this)

Scalar negation was already complete — `@ne` (≠), `@nin` (NOT IN), `@isnull => false` (IS NOT NULL),
and `@gt/@gte/@lt/@lte` are mutual negations — and any top-level `AND` group is De-Morgan-invertible by
hand. The **pattern/range lookups were the only ones with no negated form and no fallback**, so
"surname does not contain 'a'" or "laps not between 1 and 10" were previously inexpressible.

**Deliberately out of scope:** `.exclude()` and `~Q` / `Qnot` group-negation. PormG is *inspired by*
Django, not a port, and the existing documented decision against `|`/`&` composition on `Q` objects
stands — a `~Q` would reopen exactly that. See the comment on #207 for the full rationale; the issue
stays open in case a future need justifies the group-negation surface.

### Behavior notes

- **NULL semantics** match `@ne` / `@nin`: `NOT LIKE` / `<>` / `NOT BETWEEN` exclude NULL rows via SQL
  three-valued logic (no Django-style `IS NULL OR …` wrapping) — documented with a `!!! note`.
- **Dialect parity:** both backends aligned; the unaccent twins stay PostgreSQL-only, mirroring their
  positive forms.
- **Parameterized:** wildcards are applied to the bound value, never interpolated into SQL.

## Implementation

`constants.jl` (7 `PormGsuffix` entries) · `parameters.jl` (`_apply_like_wildcards` twins) ·
`build_helpers.jl` (`is_like_op` × 3, `BETWEEN`→`NOT BETWEEN`, Dialect dispatch, `nrange` parse for
vector + tuple, allowed-op lists) · `Dialect.jl` (6 new PG/SQLite/Abstract renderer families).

## Tests & docs

- **Unit:** `test_operators.jl` (PG shape) + `test_alignment_sqlite.jl` (SQLite render), each asserting
  the `NOT ` prefix (so a test can't pass on the positive form) and with **cause-checked** throw guards.
- **Docs:** negation table + NULL note in `filters_and_aggregates.md`; decision-guide row in `q_objects.md`.
- **Verification:** full `Pkg.test()` **4226/4226** (incl. Aqua) on the current `main` base; docs build green.

## Versioning

Additive / non-breaking → **no version bump** (batched under `0.3.0` with the other same-day PRs); no
`UPGRADING.md` entry required.

Refs #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
