### PR TITLE
fix(#216): tolerate CRLF line endings in upgrade_guide parser (fixes Windows CI)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@
 # Shell scripts must stay LF: a CRLF `#!/usr/bin/env bash\r` shebang / `set -euo\r` breaks
 # under bash on a Windows checkout (autocrlf=true would otherwise rewrite LF -> CRLF).
 *.sh text eol=lf
+# Markdown stays LF: `upgrade_guide` parses UPGRADING.md with a `(?m)^---$` block separator
+# that a `---\r` line (CRLF checkout) never matches — see the parser's own CRLF normalization
+# in src/tools.jl. The parser tolerates CRLF regardless; pinning LF keeps the repo consistent.
+*.md text eol=lf

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -168,7 +168,23 @@ function _read_upgrading_entries()
     path = joinpath(Base.pkgdir(@__MODULE__), "UPGRADING.md")
     isfile(path) || throw(ArgumentError(
         "UPGRADING.md not found next to the installed PormG (looked in $(dirname(path)))."))
-    text = read(path, String)
+    return _parse_upgrading(read(path, String))
+end
+
+"""
+    _parse_upgrading(text::AbstractString) -> Vector{_UpgradeEntry}
+
+Parse raw `UPGRADING.md` text into change entries, newest-first (see `_read_upgrading_entries`).
+Split out so the parser can be exercised on hand-fed text — the CRLF-robustness regression in
+particular — without touching the on-disk file.
+
+Line endings are normalized to `\\n` up front: a Windows checkout can store `UPGRADING.md`
+with `\\r\\n` (only `*.jl`/`*.sh` are pinned to `eol=lf`), and the `(?m)^---[ \\t]*\$` block
+separator never matches a `---\\r` line — without this the whole file collapses into a single
+bogus entry and every scoped lookup comes back empty.
+"""
+function _parse_upgrading(text::AbstractString)
+    text = replace(text, "\r\n" => "\n", "\r" => "\n")
 
     # Drop the "## Template for new entries" section: its body is an HTML comment holding a
     # fake `## …` heading and a `- **Version**:` placeholder that would parse as a bogus entry.

--- a/test/unit/test_upgrade_guide.jl
+++ b/test/unit/test_upgrade_guide.jl
@@ -60,6 +60,26 @@ using PormG
         @test all(e -> !occursin('\n', e.title) && !isempty(e.body), all_entries)
     end
 
+    # ── CRLF robustness: a Windows checkout stores UPGRADING.md with \r\n (only *.jl /
+    #    *.sh are pinned to eol=lf), and the `(?m)^---$` block separator never matches a
+    #    `---\r` line — collapsing the whole file into one bogus entry, so every scoped
+    #    lookup comes back empty. This regressed on Windows CI since #216 landed. Exercised
+    #    on every platform by feeding CRLF text straight to the parser (Linux CI never
+    #    checks the file out as CRLF, so it can't catch this via the on-disk path).
+    @testset "parser tolerates CRLF line endings (Windows checkout)" begin
+        path = joinpath(pkgdir(PormG), "UPGRADING.md")
+        lf   = replace(read(path, String), "\r\n" => "\n")   # normalize whatever is on disk
+        crlf = replace(lf, "\n" => "\r\n")
+
+        from_lf   = PormG._parse_upgrading(lf)
+        from_crlf = PormG._parse_upgrading(crlf)
+
+        @test !isempty(from_crlf)
+        @test from_crlf == from_lf   # identical parse regardless of line endings (version/title/body)
+        # The concrete CI symptom: the stamped 0.2.0/#197 entry must survive the block split.
+        @test any(e -> occursin("(#197)", e.title) && e.version == v"0.2.0", from_crlf)
+    end
+
     # ── human output: header + entry, internal rollout table trimmed off ────────
     @testset "printed guide: header, entry, no per-app rollout" begin
         out = sprint(io -> PormG.upgrade_guide(io; from = v"0.1.0", to = v"0.2.0"))


### PR DESCRIPTION
## Problem

CI has been **red on Windows** (green on Ubuntu) since **#220 / #216** landed — every merge to `main` since (`#221`–`#227`). `test/unit/test_upgrade_guide.jl` reports `6 failed, 2 errored`, all in the `structured scope 0.1.0 → 0.2.0` and `printed guide` testsets.

### Root cause

`.gitattributes` pins `*.jl` and `*.sh` to `eol=lf` but **not `*.md`**, so on the Windows runner (`core.autocrlf=true`) `UPGRADING.md` is checked out with `\r\n`. The parser's block separator at `src/tools.jl` —

```julia
for block in split(text, r"(?m)^---[ \t]*$")
```

never matches a `---\r` line: `[ \t]*` won't consume the `\r`, and `$` sits before `\n`, not `\r`. So `split` returns the **whole file as one block**, which collapses into a single bogus entry (first `##` heading + newest `**Version**` bullet). Every scoped lookup then comes back empty.

Reproduced deterministically — same file, `LF → 28 blocks`, `CRLF → 1 block`. Content-independent, which is why it predates and is unrelated to the recent naming/export PRs.

## Fix

- **`src/tools.jl`** — normalize `\r\n`/`\r` → `\n` at the top of the parser. Split `_read_upgrading_entries()` (reads file) from `_parse_upgrading(text)` (parses) so the CRLF path is testable off-disk. This also fixes the **user-facing** feature: a consuming app reading its dev'd `UPGRADING.md` on Windows hit the identical bug.
- **`test/unit/test_upgrade_guide.jl`** — regression test that injects CRLF into the real file's text and asserts `from_crlf == from_lf` plus the #197/0.2.0 entry survives. Runs on every platform (Linux CI never checks the file out as CRLF, so it can't catch this via disk).
- **`.gitattributes`** — pin `*.md` to `eol=lf` for repo-checkout consistency (hygiene; the parser tolerates CRLF regardless).
- **`Project.toml`** — `0.3.0 → 0.3.1` (z-bump: bug fix, no behavior change → no `UPGRADING.md` entry).

## Verification

`test_upgrade_guide.jl` standalone: **27/27 pass** (24 prior + 3 new CRLF asserts). The refactored helper's only caller is `upgrade_guide` itself (signature unchanged), so the LF path is untouched and all pre-existing tests stay green. Parser-only change — no DB surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)