### PR TITLE
fix(#206): repair install_ai_skills + refresh the pormg-usage consumer skill

### DIFF
--- a/.github/skills/pormg-usage/SKILL.md
+++ b/.github/skills/pormg-usage/SKILL.md
@@ -21,11 +21,11 @@ PormG exposes a fluent, expressive query API. Your default posture is:
 This skill is split so the common read/query path stays lean. Read these sibling files **only when the task needs them**:
 
 - **[`reference.md`](reference.md)** — full field-type table, field parameters, and `on_delete` options. Load when *defining models* or choosing a field type.
-- **[`writing.md`](writing.md)** — migrations flow, create/update/delete, bulk insert/copy/update, and transactions. Load when *changing data or schema*.
+- **[`writing.md`](writing.md)** — migrations flow, create/update/delete, the `row.save()` lifecycle, many-to-many managers, bulk insert/copy/update, and transactions (`atomic`/savepoints/`select_for_update`). Load when *changing data or schema*.
 
 > Building a **package on top of** PormG (extension hooks like `register_ignore_tables!`, `set_before_connect_hook`, the package-extension pattern)? That's a framework-author topic — see `docs/src/extending.md`, not this skill.
 
-Everything below covers setup and the read/query surface.
+Everything below covers setup, the read/query surface, and a summary of the write path (full detail in `writing.md`).
 
 ---
 
@@ -147,9 +147,40 @@ df   = query |> DataFrame   # DataFrames.DataFrame
 | `.list(:json)` | `String` | Results as JSON string. |
 | `query \|> DataFrame` | `DataFrame` | Tabular output. |
 | `.first()` | `PormGRow` or `nothing` | First matching row. |
-| `.get(filters...)` | `PormGRow` | Exactly one matching row, or a typed exception. |
+| `.get(filters...)` | `PormGRow` | Exactly one matching row, or raises `DoesNotExist` / `MultipleObjectsReturned`. |
 | `.count()` | `Int` | `SELECT COUNT(*)`. |
 | `.exists()` | `Bool` | True if any rows match. |
+
+---
+
+## Writing & Mutating Data
+
+Full detail (create/update/delete, bulk ops, transactions) is in [`writing.md`](writing.md); this
+is the at-a-glance surface so you don't reach for a stale pattern.
+
+**Row lifecycle.** `create()`, `get()`, `first()`, and `list()` return `PormGRow` values (not `Dict`
+— changed in #166); `update_or_create()` returns `(row::PormGRow, created::Bool)`. A `PormGRow` is
+dirty-tracked: assign fields, then `save()` writes only the changed columns.
+```julia
+driver = M.Driver.objects.create("forename" => "Ayrton", "surname" => "Senna")  # PormGRow
+driver.nationality = "Brazilian"    # dirty-tracked on assignment
+driver.save()                       # UPDATE ... WHERE <pk>; returns the row (no-op if clean)
+
+# Queryset .update() returns the matched-row count (Int), not a row:
+n = M.Result.objects.filter("raceid" => 1).update("points" => F("points") + 1)
+```
+
+**Many-to-many managers** (bang-free since 0.3.0) — access a `ManyToMany` field declared on the
+model (here `Driver` declares `sponsors`) to get a manager: `driver.sponsors.add(1, 2)`,
+`.remove(2)`, `.set(1, 4, 5)`, `.clear()`, `.all()`.
+
+**Transactions** — `atomic("db") do … end` (friendly alias of `run_in_transaction`); a nested
+`atomic` on the same db is a SAVEPOINT; `atomic("db"; durable=true)` forces a top-level transaction.
+Row locking: `query.select_for_update().list()` (PostgreSQL only; must run inside a transaction;
+silent no-op on SQLite).
+
+**`get()` exceptions** — `get()` raises `PormG.DoesNotExist` when nothing matches and
+`PormG.MultipleObjectsReturned` when more than one row matches. Catch them to handle lookups.
 
 ---
 

--- a/.github/skills/pormg-usage/writing.md
+++ b/.github/skills/pormg-usage/writing.md
@@ -42,16 +42,31 @@ driver = M.Driver.objects.create(
     "nationality" => "Brazilian",
     "driverref"   => "senna"
 )
-# Returns Dict with all fields including the new PK
+# Returns a PormGRow (since #166) — the same row object get()/first()/list() return,
+# fully populated (including the new PK) and ready to mutate and save().
+new_id = driver[:driverid]
 ```
 
-### Update matching records
+### Mutate a fetched row and persist with `row.save()`
+`get()`, `first()`, `list()`, and `create()` return `PormGRow` values (and `update_or_create()`
+returns `(row::PormGRow, created::Bool)`). Assigning a field marks it dirty; `save()` writes only
+the changed columns.
 ```julia
-M.Driver.objects.
+driver = M.Driver.objects.get("driverref" => "senna")   # a PormGRow
+driver.nationality = "Brazil"        # dirty-tracked on assignment
+driver.save()                        # UPDATE ... WHERE <pk> = ...; returns the PormGRow
+# save() is a no-op (returns the row unchanged) when nothing was mutated.
+# Inspect without executing: driver.save(show_query=:sql)
+```
+
+### Update matching records (queryset)
+```julia
+n = M.Driver.objects.
     filter("driverid" => 1).
     update("nationality" => "Brazil")
+# Queryset .update() returns the matched-row count (Int), not a row.
 
-# With F-expression (atomic)
+# With F-expression (atomic, at the database)
 M.Result.objects.
     filter("resultid__@in" => [1, 2, 3]).
     update("points" => F("points") * 1.1)
@@ -67,6 +82,22 @@ sql = M.Result.objects.filter("raceid" => 999).delete(show_query=:sql)
 
 # Delete all (requires explicit opt-in to prevent accidents)
 M.Just_a_test_deletion.objects.delete(allow_delete_all=true)
+```
+
+## Many-to-Many Relationships
+
+Access a `ManyToMany` field on a fetched row to get a relation manager, then call its
+bang-free methods (`add`/`remove`/`clear`/`set`/`all` — renamed from `add!`/… in 0.3.0).
+Targets may be primary keys or row objects. (The example assumes the model declares the
+relation — here `Driver` has a `sponsors` `ManyToManyField`.)
+```julia
+driver = M.Driver.objects.get("driverref" => "senna")
+
+driver.sponsors.add(1, 2)                 # link sponsors 1 and 2
+driver.sponsors.remove(2)                 # unlink sponsor 2
+changes = driver.sponsors.set(1, 4, 5)    # replace the whole set → (added=…, removed=…)
+driver.sponsors.clear()                   # unlink all
+rows = driver.sponsors.all() |> DataFrame # query the related rows
 ```
 
 ## Bulk Operations
@@ -112,13 +143,48 @@ end
 
 ## Transactions
 
+Wrap multiple writes so they commit together or all roll back on error. `atomic(db) do … end`
+is the friendly alias of `run_in_transaction`; both take a db-key `String`.
 ```julia
 using PormG
 
-# Wrap multiple operations in a single atomic transaction
-PormG.run_in_transaction("db") do
+atomic("db") do
     M.Race.objects.create("year" => 2025, "name" => "New Race", "date" => today())
     bulk_insert(M.Result.objects, results_df)
 end
-# All operations commit together, or all roll back on error
+# All operations commit together, or all roll back on error.
+```
+
+**Nested `atomic` = SAVEPOINT.** A nested `atomic`/`run_in_transaction` on the same db becomes
+a savepoint (partial rollback), not a second top-level transaction:
+```julia
+atomic("db") do
+    M.Race.objects.create("year" => 2025, "name" => "New Race", "date" => today())
+    try
+        atomic("db") do                       # SAVEPOINT
+            M.Result.objects.create("raceid" => 1, "driverid" => 1, "points" => 25)
+        end                                    # rolls back to the savepoint on error…
+    catch
+        # …leaving the outer Race insert intact; the outer transaction continues.
+    end
+end
+
+# Force a real top-level transaction (throws if one is already active):
+atomic("db"; durable=true) do
+    # ...
+end
+```
+
+**Row locking — `select_for_update()`** (PostgreSQL; silent no-op on SQLite). Chainable; must
+run inside a transaction, and locks the matched rows until COMMIT:
+```julia
+atomic("db") do
+    standing = M.Constructor_standings.objects.
+        filter("constructorid" => 131, "raceid" => 1120).
+        select_for_update().                   # kwargs: nowait, skip_locked, no_key
+        list() |> first
+    M.Constructor_standings.objects.
+        filter("constructorstandingsid" => standing[:constructorstandingsid]).
+        update("points" => standing[:points] + 25)
+end
 ```

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PormG"
 uuid = "7d8d7541-4d3d-4580-80a2-17064efb0993"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["PingoLee <eurafael@msn.com>"]
 
 [deps]

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -102,8 +102,8 @@ function setup(path::String = DB_PATH)
 
     println()
     println(_emsg("\e[34m--- AI Assistant Setup ---\e[0m"))
-    println("PormG can install 'AI skills' (.cursor/skills) to help coding assistants")
-    println("(Cursor and other agents) understand the PormG API in your project.")
+    println("PormG can install 'AI skills' (.github/skills) to help coding assistants")
+    println("(GitHub Copilot, Claude, Cursor, and other agents) understand the PormG API in your project.")
     print("Do you want to install PormG AI skills? (Y/n) [Default Y]: ")
     
     choice = readline() |> strip |> lowercase
@@ -115,29 +115,44 @@ end
 """
     install_ai_skills(target_dir::String = pwd())
 
-Copy PormG AI skill blueprints to the target project's `.cursor/skills` directory.
-This helps AI assistants (Cursor and other agents) provide better PormG code suggestions.
+Copy PormG's AI skill blueprint into the target project's `.github/skills/pormg-usage/`
+directory. This helps AI assistants (GitHub Copilot, Claude, Cursor, and other agents)
+provide accurate PormG code suggestions.
 
-The skill blueprint lives in the PormG package itself under `.cursor/skills/pormg-usage/`.
+The blueprint ships with the PormG package under `.github/skills/pormg-usage/` and is a
+multi-file bundle — `SKILL.md` plus the supporting `reference.md`/`writing.md` it links to.
+The **whole directory** is copied so none of `SKILL.md`'s relative links dangle after install.
 """
 function install_ai_skills(target_dir::String = pwd())
-    # @__DIR__ is src/ — navigate up to package root then into .cursor/skills
-    pkg_root = dirname(@__DIR__)
-    skill_src = joinpath(pkg_root, ".cursor", "skills", "pormg-usage", "SKILL.md")
-
-    target_skill_dir  = joinpath(target_dir, ".cursor", "skills", "pormg-usage")
-    target_skill_file = joinpath(target_skill_dir, "SKILL.md")
+    # Resolve the package root the same way `upgrade_guide` does (works for a
+    # registry install, not just a dev checkout). The blueprint moved from
+    # `.cursor/skills/` to `.github/skills/` — see commit ee2ad67.
+    skill_src_dir    = joinpath(Base.pkgdir(@__MODULE__), ".github", "skills", "pormg-usage")
+    target_skill_dir = joinpath(target_dir, ".github", "skills", "pormg-usage")
 
     try
-        mkpath(target_skill_dir)
-
-        if isfile(skill_src)
-            cp(skill_src, target_skill_file; force=true)
-            println(_emsg("\e[32mPormG AI skill installed → $target_skill_file\e[0m"))
-            println("Your coding assistant now understands PormG's query API, models, and migrations.")
-        else
-            @warn "Could not find PormG skill blueprint" expected_path=skill_src
+        if !isdir(skill_src_dir)
+            @warn "Could not find PormG skill blueprint" expected_path=skill_src_dir
+            return
         end
+
+        # Copy every file in the bundle so sibling links (SKILL.md → reference.md /
+        # writing.md) resolve in the consumer project. Flat bundle only — per-file
+        # (not a whole-dir replace) so any files the consumer added alongside it are
+        # left intact; add a recursive walk here if the bundle ever grows subdirs.
+        files = filter(f -> isfile(joinpath(skill_src_dir, f)), readdir(skill_src_dir))
+        if isempty(files)
+            @warn "PormG skill blueprint has no files to install" source=skill_src_dir
+            return
+        end
+
+        mkpath(target_skill_dir)
+        for f in files
+            cp(joinpath(skill_src_dir, f), joinpath(target_skill_dir, f); force=true)
+        end
+
+        println(_emsg("\e[32mPormG AI skill installed ($(length(files)) files) → $target_skill_dir\e[0m"))
+        println("Your coding assistant now understands PormG's query API, models, migrations, and write path.")
     catch e
         @error "Failed to install AI skills" exception=e
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,7 @@ end
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")
     @testset "Upgrade Guide Emitter (#216)" include("unit/test_upgrade_guide.jl")
+    @testset "AI Skill Installer (#206)" include("unit/test_install_ai_skills.jl")
     # include("unit/test_migration_planner.jl")
 end
 

--- a/test/unit/test_install_ai_skills.jl
+++ b/test/unit/test_install_ai_skills.jl
@@ -1,0 +1,66 @@
+# ==============================================================================
+# UNIT TESTS: install_ai_skills — copies the pormg-usage skill bundle (issue #206)
+#
+# `PormG.install_ai_skills(dir)` copies the multi-file skill blueprint that ships under
+# `.github/skills/pormg-usage/` into `<dir>/.github/skills/pormg-usage/`. Before #206 it
+# read from a deleted `.cursor/` path (so it copied nothing) and, even path-fixed, copied
+# only `SKILL.md` — leaving `SKILL.md`'s relative links to reference.md/writing.md dangling
+# in the consumer project.
+#
+# These tests pin: (1) the full bundle is installed into `.github/skills` (not the obsolete
+# `.cursor`), and (2) every relative markdown link inside the installed files resolves to a
+# sibling file — the exact #206 defect, and a guard against any future dangling link.
+#
+# Runs WITHOUT a live database — it only copies bundled markdown files.
+# ==============================================================================
+
+using Test
+using PormG
+
+@testset "install_ai_skills copies the full skill bundle with resolving links" begin
+    src_dir = joinpath(pkgdir(PormG), ".github", "skills", "pormg-usage")
+    @test isdir(src_dir)                                   # sanity: blueprint ships with the package
+    src_files = filter(f -> isfile(joinpath(src_dir, f)), readdir(src_dir))
+    @test !isempty(src_files)
+
+    mktempdir() do dir
+        PormG.install_ai_skills(dir)
+
+        installed_dir = joinpath(dir, ".github", "skills", "pormg-usage")
+        @test isdir(installed_dir)
+
+        # (1) every source file landed
+        for f in src_files
+            @test isfile(joinpath(installed_dir, f))
+        end
+
+        # (2) every relative markdown link inside the installed files resolves.
+        # Inline `](target)` links only — reference-style/titled links aren't parsed
+        # (the bundle uses none). `links_checked` guards against the loop passing
+        # vacuously if the files ever lose all inline links.
+        link_re = r"\]\(([^)]+)\)"
+        links_checked = 0
+        for f in readdir(installed_dir)
+            endswith(f, ".md") || continue
+            text = read(joinpath(installed_dir, f), String)
+            for m in eachmatch(link_re, text)
+                target = m.captures[1]
+                (startswith(target, "http://") || startswith(target, "https://") ||
+                 startswith(target, "#")) && continue        # external URL / same-page anchor
+                path = first(split(target, '#'))             # strip any #anchor suffix
+                isempty(path) && continue
+                links_checked += 1
+                @test isfile(joinpath(installed_dir, path))
+            end
+        end
+        @test links_checked > 0                              # the resolution loop actually ran
+    end
+end
+
+@testset "install_ai_skills targets .github/skills, not the obsolete .cursor" begin
+    mktempdir() do dir
+        PormG.install_ai_skills(dir)
+        @test isdir(joinpath(dir, ".github", "skills", "pormg-usage"))
+        @test !isdir(joinpath(dir, ".cursor"))
+    end
+end


### PR DESCRIPTION
## What & why

The consumer-facing AI skill (`.github/skills/pormg-usage/`, installed into downstream projects by `install_ai_skills`) had drifted from the code, and the installer itself was broken.

**The installer was a silent no-op.** It read from `<pkg>/.cursor/skills/pormg-usage/SKILL.md`, but `.cursor/` was removed in `ee2ad67` when skills moved to `.github/skills/` — so `isfile` was false and it copied nothing. Even with the path fixed it copied only `SKILL.md`, leaving `SKILL.md`'s relative links to `reference.md`/`writing.md` dangling in the consumer project (the crux of #206).

## Changes

- **`src/tools.jl` — `install_ai_skills`**: repoint the source to `.github/skills/pormg-usage/` (via `Base.pkgdir`, matching the `upgrade_guide` idiom) and copy the **whole bundle** so no installed link dangles. Install target is the consumer's `.github/skills/pormg-usage/`. Empty-bundle guard; `setup` prose updated.
- **`.github/skills/pormg-usage/writing.md`**: `create()` returns a `PormGRow` (was "Returns Dict", stale since #166) + the `row.save()` lifecycle; new **Many-to-Many** section (bang-free `add`/`remove`/`clear`/`set`/`all`, #201); expanded **Transactions** (`atomic`/nested savepoints/`select_for_update`).
- **`.github/skills/pormg-usage/SKILL.md`**: name the `get` exceptions (`DoesNotExist`/`MultipleObjectsReturned`) in the terminal table; add a "Writing & Mutating Data" summary; update the supporting-file description.
- **`test/unit/test_install_ai_skills.jl`** (new, wired into `runtests.jl`): installs into a temp dir and asserts the full bundle lands **and** every relative markdown link resolves — guards the exact #206 defect and any future dangling link.
- **`Project.toml`**: `0.3.2 → 0.3.3` (z-bump; broken unexported convenience + docs, no consumer source change → no `UPGRADING.md` entry).

## Verification

- Unit suite: **4245/4245 passed** (`Pkg.test` equivalent). New test: 16/16 + 2/2.
- Reviewed by three parallel reviewers (source+versioning, test, doc-content). Source **APPROVE**; test no blockers; doc-content surfaced three example bugs (a `points` field wrong on `Driver`, `update_or_create`'s tuple return, and an M2M relation implied on `Driver`) — **all fixed**. Every added API claim re-checked against `src/`.

## Notes

- Deliberately **not** in this PR: `pormg-changed-code-review/SKILL.md` still references the removed `.cursor` in its diff checklist — same `ee2ad67` root cause but a different skill, left for a separate cleanup.
- The issue's M2M method names (`add!`/…) were stale — #201 dropped the bangs; the skill documents the current bang-free names.

Closes #206
