### PR TITLE
fix(#204): steer FK-read errors to values() projection, not on()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -75,6 +75,26 @@ driver.save()
 
 For framework integrations that require plain dictionaries, use `.list(:dict)`. For tabular analysis, pipe the query to `DataFrame`.
 
+!!! warning "No lazy FK traversal — project related columns up front"
+    PormG never lazily loads a related row. Accessing a ForeignKey you did not
+    project (`row.driverid`, or traversing further with `row.driverid.forename`)
+    raises an `ArgumentError`. Project what you need up front with `values(...)`,
+    then read it off the row by its key:
+
+    ```julia
+    # ✗ raises: driverid was not projected, and PormG won't lazily load it
+    row = M.Result.objects.values("resultid", "points").first()
+    driver_name = row.driverid.forename
+
+    # ✓ project the related column, then read it
+    row = M.Result.objects.values("resultid", "driverid__forename").first()
+    driver_name = row[:driverid__forename]
+
+    # ✓ or project the raw foreign-key value
+    row = M.Result.objects.values("resultid", "driverid").first()
+    driver_id = row[:driverid]
+    ```
+
 ---
 
 ## Query Styles

--- a/docs/src/read/values_and_joins.md
+++ b/docs/src/read/values_and_joins.md
@@ -69,6 +69,26 @@ WHERE "Tb_3"."status" = $1
 !!! note
     PormG uses table aliases (`Tb`, `Tb_1`, `Tb_2`, …) automatically. You never need to manage aliases yourself. Each joined table gets a sequential alias.
 
+!!! warning "No lazy FK traversal — project related columns up front"
+    PormG never lazily loads a related row. Accessing a ForeignKey you did not
+    project (`row.driverid`, or traversing further with `row.driverid.forename`)
+    raises an `ArgumentError`. Project what you need up front with `values(...)`,
+    then read it off the row by its key:
+
+    ```julia
+    # ✗ raises: driverid was not projected, and PormG won't lazily load it
+    row = M.Result.objects.values("resultid", "points").first()
+    driver_name = row.driverid.forename
+
+    # ✓ project the related column, then read it
+    row = M.Result.objects.values("resultid", "driverid__forename").first()
+    driver_name = row[:driverid__forename]
+
+    # ✓ or project the raw foreign-key value
+    row = M.Result.objects.values("resultid", "driverid").first()
+    driver_id = row[:driverid]
+    ```
+
 ---
 
 ## Multi-Level Joins

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -914,8 +914,11 @@ function Base.getproperty(row::PormGRow, sym::Symbol)
 
   if haskey(model.fields, String(normalized)) && model.fields[String(normalized)] isa Models.sForeignKey
     throw(ArgumentError(
-      "$(model.name).$(normalized) is a ForeignKey. Lazy FK traversal is not supported in PormG. " *
-      "Use `.on(\"$(normalized)\")` in your query to eagerly join the related table."
+      "$(model.name).$(normalized) is a ForeignKey that this row didn't project; " *
+      "PormG does not support lazy FK access (`row.$(normalized)`). " *
+      "Project it up front in `values(...)`: add `\"$(normalized)\"` for the raw key value, " *
+      "or `\"$(normalized)__<field>\"` for a column from the related table — " *
+      "then read it as `row[:$(normalized)]` or `row[:$(normalized)__<field>]`."
     ))
   end
 

--- a/test/integration/test_row_and_get.jl
+++ b/test/integration/test_row_and_get.jl
@@ -105,7 +105,15 @@ end
 
     standings = M.Driver_standings.objects.values("driverstandingsid").limit(1).first()
     @test standings isa PormGRow
-    @test_throws ArgumentError standings.driverId
+    # Accessing an un-projected ForeignKey (`driverid`) triggers the lazy-FK refusal.
+    # Lock not just the error TYPE but the guidance: it must steer to up-front
+    # `values("fk__field")` projection and never re-suggest `.on(...)` (which throws
+    # its own error and does not project columns — issue #204).
+    err = try; standings.driverid; nothing; catch e; e; end
+    @test err isa ArgumentError
+    @test occursin("values(", err.msg)   # steers to projection
+    @test occursin("__", err.msg)        # via the __ lookup
+    @test !occursin(".on(", err.msg)     # never re-suggests the on() dead end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Accessing an un-projected `ForeignKey` on a fetched `PormGRow` raised an `ArgumentError` whose hint pointed users at `.on("driverid")` — but `on()` throws its own error when given no predicate and never projects columns, so the hint dead-ended. The supported pattern is up-front projection with the `__` lookup.

This reworks the diagnostic to steer to `values(...)`, covering **both** things the branch fires for:

- **raw FK value** → `values("driverid")`, read as `row[:driverid]`
- **a related column** → `values("driverid__forename")`, read as `row[:driverid__forename]`

## Changes

- **`src/querybuilder/types.jl`** — reword the FK-read `ArgumentError` (both remedies, no more `.on()`).
- **`test/integration/test_row_and_get.jl`** — strengthen the regression test to lock the *guidance* (asserts the message steers to `values(`/`__` and never re-suggests `.on(`). Also fixes a latent bug: the old test accessed a camelCase field name that never matched the FK, so it silently validated the generic "no field" branch instead of the FK-traversal branch.
- **`docs/src/read/index.md`, `docs/src/read/values_and_joins.md`** — add a "No lazy FK traversal — project up front" `!!! warning` admonition (✗ un-projected access + ✓ related-column + ✓ raw-key examples, F1 domain).
- **`Project.toml`** — `0.3.1 → 0.3.2` (z-bump; diagnostic wording + docs, no behavior/API change → no `UPGRADING.md` entry).

## Verification

- SQLite integration: **1802/1802 passed** (re-verified on the rebased tree).
- PostgreSQL integration: **1836/1836 passed**.
- Docs build: clean; all three example variants render on both pages.
- Reviewed by three parallel reviewers (source, test, docs) — no blockers; two should-fixes applied (raw-key remedy; corrected ✗ doc example).

## Follow-up

The strengthened test is forced to `occursin` on message text because every failure condition throws a bare `ArgumentError`. Filed #231 (`pre-publish`) to introduce a semantic error taxonomy (typed `PormGError` subtypes) so consumers can `catch` a type instead of matching a string — the higher-leverage architectural fix, deliberately kept out of this `priority:low` change.

Closes #204
