### PR TITLE
fix(#205): default_env: env selection + fail-loud config load

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Prefer to wire it up by hand? The next steps show the files `setup()` would crea
 `db/connection.yml`:
 
 ```yaml
-env: dev
+default_env: dev
 
 dev:
   adapter: PostgreSQL       # or SQLite

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,6 +60,81 @@ PormG bump, point an agent (or yourself) at this file — read it from the dev'd
 
 ---
 
+## `connection.yml` env selection: `env:` → `default_env:`; `load()` fails loud on a missing config (#205)
+
+- **Version**: 0.3.1
+- **PormG ref**: issue #205 ; `src/Configuration.jl`, `src/Generator.jl`,
+  `src/querybuilder/{exceptions,execution,execution_bulk,many_to_many,deletion}.jl`,
+  `README.md`, `docs/src/{index,configuration/connection_yml,configuration/setup}.md`
+- **Recorded**: 2026-07-24
+- **Severity**: **behavior change** — three parts, all with clear, cheap migrations. Most apps: just
+  rename the yaml key. Part of the `0.3.x` pre-publish wave — roll it forward together with the
+  other `0.3.*` entries.
+
+### What changed
+
+1. **`env:` → `default_env:` (yaml).** The top-level `env:` key was always **inert** — the code that
+   read it had been commented out, so `env: prod` silently did nothing. It is renamed to
+   `default_env:` and given a real job: the **lowest-priority** environment default. Resolution
+   precedence, first wins: **`env=` kwarg › `ENV["PORMG_ENV"]` › file `default_env:` › `"dev"`.**
+   A leftover bare `env:` key is ignored and PormG **warns once per file** to rename it. `default_env:`
+   is optional — omit it and PormG uses `dev`.
+2. **`load()` fails loud on a missing config.** `PormG.Configuration.load(path)` used to scaffold a
+   skeleton, log an `@error`, and `return nothing` when the folder/yml was missing — a typo'd path
+   became a silent no-op that resurfaced later as a confusing settings-lookup error. It now **throws**
+   `MissingDatabaseConfigurationException` (newly defined; the name was previously thrown-but-undefined,
+   so a missing env block raised `UndefVarError`). First-run scaffolding is now explicit:
+   `PormG.setup(path)` or `load(path; scaffold=true)`. A missing env block error now lists the
+   available blocks.
+3. **Write-disabled message standardized.** The `change_data: false` guard's error is unified across
+   all write paths (insert / update / delete / update_or_create / bulk_insert|copy|update /
+   many-to-many add|remove|clear / primary-key allocation): it now reads *"…is not allowed to write.
+   … set `change_data: true` under the `config:` block…"* Only code that **string-matched** the old
+   per-operation wording (`not allowed to insert`/`update`/`delete`) is affected.
+
+### How to find the calls to migrate
+
+```
+rg -n '^env:' <app>/**/connection.yml                    # 1. rename the dead key → default_env: (or delete)
+rg -n 'Configuration\.load\(' <app>/src                  # 2. any load() that relied on auto-scaffold-on-missing (rare)
+rg -n 'not allowed to (insert|update|delete)' <app>/src  # 3. catch blocks string-matching the old write message
+```
+
+### Migrate your app
+
+```yaml
+# ✗ before — inert; selected nothing
+env: dev
+
+# ✓ after — an optional lowest-priority default; omit it entirely and PormG uses `dev`
+default_env: dev
+```
+
+```julia
+# load() on a missing/typo'd path was a silent no-op (scaffold + nothing) → it now THROWS.
+# If you relied on load() creating the skeleton, be explicit:
+PormG.Configuration.load("db"; scaffold=true)      # or: PormG.setup("db")
+
+# A catch that keyed on the old per-op write message → match the type + the new stable phrase:
+catch e
+    e isa ArgumentError && occursin("not allowed to write", e.msg) && handle()
+```
+
+The recommended server pattern is unchanged and preferred: let the host resolve its environment and
+pass it explicitly — `load(...; env=current_env())` — so `connection.yml` is identical across
+environments. `default_env:` is a convenience for scripts/single-env apps.
+
+### Per-app rollout
+
+| App | Status | Notes |
+|-----|--------|-------|
+| app-1 | ⏳ | rename `env:` → `default_env:` in each `connection.yml` (or delete); grep the 3 patterns above |
+| app-2 | ⏳ | same |
+| app-3 | ⏳ | same |
+| app-4 | ⏳ | same |
+
+---
+
 ## Public naming settled — ToChar, formatter, aggregate, M2M `add`/`remove`/`clear`/`set`, setup unexported (#201)
 
 - **Version**: 0.3.0

--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -4,7 +4,7 @@ PormG uses a centralized YAML configuration file—typically located at `db/conn
 
 ## Creating `connection.yml`
 
-During standard initialization, `PormG.Configuration.load()` will check for a `connection.yml` in your `DB_PATH`. If it does not exist, PormG provides interactive prompts (in `dev` environments) or throws an error.
+During standard initialization, `PormG.Configuration.load(path)` reads a `connection.yml` from `path` (default `DB_PATH`). If the folder or file is missing it **throws** a `MissingDatabaseConfigurationException` that points you at `PormG.setup(path)` (interactive) or `load(path; scaffold=true)` (writes an editable skeleton) — it no longer silently scaffolds a file and returns.
 
 To scaffold it programmatically, you can run:
 
@@ -18,14 +18,14 @@ Or you can manually create the `connection.yml` file and populate it using the s
 
 ## Adapters & Environments
 
-PormG uses an explicit `env` key at the root of the file to determine which nested configuration maps to the current active environment. The primary supported adapters are `PostgreSQL` and `SQLite`.
+Each top-level block (`dev`, `prod`, `test`, …) describes one environment, and PormG loads whichever one is active. The active environment is chosen by the `env=` argument to `load(...)`, the `PORMG_ENV` variable, or an optional top-level `default_env:` key — see [Multi-environment Routing](#Multi-environment-Routing) below. The primary supported adapters are `PostgreSQL` and `SQLite`.
 
 ### Using PostgreSQL
 
 To use a PostgreSQL database, assign `adapter: PostgreSQL` and configure your credentials.
 
 ```yaml
-env: dev
+default_env: dev
 
 dev:
   adapter: PostgreSQL
@@ -59,7 +59,7 @@ prod:
 When using SQLite, the parameters are simplified. You specify `adapter: SQLite` and pass the path (or file name) of the SQLite database to the `database` property. Missing elements like host, username, or port safely get ignored.
 
 ```yaml
-env: dev
+default_env: dev
 
 dev:
   adapter: SQLite
@@ -135,7 +135,17 @@ SQLite configurations ignore `extensions` with a warning, and `iunaccent_contain
 
 ## Multi-environment Routing
 
-The line `env: dev` instructs PormG to read from the block named `dev`. When you deploy your application (or if running `nitro_server` in another environment), you can change `env: prod` or set the system environment variable `PORMG_ENV=prod` to override the top-level YAML key seamlessly without modifying code.
+PormG selects the active environment block by this precedence — **first match wins**:
+
+1. the `env=` argument to `load(...)` — e.g. `PormG.Configuration.load("db"; env="prod")`;
+2. the `PORMG_ENV` environment variable — e.g. `PORMG_ENV=prod`;
+3. the optional top-level `default_env:` key in this file — e.g. `default_env: prod`;
+4. otherwise `dev`.
+
+The recommended pattern for a server is to let the **host** resolve its own environment and pass it explicitly: a framework (or your `bootstrap`) reads its own env var and calls `load(...; env=…)`, so the same `connection.yml` works unchanged in every environment. `default_env:` is a convenience for scripts and single-environment apps that would rather pin a default in the file than set an env var — omit it and PormG falls back to `dev`.
+
+!!! note "The bare `env:` key is ignored"
+    A top-level `env:` key (as opposed to `default_env:`) does **nothing** — it was renamed to `default_env:`. If a stale config still has `env:`, PormG warns once on load and keeps using the environment resolved above.
 
 ## Pre-connect hooks
 

--- a/docs/src/configuration/setup.md
+++ b/docs/src/configuration/setup.md
@@ -60,4 +60,4 @@ PormG supports explicit environment loading via `env`:
 PormG.Configuration.load("db"; env="prod")
 ```
 This is the **preferred method** for server applications, as it avoids relying on global `ENV` state.
-If `env` is not provided, PormG will fallback to `ENV["PORMG_ENV"]` (defaults to `dev`).
+If `env` is not provided, PormG falls back to `ENV["PORMG_ENV"]`, then to a top-level `default_env:` key in `connection.yml`, then to `dev`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -75,7 +75,7 @@ This creates a `db/` folder with a `connection.yml` template and a `models.jl` s
 Open `db/connection.yml` and configure your database:
 
 ```yaml
-env: dev
+default_env: dev
 
 dev:
   adapter: PostgreSQL
@@ -93,7 +93,7 @@ dev:
 For SQLite, use:
 
 ```yaml
-env: dev
+default_env: dev
 
 dev:
   adapter: SQLite

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -67,6 +67,17 @@ const DEV   = "dev"
 const PROD  = "prod"
 const TEST  = "test"
 
+# Raised when configuration cannot be loaded: a missing folder/yml (`load` no longer silently
+# scaffolds + returns `nothing` — #205) or a selected environment with no matching block in the
+# yaml. Typed so callers can `catch e; e isa MissingDatabaseConfigurationException`. Previously the
+# "no matching block" path referenced this name without defining it, so it threw an `UndefVarError`
+# instead of the intended message.
+struct MissingDatabaseConfigurationException <: Exception
+  msg::String
+end
+Base.showerror(io::IO, e::MissingDatabaseConfigurationException) =
+  print(io, "MissingDatabaseConfigurationException: ", e.msg)
+
 #
 # Thread-Local Transaction Context
 # This ensures that fetch() calls within a transaction use the same connection
@@ -208,8 +219,35 @@ function env(;path::String=DB_PATH)::String
 end
 env(x::String) = env(path=x)
 
-function _effective_env(env::Union{Nothing, String})::String
-  return env === nothing ? (haskey(ENV, "PORMG_ENV") ? ENV["PORMG_ENV"] : DEV) : env
+# Resolve the active environment (#205). Precedence, first wins:
+#   1. explicit `env=` kwarg to `load(...)`
+#   2. `ENV["PORMG_ENV"]` (set by the user or a host framework)
+#   3. the yaml's top-level `default_env:` (a per-file default)
+#   4. `"dev"`
+function _effective_env(env::Union{Nothing, String}, file_default::Union{Nothing, String} = nothing)::String
+  env !== nothing && return env
+  haskey(ENV, "PORMG_ENV") && return ENV["PORMG_ENV"]
+  file_default !== nothing && return file_default
+  return DEV
+end
+
+# Read only the top-level `default_env:` from a connection.yml, for env precedence (#205).
+# Returns it as a String, or `nothing` when the key is absent/blank. Parsed independently of
+# `read_db_connection_data` (a tiny yaml — negligible) so that function keeps its signature; a parse
+# error here is swallowed (returns `nothing`) and surfaces properly when `read_db_connection_data`
+# re-parses.
+function _peek_default_env(db_settings_file::String)::Union{Nothing, String}
+  raw = try
+    open(db_settings_file) do io
+      YAML.load(io)
+    end
+  catch
+    return nothing
+  end
+  raw isa AbstractDict || return nothing
+  val = get(raw, "default_env", nothing)
+  (val === nothing || (val isa AbstractString && isempty(strip(val)))) && return nothing
+  return string(val)
 end
 
 function _resolve_loaded_key(path_or_key::String)::Union{Nothing, String}
@@ -498,17 +536,13 @@ function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{
     YAML.load(io)
   end
 
-  # println(db_conn_data)
-
-  # if  haskey(db_conn_data, "env") && db_conn_data["env"] !== nothing
-  #   Base.ENV["PORMG_ENV"] =  if strip(uppercase(string(db_conn_data["env"]))) == """ENV["GENIE_ENV"]"""
-  #                               haskey(ENV, "GENIE_ENV") ? ENV["GENIE_ENV"] : DEV
-  #                             else
-  #                               db_conn_data["env"]
-  #                             end
-
-  #   settings.app_env = Base.ENV["PORMG_ENV"]
-  # end
+  # The top-level `env:` key is inert (#205): it was renamed to `default_env:`, and a bare `env:`
+  # never selected anything (its reader was long dead). Warn once per file so stale configs get a
+  # migration nudge — the environment comes from `load(...; env=)`, `ENV["PORMG_ENV"]`, or the
+  # file's `default_env:`, never from `env:`.
+  if haskey(db_conn_data, "env")
+    @warn "Ignoring the legacy top-level `env:` key in $(db_settings_file) — it was renamed to `default_env:` (#205) and a bare `env:` no longer selects an environment. Rename it to `default_env:` or remove it. Active environment: $(settings.app_env)." maxlog=1 _id=Symbol(:pormg_legacy_env_key_, db_settings_file)
+  end
 
   if  haskey(db_conn_data, settings.app_env)
       if haskey(db_conn_data[settings.app_env], "config") && isa(db_conn_data[settings.app_env]["config"], Dict)
@@ -531,33 +565,45 @@ function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{
       end
   end
 
-  haskey(db_conn_data, settings.app_env) ?
-    db_conn_data[settings.app_env] :
-    throw(MissingDatabaseConfigurationException("DB configuration for $(settings.app_env) not found"))
+  haskey(db_conn_data, settings.app_env) && return db_conn_data[settings.app_env]
+
+  # No block for the selected env — list the available ones so the fix is obvious (#205).
+  available = sort!(String[string(k) for (k, v) in db_conn_data if v isa AbstractDict])
+  avail_str = isempty(available) ? "(none defined)" : join(available, ", ")
+  throw(MissingDatabaseConfigurationException(
+    "environment \"$(settings.app_env)\" not found in $(db_settings_file); available: $(avail_str). " *
+    "Select one with `load(...; env=\"…\")`, `ENV[\"PORMG_ENV\"]`, or a top-level `default_env:` in the yaml."))
 end
 
 
-function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothing} = nothing, env::Union{Nothing,String} = nothing, config::Dict{String,PormGSettings} = config)
+function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothing} = nothing, env::Union{Nothing,String} = nothing, scaffold::Bool = false, config::Dict{String,PormGSettings} = config)
   # create settings if does not exists
   path === nothing && (path = DB_PATH )
-  selected_env = _effective_env(env)
 
   @pormg_debug false
 
-  # check if the path exists
-  if !isdir(path)
-    Generator.create_db_folder_and_yml(path=path)
-    @error("The database $(path) does not exist. A new folder and configuration file have been created. Please edit the file and run again.")
-    return nothing
+  db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME)
+
+  # Fail loudly on a missing folder/yml (#205). The old behavior — scaffold a skeleton, log an
+  # `@error`, and `return nothing` — turned a typo'd path into a silent no-op that resurfaced far
+  # away as a confusing settings-lookup error. First-run scaffolding is now explicit: pass
+  # `scaffold=true`, or use `PormG.setup(path)`.
+  if !isdir(path) || !isfile(db_settings_file)
+    if scaffold
+      Generator.create_db_folder_and_yml(path=path)
+      @info "PormG wrote a new configuration skeleton at $(db_settings_file). Edit it, then call `PormG.Configuration.load(\"$(path)\")` again."
+      return nothing
+    end
+    missing_what = !isdir(path) ? "the folder \"$(path)\" does not exist" :
+                                  "no \"$(PORMG_DB_CONFIG_FILE_NAME)\" was found in \"$(path)\""
+    throw(MissingDatabaseConfigurationException(
+      "cannot load PormG configuration: $(missing_what). Create it interactively with " *
+      "`PormG.setup(\"$(path)\")`, or call `PormG.Configuration.load(\"$(path)\"; scaffold=true)` " *
+      "to write a skeleton to edit."))
   end
 
-  # check if the yml file exists
-  db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME)
-  if !isfile(db_settings_file)
-    Generator.create_db_folder_and_yml(path=path)
-    @error("The database $(db_settings_file) does not exist. A new configuration file have been created. Please edit the configuration.yml file and run again.")
-    return nothing
-  end
+  # Resolve the environment with the file's `default_env:` folded into the precedence (#205).
+  selected_env = _effective_env(env, _peek_default_env(db_settings_file))
 
   if haskey(config, path) && config[path].connections !== nothing
     close_pool!(config[path].connections)

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -31,7 +31,7 @@ function create_db_folder_and_yml(;
         if lowercase(adapter) == "sqlite"
             db_name = isempty(database) ? "database.sqlite" : database
             write(f, """
-env: dev
+default_env: dev
 
 dev:
   adapter: SQLite
@@ -43,7 +43,7 @@ dev:
 """)
         else
             write(f, """
-env: dev
+default_env: dev
 
 dev:
   adapter: $adapter

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -59,7 +59,7 @@ function delete(objct::SQLObjectHandler;
   settings, connection, conn_key = get_settings(objct, connection=connection)
     
   # check if is allowed to delete
-  !settings.change_data && throw(_argerr("Error in delete, the connection \e[4m\e[31m$conn_key\e[0m not allowed to delete"))
+  !settings.change_data && throw(_write_not_allowed("delete", conn_key))
 
   if objct.object.limit > 0 || objct.object.offset > 0 || !isempty(objct.object.order)
     throw(ArgumentError(

--- a/src/querybuilder/exceptions.jl
+++ b/src/querybuilder/exceptions.jl
@@ -29,3 +29,13 @@ _argerr(msg::AbstractString) = ArgumentError(_emsg(msg))
 # Exceptions and escape every typed catch.
 _unsupported_conn(op::AbstractString, conn) = error(_emsg(
   "PormG internal error in $(op): unsupported connection type $(typeof(conn)) — expected a PostgreSQL or SQLite connection pool."))
+
+# Standard actionable error for a write blocked by `change_data: false` (#205). Every DML entry
+# point (insert, update, delete, update_or_create, bulk_*, many-to-many add/remove/clear,
+# primary-key allocation) shares this one message so a user hitting any of them gets the same fix —
+# writes are disabled by default (safety-first), which is the common first-`create` trap, and the
+# message must name where to fix it: the `config:` block of the active environment in connection.yml.
+_write_not_allowed(operation::AbstractString, conn_key) = _argerr(
+  "Error in $(operation): the connection \e[4m\e[31m$(conn_key)\e[0m is not allowed to write. " *
+  "Writes are disabled by default — set \e[1mchange_data: true\e[0m under the `config:` block of the active " *
+  "environment in connection.yml to enable creates, updates, and deletes.")

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -549,7 +549,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
   set_context!(parameters, :select)
 
   # check if is allowed to insert
-  !settings.change_data && throw(_argerr("Error in insert, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("insert", conn_key))
 
   # Fill defaults/auto_now/auto_now_add/UUID, reserve SQLite ids, validate, and collect the quoted
   # physical columns + bound VALUES params. Shared with _update_or_create (#30) so both build the
@@ -645,7 +645,7 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
   parameters = get_parameter(connection)
   set_context!(parameters, :select)
 
-  !settings.change_data && throw(_argerr("Error in update_or_create, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("update_or_create", conn_key))
 
   quoted_field_columns, param_values, pk_exist, pk_field =
     _prepare_row_insert!(real_obj, model, settings, connection, parameters)
@@ -1189,7 +1189,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   settings, connection, conn_key = get_settings(objct, connection=connection)
 
   # Check if is allowed to update
-  !settings.change_data && throw(_argerr("Error in update, the connection \e[4m\e[31m$conn_key\e[0m not allowed to update"))
+  !settings.change_data && throw(_write_not_allowed("update", conn_key))
 
   # Guard: limit(), offset(), and order_by() cannot be combined with update().
   # Standard SQL UPDATE does not support these clauses. Silently dropping them

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -237,7 +237,7 @@ end
 function allocate_primary_keys(objct::SQLObjectHandler, df_o::DataFrames.DataFrame; clone::Bool=true)
   model = objct.object.model
   settings, connection, conn_key = get_settings(objct)
-  !settings.change_data && throw(_argerr("Error in allocate_primary_keys, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("allocate_primary_keys", conn_key))
 
   # NOT the #132 zero-copy wrapper: unlike the bulk ops' internal working frames, this
   # frame is RETURNED to the caller, so shared vectors would be user-visible aliasing —
@@ -855,7 +855,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   
 
   # check if is allowed to insert
-  !settings.change_data && throw(_argerr("Error in bulk_insert, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("bulk_insert", conn_key))
 
   # If no rows then nothing to do
   if size(df_o, 1) == 0
@@ -985,7 +985,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   !(connection isa PormGPostgres) && throw(ArgumentError("bulk_copy is only supported for PostgreSQL. Use bulk_insert for SQLite."))
 
   # check if is allowed to insert
-  !settings.change_data && throw(_argerr("Error in bulk_copy, the connection \e[4m\e[31m$conn_key\e[0m not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("bulk_copy", conn_key))
 
   # If no rows then nothing to do
   if size(df_o, 1) == 0
@@ -1315,7 +1315,7 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
   settings, connection, conn_key = get_settings(objct)
 
   # check if is allowed to insert
-  !settings.change_data && throw(_argerr("Error in bulk_update, the connection \e[4m\e[31m$conn_key\e[0m not allowed to update"))
+  !settings.change_data && throw(_write_not_allowed("bulk_update", conn_key))
 
   # If no rows then nothing to do
   if size(df_o, 1) == 0

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -125,7 +125,7 @@ function add(manager::ManyToManyManager, targets...)
   isempty(target_ids) && return nothing
 
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many add, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to insert"))
+  !settings.change_data && throw(_write_not_allowed("many-to-many add", conn_key))
 
   table_name = safe_table_identifier(manager.relation.through_model, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
@@ -177,7 +177,7 @@ function remove(manager::ManyToManyManager, targets...)
   isempty(target_ids) && return nothing
 
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many remove, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
+  !settings.change_data && throw(_write_not_allowed("many-to-many remove", conn_key))
 
   table_name = safe_table_identifier(manager.relation.through_model, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
@@ -202,7 +202,7 @@ end
 function clear(manager::ManyToManyManager)
   _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   settings, connection, conn_key = _m2m_settings(manager)
-  !settings.change_data && throw(_argerr("Error in many-to-many clear, the connection \e[4m\e[31m$conn_key\e[0m is not allowed to delete"))
+  !settings.change_data && throw(_write_not_allowed("many-to-many clear", conn_key))
 
   parameters = get_parameter(connection)
   set_context!(parameters, :where)

--- a/test/integration/db_test_migration_pg/connection.yml
+++ b/test/integration/db_test_migration_pg/connection.yml
@@ -7,7 +7,7 @@
 #
 # `database` is a DEDICATED disposable DB — the edge-case suite DROPs every table in it
 # and auto-creates/drops it — so it must NOT be the shared pormg_teste.
-env: dev
+default_env: dev
 
 dev:
   adapter: "PostgreSQL"

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -439,3 +439,115 @@ end
         _cleanup_configuration_test_keys([key_off])
     end
 end
+
+# ── #205: connection.yml env selection + fail-loud load ────────────────────────────────────────
+# Pins the config-loading onboarding fixes: `default_env:` is honored as the lowest-priority
+# environment selector, the legacy `env:` key is inert but warns, `load` throws (rather than
+# silently scaffolding + returning `nothing`) on a missing folder/yml with an opt-in `scaffold=true`,
+# and a missing env block reports the available ones. All DB-free (SQLite `:memory:`), isolated via
+# `mktempdir` + `_cleanup_configuration_test_keys`.
+@testset "config env selection + fail-loud load (#205)" begin
+    MDCE = PormG.Configuration.MissingDatabaseConfigurationException
+
+    # dev (read-only) + prod (writable) blocks, so the selected env is identifiable by change_data.
+    _dev_prod_blocks =
+        "dev:\n  adapter: SQLite\n  database: \":memory:\"\n  config:\n    change_db: false\n    change_data: false\n" *
+        "prod:\n  adapter: SQLite\n  database: \":memory:\"\n  config:\n    change_db: true\n    change_data: true\n"
+
+    @testset "default_env: honored as the lowest-priority default" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            write(joinpath(db_dir, "connection.yml"), "default_env: prod\n" * _dev_prod_blocks)
+
+            # No `env=` and no PORMG_ENV → the file's `default_env: prod` beats the built-in `dev`.
+            withenv("PORMG_ENV" => nothing) do
+                PormG.Configuration.load(db_dir)
+            end
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.app_env == "prod"
+            @test s.change_data == true
+
+            # An explicit `env=` outranks `default_env:` → back to the dev block.
+            withenv("PORMG_ENV" => nothing) do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+            s2 = PormG.Configuration.get_settings(db_dir)
+            @test s2.app_env == "dev"
+            @test s2.change_data == false
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "PORMG_ENV outranks default_env:" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            write(joinpath(db_dir, "connection.yml"), "default_env: prod\n" * _dev_prod_blocks)
+
+            # The middle precedence rung: ENV["PORMG_ENV"] beats the file's default_env: prod.
+            withenv("PORMG_ENV" => "dev") do
+                PormG.Configuration.load(db_dir)
+            end
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.app_env == "dev"
+            @test s.change_data == false
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "legacy env: key is inert and warns" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            # A bare `env: prod` must NOT select prod; with no PORMG_ENV/kwarg the env falls to the
+            # built-in `dev`, and a one-time deprecation warning fires.
+            write(joinpath(db_dir, "connection.yml"), "env: prod\n" * _dev_prod_blocks)
+
+            withenv("PORMG_ENV" => nothing) do
+                @test_logs (:warn,) match_mode=:any PormG.Configuration.load(db_dir)
+            end
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.app_env == "dev"          # bare `env: prod` ignored
+            @test s.change_data == false      # dev block
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "load throws on a missing folder/yml (no silent scaffold)" begin
+        mktempdir() do temp_root
+            missing_dir = joinpath(temp_root, "nope")
+            @test_throws MDCE PormG.Configuration.load(missing_dir)
+            @test !isdir(missing_dir)                       # nothing scaffolded behind our back
+
+            empty_dir = joinpath(temp_root, "empty"); mkpath(empty_dir)
+            @test_throws MDCE PormG.Configuration.load(empty_dir)    # folder exists, no yml
+
+            # Opt-in scaffolding writes a skeleton (with default_env:, no legacy env:) and returns.
+            scaffold_dir = joinpath(temp_root, "scaffolded")
+            PormG.Configuration.load(scaffold_dir; scaffold=true)
+            yml = read(joinpath(scaffold_dir, "connection.yml"), String)
+            @test occursin("default_env:", yml)
+            @test !occursin(r"^env:"m, yml)                 # no bare legacy key
+        end
+    end
+
+    @testset "missing env block lists the available blocks" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            _write_configuration_test_connection(joinpath(db_dir, "connection.yml"))  # dev + test
+
+            err = nothing
+            try
+                PormG.Configuration.load(db_dir; env="staging")
+            catch e
+                err = e
+            end
+            @test err isa MDCE
+            @test occursin("staging", err.msg)
+            @test occursin("dev", err.msg) && occursin("test", err.msg)
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+end

--- a/test/unit/test_execution_show.jl
+++ b/test/unit/test_execution_show.jl
@@ -158,7 +158,10 @@ end
     end
 
     @test err isa ArgumentError
-    @test occursin("not allowed to delete", lowercase(sprint(showerror, err)))
+    # #205: unified write-disabled message names the op and points at the `config:` block.
+    let m = lowercase(sprint(showerror, err))
+      @test occursin("error in delete:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
+    end
   finally
     PormG.config["default"].change_data = previous_change_data
   end
@@ -179,7 +182,9 @@ end
     end
 
     @test err isa ArgumentError
-    @test occursin("not allowed to update", lowercase(sprint(showerror, err)))
+    let m = lowercase(sprint(showerror, err))
+      @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
+    end
 
     inspect_err = try
       q.update("forename" => "Blocked", show_query=:dict)
@@ -189,7 +194,9 @@ end
     end
 
     @test inspect_err isa ArgumentError
-    @test occursin("not allowed to update", lowercase(sprint(showerror, inspect_err)))
+    let m = lowercase(sprint(showerror, inspect_err))
+      @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
+    end
   finally
     PormG.config["default"].change_data = previous_change_data
   end


### PR DESCRIPTION
## Summary

Resolves #205 — three silent config-loading traps in `connection.yml`, plus a latent undefined-exception bug.

- **`env:` → optional `default_env:`** — the top-level `env:` key was inert (its reader was dead code, so `env: prod` silently did nothing). Renamed to `default_env:` and wired as the **lowest-priority** environment default: `env=` kwarg › `ENV["PORMG_ENV"]` › file `default_env:` › `"dev"`. A leftover bare `env:` warns once per file.
- **`load()` fails loud** — throws `MissingDatabaseConfigurationException` (newly defined; the name was previously thrown-but-undefined → a missing env block raised `UndefVarError`) on a missing folder/yml, instead of silently scaffolding + returning `nothing`. Opt-in `scaffold=true` restores skeleton-writing; `setup()` unchanged. A missing env block now lists the available blocks.
- **Standardized the `change_data` write-disabled error** across all **11** write paths (insert / update / delete / update_or_create / bulk_insert·copy·update / m2m add·remove·clear / pk-allocation) via a shared `_write_not_allowed(op, conn_key)` helper — names the op and points at the `config:` block.
- Generator template, README, docs (incl. a rewritten *Multi-environment Routing* section), and a `0.3.1` `UPGRADING.md` entry.

## Versioning

Version stays **`0.3.1`** (unreleased) — folds into the 0.3.x pre-publish wave so consuming apps (on 0.2.x) migrate `0.2 → 0.3.x` in one pass. `UPGRADING.md` carries the `before → after` and per-app rollout table.

## Testing

Full unit suite **4244/4244** (incl. Aqua). New `#205` testset pins the `default_env` precedence (all 3 rungs), the legacy-`env:` warn, fail-loud `load`, `scaffold=true`, and the available-blocks error. Rebased onto current `main` (#204) and re-verified green.

## Notes

- #203 had already removed the `ENV["PORMG_ENV"]="dev"` force-set (a module-body statement that never ran at runtime under precompilation), so no force-set work was needed here — and the feared "dev→test test-suite flip" never actually existed.
- Fixed 3 pre-existing tests that asserted the old per-op write-message wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
