### PR TITLE
refactor(#225): remove obsolete _get_join_query (dead code)

### DIFF
--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -378,50 +378,6 @@ function _check_filter(x::Pair)
   end
 end
 
-# does this obsolet?
-function _get_join_query(array::Vector{String}; array_store::Vector{String}=String[])
-  array = copy(array)
-  for i in 1:size(array, 1)
-    for (k, value) in PormGsuffix
-      if endswith(array[i], k)
-        array[i] = array[i][1:end-length(k)]
-      end
-    end
-    for (k, value) in PormGtransform
-      if endswith(array[i], k)
-        array[i] = array[i][1:end-length(k)]
-      end
-    end
-  end
-
-  # how join to Vector
-  append!(array_store, array)
-  unique!(array_store)
-  return array_store
-end
-
-function _get_join_query(x::Tuple{Pair{String,Integer},Vararg{Pair{String,Integer}}}; array_store::Vector{String}=String[])
-  array = String[]
-  for (k, v) in x
-    push!(array, k)
-  end
-  _get_join_query(array, array_store=array_store)
-end
-function _get_join_query(x::Tuple{String,Vararg{String}}; array_store::Vector{String}=String[])
-  array = String[]
-  for v in x
-    push!(array, v)
-  end
-  _get_join_query(array, array_store=array_store)
-end
-function _get_join_query(x::Dict{String,Union{Integer,String}}; array_store::Vector{String}=String[])
-  array = String[]
-  for (k, v) in x
-    push!(array, k)
-  end
-  _get_join_query(array, array_store=array_store)
-end
-
 function _get_alias_name(df::DataFrames.DataFrame, alias::String)
   array = vcat(df.alias_a, df.alias_b)
   count = 1


### PR DESCRIPTION
## Summary

Removes the obsolete `_get_join_query` helper (comment + 4 overloads, 44 lines) from
`src/querybuilder/build_helpers.jl`. It was **dead code**:

- **No callers** — not exported, no reflection reference; the live filter/join path splits the key on
  `"__@"` and does an exact `haskey(PormGsuffix, …)` lookup, never routing through this function.
- **Latent bug** — it stripped a trailing suffix via `endswith` over unordered `Dict` iteration, so
  `foo__ncontains` ambiguously matched both `ncontains` and `contains`. Harmless only because uncalled.

Pure internal cleanup, no public/behavior change. `PormGsuffix` / `PormGtransform` remain (still used
elsewhere — 19 / 6 other references).

## Verification

- `grep -rn _get_join_query src/ test/ docs/` → **zero** references after removal.
- Full `Pkg.test()` (incl. Aqua) **4226/4226**, unchanged from before the deletion.

## Versioning

Internal dead-code removal → no version bump, no `UPGRADING.md` entry. Stays under `0.3.0`.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
