### PR TITLE
feat(#231): semantic error taxonomy — typed PormGError instead of bare ArgumentError

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,6 +67,73 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.3.0`, dates
 
 ---
 
+## Query-builder errors are a typed `PormGError` taxonomy — stop catching `ArgumentError` (#231)
+
+- **Version**: Unreleased
+- **PormG ref**: issue #231 ; `src/PormG.jl` (abstract root + exports), `src/querybuilder/exceptions.jl`
+  (subtypes + `showerror` + `_write_not_allowed`), the throw sites across `src/querybuilder/*.jl`,
+  `docs/src/api.md`
+- **Recorded**: 2026-07-24
+- **Severity**: **breaking (error contract)** — every query-builder misuse now raises a subtype of
+  `PormGError` (`<: Exception`) instead of a bare `ArgumentError`/`ErrorException`. The subtypes are
+  **NOT** `<: ArgumentError` (a clean break), so `catch ArgumentError` / `occursin(text, e.msg)` blocks
+  around PormG query calls stop matching. Part of the `0.3.x` pre-publish wave; extends the #197
+  typed-exception lineage. **Supersedes the type in the #205 entry below:** the standardized
+  write-disabled error is now `PermissionError`, not `ArgumentError`.
+
+### What changed
+
+Query-builder failures now carry a semantic **type**, so callers react programmatically instead of
+matching a message string. The root is `PormGError <: Exception`; catch it for any query-builder
+failure, or a specific subtype:
+
+| Subtype | Raised when |
+|---------|-------------|
+| `UnknownFieldError` / `LazyTraversalError` (both `<: FieldAccessError`) | field/column/`__`-path not found; or an unprojected `ForeignKey` read off a fetched row (steer to `values(...)`) |
+| `FilterError` | invalid filter argument/shape; operator misuse on a JSON/subquery column |
+| `QueryBuildError` | structural/API misuse (joins, CTEs, projection, ordering, window/bulk config) — the long-tail default |
+| `UnsafeMutationError` | `update()`/`delete()` without a filter (or another unsafe shape) |
+| `InvalidValueError` | value coercion/type mismatch on insert/update; identifier-safety guard; interval/duration parse |
+| `PermissionError` | connection not allowed to insert/update/delete (`change_data=false`) — this is the #205 write-disabled error, now typed |
+| `UnsupportedConnectionError` | connection is neither PostgreSQL nor SQLite, or a model is not bound to a connection |
+| `DoesNotExist` / `MultipleObjectsReturned` | `get()` found zero / more than one row (reparented under `PormGError`) |
+
+**Out of scope (still `ArgumentError`):** field-constructor validation (`src/models/fields.jl`) and
+model/schema-definition errors (`src/Models.jl`). A follow-up issue migrates those.
+
+### How to find the calls to migrate
+
+```
+rg -n 'catch|@test_throws|isa' <app> | rg 'ArgumentError|ErrorException'
+```
+
+Focus on blocks wrapping PormG query calls (`filter`/`values`/`update`/`delete`/`get`/row access/`bulk_*`).
+Field-definition and model-definition errors still throw `ArgumentError` — leave those.
+
+### Migrate your app
+
+```julia
+# ✗ before — coupled to the message wording (incl. the #205 write-disabled catch)
+try
+    run_query()
+catch e
+    e isa ArgumentError && occursin("not allowed to write", e.msg) && fall_back_to_readonly()
+    rethrow(e)
+end
+
+# ✓ after — catch the semantic type, or the abstract root for any query-builder misuse
+try
+    run_query()
+catch e
+    e isa PormG.PermissionError    && return fall_back_to_readonly()  # the #205 write-disabled case
+    e isa PormG.LazyTraversalError && return steer_to_projection()    # unprojected FK read
+    e isa PormG.PormGError         && return handle_pormg_error(e)    # anything the QB rejected
+    rethrow(e)
+end
+```
+
+---
+
 ## `connection.yml` env selection: `env:` → `default_env:`; `load()` fails loud on a missing config (#205)
 
 - **Version**: Unreleased

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -630,6 +630,7 @@ PormG's type hierarchy provides the foundation for the query builder and model s
 | `SQLTypeCTE` | Common Table Expression type. |
 | `PormGModel` | Base for model types. |
 | `PormGField` | Base for field type definitions. |
+| `PormGError` | Root of the semantic error taxonomy (`<: Exception`). Every query-builder misuse raises a subtype (see [Error taxonomy](#error-taxonomy)); `catch PormGError` catches them all. |
 
 ---
 
@@ -644,6 +645,36 @@ scope — the SQL function constructors are *not* among them (see
 
 ### Rows & exceptions
 `PormGRow`, `pk`, `DoesNotExist`, `MultipleObjectsReturned`
+
+### Error taxonomy
+Every query-builder misuse raises a subtype of `PormGError` (`<: Exception`) so callers can
+`catch` a **type** instead of matching on a message string. Catch `PormGError` for any
+query-builder failure, or a specific subtype for a specific reaction (#231):
+
+`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `PermissionError`, `UnsupportedConnectionError`
+
+| Type | Raised when |
+| :--- | :--- |
+| `FieldAccessError` *(abstract)* | Umbrella for field/accessor lookup failures — `catch` it to get both cases below. |
+| `UnknownFieldError` | A field, alias, column, or `__` lookup path does not exist on the model or projected row. |
+| `LazyTraversalError` | An unprojected `ForeignKey` was read off a fetched row — project it in `values(...)` first. |
+| `FilterError` | Invalid filter argument/shape, or an operator misused on a JSON/subquery column. |
+| `QueryBuildError` | Structural/API misuse while building a query (joins, CTEs, projection, ordering, window/bulk config). |
+| `UnsafeMutationError` | An `update()`/`delete()` was requested without a filter (or another unsafe shape). |
+| `InvalidValueError` | A value failed coercion/type validation, an identifier failed the safety check, or an interval/duration could not be parsed. |
+| `PermissionError` | The connection is not permitted to insert/update/delete (`change_data=false`). |
+| `UnsupportedConnectionError` | A connection is neither PostgreSQL nor SQLite, or a model is not bound to a connection. |
+| `DoesNotExist` / `MultipleObjectsReturned` | `get()` found zero / more than one row. Both are `<: PormGError`. |
+
+```julia
+try
+    M.Result.objects.update("points" => 25)   # no filter → refused, protects every row
+catch e
+    e isa PormG.UnsafeMutationError && @warn "add a filter before update()"
+    e isa PormG.PermissionError    && @warn "this connection is read-only"
+    rethrow(e)
+end
+```
 
 ### Bulk Operations
 `bulk_insert`, `bulk_update`, `bulk_copy`, `allocate_primary_keys`

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -71,6 +71,12 @@ abstract type PormGField <: PormGAbstractType end # define the type of the colum
 
 abstract type Migration <: PormGAbstractType end
 
+# Root of the semantic error taxonomy (#231). Subtypes <: Exception (NOT <: ArgumentError — a
+# clean break, so callers catch a type instead of string-matching a message). Declared at the top
+# module level so every submodule can `import PormG: PormGError`; the concrete query-builder
+# subtypes live in `src/querybuilder/exceptions.jl`. Extends the #197 typed-exception lineage.
+abstract type PormGError <: Exception end
+
 const config::Dict{String,PormGSettings} = Dict()
 
 include("constants.jl")
@@ -133,6 +139,9 @@ include("QueryBuilder.jl")
 # live solely in `PormG.Functions` (below). There is intentionally no `PormG.Sum`: the
 # function library has exactly one home, reached via `using PormG.Functions` / `PormG.Functions.X`.
 import .QueryBuilder: object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Subquery, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+# Semantic error taxonomy concrete subtypes (#231); the abstract `PormGError` root is defined
+# above in this module. Bridge the QueryBuilder-defined subtypes up so `using PormG` exposes them.
+import .QueryBuilder: FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError, QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError
 
 """
     PormG.Functions
@@ -165,6 +174,8 @@ end
 # Curated top-level surface: query primitives only. The SQL function constructors above
 # live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
 export object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Subquery, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+# Semantic error taxonomy (#231): catch `PormGError` for any query-builder misuse, or a specific subtype.
+export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError, QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -7,6 +7,7 @@ import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_sym
 import PormG: Dialect, Models
 import PormG: config
 import PormG: SQLType, PormGSettings, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField
+import PormG: PormGError  # root of the semantic error taxonomy (#231); concrete subtypes in querybuilder/exceptions.jl
 import PormG: PormGsuffix, PormGtransform, JSON_CONTAINMENT_OPERATORS, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
@@ -94,6 +95,9 @@ export get
 # methods and explicit `import PormG.QueryBuilder: page`/`query`/`update` are unaffected —
 # export status only governs the bare-`using` dump.
 export PormGRow, pk, DoesNotExist, MultipleObjectsReturned
+# Semantic error taxonomy (#231): every query-builder misuse throws a PormGError subtype.
+export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError,
+  QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError
 # do_count and do_exists are now strictly used as functors (query.count(), query.exists())
 export bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -19,7 +19,7 @@ function get_settings(obj::Union{SQLObject,SQLObjectHandler}; connection::Union{
     if length(config) == 1
       conn_key = first(keys(config))
     else
-      throw(ArgumentError("Model '$(q.model.name)' is not bound to a database connection key. " *
+      throw(UnsupportedConnectionError("Model '$(q.model.name)' is not bound to a database connection key. " *
         "Call `set_models()` or `PormG.@import_models` to bind the model before querying."))
     end
   end
@@ -94,9 +94,9 @@ function _check_function(x::Vector{String})
       if haskey(PormGsuffix, x[end])
         yes = "you can use \"column__@\e[32m$(x[end])\e[0m\""
         not = "you can not use \"column__\e[31m@$(x[end])__@function\e[0m\". valid functions are:\n$(joined_keys_with_prefix_func)\e[0m\nvalid operators are:\n$(joined_keys_with_prefix_oper)\e[0m"
-        throw(_argerr("\e[4m\e[31m$(x[end])\e[0m is not allowed.\n$yes\n$not"))
+        throw(FilterError("\e[4m\e[31m$(x[end])\e[0m is not allowed.\n$yes\n$not"))
       else
-        throw(_argerr("\"$(x[1])__\e[31m@$(x[end])\e[0m\" is invalid;\n please use a valid function:\n  - $(joined_keys_with_prefix_func)\e[0m\nor a valid operator:\n  - $(joined_keys_with_prefix_oper)\e[0m"))
+        throw(FilterError("\"$(x[1])__\e[31m@$(x[end])\e[0m\" is invalid;\n please use a valid function:\n  - $(joined_keys_with_prefix_func)\e[0m\nor a valid operator:\n  - $(joined_keys_with_prefix_oper)\e[0m"))
       end
     end
   end
@@ -166,7 +166,7 @@ function _raise_invalid_filter_operator(field_path::Vector{String}, shape::Abstr
     # No __@ suffix at all: a bare field was paired with a $shape value.
     field = field_path[end]
     examples = join(map(a -> "$(field)__@" * a, allowed), ", ")
-    throw(_argerr("Error in filter: field \e[31m$(field)\e[0m was given a $(shape) value but no operator.\n" *
+    throw(FilterError("Error in filter: field \e[31m$(field)\e[0m was given a $(shape) value but no operator.\n" *
                   "With a $(shape) value, use one of: $(examples)"))
   end
   suffix = field_path[end]
@@ -175,12 +175,12 @@ function _raise_invalid_filter_operator(field_path::Vector{String}, shape::Abstr
     # input looks like a near-miss, suggest the intended one (e.g. @notin → @nin).
     suggestion = _suggest_operator(suffix)
     hint = suggestion === nothing ? "" : " Did you mean \e[32m@$(suggestion)\e[0m?"
-    throw(_argerr("Error in filter: \e[31m@$(suffix)\e[0m is not a valid operator.$(hint)\n" *
+    throw(FilterError("Error in filter: \e[31m@$(suffix)\e[0m is not a valid operator.$(hint)\n" *
                   "Valid operators: $(all_opers)\n" *
                   "With a $(shape) value, use one of: $(allowed_opers)"))
   else
     # Known operator, but not valid for this value shape (e.g. @gte with a vector).
-    throw(_argerr("Error in filter: operator \e[31m@$(suffix)\e[0m is not valid with a $(shape) value.\n" *
+    throw(FilterError("Error in filter: operator \e[31m@$(suffix)\e[0m is not valid with a $(shape) value.\n" *
                   "With a $(shape) value, use one of: $(allowed_opers)"))
   end
 end
@@ -241,7 +241,7 @@ function _get_pair_to_oper(x::Pair{Vector{String},Vector{T}}) where T<:Union{Mis
     return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   elseif suffix in ("range", "nrange")   # #207: nrange = NOT BETWEEN, same 2-value shape
     if length(x.second) != 2
-      throw(_argerr("Error in filter, '$(suffix)' operator requires exactly 2 values, got $(length(x.second))"))
+      throw(FilterError("Error in filter, '$(suffix)' operator requires exactly 2 values, got $(length(x.second))"))
     end
     return OperObject(operator=PormGsuffix[suffix], values=x.second, column=SQLField(_check_function(x.first[1:end-1]), join(x.first[1:end-1], "__")))
   elseif suffix in ("has_any_keys", "has_keys")
@@ -354,7 +354,7 @@ function _validate_membership_subquery(v::SQLTypeOper)
     "The subquery currently selects $(projection_count) columns: $(_summarize_projection_labels(projection_labels))."
   end
 
-  throw(ArgumentError(
+  throw(FilterError(
     "PormG: '$lookup' requires a subquery that returns exactly one column. " *
     detail * " Fix: call .values(\"field_name\") on the subquery so it projects only the key used by the filter."
   ))
@@ -374,7 +374,7 @@ function _check_filter(x::Pair)
       rethrow(e)
     end
   else
-    throw(_argerr("Error in filter: '$(x.first) => ...' must use a String key, got $(typeof(x.first))"))
+    throw(FilterError("Error in filter: '$(x.first) => ...' must use a String key, got $(typeof(x.first))"))
   end
 end
 
@@ -436,14 +436,14 @@ function _check_if_field_is_a_operator(field::String)
     "year", "iso_year", "quarter", "month", "day", "week", "week_day", "iso_week_day",
     "hour", "minute", "second", "isnull", "regex", "iregex"]
   if field in common_operators
-    throw(_argerr("The filter operator '\e[31m$field\e[0m' requires '@' prefix. Use '\e[32m$field\e[0m' => ... as part of '__\e[33m@$field\e[0m' syntax. Example: \e[36mq.filter(\"name__@$field\" => value)\e[0m"))
+    throw(FilterError("The filter operator '\e[31m$field\e[0m' requires '@' prefix. Use '\e[32m$field\e[0m' => ... as part of '__\e[33m@$field\e[0m' syntax. Example: \e[36mq.filter(\"name__@$field\" => value)\e[0m"))
   end
 end
 
 function _normalize_join_type(join_type::String)
   valid_joins = ["INNER", "LEFT", "RIGHT", "FULL", "CROSS"]
   normalized = uppercase(strip(join_type))
-  normalized in valid_joins || throw(ArgumentError("Invalid join type '$(join_type)'. Valid types: $(join(valid_joins, ", "))"))
+  normalized in valid_joins || throw(QueryBuildError("Invalid join type '$(join_type)'. Valid types: $(join(valid_joins, ", "))"))
   return normalized
 end
 
@@ -480,7 +480,7 @@ function _solve_field(field::String, model::PormGModel, instruct::SQLInstruction
   if !(field in model.field_names)
     _check_if_field_is_a_operator(field)
     @pormg_debug false
-    throw(_argerr("The field \e[31m$(field)\e[0m not found in \e[34m$(model.name)\e[0m: \e[32m$(join(model.field_names, ", "))\e[0m"))
+    throw(UnknownFieldError("The field \e[31m$(field)\e[0m not found in \e[34m$(model.name)\e[0m: \e[32m$(join(model.field_names, ", "))\e[0m"))
   end
   # (instruct.django !== nothing && hasfield(model.fields[field] |> typeof, :to)) && (field = string(field, "_id"))
 
@@ -576,12 +576,12 @@ function _resolve_window_expression(v, instruc::SQLInstruction)
   if v isa Symbol
     return _resolve_window_expression(String(v), instruc)
   elseif v isa String
-    isempty(v) && throw(ArgumentError("Window expression fields cannot be empty"))
+    isempty(v) && throw(QueryBuildError("Window expression fields cannot be empty"))
     return _get_select_query(_check_function(v), instruc)
   elseif v isa SQLType
     return _get_select_query(v, instruc)
   else
-    throw(ArgumentError("Unsupported window expression $(repr(v)) of type $(typeof(v))"))
+    throw(QueryBuildError("Unsupported window expression $(repr(v)) of type $(typeof(v))"))
   end
 end
 
@@ -590,10 +590,10 @@ _normalize_window_orientation(orientation::AbstractString)::String =
   _normalize_order_orientation(orientation; context="Window ORDER BY")
 
 function _resolve_window_order(v::String, instruc::SQLInstruction)::String
-  isempty(v) && throw(ArgumentError("Window ORDER BY fields cannot be empty"))
+  isempty(v) && throw(QueryBuildError("Window ORDER BY fields cannot be empty"))
   orientation = startswith(v, "-") ? "DESC" : "ASC"
   field = startswith(v, "-") ? v[2:end] : v
-  isempty(field) && throw(ArgumentError("Window ORDER BY fields cannot be empty"))
+  isempty(field) && throw(QueryBuildError("Window ORDER BY fields cannot be empty"))
   return string(_resolve_window_expression(field, instruc), " ", orientation)
 end
 
@@ -615,9 +615,9 @@ function _build_over_clause(over::WindowSpec, instruc::SQLInstruction)::String
   end
 
   if over.frame !== nothing
-    instruc.connection isa PormGSQLite && throw(ArgumentError("SQLite window functions in PormG do not support explicit frame specifications yet. Remove frame=$(repr(over.frame)) or use PostgreSQL."))
+    instruc.connection isa PormGSQLite && throw(QueryBuildError("SQLite window functions in PormG do not support explicit frame specifications yet. Remove frame=$(repr(over.frame)) or use PostgreSQL."))
     frame = strip(over.frame)
-    isempty(frame) && throw(ArgumentError("Window frame cannot be empty"))
+    isempty(frame) && throw(QueryBuildError("Window frame cannot be empty"))
     push!(parts, frame)
   end
 
@@ -640,7 +640,7 @@ function _get_select_query(v::WindowFunction, instruc::SQLInstruction; _as::Unio
 
   if v.column === nothing
     v.function_name in ["LAG", "LEAD", "FIRST_VALUE", "LAST_VALUE", "NTH_VALUE"] &&
-      throw(ArgumentError("$(v.function_name) requires a column argument; got nothing"))
+      throw(QueryBuildError("$(v.function_name) requires a column argument; got nothing"))
     return getfield(Dialect, func_name)(over_sql, instruc.connection)
   end
 
@@ -657,8 +657,8 @@ function _get_select_query(v::WindowFunction, instruc::SQLInstruction; _as::Unio
     return getfield(Dialect, func_name)(resolved_column, over_sql, resolved_kwargs, instruc.connection)
   elseif v.function_name == "NTH_VALUE"
     n = get(v.kwargs, "n", nothing)
-    n isa Integer || throw(ArgumentError("NthValue requires a positive integer n"))
-    n <= 0 && throw(ArgumentError("NthValue n must be a positive integer"))
+    n isa Integer || throw(QueryBuildError("NthValue requires a positive integer n"))
+    n <= 0 && throw(QueryBuildError("NthValue n must be a positive integer"))
     return getfield(Dialect, func_name)(resolved_column, n, over_sql, instruc.connection)
   else
     return getfield(Dialect, func_name)(resolved_column, over_sql, instruc.connection)
@@ -822,7 +822,7 @@ end
 function _resolve_outer_ref_field_name(ref::OuterRefObject, outer::SQLInstruction)::String
   if ref.field_name == "pk"
     pk_field = Models.get_model_pk_field(outer.object.model)
-    pk_field === nothing && throw(ArgumentError("OuterRef(\"pk\") requires the outer model '$(outer.object.model.name)' to define exactly one primary key field"))
+    pk_field === nothing && throw(QueryBuildError("OuterRef(\"pk\") requires the outer model '$(outer.object.model.name)' to define exactly one primary key field"))
     return String(pk_field)
   end
   return ref.field_name
@@ -934,7 +934,7 @@ function _resolve_cjoin_on_alias_column(v::String, instruc::SQLInstruction)
   config = get(instruc.object.custom_join, alias, nothing)
   (config isa Dict{String,Any} && get(config, "no_anchor", false) == true) || return nothing
   target_model = getfield(instruc.object.model._module, Symbol(config["target_model"]::String))::PormGModel
-  (col in target_model.field_names) || throw(_argerr(
+  (col in target_model.field_names) || throw(UnknownFieldError(
     "cjoin_on: column '$(col)' not found on aliased model '$(target_model.name)' (alias '$(alias)')."))
   return string(quote_identifier(alias, instruc.connection), ".",
                 quote_identifier(Models.field_db_column(target_model.fields[col], col), instruc.connection))
@@ -946,7 +946,7 @@ function _get_filter_query(v::ExistsObject, instruc::SQLInstruction)
   return _build_exists_query(v.query, instruc)
 end
 function _get_filter_query(v::OuterRefObject, instruc::SQLInstruction)
-  instruc.outer === nothing && throw(ArgumentError("OuterRef(\"$(v.field_name)\") can only be resolved while building a correlated subquery such as Exists(subquery)."))
+  instruc.outer === nothing && throw(QueryBuildError("OuterRef(\"$(v.field_name)\") can only be resolved while building a correlated subquery such as Exists(subquery)."))
   return _get_filter_query(_resolve_outer_ref_field_name(v, instruc.outer), instruc.outer)
 end
 # function _get_filter_query(v::SQLTypeText, instruc::SQLInstruction)
@@ -976,7 +976,7 @@ function _json_numeric_rhs(value)
   s = strip(string(value))
   n = tryparse(Int, s); n !== nothing && return n
   f = tryparse(Float64, s); (f !== nothing && isfinite(f)) && return f
-  throw(_argerr("A numeric JSON comparison requires a number; got \e[31m$(value)\e[0m."))
+  throw(FilterError("A numeric JSON comparison requires a number; got \e[31m$(value)\e[0m."))
 end
 
 # #27: render a comparison against a JSON path lookup (e.g. `payload__driver`). The RHS binds
@@ -1002,7 +1002,7 @@ function _render_json_lookup_comparison(v::SQLTypeOper, column::String, instruc:
     ph = add_parameter!(instruc, _json_numeric_rhs(v.values))
     return string(lhs, " ", op, " ", ph)
   else
-    throw(_argerr("The operator \e[31m$(op)\e[0m is not supported on a JSON path lookup. Use =, !=, <, <=, >, >=, or __@isnull."))
+    throw(FilterError("The operator \e[31m$(op)\e[0m is not supported on a JSON path lookup. Use =, !=, <, <=, >, >=, or __@isnull."))
   end
 end
 
@@ -1013,11 +1013,11 @@ end
 function _render_json_operator(v::SQLTypeOper, column::String, instruc::SQLInstruction)::String
   col_as = isa(v.column, SQLTypeField) ? v.column._as : nothing
   if col_as !== nothing && haskey(instruc.json_lookup_cache, col_as)
-    throw(_argerr("The \e[31m@$(v.operator)\e[0m operator applies to a JSON column, not a nested key path (\e[31m$(col_as)\e[0m); this is not supported in v1."))
+    throw(FilterError("The \e[31m@$(v.operator)\e[0m operator applies to a JSON column, not a nested key path (\e[31m$(col_as)\e[0m); this is not supported in v1."))
   end
   base = _resolve_json_operator_field(v, instruc)
   (base !== nothing && Models.is_json_field(base)) ||
-    throw(_argerr("The \e[31m@$(v.operator)\e[0m operator requires a JSONField column; \e[31m$(something(col_as, "the target"))\e[0m is not JSON."))
+    throw(FilterError("The \e[31m@$(v.operator)\e[0m operator requires a JSONField column; \e[31m$(something(col_as, "the target"))\e[0m is not JSON."))
   op = v.operator
   ph = if op == "jcontains"
     add_parameter!(instruc, Models.format_json_sql(v.values); sql_type="jsonb")
@@ -1025,7 +1025,7 @@ function _render_json_operator(v::SQLTypeOper, column::String, instruc::SQLInstr
     add_parameter!(instruc, string(v.values))
   else  # has_any_keys / has_keys
     v.values isa AbstractVector ||
-      throw(_argerr("The \e[31m@$(op)\e[0m operator requires an array of keys, e.g. filter(\"col__@$(op)\" => [\"a\", \"b\"]); got a single value."))
+      throw(FilterError("The \e[31m@$(op)\e[0m operator requires an array of keys, e.g. filter(\"col__@$(op)\" => [\"a\", \"b\"]); got a single value."))
     add_parameter!(instruc, String.(v.values); sql_type="text[]")
   end
   return getfield(Dialect, Symbol(op))(instruc.connection, column, ph)
@@ -1078,7 +1078,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     # Subqueries - these are safe since they're built through PormG.jl
     if !(v.operator in ["IN", "NOT IN"])
       @pormg_debug
-      throw(_argerr("Invalid subquery filter on \"$(v.column.field)\": a queryset value requires a membership operator — use \"$(v.column.field)__@in\" => subquery or __@nin."))
+      throw(FilterError("Invalid subquery filter on \"$(v.column.field)\": a queryset value requires a membership operator — use \"$(v.column.field)__@in\" => subquery or __@nin."))
     end
     _validate_membership_subquery(v)
     placeholders = query(v.values, table_alias=instruc.table_alias, connection=instruc.connection, parameters=instruc.parameters, outer=instruc)
@@ -1124,7 +1124,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       catch e
         @pormg_debug false
         if contains(string(e), "The date") && contains(string(e), "is invalid")
-          throw(_argerr("The \e[4m\e[31m$(v.column.field)\e[0m field is the type \e[4m\e[32m$(instruc.object.model.fields[v.column.field].type)\e[0m. Please check the value: \e[4m\e[31m$(v.values)\e[0m"))
+          throw(FilterError("The \e[4m\e[31m$(v.column.field)\e[0m field is the type \e[4m\e[32m$(instruc.object.model.fields[v.column.field].type)\e[0m. Please check the value: \e[4m\e[31m$(v.values)\e[0m"))
         end
         @pormg_debug false
         rethrow(e)
@@ -1141,7 +1141,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
       placeholders = add_parameter!(instruc, v.values, contains=is_like_op, operator=v.operator)
     else
       @pormg_debug false
-      throw(_argerr("Field \"$(v.column.field)\" not found in model $(instruc.object.model.name)"))
+      throw(UnknownFieldError("Field \"$(v.column.field)\" not found in model $(instruc.object.model.name)"))
     end
   end
 
@@ -1170,7 +1170,7 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     @pormg_debug false
     return getfield(Dialect, Symbol(v.operator))(instruc.connection, column, placeholders)
   else
-    throw(_argerr("Invalid filter operator: $(v.operator) is not a supported operator."))
+    throw(FilterError("Invalid filter operator: $(v.operator) is not a supported operator."))
   end
 end
 function _get_filter_query(q::SQLTypeQ, instruc::SQLInstruction)

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -11,7 +11,7 @@ function _determine_join_type(field::PormGField; previus_how::Union{String, Noth
     if second_fild_name !== nothing
       _check_if_field_is_a_operator(second_fild_name)
     end
-    throw(ArgumentError("The field '$(field)' does not have a 'how' property"))
+    throw(QueryBuildError("The field '$(field)' does not have a 'how' property"))
   elseif field.how !== nothing && !isempty(field.how)
     return _normalize_join_type(field.how)
   end
@@ -87,7 +87,7 @@ function _resolve_django_join_field(model::PormGModel, field_name::String, instr
     # The field exists directly. Reject the explicit "_id" FK form (callers must use the short form).
     if endswith(field_name, "_id") && hasfield(typeof(field), :to)
       short_name = field_name[1:end-3]
-      throw(ArgumentError("In Django-style join paths use '$(short_name)__...' instead of '$(field_name)__...'."))
+      throw(QueryBuildError("In Django-style join paths use '$(short_name)__...' instead of '$(field_name)__...'."))
     end
     return field_name
   end
@@ -118,7 +118,7 @@ function _resolve_m2m_side_model(_module::Module, binding::String, model_name::S
     Models.format_model_name(model.name) == target_name && return model
   end
 
-  throw(ArgumentError("The many-to-many model $(binding) for accessor $(field_name) is not defined"))
+  throw(QueryBuildError("The many-to-many model $(binding) for accessor $(field_name) is not defined"))
 end
 
 function _resolve_many_to_many_related_model(_module::Module, relation::Models.ManyToManyRelation)::PormGModel
@@ -170,7 +170,7 @@ function _row_join_for_alias(row_join::Vector{Dict{String, Union{String, Vector{
   for row in row_join
     row["alias_b"] == alias && return row
   end
-  throw(ArgumentError("Internal error: join alias $(alias) was not found in row_join"))
+  error(_emsg("PormG internal error: join alias $(alias) was not found in row_join — this should not happen; please report it."))
 end
 
 # Shared helper used at the four sites in `_build_row_join` where a many-to-many
@@ -212,7 +212,7 @@ function _validate_json_key_segments(segments::Vector{String})::Vector{String}
     if occursin(r"^\d+$", seg) || occursin(SAFE_IDENTIFIER_PATTERN, seg)
       continue
     end
-    throw(_argerr("Invalid JSON key segment \e[31m$(seg)\e[0m in a JSON path lookup. Segments must be a non-negative integer (array index) or a simple key (letters, digits, underscore). Keys with spaces, dots, or quotes are not addressable via the `__` path syntax."))
+    throw(InvalidValueError("Invalid JSON key segment \e[31m$(seg)\e[0m in a JSON path lookup. Segments must be a non-negative integer (array index) or a simple key (letters, digits, underscore). Keys with spaces, dots, or quotes are not addressable via the `__` path syntax."))
   end
   return segments
 end
@@ -262,7 +262,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     cte_name = vector[1]
     cte_dict = instruct.object.ctes[cte_name]
     if !haskey(cte_dict, "model")
-      throw(ArgumentError("Internal error: CTE $(cte_name) has not been materialized yet"))
+      error(_emsg("PormG internal error: CTE $(cte_name) has not been materialized yet — this should not happen; please report it."))
     end
     cte_model = cte_dict["model"]::PormGModel
     
@@ -277,7 +277,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       # does not apply to a CROSS JOIN (INNER-like by nature).
       if !haskey(cte_model.fields, vector[2])
         available = join(collect(keys(cte_model.fields)), ", ")
-        throw(ArgumentError("CTE field '$(vector[2])' not found in '$(cte_name)'; available fields: $(available)"))
+        throw(UnknownFieldError("CTE field '$(vector[2])' not found in '$(cte_name)'; available fields: $(available)"))
       end
       row_join["a"] = instruct.object.model.name
       row_join["alias_a"] = instruct.alias
@@ -303,7 +303,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
 
       if !haskey(cte_model.fields, cte_table_key)
         available = join(collect(keys(cte_model.fields)), ", ")
-        throw(ArgumentError("CTE join_field column '$(cte_table_key)' not found in $(cte_name); available fields: $(available)"))
+        throw(UnknownFieldError("CTE join_field column '$(cte_table_key)' not found in $(cte_name); available fields: $(available)"))
       end
 
 
@@ -317,7 +317,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
         row_join["alias_a"] = v_split[1] |> string
         row_join["key_a"] = v_split[2] |> string
       else
-        throw(ArgumentError("Main table join_field column '$(main_table_key)' not found in $(instruct.object.model.name); available fields: $(join(instruct.object.model.field_names, ", "))"))
+        throw(UnknownFieldError("Main table join_field column '$(main_table_key)' not found in $(instruct.object.model.name); available fields: $(join(instruct.object.model.field_names, ", "))"))
       end
 
       # Set up the join with the CTE
@@ -405,7 +405,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     end
   else
     @pormg_debug false
-    throw(_argerr("the column \e[4m\e[31m$(vector[1])\e[0m not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m, that contains the fields: \e[4m\e[32m$(join(instruct.object.model.field_names, ", "))\e[0m and the related objects: \e[4m\e[32m$(join(keys(instruct.object.model.related_objects), ", "))\e[0m"))
+    throw(UnknownFieldError("the column \e[4m\e[31m$(vector[1])\e[0m not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m, that contains the fields: \e[4m\e[32m$(join(instruct.object.model.field_names, ", "))\e[0m and the related objects: \e[4m\e[32m$(join(keys(instruct.object.model.related_objects), ", "))\e[0m"))
   end
 
   if !m2m_inserted
@@ -489,7 +489,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       s_model = Symbol(uppercasefirst(string(new_object.related_objects[vector[1]][3])))
       reverse_model = getfield(foreing_table_module, s_model)
       length(vector) == 1 && throw(_argerr("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
-      !(vector[2] in reverse_model.field_names) && throw(_argerr("Invalid field path: the column $(vector[2]) not found in $(reverse_model.name)"))
+      !(vector[2] in reverse_model.field_names) && throw(UnknownFieldError("Invalid field path: the column $(vector[2]) not found in $(reverse_model.name)"))
       row_join["a"] = prev_b
       row_join["alias_a"] = tb_alias
       join_field = reverse_model.fields[new_object.related_objects[vector[1]][1] |> String]
@@ -513,7 +513,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       end
 
     else
-      throw(_argerr("Invalid field path: the column $(vector[1]) not found in $(new_object.name)"))
+      throw(UnknownFieldError("Invalid field path: the column $(vector[1]) not found in $(new_object.name)"))
     end
 
     @pormg_debug false   

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -267,7 +267,7 @@ function get_filter_query(object::SQLObject, instruc::SQLInstruction)::Nothing
     elseif isa(v, Union{SQLTypeQor,SQLTypeQ,SQLTypeF})
       push!(instruc._where, _get_filter_query(v, instruc))
     else
-      throw(_argerr("Invalid filter entry: $(v) (::$(typeof(v))) is not a Q, Qor, or operator expression."))
+      throw(FilterError("Invalid filter entry: $(v) (::$(typeof(v))) is not a Q, Qor, or operator expression."))
     end
   end
   return nothing

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -65,14 +65,14 @@ function _normalize_cjoin_filter_key(key::String, prefix::String, foreign_model:
 
   if startswith(key, prefix * "__")
     suffix = key[length(prefix) + 3:end]
-    isempty(suffix) && throw(ArgumentError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. Provide a field on the joined model after the join path prefix."))
+    isempty(suffix) && throw(FilterError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. Provide a field on the joined model after the join path prefix."))
 
     base_field = String(split(suffix, "__")[1])
     if base_field in foreign_model.field_names || haskey(foreign_model.related_objects, base_field)
       return key
     end
 
-    throw(ArgumentError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. The joined model '$(foreign_model.name)' does not contain the field or related path '$(base_field)'."))
+    throw(FilterError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. The joined model '$(foreign_model.name)' does not contain the field or related path '$(base_field)'."))
   end
 
   base_field = String(split(key, "__")[1])
@@ -80,7 +80,7 @@ function _normalize_cjoin_filter_key(key::String, prefix::String, foreign_model:
     return string(prefix, "__", key)
   end
 
-  throw(ArgumentError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. cjoin filters modify the JOIN ON clause and must target fields on the joined model '$(foreign_model.name)'. Use a joined-model field like '$(prefix)__field' (or just 'field' for auto-prefixing), and keep base-query filters in .filter(...)."))
+  throw(FilterError("Invalid cjoin filter field '$(key)' for join path '$(prefix)'. cjoin filters modify the JOIN ON clause and must target fields on the joined model '$(foreign_model.name)'. Use a joined-model field like '$(prefix)__field' (or just 'field' for auto-prefixing), and keep base-query filters in .filter(...)."))
 end
 
 function _prefix_join_filter(filter, prefix::String, foreign_model::Union{PormGModel,Nothing})
@@ -155,11 +155,11 @@ function _collect_join_filters(filters)
       if isa(f, Union{Pair,SQLTypeQ,SQLTypeQor,SQLTypeOper,SQLTypeF})
         push!(_filters, f)
       else
-        throw(ArgumentError("Invalid filter type in array: $(typeof(f)). Use Pair, Q, Qor, OP, or F expressions."))
+        throw(FilterError("Invalid filter type in array: $(typeof(f)). Use Pair, Q, Qor, OP, or F expressions."))
       end
     end
   else
-    throw(ArgumentError("Invalid filters type: $(typeof(filters)). Use a Pair, Q, Qor, OP, F expression, or an array of these."))
+    throw(FilterError("Invalid filters type: $(typeof(filters)). Use a Pair, Q, Qor, OP, F expression, or an array of these."))
   end
 
   return _filters
@@ -167,7 +167,7 @@ end
 
 function _resolve_join_target_model(q::SQLObject, join_path::String)
   parts = split(join_path, "__")
-  isempty(parts) && throw(ArgumentError("on() requires a non-empty join path."))
+  isempty(parts) && throw(QueryBuildError("on() requires a non-empty join path."))
 
   current_model = q.model
   current_module = q.model._module
@@ -176,7 +176,7 @@ function _resolve_join_target_model(q::SQLObject, join_path::String)
     current_path = join(parts[1:index], "__")
 
     if index == 1 && haskey(q.ctes, part)
-      throw(ArgumentError("on() does not target CTE names. Use with(..., join_type=...) to configure CTE join types."))
+      throw(QueryBuildError("on() does not target CTE names. Use with(..., join_type=...) to configure CTE join types."))
     end
 
     field = if part in current_model.field_names
@@ -189,7 +189,7 @@ function _resolve_join_target_model(q::SQLObject, join_path::String)
 
     if field !== nothing
       if !hasproperty(field, :to) || field.to === nothing
-        throw(ArgumentError("Join path '$(join_path)' stops at base field '$(part)', which is not a relation. Use cjoin(..., field=...) first if this path depends on a custom link."))
+        throw(QueryBuildError("Join path '$(join_path)' stops at base field '$(part)', which is not a relation. Use cjoin(..., field=...) first if this path depends on a custom link."))
       end
 
       current_model = field.to isa PormGModel ? field.to : getfield(current_module, Symbol(String(field.to)))
@@ -205,7 +205,7 @@ function _resolve_join_target_model(q::SQLObject, join_path::String)
         current_model = getfield(current_module, reverse_model)
       end
     else
-      throw(ArgumentError("Join path '$(join_path)' is invalid. The segment '$(part)' is not a relation on model '$(current_model.name)'."))
+      throw(QueryBuildError("Join path '$(join_path)' is invalid. The segment '$(part)' is not a relation on model '$(current_model.name)'."))
     end
   end
 
@@ -224,14 +224,14 @@ function on(q::SQLObject, join_path::String, filters::AbstractVector; join_type:
     elseif isa(prefixed, FilterType)
       push!(parsed_filters, prefixed)
     else
-      throw(ArgumentError("Invalid filter type: $(typeof(prefixed)). Use Pair, Q, Qor, OP, or F expressions."))
+      throw(FilterError("Invalid filter type: $(typeof(prefixed)). Use Pair, Q, Qor, OP, or F expressions."))
     end
   end
 
   existing = get(q.custom_join, join_path, Dict{String,Any}())
 
   if isempty(parsed_filters) && join_type === nothing
-    throw(ArgumentError("on() requires at least one ON predicate or a join_type override."))
+    throw(QueryBuildError("on() requires at least one ON predicate or a join_type override."))
   end
 
   existing_join_type = get(existing, "join_type", nothing)
@@ -305,19 +305,19 @@ function cjoin(
 
   # # Validations
   if main_join === nothing
-    throw(ArgumentError("Please, main_join argument is required to create a new join."))
+    throw(QueryBuildError("Please, main_join argument is required to create a new join."))
   end
 
   # if field_destination !== nothing && !contains(field_destination, "__")
-  #   throw(ArgumentError("Invalid field_destination format: '$field_destination'. Expected format 'related_model__field'."))
+  #   throw(QueryBuildError("Invalid field_destination format: '$field_destination'. Expected format 'related_model__field'."))
   # end
   if (split(main_join.first, "__") |> length) > 1
-    throw(ArgumentError("That is not supported yet: main_join with related fields. Please, provide just the field name of the main model."))
+    throw(QueryBuildError("That is not supported yet: main_join with related fields. Please, provide just the field name of the main model."))
   end
 
   @pormg_debug false
   if (split(main_join.first, "__") |> length) == 1 && main_join.first ∉ q.model.field_names
-    throw(ArgumentError("The field '$(main_join.first)' is not a field in model '$(q.model.table_name)'. The fields are: $(q.model.field_names)"))
+    throw(UnknownFieldError("The field '$(main_join.first)' is not a field in model '$(q.model.table_name)'. The fields are: $(q.model.field_names)"))
   end
 
   # Validation: if field already exists as a FK on the model, ensure target model matches
@@ -334,7 +334,7 @@ function cjoin(
 
     # Compare case-insensitively since model names may be capitalized differently
     if existing_target !== nothing && lowercase(existing_target) != lowercase(main_join.second)
-      throw(ArgumentError("Field '$(main_join.first)' is already a ForeignKey pointing to '$(existing_target)', but cjoin attempted to join with '$(main_join.second)'. To add ON conditions to an existing FK, the target model must match. Use cjoin(query, \"$(main_join.first)\" => \"$(existing_target)\", filters=[...]) instead."))
+      throw(QueryBuildError("Field '$(main_join.first)' is already a ForeignKey pointing to '$(existing_target)', but cjoin attempted to join with '$(main_join.second)'. To add ON conditions to an existing FK, the target model must match. Use cjoin(query, \"$(main_join.first)\" => \"$(existing_target)\", filters=[...]) instead."))
     end
   end
 
@@ -346,14 +346,14 @@ function cjoin(
 
     #   test_result = Models.ForeignKey(Result, pk_field="resultId", on_delete="CASCADE", null=true, related_name="test_deletion"),
     if !isdefined(q.model._module, main_join.second |> Symbol)
-      throw(ArgumentError("Model '$(main_join.second)' not found in module. Please remember that model names are case-sensitive."))
+      throw(QueryBuildError("Model '$(main_join.second)' not found in module. Please remember that model names are case-sensitive."))
       return nothing
     end
     foreign_model = getfield(q.model._module, Symbol(main_join.second))
     @pormg_debug false
     pk_field = Models.get_model_pk_field(foreign_model)
     if !isa(pk_field, Symbol)
-      throw(ArgumentError("Foreign model '$(foreign_model.name)' does not have a valid/single primary key field."))
+      throw(QueryBuildError("Foreign model '$(foreign_model.name)' does not have a valid/single primary key field."))
     end
 
     if warn
@@ -393,7 +393,7 @@ function cjoin(
     elseif isa(prefixed, FilterType)
       push!(parsed_filters, prefixed)
     else
-      throw(ArgumentError("Invalid filter type: $(typeof(prefixed)). Use Pair, Q, Qor, OP, or F expressions."))
+      throw(FilterError("Invalid filter type: $(typeof(prefixed)). Use Pair, Q, Qor, OP, or F expressions."))
     end
   end
 
@@ -402,7 +402,7 @@ function cjoin(
   if !haskey(q.custom_join, main_join.first)
     q.custom_join[main_join.first] = Dict{String,Any}("filters" => parsed_filters, "field" => field)
   else
-    throw(ArgumentError("Join path '$(main_join.first)' already exists"))
+    throw(QueryBuildError("Join path '$(main_join.first)' already exists"))
   end
 
 
@@ -424,7 +424,7 @@ function cjoin(q::SQLObjectHandler, main_join::Union{Pair{String,String},Nothing
   _filters = _collect_join_filters(filters)
 
   if field !== nothing && !isa(field, PormGField)
-    throw(ArgumentError("Invalid field type: $(typeof(field)). Use a PormGField or nothing."))
+    throw(QueryBuildError("Invalid field type: $(typeof(field)). Use a PormGField or nothing."))
   end
 
   @pormg_debug false
@@ -467,7 +467,7 @@ function cjoin_on(q::SQLObject, target_model::String, on::AbstractVector; alias:
     elseif isa(f, FilterType)
       push!(parsed, f)
     else
-      throw(_argerr("Invalid cjoin_on `on` element: $(typeof(f)). Use Pair, Q, Qor, OP, or F expressions."))
+      throw(FilterError("Invalid cjoin_on `on` element: $(typeof(f)). Use Pair, Q, Qor, OP, or F expressions."))
     end
   end
   isempty(parsed) && throw(_argerr("cjoin_on requires at least one `on` predicate."))
@@ -609,7 +609,7 @@ function _set_field_from_sql_function(func::SQLTypeFunction, field::String, inst
     elseif haskey(fields, field)
       return fields[field]
     else
-      throw(_argerr("Error in _set_field_from_sql_function, the field \e[4m\e[31m$(field)\e[0m (base column: \e[31m$(base_col)\e[0m) not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m"))
+      throw(UnknownFieldError("Error in _set_field_from_sql_function, the field \e[4m\e[31m$(field)\e[0m (base column: \e[31m$(base_col)\e[0m) not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m"))
     end
   end
 
@@ -620,7 +620,7 @@ function _set_field_from_sql_function(func::String, field::String, instruct::SQL
   elseif haskey(instruct.object.model.fields, field)
     return instruct.object.model.fields[field]
   else
-    throw(_argerr("Error in _set_field_from_sql_function, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m"))
+    throw(UnknownFieldError("Error in _set_field_from_sql_function, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(instruct.object.model.name)\e[0m"))
   end
 end
 

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -62,7 +62,7 @@ function delete(objct::SQLObjectHandler;
   !settings.change_data && throw(_write_not_allowed("delete", conn_key))
 
   if objct.object.limit > 0 || objct.object.offset > 0 || !isempty(objct.object.order)
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call delete() on a query that has limit(), offset(), or order_by() set. " *
       "The deletion collector operates on complete filtered object sets so counts, cascades, " *
       "and constraint handling stay deterministic. Filter by primary key explicitly to delete " *
@@ -71,7 +71,7 @@ function delete(objct::SQLObjectHandler;
   end
 
   if objct.object.distinct
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call delete() on a query with distinct(). " *
       "DISTINCT collapses the result set, making the deletion collector's " *
       "cascade counting unreliable. Remove distinct() or filter by primary key."
@@ -79,7 +79,7 @@ function delete(objct::SQLObjectHandler;
   end
 
   if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.aggregate, objct.object.values)
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call delete() on a query with group_by() / annotate aggregations. " *
       "GROUP BY collapses rows, making cascade counting and constraint handling " *
       "unreliable. Remove the aggregation or filter by primary key."
@@ -88,7 +88,7 @@ function delete(objct::SQLObjectHandler;
 
   # don't allow to delete without filter
   if !allow_delete_all && objct.object.filter |> isempty
-    throw(_argerr(
+    throw(UnsafeMutationError(
       "Error in delete, the delete must have a filter. " *
       "To delete every row, pass \e[4m\e[31mallow_delete_all = true\e[0m explicitly, e.g. " *
       "Model.objects.delete(allow_delete_all = true) or delete(query; allow_delete_all = true)."
@@ -214,13 +214,13 @@ function resolve_delete_key(model::PormGModel; fallback::Union{Nothing,String}=n
 
   if fallback !== nothing
     # Match the user-supplied fallback verbatim — field lookup is case-sensitive (#57).
-    fallback in model.field_names || throw(ArgumentError("The fallback delete field $(fallback) was not found in $(model.name)"))
+    fallback in model.field_names || throw(UnknownFieldError("The fallback delete field $(fallback) was not found in $(model.name)"))
     return fallback
   end
 
   allow_direct && return DIRECT_DELETE_KEY_SENTINEL
 
-  throw(ArgumentError("Delete on $(model.name) requires a primary key or an explicit fallback delete field"))
+  throw(QueryBuildError("Delete on $(model.name) requires a primary key or an explicit fallback delete field"))
 end
 
 # Shared helper: resolves the delete key for a related model and returns a properly filtered
@@ -350,7 +350,7 @@ function handle_on_delete!(collector::DeletionCollector, field_name::Union{Strin
     @pormg_debug false
     # check if the field allow null
     if !field.null
-      throw(_argerr("Error in delete, the field \e[4m\e[31m$(field_name)\e[0m not allow null"))
+      throw(InvalidValueError("Error in delete, the field \e[4m\e[31m$(field_name)\e[0m not allow null"))
     end
 
     # Add field update to set field to NULL
@@ -382,7 +382,7 @@ function topological_sort(dependencies::Dict{PormGModel, Set{PormGModel}})
   
   function visit(node)
     if node in temp_mark
-      throw(ArgumentError("Circular dependency detected in model relationships"))
+      throw(QueryBuildError("Circular dependency detected in model relationships"))
     end
     
     if !(node in perm_mark)
@@ -438,7 +438,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
   @pormg_debug false
   if size(keys, 1) == 1 && keys[1][:key] == DIRECT_DELETE_KEY_SENTINEL
     objct = keys[1][:objct]
-    isempty(objct.object.filter) || throw(ArgumentError("Delete on keyless model $(model.name) with filters is not supported; define a primary key or delete all rows explicitly"))
+    isempty(objct.object.filter) || throw(QueryBuildError("Delete on keyless model $(model.name) with filters is not supported; define a primary key or delete all rows explicitly"))
 
     deleted_counter[model.name] = show_query === :execute ? (objct |> do_count) : 0
     sql = "DELETE FROM $(model.name |> lowercase)"
@@ -469,7 +469,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     # Multi-path merge: all entries for the same model share the same resolved key field.
     # Keyless (sentinel) models reaching this path are not supported.
     pk_field = keys[1][:key]
-    pk_field == DIRECT_DELETE_KEY_SENTINEL && throw(ArgumentError("Multi-path delete on keyless model $(model.name) is not supported; define a primary key"))
+    pk_field == DIRECT_DELETE_KEY_SENTINEL && throw(QueryBuildError("Multi-path delete on keyless model $(model.name) is not supported; define a primary key"))
     _query = model |> object;
     or_object = Qor("$(pk_field)__@in" => keys[1][:objct])
     for (index, key) in enumerate(keys)
@@ -499,7 +499,7 @@ function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::Porm
   # Update field values using query object like CASCADE
   @pormg_debug false
   pk_field = keys[:key]
-  pk_field == DIRECT_DELETE_KEY_SENTINEL && throw(ArgumentError("Cannot update field on keyless model $(model.name); define a primary key"))
+  pk_field == DIRECT_DELETE_KEY_SENTINEL && throw(QueryBuildError("Cannot update field on keyless model $(model.name); define a primary key"))
   _query = keys[:objct]
   parameters = get_parameter(connection)
   value_sql = value === nothing ? "NULL" : model.fields[field].formatter(value)

--- a/src/querybuilder/exceptions.jl
+++ b/src/querybuilder/exceptions.jl
@@ -1,13 +1,122 @@
-struct DoesNotExist <: Exception
+# ── Semantic error taxonomy (#231) ──────────────────────────────────────────
+# Every query-builder misuse throws a subtype of `PormGError` (defined in the top PormG module,
+# `<: Exception`) so a consuming app catches a TYPE, not a message substring. This extends the
+# #197 lineage (throw real Exceptions, not raw Strings). The subtypes are deliberately **NOT**
+# `<: ArgumentError` — a clean pre-publish break (see UPGRADING.md, `## Unreleased` → next 0.3.0).
+#
+# `_emsg` (the single shared definition in `tools.jl`, imported via QueryBuilder's
+# `import PormG: … _emsg`) strips ANSI escape codes whenever Julia is not in color mode, so
+# coloured error tokens render in the REPL and as plain text in every non-TTY sink (CI output,
+# file logs, `sprint(showerror, e)`). Each subtype's inner constructor applies `_emsg` at
+# construction, so `.msg` is clean off-TTY (several tests read `err.msg`).
+
+# Field/accessor lookup failures share an abstract mid-node so `catch FieldAccessError` catches
+# both "no such field" and "unsupported lazy traversal". Everything else in the taxonomy is flat.
+abstract type FieldAccessError <: PormGError end
+
+"""
+    UnknownFieldError(msg) <: FieldAccessError <: PormGError
+
+A field, alias, column, or `__` lookup path does not exist on the model or the projected row.
+"""
+struct UnknownFieldError <: FieldAccessError
+  msg::String
+  UnknownFieldError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    LazyTraversalError(msg) <: FieldAccessError <: PormGError
+
+An unprojected `ForeignKey` was read off a fetched row. PormG has no lazy FK traversal; the
+message steers the caller to up-front `values(...)` projection (#204).
+"""
+struct LazyTraversalError <: FieldAccessError
+  msg::String
+  LazyTraversalError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    FilterError(msg) <: PormGError
+
+An invalid filter argument/shape, or an operator misused on a JSON/subquery column.
+"""
+struct FilterError <: PormGError
+  msg::String
+  FilterError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    QueryBuildError(msg) <: PormGError
+
+Structural/API misuse while building a query — joins, CTEs, projection, ordering, window and
+bulk configuration, and the like. The default bucket for query-builder misuse that isn't one of
+the sharper categories below.
+"""
+struct QueryBuildError <: PormGError
+  msg::String
+  QueryBuildError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    UnsafeMutationError(msg) <: PormGError
+
+An UPDATE or DELETE was requested without a filter (or in another unsafe shape) and refused.
+"""
+struct UnsafeMutationError <: PormGError
+  msg::String
+  UnsafeMutationError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    InvalidValueError(msg) <: PormGError
+
+A value failed coercion/type validation on insert/update, an identifier failed the fail-closed
+safety check, or an interval/duration literal could not be parsed.
+"""
+struct InvalidValueError <: PormGError
+  msg::String
+  InvalidValueError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    PermissionError(msg) <: PormGError
+
+The connection is not permitted to insert/update/delete — its settings carry `change_data=false`.
+"""
+struct PermissionError <: PormGError
+  msg::String
+  PermissionError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    UnsupportedConnectionError(msg) <: PormGError
+
+A connection that is neither a PostgreSQL nor a SQLite pool (or a model not bound to a
+connection) reached an execution path. The catchable replacement for the internal
+`ErrorException` introduced in #197.
+"""
+struct UnsupportedConnectionError <: PormGError
+  msg::String
+  UnsupportedConnectionError(msg::AbstractString) = new(_emsg(msg))
+end
+
+# get() cardinality errors — reparented from `Exception` to `PormGError` (#231) so
+# `catch PormGError` catches them too. They keep their structured fields and field-built
+# `showerror` (below), which is why they don't use the uniform `msg::String` shape.
+struct DoesNotExist <: PormGError
   model_name::String
   filters::String
 end
 
-struct MultipleObjectsReturned <: Exception
+struct MultipleObjectsReturned <: PormGError
   model_name::String
   count::Int
   filters::String
 end
+
+# One `showerror` covers every `msg`-carrying subtype. DoesNotExist / MultipleObjectsReturned
+# override with their field-built messages (a more specific method wins on dispatch).
+Base.showerror(io::IO, e::PormGError) = print(io, e.msg)
 
 Base.showerror(io::IO, e::DoesNotExist) =
   print(io, "$(e.model_name).DoesNotExist: No record found matching filters: $(e.filters)")
@@ -15,27 +124,26 @@ Base.showerror(io::IO, e::DoesNotExist) =
 Base.showerror(io::IO, e::MultipleObjectsReturned) =
   print(io, "$(e.model_name).MultipleObjectsReturned: Expected 1 record, got $(e.count) for filters: $(e.filters)")
 
-# ── Error-message colorization (TTY-aware) ──────────────────────────────────
-# `_emsg` (the single shared definition in `tools.jl`, imported via QueryBuilder's
-# `import PormG: … _emsg`) strips ANSI escape codes whenever Julia is not in color
-# mode, so coloured error tokens render in the REPL and as plain text in every
-# non-TTY sink (CI output, file logs, `sprint(showerror, e)`). `_argerr` wraps the
-# common case so a call site only changes `ArgumentError(` → `_argerr(`.
-_argerr(msg::AbstractString) = ArgumentError(_emsg(msg))
+# ── Throw-site funnels ──────────────────────────────────────────────────────
+# `_argerr` is the long-tail default: a call site changes only `ArgumentError(` → `_argerr(` and
+# lands on `QueryBuildError`. Sharper categories (Field/Filter/Permission/UnsafeMutation/…) are
+# chosen explicitly at their sites. The subtype constructor applies `_emsg`, so there is no
+# double-strip and no raw ANSI leaks into non-TTY sinks.
+_argerr(msg::AbstractString) = QueryBuildError(msg)
 
-# Internal dispatch fallback (#197): a connection object that is neither a PostgreSQL nor a
-# SQLite pool reached an execution path. Typed (ErrorException) so downstream
-# `catch e; e isa Exception` works — these sites previously threw raw Strings, which are not
-# Exceptions and escape every typed catch.
-_unsupported_conn(op::AbstractString, conn) = error(_emsg(
+# Internal dispatch fallback (#197, retyped in #231): a connection object that is neither a
+# PostgreSQL nor a SQLite pool reached an execution path — now a catchable `PormGError` subtype.
+# Throws directly (call sites invoke it bare, not wrapped in `throw`).
+_unsupported_conn(op::AbstractString, conn) = throw(UnsupportedConnectionError(
   "PormG internal error in $(op): unsupported connection type $(typeof(conn)) — expected a PostgreSQL or SQLite connection pool."))
 
-# Standard actionable error for a write blocked by `change_data: false` (#205). Every DML entry
-# point (insert, update, delete, update_or_create, bulk_*, many-to-many add/remove/clear,
-# primary-key allocation) shares this one message so a user hitting any of them gets the same fix —
-# writes are disabled by default (safety-first), which is the common first-`create` trap, and the
-# message must name where to fix it: the `config:` block of the active environment in connection.yml.
-_write_not_allowed(operation::AbstractString, conn_key) = _argerr(
+# Standard actionable error for a write blocked by `change_data: false` (#205), typed as
+# `PermissionError` (#231). Every DML entry point (insert, update, delete, update_or_create,
+# bulk_*, many-to-many add/remove/clear, primary-key allocation) shares this one message so a user
+# hitting any of them gets the same fix — writes are disabled by default (safety-first, the common
+# first-`create` trap), and the message names where to fix it: the `config:` block of the active
+# environment in connection.yml.
+_write_not_allowed(operation::AbstractString, conn_key) = PermissionError(
   "Error in $(operation): the connection \e[4m\e[31m$(conn_key)\e[0m is not allowed to write. " *
   "Writes are disabled by default — set \e[1mchange_data: true\e[0m under the `config:` block of the active " *
   "environment in connection.yml to enable creates, updates, and deletes.")

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -55,7 +55,7 @@ function _show_query_result(mode::Symbol, sql::String, connection::Union{Nothing
         :parameter_buckets => bucket_breakdown
     )
   else
-    throw(ArgumentError("Invalid show_query mode: $mode. Must be one of: :sql, :dict, :inspection, :params, :none"))
+    throw(QueryBuildError("Invalid show_query mode: $mode. Must be one of: :sql, :dict, :inspection, :params, :none"))
   end
 end
 
@@ -140,7 +140,7 @@ function inspect_query(q::SQLObjectHandler; connection::Union{Nothing, PormGPost
       # steps).  Return the result as-is so callers can inspect every step.
       return res isa Tuple ? res[2] : res
   else
-      throw(ArgumentError("Unsupported or unknown operation for inspection: $operation"))
+      throw(QueryBuildError("Unsupported or unknown operation for inspection: $operation"))
   end
 end
 inspect_query(; kwargs...) = (objct) -> inspect_query(objct; kwargs...)
@@ -191,7 +191,7 @@ function query(q::SQLObjectHandler;
   # :inspection, etc.) must be allowed to build joined queries without .values() so that
   # inspect_query() and show_query=:dict work on un-projected joined queries.
   if isempty(q.object.values) && !isempty(instruction.join) && show_query === :execute
-    throw(ArgumentError("PormG: Joined queries must explicitly select fields using .values(...) to prevent duplicate column names. Tip: Use .values(\"*\", \"joined_model__field_name\") to select all main table fields alongside specific joined fields."))
+    throw(QueryBuildError("PormG: Joined queries must explicitly select fields using .values(...) to prevent duplicate column names. Tip: Use .values(\"*\", \"joined_model__field_name\") to select all main table fields alongside specific joined fields."))
   end
 
   # Restore the context for parent query if this was a subquery
@@ -493,7 +493,7 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
       elseif model.fields[field].null || model.fields[field].primary_key
         continue
       else
-        throw(_argerr("Error in insert, the field \e[4m\e[31m$(field)\e[0m not allow null"))
+        throw(InvalidValueError("Error in insert, the field \e[4m\e[31m$(field)\e[0m not allow null"))
       end
     end
   end
@@ -519,7 +519,7 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
   for field in keys(real_obj.insert)
     # Validation checks
     validate_field_data(model, field, real_obj.insert[field], "insert"; allow_primary_key = true)
-    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in create(); use $(model.name).$(field)(source_id).add(target_id) after creating the source row"))
+    Models.is_many_to_many_field(model.fields[field]) && throw(QueryBuildError("ManyToManyField $(model.name).$(field) cannot be written in create(); use $(model.name).$(field)(source_id).add(target_id) after creating the source row"))
 
     # check if the field is a primary key
     model.fields[field].primary_key && (pk_exist = true; push!(pk_field, field))
@@ -901,7 +901,7 @@ function _decompose_period(period::Union{Dates.Period, Dates.CompoundPeriod})
     elseif p isa Microsecond ; frac_nanos += Int64(val) * 1_000
     elseif p isa Nanosecond  ; frac_nanos += Int64(val)
     else
-      throw(_argerr("Unsupported duration component $(typeof(p)) in F-expression date arithmetic"))
+      throw(InvalidValueError("Unsupported duration component $(typeof(p)) in F-expression date arithmetic"))
     end
   end
   comps = Tuple{Symbol, Real}[]
@@ -931,7 +931,7 @@ function _render_date_period_arithmetic(v::FExpression, instruc::SQLInstruction)
   # throw when the field is known AND known to be non-date; stay silent for unresolved/nested lefts.
   if v.field_name isa String && _field_type_known(v.field_name, instruc) &&
      _date_field_type(v.field_name, instruc) === nothing
-    throw(_argerr("F(\"$(v.field_name)\") ± a duration requires a DATE/TIMESTAMP field; \"$(v.field_name)\" is not a date/time column"))
+    throw(InvalidValueError("F(\"$(v.field_name)\") ± a duration requires a DATE/TIMESTAMP field; \"$(v.field_name)\" is not a date/time column"))
   end
 
   if instruc.connection isa PormGPostgres
@@ -1197,7 +1197,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   # would mutate ALL matching rows, not just 5). To update a bounded set of rows,
   # filter by primary key explicitly or compose a subquery.
   if real_obj.limit > 0 || real_obj.offset > 0 || !isempty(real_obj.order)
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call update() on a query that has limit(), offset(), or order_by() set. " *
       "Standard SQL UPDATE does not support these clauses, and silently dropping them " *
       "risks updating more rows than intended. " *
@@ -1206,7 +1206,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   end
 
   if real_obj.distinct
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call update() on a query with distinct(). " *
       "DISTINCT collapses the result set, which would cause UPDATE to target " *
       "different rows than intended. Remove distinct() or filter by primary key."
@@ -1214,7 +1214,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   end
 
   if any(v -> isa(v, SQLTypeField) && isa(v.field, Union{SQLTypeFunction, SQLTypeF}) && v.field.aggregate, real_obj.values)
-    throw(ArgumentError(
+    throw(UnsafeMutationError(
       "Cannot call update() on a query with group_by() / annotate aggregations. " *
       "GROUP BY collapses rows, making the UPDATE target ambiguous. " *
       "Remove the aggregation or filter by primary key."
@@ -1224,7 +1224,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   instruction = build(real_obj, table_alias=table_alias, connection=connection) 
 
   # Don't allow to update a field without filter
-  instruction._where |> isempty && throw(_argerr("update() requires a filter — refusing to update every row. Add .filter(...) before .update(...)."))
+  instruction._where |> isempty && throw(UnsafeMutationError("update() requires a filter — refusing to update every row. Add .filter(...) before .update(...)."))
   
   parameters = instruction.parameters
   fields = model.field_names
@@ -1247,7 +1247,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   for field in keys(objct.insert)    
     # Validation checks
     validate_field_data(model, field, objct.insert[field], "update"; allow_primary_key = false)
-    Models.is_many_to_many_field(model.fields[field]) && throw(ArgumentError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add, remove, clear, or set methods"))
+    Models.is_many_to_many_field(model.fields[field]) && throw(QueryBuildError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add, remove, clear, or set methods"))
     
     quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)  # db_column (#50)
 
@@ -1516,7 +1516,7 @@ function list(objct::SQLObjectHandler, ::Val{:json}; show_query::Symbol = :execu
 end
 
 function list(objct::SQLObjectHandler, ::Val{F}; kwargs...) where F
-  throw(ArgumentError("Unknown list format :$F. Expected :row, :dict, or :json."))
+  throw(QueryBuildError("Unknown list format :$F. Expected :row, :dict, or :json."))
 end
 
 list(objct::SQLObjectHandler, format::Symbol; kwargs...) = list(objct, Val(format); kwargs...)
@@ -1616,15 +1616,15 @@ end
 function _row_related_model(model::PormGModel, fk_meta::Models.sForeignKey)::PormGModel
   fk_meta.to isa PormGModel && return fk_meta.to
 
-  model._module !== nothing || throw(ArgumentError("Cannot resolve related model $(fk_meta.to) for $(model.name); model module is not initialized."))
+  model._module !== nothing || throw(QueryBuildError("Cannot resolve related model $(fk_meta.to) for $(model.name); model module is not initialized."))
   related = Base.invokelatest(getfield, model._module, Symbol(fk_meta.to))
   related isa PormGModel && return related
-  throw(ArgumentError("Related model $(fk_meta.to) for $(model.name) is not a PormG model."))
+  throw(QueryBuildError("Related model $(fk_meta.to) for $(model.name) is not a PormG model."))
 end
 
 function _row_require_data_key(data::Dict{Symbol,Any}, key::Symbol, context::String)
   haskey(data, key) && return data[key]
-  throw(ArgumentError("Cannot save() $(context): row data does not include required key '$(key)'. Select it before mutating and saving the row."))
+  throw(QueryBuildError("Cannot save() $(context): row data does not include required key '$(key)'. Select it before mutating and saving the row."))
 end
 
 """
@@ -1646,10 +1646,13 @@ function save(row::PormGRow; show_query::Symbol = :execute)
   pk_sym = try
     Models.get_model_pk_field(model)
   catch e
+    # `get_model_pk_field` lives in Models, which is OUT OF SCOPE for the #231 error taxonomy and
+    # still throws `ArgumentError` (not a `PormGError`). Keep `isa ArgumentError` here; revisit when
+    # the Models error contract migrates. The re-thrown save() error below is in-scope (QueryBuildError).
     e isa ArgumentError || rethrow(e)
-    throw(ArgumentError("save() requires exactly one primary key field; $(model.name) is not supported."))
+    throw(QueryBuildError("save() requires exactly one primary key field; $(model.name) is not supported."))
   end
-  pk_sym === nothing && throw(ArgumentError("save() requires exactly one primary key field; $(model.name) is not supported."))
+  pk_sym === nothing && throw(QueryBuildError("save() requires exactly one primary key field; $(model.name) is not supported."))
 
   own_updates = Dict{String,Any}()
   fk_updates = Dict{Symbol,Dict{String,Any}}()
@@ -1674,7 +1677,7 @@ function save(row::PormGRow; show_query::Symbol = :execute)
   end
 
   conflict = intersect(touched_fk_fields, Set(keys(fk_updates)))
-  isempty(conflict) || throw(ArgumentError(
+  isempty(conflict) || throw(QueryBuildError(
     "Cannot save() a row after mutating both FK field(s) $(collect(conflict)) and projected '__' fields under the same prefix. Save the FK change separately first."
   ))
 
@@ -1692,7 +1695,7 @@ function save(row::PormGRow; show_query::Symbol = :execute)
     for fk_sym in sort(collect(keys(fk_updates)); by=String)
       fk_meta = model.fields[String(fk_sym)]::Models.sForeignKey
       if fk_meta.pk_field === nothing
-        throw(ArgumentError(
+        throw(QueryBuildError(
           "save() cannot update projected fields under '$(fk_sym)' because the FK's " *
           "target primary key has not been resolved. Call set_models() to initialize " *
           "the model before using save() with projected FK fields."

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -20,11 +20,11 @@ function _normalize_bulk_columns(columns)
       elseif column isa Pair{String, String}
         push!(_columns, column)
       else
-        throw(ArgumentError("Invalid column specification: $column"))
+        throw(QueryBuildError("Invalid column specification: $column"))
       end
     end
   else
-    throw(ArgumentError("Invalid columns argument: $columns"))
+    throw(QueryBuildError("Invalid columns argument: $columns"))
   end
   return _columns
 end
@@ -48,19 +48,19 @@ function _normalize_bulk_match_on(match_on)::Vector{String}
   elseif match_on isa AbstractString
     push!(_match_on, match_on)
   elseif match_on isa Pair
-    throw(ArgumentError(_match_on_pair_migration_msg(match_on)))
+    throw(QueryBuildError(_match_on_pair_migration_msg(match_on)))
   elseif match_on isa Vector
     for key in match_on
       if key isa AbstractString
         push!(_match_on, key)
       elseif key isa Pair
-        throw(ArgumentError(_match_on_pair_migration_msg(key)))
+        throw(QueryBuildError(_match_on_pair_migration_msg(key)))
       else
-        throw(ArgumentError("Invalid match_on specification: $key"))
+        throw(QueryBuildError("Invalid match_on specification: $key"))
       end
     end
   else
-    throw(ArgumentError("Invalid match_on argument: $match_on"))
+    throw(QueryBuildError("Invalid match_on argument: $match_on"))
   end
   return _match_on
 end
@@ -106,11 +106,11 @@ function _normalize_bulk_filters(filters)
       if f isa Union{String, Pair{String, <:Any}}
         push!(_filters, f)
       else
-        throw(ArgumentError("Invalid filter specification: $f"))
+        throw(QueryBuildError("Invalid filter specification: $f"))
       end
     end
   else
-    throw(ArgumentError("Invalid filters argument: $filters"))
+    throw(QueryBuildError("Invalid filters argument: $filters"))
   end
   return _filters
 end
@@ -172,7 +172,7 @@ it is blank (`missing`, `nothing`, or an empty string), ids are reserved from th
 
 If the column contains **mixed** values—some rows have explicit pk values and some are
 blank—a `@warn` is emitted and the DataFrame is still returned unchanged. The blank rows
-are left as-is and will raise an `ArgumentError` when `bulk_insert` is called. To resolve
+are left as-is and will raise a `QueryBuildError` when `bulk_insert` is called. To resolve
 this you can: (1) provide a pk value for every row, (2) remove the pk column so all ids
 are allocated automatically, or (3) pre-fill the blank rows before calling this function.
 
@@ -254,7 +254,7 @@ function allocate_primary_keys(objct::SQLObjectHandler, df_o::DataFrames.DataFra
   isempty(pk_fields) && return df
 
   if length(pk_fields) > 1
-    throw(ArgumentError("allocate_primary_keys: model $(model.name) has multiple auto-generated primary keys ($(join(pk_fields, ", "))); only models with a single auto-generated pk are supported"))
+    throw(QueryBuildError("allocate_primary_keys: model $(model.name) has multiple auto-generated primary keys ($(join(pk_fields, ", "))); only models with a single auto-generated pk are supported"))
   end
 
   pk_field = pk_fields[1]
@@ -268,7 +268,7 @@ function allocate_primary_keys(objct::SQLObjectHandler, df_o::DataFrames.DataFra
       if has_blank
         n_blank = count(_is_blank_bulk_primary_key_value, col)
         @warn "allocate_primary_keys: column '$pk_field' in model $(model.name) has mixed values — $n_blank blank row(s) alongside explicit pk values. " *
-              "The DataFrame is returned unchanged. Those blank rows will raise an ArgumentError at bulk_insert time. " *
+              "The DataFrame is returned unchanged. Those blank rows will raise a QueryBuildError at bulk_insert time. " *
               "Options: (1) supply a pk value for every row, (2) remove the column so all ids are allocated automatically, " *
               "or (3) pre-fill the blank rows before calling allocate_primary_keys."
       end
@@ -291,7 +291,7 @@ function allocate_primary_keys(objct::SQLObjectHandler, df_o::DataFrames.DataFra
       end
     end
   else
-    throw(ArgumentError("allocate_primary_keys: unsupported connection type $(typeof(connection))"))
+    throw(UnsupportedConnectionError("allocate_primary_keys: unsupported connection type $(typeof(connection))"))
   end
 
   df[!, pk_field] = ids
@@ -306,7 +306,7 @@ function _single_auto_generated_primary_key(model::PormGModel)
   isempty(pk_fields) && return nothing
 
   if length(pk_fields) > 1
-    throw(ArgumentError("allocate_primary_keys: model $(model.name) has multiple auto-generated primary keys ($(join(pk_fields, ", "))); only models with a single auto-generated pk are supported"))
+    throw(QueryBuildError("allocate_primary_keys: model $(model.name) has multiple auto-generated primary keys ($(join(pk_fields, ", "))); only models with a single auto-generated pk are supported"))
   end
 
   return pk_fields[1]
@@ -457,9 +457,9 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
           # consistent with the string/auto-detect/match_on paths above.
           candidates = _case_fold_candidates(column.first, names(df))
           isempty(candidates) ||
-            throw(_argerr(_bulk_case_mismatch_msg(operation, column.first, candidates,
+            throw(UnknownFieldError(_bulk_case_mismatch_msg(operation, column.first, candidates,
               "\"$(candidates[1])\" => \"$(column.second)\"")))
-          throw(_argerr("Error in bulk_$(operation), the column \e[4m\e[31m$(column.first)\e[0m mapped to field \e[4m\e[31m$(column.second)\e[0m is not in the DataFrame; available columns: \e[4m\e[32m$(names(df))\e[0m"))
+          throw(UnknownFieldError("Error in bulk_$(operation), the column \e[4m\e[31m$(column.first)\e[0m mapped to field \e[4m\e[31m$(column.second)\e[0m is not in the DataFrame; available columns: \e[4m\e[32m$(names(df))\e[0m"))
         end
       else
         # String column: match the DataFrame column name EXACTLY (case-sensitive).
@@ -471,7 +471,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
           # silently case-folding (see the case-sensitive matching contract above).
           candidates = _case_fold_candidates(column, names(df))
           isempty(candidates) ||
-            throw(_argerr(_bulk_case_mismatch_msg(operation, column, candidates,
+            throw(UnknownFieldError(_bulk_case_mismatch_msg(operation, column, candidates,
               "\"$(candidates[1])\" => \"$(column)\"")))
           # Truly absent — it may be an auto-populated field added later (e.g. updated_at).
           push!(fields_df, column)
@@ -489,7 +489,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       else
         candidates = _case_fold_candidates(col_name, fields)
         isempty(candidates) ||
-          throw(_argerr(_bulk_case_mismatch_msg(operation, col_name, candidates,
+          throw(UnknownFieldError(_bulk_case_mismatch_msg(operation, col_name, candidates,
             "\"$(col_name)\" => \"$(candidates[1])\"")))
       end
     end
@@ -533,7 +533,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
         elseif f_meta.primary_key
           # It's a PK, we'll collect it later
         elseif !f_meta.null && operation in [:insert, :copy]
-          throw(_argerr("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m does not allow null and has no default value"))
+          throw(InvalidValueError("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m does not allow null and has no default value"))
         end
       end
 
@@ -566,7 +566,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   
   # Final sanity check for fields_df existence in model
   for field in fields_df
-    in(field, fields) || throw(_argerr("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(model.name)\e[0m"))
+    in(field, fields) || throw(UnknownFieldError("Error in bulk_$operation, the field \e[4m\e[31m$(field)\e[0m not found in \e[4m\e[32m$(model.name)\e[0m"))
   end
 
   # Return fields_df cleaned up (unique and existing in mapping)
@@ -586,7 +586,7 @@ function _ensure_unique_bulk_update_keys!(df::DataFrames.DataFrame,
     key = Tuple(row[mapping[field]] for field in dynamic_filters)
     if haskey(seen_keys, key)
       filters_text = join(dynamic_filters, ", ")
-      throw(ArgumentError("Error in bulk_update, duplicate dynamic filter key values detected for filters [$filters_text] at rows $(seen_keys[key]) and $(index): $(collect(key))"))
+      throw(QueryBuildError("Error in bulk_update, duplicate dynamic filter key values detected for filters [$filters_text] at rows $(seen_keys[key]) and $(index): $(collect(key))"))
     end
     seen_keys[key] = index
   end
@@ -608,7 +608,7 @@ function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
   kind::String="match_on")
 
   field in model.field_names ||
-    throw(_argerr("bulk_update: $(kind) field \e[4m\e[31m$(field)\e[0m is not a field of model $(model.name)"))
+    throw(UnknownFieldError("bulk_update: $(kind) field \e[4m\e[31m$(field)\e[0m is not a field of model $(model.name)"))
 
   resolved = if haskey(mapping, field)
     # `columns=` mapping wins. If the df ALSO carries a column named exactly like the
@@ -624,9 +624,9 @@ function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
     # loud error, not a silent fold (see the case-sensitive matching contract above).
     candidates = _case_fold_candidates(field, names(df))
     isempty(candidates) ||
-      throw(_argerr(_bulk_case_mismatch_msg(:update, field, candidates,
+      throw(UnknownFieldError(_bulk_case_mismatch_msg(:update, field, candidates,
         "columns = [..., \"$(candidates[1])\" => \"$(field)\"]")))
-    throw(_argerr("bulk_update: $(kind) column \e[4m\e[31m$(field)\e[0m not found in the DataFrame (columns: $(names(df))) and no columns= mapping targets that field"))
+    throw(UnknownFieldError("bulk_update: $(kind) column \e[4m\e[31m$(field)\e[0m not found in the DataFrame (columns: $(names(df))) and no columns= mapping targets that field"))
   end
 
   mapping[field] = resolved
@@ -718,17 +718,17 @@ function _resolve_bulk_update_keys!(df::DataFrames.DataFrame, model::PormGModel,
     # Only meaningful when match_on is absent: turn the old dynamic-in-`filters`
     # usage into an actionable migration error instead of the generic one.
     if !match_on_given && _is_legacy_dynamic_filter(f, df, model)
-      throw(ArgumentError(_bulk_update_migration_msg(f)))
+      throw(QueryBuildError(_bulk_update_migration_msg(f)))
     end
     # ── end shim ───────────────────────────────────────────────────────────────
 
-    f isa Pair || throw(ArgumentError(_bulk_update_static_only_msg(f)))
+    f isa Pair || throw(QueryBuildError(_bulk_update_static_only_msg(f)))
     push!(static_filters, f.first => f.second)
   end
 
   # Fallback: nothing to match on => use the model primary key(s)
   if isempty(dynamic_filters)
-    isempty(pks) && throw(ArgumentError(
+    isempty(pks) && throw(QueryBuildError(
       "bulk_update: no match_on= given and model $(model.name) has no primary key to match on"))
     for pk in pks
       _resolve_match_column!(df, model, mapping, fields_df, dynamic_filters, pk; kind="primary key")
@@ -982,7 +982,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   # Resolve settings
   settings, connection, conn_key = get_settings(objct)
 
-  !(connection isa PormGPostgres) && throw(ArgumentError("bulk_copy is only supported for PostgreSQL. Use bulk_insert for SQLite."))
+  !(connection isa PormGPostgres) && throw(UnsupportedConnectionError("bulk_copy is only supported for PostgreSQL. Use bulk_insert for SQLite."))
 
   # check if is allowed to insert
   !settings.change_data && throw(_write_not_allowed("bulk_copy", conn_key))
@@ -1080,7 +1080,7 @@ function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{St
     try
       model.fields[field].formatter(row[col_name])
     catch e
-      throw(_argerr("Error in bulk processing, the field \e[4m\e[31m$(field)\e[0m (col: $(col_name)) in row \e[4m\e[31m$(index)\e[0m has a value that can't be formatted: \e[4m\e[31m$(row[col_name])\e[0m"))
+      throw(InvalidValueError("Error in bulk processing, the field \e[4m\e[31m$(field)\e[0m (col: $(col_name)) in row \e[4m\e[31m$(index)\e[0m has a value that can't be formatted: \e[4m\e[31m$(row[col_name])\e[0m"))
     end
   end  
 end
@@ -1141,7 +1141,7 @@ function _normalize_on_conflict(on_conflict, model::PormGModel, fields_df::Vecto
       throw(_argerr("Error in bulk_insert, on_conflict $kind has duplicate column entries"))
     for col in cols
       haskey(model.fields, col) ||
-        throw(_argerr("Error in bulk_insert, on_conflict $kind column $(col) is not a field of " *
+        throw(UnknownFieldError("Error in bulk_insert, on_conflict $kind column $(col) is not a field of " *
           "model $(model.name)"))
       kind === :set && !(col in insert_cols) &&
         throw(_argerr("Error in bulk_insert, on_conflict set column $(col) does not participate " *

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -14,7 +14,7 @@ a.filter(Q("name" => "John", Qor("age" => 18, "age" => 19)))
 ```
 """
 function Q(x...)
-  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
+  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(FilterError("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
   return QObject(filters = colect)
 end
 
@@ -34,7 +34,7 @@ a.filter(Qor("name" => "John", Q("age__gte" => 18, "age__lte" => 19)))
 ```
 """
 function Qor(x...)
-  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(_argerr("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
+  colect = [isa(v, Pair) ? _check_filter(v) : isa(v, FilterType) ? v : throw(FilterError("Invalid argument: $(v); please use a pair (key => value).")) for v in x]
   return QorObject(or = colect)
 end
 
@@ -88,7 +88,7 @@ function _window_part_vector(value, part_name::String)::Vector{WindowPartitionPa
   parts = WindowPartitionPart[]
   for item in values
     item isa Symbol && (item = String(item))
-    item isa WindowPartitionPart || throw(ArgumentError("WindowOver $part_name entries must be strings, SQL fields, SQL functions, or F expressions. Got $(typeof(item))."))
+    item isa WindowPartitionPart || throw(QueryBuildError("WindowOver $part_name entries must be strings, SQL fields, SQL functions, or F expressions. Got $(typeof(item))."))
     push!(parts, item)
   end
   return parts
@@ -100,7 +100,7 @@ function _window_order_vector(value)::Vector{WindowOrderPart}
   parts = WindowOrderPart[]
   for item in values
     item isa Symbol && (item = String(item))
-    item isa WindowOrderPart || throw(ArgumentError("WindowOver order_by entries must be strings or SQLOrder objects. Got $(typeof(item))."))
+    item isa WindowOrderPart || throw(QueryBuildError("WindowOver order_by entries must be strings or SQLOrder objects. Got $(typeof(item))."))
     push!(parts, item)
   end
   return parts
@@ -125,14 +125,14 @@ RowNumber(; over::WindowSpec=WindowOver()) = WindowFunction(function_name="ROW_N
 RowNumber(over::WindowSpec) = RowNumber(over=over)
 
 function Lag(x::WindowColumnPart; offset::Integer=1, default=nothing, over::WindowSpec=WindowOver())
-  offset < 0 && throw(ArgumentError("Lag offset must be a non-negative integer"))
+  offset < 0 && throw(QueryBuildError("Lag offset must be a non-negative integer"))
   kwargs = Dict{String,Any}("offset" => offset)
   default !== nothing && (kwargs["default"] = default)
   return WindowFunction(function_name="LAG", column=x, over=over, kwargs=kwargs)
 end
 
 function Lead(x::WindowColumnPart; offset::Integer=1, default=nothing, over::WindowSpec=WindowOver())
-  offset < 0 && throw(ArgumentError("Lead offset must be a non-negative integer"))
+  offset < 0 && throw(QueryBuildError("Lead offset must be a non-negative integer"))
   kwargs = Dict{String,Any}("offset" => offset)
   default !== nothing && (kwargs["default"] = default)
   return WindowFunction(function_name="LEAD", column=x, over=over, kwargs=kwargs)
@@ -141,7 +141,7 @@ end
 FirstValue(x::WindowColumnPart; over::WindowSpec=WindowOver()) = WindowFunction(function_name="FIRST_VALUE", column=x, over=over)
 LastValue(x::WindowColumnPart; over::WindowSpec=WindowOver()) = WindowFunction(function_name="LAST_VALUE", column=x, over=over)
 function NthValue(x::WindowColumnPart, n::Integer; over::WindowSpec=WindowOver())
-  n <= 0 && throw(ArgumentError("NthValue n must be a positive integer"))
+  n <= 0 && throw(QueryBuildError("NthValue n must be a positive integer"))
   return WindowFunction(function_name="NTH_VALUE", column=x, over=over, kwargs=Dict{String,Any}("n" => n))
 end
 
@@ -479,7 +479,7 @@ end
 
 function ISNULL(v::String , value::Bool)
   if contains(v, "(")
-    throw(_argerr("Error in ISNULL: the column $(v) cannot be a function expression."))
+    throw(FilterError("Error in ISNULL: the column $(v) cannot be a function expression."))
   end
   if value
     return string(v, " IS NULL")
@@ -528,13 +528,13 @@ function limit!(object::SQLObject, limit::Tuple{Integer})
   object.limit = limit[1]
 end
 function limit!(object::SQLObject, limit)
-  throw(ArgumentError("Error in page, limit must be an Integer"))
+  throw(QueryBuildError("Error in page, limit must be an Integer"))
 end
 function offset!(object::SQLObject, offset::Tuple{Integer})
   object.offset = offset[1]
 end
 function offset!(object::SQLObject, offset)
-  throw(ArgumentError("Error in page, offset must be an Integer"))
+  throw(QueryBuildError("Error in page, offset must be an Integer"))
 end
 function page!(object::SQLObject, v::Tuple{Integer, Integer})
   object.limit = v[1]

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -23,7 +23,7 @@ function _m2m_model_from_binding(_module::Module, binding::String, table_name::S
     Models.format_model_name(model.name) == target_name && return model
   end
 
-  throw(ArgumentError("The many-to-many related model $(binding) is not defined"))
+  throw(QueryBuildError("The many-to-many related model $(binding) is not defined"))
 end
 
 function _m2m_extract_pk(value, pk_field::String)
@@ -53,7 +53,7 @@ function _m2m_settings(manager::ManyToManyManager)
     if length(config) == 1
       conn_key = first(keys(config))
     else
-      throw(ArgumentError("Model '$(manager.owner_model.name)' is not bound to a database connection key. Call set_models() before using a many-to-many manager."))
+      throw(UnsupportedConnectionError("Model '$(manager.owner_model.name)' is not bound to a database connection key. Call set_models() before using a many-to-many manager."))
     end
   end
   settings = get_configuration_settings(conn_key)
@@ -80,14 +80,17 @@ function _m2m_has_extra_fields(manager::ManyToManyManager)::Bool
   owner_module = manager.owner_model._module
   owner_module === nothing && return false
 
-  # Only catch ArgumentError ("binding not found") — the expected failure when
+  # Only catch PormGError ("binding not found") — the expected failure when
   # the through model is auto-generated and not registered in the module.
   # Any other exception (type error, module error, etc.) should propagate so
   # the caller is not silently allowed to mutate a through table with extra fields.
   through_model = try
     _m2m_model_from_binding(owner_module, manager.relation.through_model, manager.relation.through_model)
   catch e
-    e isa ArgumentError && return false
+    # The binding-not-found signal from _m2m_model_from_binding is now QueryBuildError <:
+    # PormGError (#231, was ArgumentError). Catch the taxonomy root so this stays robust to
+    # reclassification; any non-PormGError (type/module error) still propagates as intended.
+    e isa PormGError && return false
     rethrow(e)
   end
 
@@ -106,7 +109,7 @@ end
 function (descriptor::ManyToManyDescriptor)(owner)
   owner_id = _m2m_extract_pk(owner, descriptor.relation.owner_pk)
   owner_module = descriptor.owner_model._module
-  owner_module === nothing && throw(ArgumentError("Many-to-many descriptor $(descriptor.accessor) requires initialized models. Call set_models() before using it."))
+  owner_module === nothing && throw(QueryBuildError("Many-to-many descriptor $(descriptor.accessor) requires initialized models. Call set_models() before using it."))
   related_model = _m2m_model_from_binding(owner_module, descriptor.relation.related_binding, descriptor.relation.related_model)
   return ManyToManyManager(descriptor.owner_model, related_model, descriptor.relation, owner_id)
 end
@@ -120,7 +123,7 @@ function _m2m_query(manager::ManyToManyManager)
 end
 
 function add(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+  _m2m_has_extra_fields(manager) && throw(QueryBuildError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   target_ids = _m2m_target_ids(manager, targets)
   isempty(target_ids) && return nothing
 
@@ -165,14 +168,14 @@ function add(manager::ManyToManyManager, targets...)
     sql = "INSERT OR IGNORE INTO $table_name ($owner_column, $related_column) VALUES $(join(groups, ", "));"
     fetch(settings, sql, parameters)
   else
-    throw(ArgumentError("Unsupported connection type $(typeof(connection)) for many-to-many add"))
+    throw(UnsupportedConnectionError("Unsupported connection type $(typeof(connection)) for many-to-many add"))
   end
 
   return nothing
 end
 
 function remove(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+  _m2m_has_extra_fields(manager) && throw(QueryBuildError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   target_ids = _m2m_target_ids(manager, targets)
   isempty(target_ids) && return nothing
 
@@ -200,7 +203,7 @@ function remove(manager::ManyToManyManager, targets...)
 end
 
 function clear(manager::ManyToManyManager)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+  _m2m_has_extra_fields(manager) && throw(QueryBuildError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   settings, connection, conn_key = _m2m_settings(manager)
   !settings.change_data && throw(_write_not_allowed("many-to-many clear", conn_key))
 
@@ -228,7 +231,7 @@ function _m2m_current_ids(manager::ManyToManyManager)::Vector{Any}
 end
 
 function set(manager::ManyToManyManager, targets...)
-  _m2m_has_extra_fields(manager) && throw(ArgumentError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
+  _m2m_has_extra_fields(manager) && throw(QueryBuildError("Cannot use direct many-to-many manager mutators (add, remove, clear, set) on relationship with a custom through model that has extra fields. Create/delete through model objects directly instead."))
   desired_ids = Set(_m2m_target_ids(manager, targets))
   settings, _, _ = _m2m_settings(manager)
 

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -137,11 +137,11 @@ function up_update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_quer
 
   for k in lookup_keys
     haskey(model.fields, k) ||
-      throw(_argerr("Error in update_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+      throw(UnknownFieldError("Error in update_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
   end
   for k in default_keys
     haskey(model.fields, k) ||
-      throw(_argerr("Error in update_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+      throw(UnknownFieldError("Error in update_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
   end
   length(unique(lookup_keys)) == length(lookup_keys) ||
     throw(_argerr("Error in update_or_create, duplicate lookup field(s)"))
@@ -184,9 +184,9 @@ function up_filter!(q::SQLObject, filter)
     elseif isa(v, Pair)
       push!(q.filter, _check_filter(v))
     else
-      # ArgumentError (not ErrorException) so filter() misuse matches the values()/order_by()
-      # siblings — this call site was the two-era inconsistency #197 calls out explicitly.
-      throw(_argerr("Invalid filter argument: $(v) (::$(typeof(v))) — use a \"field\" => value pair, a Q(key => value, …), or a Qor(key => value, …)."))
+      # FilterError (a PormGError) so filter() misuse matches the values()/order_by() siblings —
+      # this call site was the two-era inconsistency #197 called out (now typed via #231).
+      throw(FilterError("Invalid filter argument: $(v) (::$(typeof(v))) — use a \"field\" => value pair, a Q(key => value, …), or a Qor(key => value, …)."))
     end
   end
   return q
@@ -194,7 +194,7 @@ end
 
 function up_db!(q::SQLObject, keys)
   if isempty(keys) || length(keys) > 1 || !isa(keys[1], String)
-    throw(ArgumentError("db() expects exactly one String argument (the database key). Received: $(keys)"))
+    throw(QueryBuildError("db() expects exactly one String argument (the database key). Received: $(keys)"))
   end
   q.connect_key = keys[1]
   return q

--- a/src/querybuilder/parameters.jl
+++ b/src/querybuilder/parameters.jl
@@ -125,7 +125,7 @@ set_context!(instruc::SQLInstruction, context::Symbol) = instruc.parameters !== 
 
 # --- PostgreSQL (unchanged behaviour) ---
 function add_parameter!(pq::PormGPostgresParam, value::AbstractArray; contains::Bool=false, operator::String="", sql_type::Union{Nothing,String}=nothing)
-  contains && (throw(ArgumentError("Contains option is not supported for array parameters")))
+  contains && (throw(FilterError("Contains option is not supported for array parameters")))
   pq.parameter_count += 1
   push!(pq.parameters, value)
   return "\$$(pq.parameter_count)$(_postgres_parameter_cast(sql_type))"
@@ -141,7 +141,7 @@ end
 
 # --- SQLite – Contextual Bucket Strategy ---
 function add_parameter!(sq::PormGSQLiteParam, value::AbstractArray; contains::Bool=false, operator::String="", sql_type::Union{Nothing,String}=nothing)
-  contains && (throw(ArgumentError("Contains option is not supported for array parameters")))
+  contains && (throw(FilterError("Contains option is not supported for array parameters")))
   # Expand array into multiple positional parameters for SQLite
   placeholders = join(fill("?", length(value)), ", ")
   for v in value

--- a/src/querybuilder/sanitization.jl
+++ b/src/querybuilder/sanitization.jl
@@ -3,7 +3,7 @@ const SAFE_IDENTIFIER_PATTERN = r"^[\p{L}_][\p{L}\p{M}\p{N}_]*$"
 
 function _validate_identifier(identifier::String)::String
     if !occursin(SAFE_IDENTIFIER_PATTERN, identifier)
-        throw(ArgumentError("Invalid SQL identifier: $identifier"))
+        throw(InvalidValueError("Invalid SQL identifier: $identifier"))
     end
     return identifier
 end
@@ -16,7 +16,7 @@ against model schema.
 function sanitize_identifier(identifier::String, valid_identifiers::Vector{String})::String
     # Validate against whitelist
     if !(identifier in valid_identifiers)
-        throw(ArgumentError("Invalid identifier: $identifier"))
+        throw(InvalidValueError("Invalid identifier: $identifier"))
     end
     
     return quote_identifier(identifier, nothing)
@@ -53,7 +53,7 @@ Validate field name against model and return quoted identifier
 function safe_field_identifier(field_name::String, model::PormGModel, conn)::String
     # Validate field exists in model
     if !(field_name in model.field_names)
-        throw(ArgumentError("Invalid field name: $field_name for model $(model.name)"))
+        throw(UnknownFieldError("Invalid field name: $field_name for model $(model.name)"))
     end
     return quote_identifier(field_name, conn)
 end
@@ -68,12 +68,12 @@ Checks:
 3. Max length for CharFields.
 4. Max digits for Decimal/Numeric fields.
 
-Returns `true` if valid, throws an `ErrorException` otherwise.
+Returns `true` if valid, throws an `InvalidValueError` otherwise (#231; was `ErrorException`).
 SQL expressions (SQLTypeF, SQLTypeFunction) skip data validation as they are evaluated by the DB.
 """
 function _validation_error(operation::String, model::PormGModel, field::String, message::String; suggestion::Union{Nothing, String}=nothing)
     suffix = suggestion === nothing ? "" : " Suggested fix: $suggestion"
-    error("Error in $operation for model $(model.name), field \"$field\": $message$suffix")
+    throw(InvalidValueError("Error in $operation for model $(model.name), field \"$field\": $message$suffix"))
 end
 
 function _type_mismatch_error(operation::String, model::PormGModel, field::String, value::Any, expected::String; suggestion::Union{Nothing, String}=nothing)

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -339,7 +339,7 @@ function Base.push!(q::SQLTypeQ, x...)
     elseif isa(v, FilterType)
       push!(q.filters, v)
     else
-      throw(_argerr("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
+      throw(FilterError("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
     end
   end
   return q
@@ -352,7 +352,7 @@ function Base.push!(q::SQLTypeQor, x...)
     elseif isa(v, FilterType)
       push!(q.or, v)
     else
-      throw(_argerr("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
+      throw(FilterError("Invalid argument: $(v); please use a pair (key => value) or a Q/Qor/OP object."))
     end
   end
   return q
@@ -386,7 +386,7 @@ function _parse_time_string_to_compoundperiod(s::AbstractString)::Dates.Compound
   normalized = Models._normalize_duration_string(s)  # -> "±H:MM:SS(.fff)" (fields may exceed 2 digits,
                                                      # e.g. bare "120" seconds normalizes to "00:00:120")
   m = match(r"^(-?)(\d+):(\d+):(\d+)(?:\.(\d+))?$", normalized)
-  m === nothing && throw(ArgumentError("Interval: could not parse normalized duration '$(normalized)'"))
+  m === nothing && throw(InvalidValueError("Interval: could not parse normalized duration '$(normalized)'"))
   sign = m.captures[1] == "-" ? -1 : 1
   parts = Dates.Period[Hour(sign * parse(Int, m.captures[2])),
                        Minute(sign * parse(Int, m.captures[3])),
@@ -649,7 +649,7 @@ end
 end
 function OuterRef(field_name::AbstractString)
   normalized = String(field_name)
-  isempty(normalized) && throw(ArgumentError("OuterRef requires a non-empty field name"))
+  isempty(normalized) && throw(QueryBuildError("OuterRef requires a non-empty field name"))
   return OuterRefObject(field_name=normalized)
 end
 Base.deepcopy(x::OuterRefObject) = OuterRefObject(field_name=x.field_name)
@@ -876,7 +876,7 @@ PormGRow(data::Dict{Symbol,<:Any}, model::PormGModel) = PormGRow(Dict{Symbol,Any
 (strips a leading underscore per `format_fild_name`; case is preserved, #57)."""
 function _normalize_row_symbol(sym::Symbol)::Symbol
   parts = split(String(sym), "__")
-  any(isempty, parts) && throw(ArgumentError("Invalid projected row field '$sym'. Empty '__' path segment."))
+  any(isempty, parts) && throw(UnknownFieldError("Invalid projected row field '$sym'. Empty '__' path segment."))
   return Symbol(join(Models.format_fild_name.(String.(parts)), "__"))
 end
 
@@ -913,7 +913,7 @@ function Base.getproperty(row::PormGRow, sym::Symbol)
   end
 
   if haskey(model.fields, String(normalized)) && model.fields[String(normalized)] isa Models.sForeignKey
-    throw(ArgumentError(
+    throw(LazyTraversalError(
       "$(model.name).$(normalized) is a ForeignKey that this row didn't project; " *
       "PormG does not support lazy FK access (`row.$(normalized)`). " *
       "Project it up front in `values(...)`: add `\"$(normalized)\"` for the raw key value, " *
@@ -922,7 +922,7 @@ function Base.getproperty(row::PormGRow, sym::Symbol)
     ))
   end
 
-  throw(ArgumentError("$(model.name) row has no field or accessor '$(sym)'"))
+  throw(UnknownFieldError("$(model.name) row has no field or accessor '$(sym)'"))
 end
 
 function Base.setproperty!(row::PormGRow, sym::Symbol, value)
@@ -935,14 +935,14 @@ function Base.setproperty!(row::PormGRow, sym::Symbol, value)
   if occursin("__", normalized_string)
     fk_name = first(split(normalized_string, "__", limit=2)) |> String
     if !(haskey(model.fields, fk_name) && model.fields[fk_name] isa Models.sForeignKey)
-      throw(ArgumentError("Cannot assign to '$(sym)': '$(fk_name)' is not a ForeignKey field on $(model.name)."))
+      throw(QueryBuildError("Cannot assign to '$(sym)': '$(fk_name)' is not a ForeignKey field on $(model.name)."))
     end
   else
     if !haskey(model.fields, normalized_string)
-      throw(ArgumentError("$(model.name) row has no writable field '$(sym)'."))
+      throw(UnknownFieldError("$(model.name) row has no writable field '$(sym)'."))
     end
     if model.fields[normalized_string].primary_key
-      throw(ArgumentError("Cannot mutate primary key field '$(normalized)' on a PormGRow."))
+      throw(QueryBuildError("Cannot mutate primary key field '$(normalized)' on a PormGRow."))
     end
   end
 
@@ -964,9 +964,9 @@ read the individual key columns instead.
 function pk(row::PormGRow)
   model = getfield(row, :_model)
   field = Models.get_model_pk_field(model)
-  field === nothing && throw(ArgumentError("$(model.name) row has no single-column primary key"))
+  field === nothing && throw(QueryBuildError("$(model.name) row has no single-column primary key"))
   data = getfield(row, :_data)
-  haskey(data, field) || throw(ArgumentError("$(model.name) row is missing its primary-key column '$(field)'"))
+  haskey(data, field) || throw(QueryBuildError("$(model.name) row is missing its primary-key column '$(field)'"))
   return data[field]
 end
 

--- a/test/integration/test_cjoin.jl
+++ b/test/integration/test_cjoin.jl
@@ -33,10 +33,10 @@ end
         # Predicates that belong to the calling model (New_join_position) are rejected
         # by cjoin. Allowing them would silently produce WHERE semantics, not ON semantics.
         q1 = M.New_join_position.objects
-        @test_throws ArgumentError q1.cjoin("result" => "Result", filters=["description" => "teste 1"], warn=false)
+        @test_throws PormGError q1.cjoin("result" => "Result", filters=["description" => "teste 1"], warn=false)
 
         q2 = M.New_join_position.objects
-        @test_throws ArgumentError q2.cjoin("result" => "Result", filters=["result__description" => "teste 1"], warn=false)
+        @test_throws PormGError q2.cjoin("result" => "Result", filters=["result__description" => "teste 1"], warn=false)
     end
 
     @testset "ON filter restricts joined rows (LEFT JOIN default)" begin
@@ -102,7 +102,7 @@ end
         query.cjoin("result" => "Result", filters=["resultid" => 1, "statusid" => 1], join_type="INNER", warn=false)
 
         # Guard: a bare DataFrame() across a multi-table cjoin is rejected
-        @test_throws ArgumentError query |> DataFrame
+        @test_throws PormGError query |> DataFrame
 
         # Wildcard selects all New_join_position columns plus the one named from Result
         query.values("*", "result__statusid")
@@ -122,7 +122,7 @@ end
         query.filter("positionorder" => 1)
 
         # Guard: missing explicit values() is rejected
-        @test_throws ArgumentError query |> DataFrame
+        @test_throws PormGError query |> DataFrame
 
         query.values("*", "driverid__surname", "raceid__name")
         df = query |> DataFrame
@@ -175,21 +175,21 @@ end
         # so it is rejected with an explicit error.
         q = M.Result.objects
         q.cjoin("driverid" => "Driver", warn=false)
-        @test_throws ArgumentError q.cjoin("driverid" => "Driver", warn=false)
+        @test_throws PormGError q.cjoin("driverid" => "Driver", warn=false)
     end
 
     @testset "cjoin to unknown model name is rejected" begin
         # Model names are looked up via isdefined/getfield in the model's module;
         # a typo or wrong casing produces a clear error rather than a runtime crash.
         q = M.New_join_position.objects
-        @test_throws ArgumentError q.cjoin("result" => "NonExistentModel")
+        @test_throws PormGError q.cjoin("result" => "NonExistentModel")
     end
 
     @testset "cjoin mismatched FK target is rejected" begin
         # When the base field is already a FK (driverid → Driver), attempting to cjoin
         # it to a different model is rejected before any SQL is generated.
         q = M.Result.objects
-        @test_throws ArgumentError q.cjoin("driverid" => "Constructor", warn=false)
+        @test_throws PormGError q.cjoin("driverid" => "Constructor", warn=false)
     end
 
     @testset "cjoin_on self-join executes and correlates correctly (#45)" begin

--- a/test/integration/test_cte.jl
+++ b/test/integration/test_cte.jl
@@ -330,7 +330,7 @@ end
         q = M.Result.objects
         sub = M.Driver.objects.filter("driverid__@lte" => 5).values("driverid")
         q.with("driver_cte" => sub, join_field="driverid" => "driverid")
-        @test_throws ArgumentError q.on("driver_cte", "driverid__@lte" => 5)
+        @test_throws PormGError q.on("driver_cte", "driverid__@lte" => 5)
     end
 
     @testset "With() duplicate CTE name is rejected" begin
@@ -341,7 +341,7 @@ end
         q.with("dup" => sub, join_field="driverid" => "driverid")
         # #197: With() now throws a typed ArgumentError (was a raw String, which no
         # `catch e; e isa Exception` could see).
-        @test_throws ArgumentError q.with("dup" => sub, join_field="driverid" => "driverid")
+        @test_throws PormGError q.with("dup" => sub, join_field="driverid" => "driverid")
     end
 
 end

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -348,7 +348,7 @@ end
         lap_query.filter("raceid" => 841, "driverid" => 20, "lap" => 1)
 
         @test lap_query.count() == 1
-        @test_throws ArgumentError lap_query.delete()
+        @test_throws PormGError lap_query.delete()
         @test lap_query.count() == 1   # Row must still be there after the rejected attempt.
 
         # Inspection of the delete-all path must produce well-formed SQL without
@@ -611,7 +611,7 @@ end
                 e
             end
 
-            @test err isa ArgumentError
+            @test err isa PormGError
             msg = _strip_ansi(lowercase(sprint(showerror, err)))
             # The error must identify the field name and the null-constraint violation.
             @test occursin("parent_id", msg)
@@ -695,7 +695,7 @@ end
             e
         end
 
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = _strip_ansi(lowercase(sprint(showerror, err)))
         # The error must name the parent table, the offending FK field,
         # and the on_delete constraint type.
@@ -768,7 +768,7 @@ end
                 e
             end
 
-            @test err isa ArgumentError
+            @test err isa PormGError
             msg = _strip_ansi(sprint(showerror, err))
             # Error must identify the parent table, the child FK field, and the constraint.
             @test occursin("Cannot delete delete_protect_parent_scratch", msg)
@@ -945,7 +945,7 @@ end
         catch e
             e
         end
-        @test err_limit isa ArgumentError
+        @test err_limit isa PormGError
         @test occursin("limit", lowercase(sprint(showerror, err_limit)))
 
         err_offset = try
@@ -954,7 +954,7 @@ end
         catch e
             e
         end
-        @test err_offset isa ArgumentError
+        @test err_offset isa PormGError
         @test occursin("offset", lowercase(sprint(showerror, err_offset)))
 
         err_order = try
@@ -963,7 +963,7 @@ end
         catch e
             e
         end
-        @test err_order isa ArgumentError
+        @test err_order isa PormGError
         @test occursin("order_by", lowercase(sprint(showerror, err_order)))
 
         @test M.Just_a_test_deletion.objects.filter("name__@contains" => "delete-guard").count() == 2
@@ -1068,7 +1068,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("distinct", lowercase(sprint(showerror, err)))
 
         # Rows must survive — the delete was rejected.
@@ -1096,7 +1096,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("group", lowercase(sprint(showerror, err)))
 
         # Rows must survive — the delete was rejected.

--- a/test/integration/test_internals.jl
+++ b/test/integration/test_internals.jl
@@ -224,8 +224,8 @@ end
     @test quote_identifier("localização", nothing) == "\"localização\""
     
     # Test malicious identifiers are rejected instead of silently rewritten
-    @test_throws ArgumentError quote_identifier("field'; DROP TABLE users; --", nothing)
-    @test_throws ArgumentError quote_identifier("field OR 1=1", nothing)
+    @test_throws PormGError quote_identifier("field'; DROP TABLE users; --", nothing)
+    @test_throws PormGError quote_identifier("field OR 1=1", nothing)
     
     # Test table name sanitization
     @test safe_table_identifier("users", nothing) == "\"users\""
@@ -315,7 +315,7 @@ end
         query.filter(bad_filter => 1)
         @test false # Should not reach here
       catch e
-        @test e isa ArgumentError
+        @test e isa PormGError
         @test occursin("is invalid;", e.msg)
       end
     end
@@ -327,16 +327,16 @@ end
     import PormG.QueryBuilder: quote_identifier
     
     # Empty identifier
-    @test_throws ArgumentError quote_identifier("", nothing)
+    @test_throws PormGError quote_identifier("", nothing)
     
     # Double quotes inside (attempt to break the identifier)
-    @test_throws ArgumentError quote_identifier("column\"name", nothing)
+    @test_throws PormGError quote_identifier("column\"name", nothing)
     
     # SQL comments
-    @test_throws ArgumentError quote_identifier("admin--", nothing)
+    @test_throws PormGError quote_identifier("admin--", nothing)
     
     # Whitespace is not part of PormG's identifier contract.
-    @test_throws ArgumentError quote_identifier("user name", nothing)
+    @test_throws PormGError quote_identifier("user name", nothing)
   end
 
 

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -213,10 +213,10 @@ end
     
     # Since the explicit through model has an extra field (`joined_year`),
     # all direct mutators (add, remove, clear, set) must raise an ArgumentError (Django behavior).
-    @test_throws ArgumentError manager.add(team_a)
-    @test_throws ArgumentError manager.remove(team_a)
-    @test_throws ArgumentError manager.clear()
-    @test_throws ArgumentError manager.set(team_a)
+    @test_throws PormGError manager.add(team_a)
+    @test_throws PormGError manager.remove(team_a)
+    @test_throws PormGError manager.clear()
+    @test_throws PormGError manager.set(team_a)
     
     # Instead, we create the intermediate record directly using the objects manager:
     M.M2m_membership_scratch.objects.create("driver" => driver[:id], "team" => team_a[:id])
@@ -316,7 +316,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         after_failed_set = Set([row[:name] for row in manager.all().list()])
         @test after_failed_set == expected
     finally
@@ -486,10 +486,10 @@ end
 
         PormG.config[PORMG_DB_FOLDER].change_data = false
         try
-            @test_throws ArgumentError readonly_manager.add(1)
-            @test_throws ArgumentError readonly_manager.remove(1)
-            @test_throws ArgumentError readonly_manager.clear()
-            @test_throws ArgumentError readonly_manager.set([1])
+            @test_throws PormGError readonly_manager.add(1)
+            @test_throws PormGError readonly_manager.remove(1)
+            @test_throws PormGError readonly_manager.clear()
+            @test_throws PormGError readonly_manager.set([1])
         finally
             PormG.config[PORMG_DB_FOLDER].change_data = orig_change_data
         end

--- a/test/integration/test_reverse_joins.jl
+++ b/test/integration/test_reverse_joins.jl
@@ -202,13 +202,13 @@ end
         # on() requires the first segment of the join path to be a FK or reverse relation.
         # Scalars like `points` (FloatField) cannot be traversed.
         q = M.Result.objects
-        @test_throws ArgumentError q.on("points", "points__@gt" => 0)
+        @test_throws PormGError q.on("points", "points__@gt" => 0)
     end
 
     @testset "on() with no filters and no join_type is rejected" begin
         # An on() call with nothing to contribute is meaningless and is rejected early.
         q = M.Result.objects
-        @test_throws ArgumentError q.on("driverid")
+        @test_throws PormGError q.on("driverid")
     end
 
 end

--- a/test/integration/test_row_and_get.jl
+++ b/test/integration/test_row_and_get.jl
@@ -23,7 +23,7 @@ import TimeZones: ZonedDateTime
     @test row.driverid == row["driverid"]
     @test haskey(row, :driverid)
     @test !haskey(row, :driverId)
-    @test_throws ArgumentError row.driverId   # getproperty validates → ArgumentError
+    @test_throws PormG.UnknownFieldError row.driverId   # camelCase misses → no field/accessor
     @test_throws KeyError row[:driverId]      # raw getindex → KeyError
     @test get(row, "missingField", :fallback) === :fallback
 
@@ -39,7 +39,7 @@ import TimeZones: ZonedDateTime
     @test parsed[1]["driverid"] == row.driverid
     @test parsed[1]["driverref"] == "hamilton"
 
-    @test_throws ArgumentError M.Driver.objects.filter("driverref" => "hamilton").list(:typo)
+    @test_throws PormG.QueryBuildError M.Driver.objects.filter("driverref" => "hamilton").list(:typo)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -106,11 +106,12 @@ end
     standings = M.Driver_standings.objects.values("driverstandingsid").limit(1).first()
     @test standings isa PormGRow
     # Accessing an un-projected ForeignKey (`driverid`) triggers the lazy-FK refusal.
-    # Lock not just the error TYPE but the guidance: it must steer to up-front
-    # `values("fk__field")` projection and never re-suggest `.on(...)` (which throws
-    # its own error and does not project columns — issue #204).
+    # #231 backs this with a semantic type (LazyTraversalError); we still lock the #204
+    # guidance wording: it must steer to up-front `values("fk__field")` projection and
+    # never re-suggest `.on(...)` (which throws its own error and does not project columns).
     err = try; standings.driverid; nothing; catch e; e; end
-    @test err isa ArgumentError
+    @test err isa PormG.LazyTraversalError    # #231: typed, was a bare ArgumentError (#204)
+    @test err isa PormG.FieldAccessError      # catch the field-access family
     @test occursin("values(", err.msg)   # steers to projection
     @test occursin("__", err.msg)        # via the __ lookup
     @test !occursin(".on(", err.msg)     # never re-suggests the on() dead end

--- a/test/integration/test_row_mutation.jl
+++ b/test/integration/test_row_mutation.jl
@@ -28,14 +28,14 @@ end
     @test :positiontext in row._dirty
 
     # Wrong-case assignment misses the lowercase-declared field (no silent normalization).
-    @test_throws ArgumentError (row.positionText = "x")
+    @test_throws PormGError (row.positionText = "x")
 
-    @test_throws ArgumentError (row.unknownField = 1)
-    @test_throws ArgumentError (row.badFk__name = "x")
+    @test_throws PormGError (row.unknownField = 1)
+    @test_throws PormGError (row.badFk__name = "x")
 
     # Primary-key mutation is rejected (driverid is Driver's PK).
     driver = M.Driver.objects.get("driverref" => "hamilton")
-    @test_throws ArgumentError (driver.driverid = driver.driverid + 1)
+    @test_throws PormGError (driver.driverid = driver.driverid + 1)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -123,7 +123,7 @@ end
         ).get()
         race_row.required_parent_id = parent[:id]
         race_row.required_parent_id__label = "race_guard_$(uuid4())"
-        @test_throws ArgumentError race_row.save()
+        @test_throws PormGError race_row.save()
     finally
         if payload !== nothing
             M.Bulk_update_payload_scratch.objects.filter("id" => payload[:id]).delete()
@@ -142,7 +142,7 @@ end
 @testset "PormGRow unsupported save targets" begin
     keyless = M.Lap_times.objects.values("raceid", "driverid", "lap", "position").limit(1).first()
     keyless.position = keyless.position
-    @test_throws ArgumentError keyless.save()
+    @test_throws PormGError keyless.save()
 
     multi_pk_model = Models.Model("row_mutation_multi_pk_scratch",
         firstid = Models.IDField(),
@@ -151,7 +151,7 @@ end
     )
     multi_pk_row = PormGRow(Dict(:firstid => 1, :secondid => 2, :label => "before"), multi_pk_model)
     multi_pk_row.label = "after"
-    @test_throws ArgumentError multi_pk_row.save()
+    @test_throws PormGError multi_pk_row.save()
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -185,5 +185,5 @@ end
 
     # save() must detect pk_field === nothing and throw ArgumentError
     # instead of building a filter on the literal string "nothing".
-    @test_throws ArgumentError row.save()
+    @test_throws PormGError row.save()
 end

--- a/test/integration/test_sql_functions.jl
+++ b/test/integration/test_sql_functions.jl
@@ -729,7 +729,7 @@ end
         # suite runs against. See issue #76.
 
         # Misaligned: distinct driverids ordered by surname (not projected) -> raises everywhere.
-        @test_throws ArgumentError begin
+        @test_throws PormGError begin
             M.Driver.objects.values("driverid").distinct().order_by("surname") |> DataFrame
         end
 
@@ -741,7 +741,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         @test occursin("surname", msg)
         @test occursin("DISTINCT", msg)
@@ -1089,7 +1089,7 @@ end
     # Returns the thrown error (or nothing). is_fanout confirms it is the #74 guard, so an unrelated
     # ArgumentError (e.g. a bad field path) cannot masquerade as a passing raise.
     fanout_err(f) = try; f(); nothing; catch e; e; end
-    is_fanout(e)  = e isa ArgumentError && occursin("fan-out", e.msg)
+    is_fanout(e)  = e isa PormGError && occursin("fan-out", e.msg)
 
     did = 1  # F1 dataset: driver 1 (Hamilton) has many driver_standings rows.
 

--- a/test/integration/test_subqueries.jl
+++ b/test/integration/test_subqueries.jl
@@ -54,7 +54,7 @@ end
         e
     end
 
-    @test err isa ArgumentError
+    @test err isa PormGError
 
     message = sprint(showerror, err)
     @test occursin("'statusid__@in' requires a subquery that returns exactly one column", message)
@@ -103,7 +103,7 @@ end
     naive.values("surname", "n" => Count("driverid"))
     naive.filter("driver_standings__position__@gte" => 1)
     err = try; naive |> DataFrame; nothing; catch e; e; end
-    @test err isa ArgumentError && occursin("fan-out", err.msg)
+    @test err isa PormGError && occursin("fan-out", err.msg)
 
     # #92 form: the aggregate moves into a correlated scalar subquery.
     standings = M.Driver_standings.objects
@@ -297,7 +297,7 @@ end
     naive.values("driverref", "n" => Count("id"))
     naive.filter("teams__name__@contains" => slug)
     err = try; naive |> DataFrame; nothing; catch e; e; end
-    @test err isa ArgumentError && occursin("fan-out", err.msg)
+    @test err isa PormGError && occursin("fan-out", err.msg)
 
     # #92 form: count the through-table rows in a correlated scalar subquery.
     links = M.M2m_link_plain_scratch.objects
@@ -374,5 +374,5 @@ end
         values("x" => Subquery(middle))
 
     err = try; q |> DataFrame; nothing; catch e; e; end
-    @test err isa ArgumentError && occursin("one level", err.msg)
+    @test err isa PormGError && occursin("one level", err.msg)
 end

--- a/test/integration/test_transactions.jl
+++ b/test/integration/test_transactions.jl
@@ -603,7 +603,7 @@ settings = PormG.config[PORMG_DB_FOLDER]
       autocommit_err = try
         M.Just_a_test_deletion.objects.filter("name" => "lockme").select_for_update().list(); nothing
       catch e; e end
-      @test autocommit_err isa ArgumentError && occursin("transaction", autocommit_err.msg)
+      @test autocommit_err isa PormGError && occursin("transaction", autocommit_err.msg)
     else
       # SQLite: select_for_update is a pure no-op — returns rows normally and never raises,
       # both inside and outside a transaction (the documented PG/SQLite divergence).

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -236,21 +236,21 @@ end
     end
     @test err !== nothing
     # #197: the guard is now a typed ArgumentError with reworded message — assert both.
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("requires a filter", lowercase(string(err)))
 
     row_after_unfiltered_attempt = M.Just_a_test_deletion.objects.filter("name" => "valid").list() |> first
     @test row_after_unfiltered_attempt[:name] == "valid"
     
     # 1. Primary Key Protection: Attempting to update the ID field should throw
-    @test_throws ErrorException query.filter("name" => "valid").update("id" => 999)
+    @test_throws PormGError query.filter("name" => "valid").update("id" => 999)
     
     # 2. Max Length Validation: CharField default max_length is 250
     long_name = "a"^256
-    @test_throws ErrorException query.filter("name" => "valid").update("name" => long_name)
+    @test_throws PormGError query.filter("name" => "valid").update("name" => long_name)
     
     # 3. Non-existent field: Should throw informative error
-    @test_throws ErrorException query.filter("name" => "valid").update("non_existent" => "foo")
+    @test_throws PormGError query.filter("name" => "valid").update("non_existent" => "foo")
 end
 
 @testset "Update inspection modes do not execute" begin
@@ -294,7 +294,7 @@ end
         @test isnothing(none_result)
         @test M.Just_a_test_deletion.objects.filter("name" => "still-not-landed").count() == 0
 
-        @test_throws ArgumentError M.Just_a_test_deletion.objects.filter("name" => "inspect-update").update(
+        @test_throws PormGError M.Just_a_test_deletion.objects.filter("name" => "inspect-update").update(
             "name" => "bad-mode",
             show_query = :bogus
         )
@@ -681,7 +681,7 @@ end
             catch e
                 e
             end
-            @test err isa ArgumentError
+            @test err isa PormGError
             @test occursin("case", lowercase(sprint(showerror, err)))
             # The failed call must not have inserted the row.
             @test M.Just_a_test_deletion.objects.filter("name" => "CaseTest").count() == 0
@@ -1411,7 +1411,7 @@ end
     catch e
         e
     end
-    @test err_limit isa ArgumentError
+    @test err_limit isa PormGError
     @test occursin("limit", lowercase(sprint(showerror, err_limit)))
 
     # offset() must be rejected
@@ -1421,7 +1421,7 @@ end
     catch e
         e
     end
-    @test err_offset isa ArgumentError
+    @test err_offset isa PormGError
     @test occursin("offset", lowercase(sprint(showerror, err_offset)))
 
     # order_by() must be rejected
@@ -1431,7 +1431,7 @@ end
     catch e
         e
     end
-    @test err_order isa ArgumentError
+    @test err_order isa PormGError
     @test occursin("order_by", lowercase(sprint(showerror, err_order)))
 
     # Verify no mutations slipped through despite the guard being in the execution path.
@@ -1542,7 +1542,7 @@ end
     catch e
         e
     end
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("case", lowercase(sprint(showerror, err)))
 
     # The failed call must not have touched the database.
@@ -1593,7 +1593,7 @@ end
             e
         end
 
-        @test err_filter isa ArgumentError
+        @test err_filter isa PormGError
         @test occursin("match_on column", lowercase(sprint(showerror, err_filter)))
         @test occursin("id", lowercase(sprint(showerror, err_filter)))
 
@@ -1609,7 +1609,7 @@ end
             e
         end
 
-        @test err_pk isa ArgumentError
+        @test err_pk isa PormGError
         @test occursin("primary key column", lowercase(sprint(showerror, err_pk)))
         @test occursin("id", lowercase(sprint(showerror, err_pk)))
 
@@ -1908,7 +1908,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("distinct", lowercase(sprint(showerror, err)))
 
         # Verify no rows were mutated.
@@ -1936,7 +1936,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("group", lowercase(sprint(showerror, err)))
 
         # Verify no rows were mutated.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ end
     @testset "JSON Containment Operators (#27)" include("unit/test_json_operators.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Typed Exceptions on Query Surface (#197)" include("unit/test_typed_exceptions.jl")
+    @testset "Semantic Error Taxonomy (#231)" include("unit/test_error_taxonomy.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")
     @testset "Configuration API" include("unit/test_configuration_api.jl")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -65,7 +65,7 @@ end
 @testset "Alignment Verification - cjoin Rejects Base-Model Filters" begin
     q = M.Result.objects
 
-    @test_throws ArgumentError begin
+    @test_throws PormGError begin
         q.cjoin("raceid" => "Race", filters=["points" => 10], warn=false)
     end
 end
@@ -161,7 +161,7 @@ end
 @testset "Alignment Verification - OuterRef requires correlated context" begin
     q = M.Result.objects.filter("raceid" => OuterRef("raceid"))
 
-    @test_throws ArgumentError begin
+    @test_throws PormGError begin
         q |> inspect_query
     end
 end
@@ -1095,7 +1095,7 @@ end
     q = M.Result.objects
 
     # This should raise an error because driverid points to Driver, not Constructor
-    @test_throws ArgumentError begin
+    @test_throws PormGError begin
         q.cjoin("driverid" => "Constructor", filters=["name" => "Ferrari"])
     end
 
@@ -1965,7 +1965,7 @@ end
     # over get_all_models; a name that matches no model raises ArgumentError.
     resolved = PormG.QueryBuilder._resolve_m2m_side_model(M, "NotABindingXyz", "m2m_rpk_sponsor_scratch", "sponsors")
     @test resolved === M.M2m_rpk_sponsor_scratch
-    @test_throws ArgumentError PormG.QueryBuilder._resolve_m2m_side_model(M, "NotABindingXyz", "no_such_model_zzz", "sponsors")
+    @test_throws PormGError PormG.QueryBuilder._resolve_m2m_side_model(M, "NotABindingXyz", "no_such_model_zzz", "sponsors")
 end
 
 @testset "Related Objects - Auto-generated related_name key format" begin
@@ -2035,7 +2035,7 @@ end
         e
     end
 
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("circular dependency", lowercase(sprint(showerror, err)))
 
     # Pin the dispatch contract: Julia infers Dict{Model_Type,...} (concrete) when keys are
@@ -2175,7 +2175,7 @@ end
     excl_err = try
       M.Result.objects.select_for_update(nowait = true, skip_locked = true); nothing
     catch e; e end
-    @test excl_err isa ArgumentError && occursin("mutually exclusive", excl_err.msg)
+    @test excl_err isa PormGError && occursin("mutually exclusive", excl_err.msg)
 end
 
 
@@ -2387,7 +2387,7 @@ end
     q_two = M.Driver.objects
     q_two.values("x" => Subquery(two_cols))
     err_two = try q_two |> inspect_query; nothing catch e; e end
-    @test err_two isa ArgumentError && occursin("exactly one column", err_two.msg)
+    @test err_two isa PormGError && occursin("exactly one column", err_two.msg)
 
     # No values() on the inner → implicit all-columns projection → same contract error.
     all_cols = M.Driver_standings.objects
@@ -2395,18 +2395,18 @@ end
     q_all = M.Driver.objects
     q_all.values("x" => Subquery(all_cols))
     err_all = try q_all |> inspect_query; nothing catch e; e end
-    @test err_all isa ArgumentError && occursin("exactly one column", err_all.msg)
+    @test err_all isa PormGError && occursin("exactly one column", err_all.msg)
 
     # Bare Subquery(...) without an alias pair → rejected at values() time.
     one_col = M.Driver_standings.objects
     one_col.filter("driverid" => OuterRef("driverid"))
     one_col.values("t" => Count("driverstandingsid"))
     err_bare = try M.Driver.objects.values("surname", Subquery(one_col)); nothing catch e; e end
-    @test err_bare isa ArgumentError && occursin("Subquery", err_bare.msg)
+    @test err_bare isa PormGError && occursin("Subquery", err_bare.msg)
 
     # Silent-drop fix: an unsupported pair value now throws instead of vanishing.
     err_pair = try M.Driver.objects.values("x" => 42); nothing catch e; e end
-    @test err_pair isa ArgumentError && occursin("Invalid values pair", err_pair.msg)
+    @test err_pair isa PormGError && occursin("Invalid values pair", err_pair.msg)
 
     # Silent-drop fix, function-pair branch: a function that constructs but fails
     # _check_function validation (Concat accepts the Int; validation rejects it) used to be
@@ -2444,7 +2444,7 @@ end
     err = Logging.with_logger(Logging.NullLogger()) do
         try q |> inspect_query; nothing catch e; e end
     end
-    @test err isa ArgumentError && occursin("one level", err.msg)
+    @test err isa PormGError && occursin("one level", err.msg)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_bulk_on_conflict.jl
+++ b/test/unit/test_bulk_on_conflict.jl
@@ -136,7 +136,7 @@ function _cbo_error(on_conflict; kwargs...)
   catch e
     e
   end
-  @test err isa ArgumentError
+  @test err isa PormGError
   return err === nothing ? "" : sprint(showerror, err)
 end
 

--- a/test/unit/test_bulk_param_limit.jl
+++ b/test/unit/test_bulk_param_limit.jl
@@ -92,7 +92,7 @@ const _effective_chunk_size  = PormG.QueryBuilder._effective_chunk_size
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("999", string(err))              # names the backend limit
         @test occursin("chunk_size", string(err))        # points at the lever
         @test occursin(r"bulk_insert"i, string(err))     # names the operation
@@ -105,7 +105,7 @@ const _effective_chunk_size  = PormG.QueryBuilder._effective_chunk_size
         catch e
             e
         end
-        @test err_fixed isa ArgumentError
+        @test err_fixed isa PormGError
         @test occursin("999", string(err_fixed))
         @test occursin(r"bulk_update"i, string(err_fixed))
     end

--- a/test/unit/test_bulk_update_column_scope.jl
+++ b/test/unit/test_bulk_update_column_scope.jl
@@ -399,7 +399,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         # The message must show the exact rewrite: mapping moves to columns=,
         # match_on keeps the bare field name.
@@ -441,7 +441,7 @@ end
 
     # A bare string in filters cannot be a constant predicate once match_on is set.
     @testset "bare-string filter with match_on is rejected" begin
-        @test_throws ArgumentError bulk_update(
+        @test_throws PormGError bulk_update(
             Metric.objects, df_upd,
             columns    = ["weight"],
             match_on   = ["id"],
@@ -465,7 +465,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("match_on", sprint(showerror, err))
     end
 
@@ -485,7 +485,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         @test occursin("columns  = [..., \"record_id\" => \"id\"]", msg)
         @test occursin("match_on = [\"id\"]", msg)
@@ -507,7 +507,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         # Assert the error CLASS and SUBJECT, not just substrings: a bare
         # occursin("id", msg) also matches "record_id" in the column dump, so it
@@ -557,7 +557,7 @@ end
             city_id = [5, 5],
             weight  = [10, 20],
         )
-        @test_throws ArgumentError bulk_update(
+        @test_throws PormGError bulk_update(
             Metric.objects, dup_df,
             columns    = ["weight"],
             match_on   = ["id", "city_id"],
@@ -580,7 +580,7 @@ end
 
     # A match_on key that is not a model field is a hard error.
     @testset "match_on referencing a non-field raises" begin
-        @test_throws ArgumentError bulk_update(
+        @test_throws PormGError bulk_update(
             Metric.objects, df_upd,
             columns    = ["weight"],
             match_on   = ["not_a_field"],
@@ -609,7 +609,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         # The error must name the case-only candidate and point at the case-sensitivity,
         # and the suggested fix is a columns= mapping (the single border crossing).
@@ -638,7 +638,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         @test occursin("Weight", msg)
         @test occursin("case", msg)
@@ -663,7 +663,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         # Auto-detect names the DataFrame column and the case-only model field it shadows.
         @test occursin("Weight", msg)
@@ -711,7 +711,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         msg = sprint(showerror, err)
         @test occursin("weight", msg)
         @test occursin("case", msg)
@@ -735,7 +735,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("totally_absent", sprint(showerror, err))
     end
 
@@ -771,7 +771,7 @@ end
         catch e
             e
         end
-        @test err isa ArgumentError
+        @test err isa PormGError
         @test occursin("primary key", lowercase(sprint(showerror, err)))
     end
 

--- a/test/unit/test_cjoin_on.jl
+++ b/test/unit/test_cjoin_on.jl
@@ -150,19 +150,19 @@ end
 
 @testset "Validation" begin
   # Unknown target model.
-  @test_throws ArgumentError SL.Lap.objects.cjoin_on("Nope", alias = "b2", on = [F("b2.raceid") == F("raceid")])
+  @test_throws PormGError SL.Lap.objects.cjoin_on("Nope", alias = "b2", on = [F("b2.raceid") == F("raceid")])
   # Duplicate alias.
-  @test_throws ArgumentError begin
+  @test_throws PormGError begin
     q = SL.Lap.objects
     q.cjoin_on("Lap", alias = "b2", on = [F("b2.raceid") == F("raceid")])
     q.cjoin_on("Circuit", alias = "b2", on = [F("b2.raceid") == F("raceid")])
   end
   # Invalid alias identifier (fail-closed).
-  @test_throws ArgumentError SL.Lap.objects.cjoin_on("Lap", alias = "b2; DROP", on = [F("b2.raceid") == F("raceid")])
+  @test_throws PormGError SL.Lap.objects.cjoin_on("Lap", alias = "b2; DROP", on = [F("b2.raceid") == F("raceid")])
   # Empty ON list.
-  @test_throws ArgumentError SL.Lap.objects.cjoin_on("Lap", alias = "b2", on = [])
+  @test_throws PormGError SL.Lap.objects.cjoin_on("Lap", alias = "b2", on = [])
   # Unknown column on the aliased model surfaces at render time.
-  @test_throws ArgumentError begin
+  @test_throws PormGError begin
     q = SL.Lap.objects
     q.cjoin_on("Lap", alias = "b2", on = [F("b2.nonexistent") == F("raceid")])
     q.values("id")

--- a/test/unit/test_complex_queries.jl
+++ b/test/unit/test_complex_queries.jl
@@ -183,7 +183,7 @@ ResultCamelDjangoModel._module = Main
     catch e
       e
     end
-    @test err_values isa ArgumentError
+    @test err_values isa PormGError
     @test contains(sprint(showerror, err_values), "driver__...")
     @test contains(sprint(showerror, err_values), "driver_id__...")
 
@@ -210,7 +210,7 @@ ResultCamelDjangoModel._module = Main
     catch e
       e
     end
-    @test err_filter isa ArgumentError
+    @test err_filter isa PormGError
     @test contains(sprint(showerror, err_filter), "driver__...")
 
     # ---- 3b-5: Multi-hop join (tests the while-loop call site) ----

--- a/test/unit/test_create_returns_pormgrow.jl
+++ b/test/unit/test_create_returns_pormgrow.jl
@@ -72,7 +72,7 @@ end
   try
     pk(bare); @test false
   catch e
-    @test e isa ArgumentError && occursin("no single-column primary key", e.msg)
+    @test e isa PormGError && occursin("no single-column primary key", e.msg)
   end
 
   # Edge: pk column absent from the row's data — distinct "missing column" throw / default behavior.
@@ -81,6 +81,6 @@ end
   try
     pk(missing_pk); @test false
   catch e
-    @test e isa ArgumentError && occursin("missing its primary-key column", e.msg)
+    @test e isa PormGError && occursin("missing its primary-key column", e.msg)
   end
 end

--- a/test/unit/test_error_message_ansi.jl
+++ b/test/unit/test_error_message_ansi.jl
@@ -36,14 +36,14 @@ const SAMPLE = "the field \e[4m\e[31mpoints\e[0m is not allowed"
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Error colorization: _argerr routes ArgumentError messages through _emsg
-# Every QueryBuilder call site builds ArgumentErrors via `_argerr`; this proves
-# the wiring (so a regression that bypasses `_emsg` is caught) without depending
-# on the ambient color mode — both sides resolve `Base.have_color` identically.
+# Error colorization: _argerr routes messages through _emsg
+# `_argerr` is the long-tail funnel; #231 makes it return `QueryBuildError` (a `PormGError`)
+# instead of `ArgumentError`, still routing the message through `_emsg`. This proves the wiring
+# (so a regression that bypasses `_emsg` is caught) without depending on the ambient color mode.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "_argerr wiring" begin
     err = _argerr(SAMPLE)
-    @test err isa ArgumentError
+    @test err isa PormG.QueryBuildError     # #231: the funnel now returns QueryBuildError
     # _argerr must produce exactly what _emsg produces under the same color mode.
     @test err.msg == _emsg(SAMPLE)
 end
@@ -162,7 +162,7 @@ PormG.config["ansi_bulk_default"] = PormG.Configuration.Settings(
     df = DataFrames.DataFrame(id = [1], weight = [5])
 
     # `match_on = ["not_a_field"]` fails the model-field check in execution_bulk.jl
-    # (`bulk_update: match_on field … is not a field of model`), a `_argerr` site.
+    # (`bulk_update: match_on field … is not a field of model`) → UnknownFieldError (#231).
     raise_bulk = () -> try
         bulk_update(model.objects, df;
             columns = ["weight"], match_on = ["not_a_field"], show_query = :dict)
@@ -173,14 +173,14 @@ PormG.config["ansi_bulk_default"] = PormG.Configuration.Settings(
 
     _with_have_color(false) do
         err = raise_bulk()
-        @test err isa ArgumentError                       # not a raw String
+        @test err isa PormG.UnknownFieldError             # #231: field-not-found, not a raw String
         @test !occursin("\e[", err.msg)
         @test !occursin("\e[", sprint(showerror, err))
     end
 
     _with_have_color(true) do
         err = raise_bulk()
-        @test err isa ArgumentError
+        @test err isa PormG.UnknownFieldError
         @test occursin("\e[", err.msg)                    # highlighting kept on-TTY
     end
 end

--- a/test/unit/test_error_taxonomy.jl
+++ b/test/unit/test_error_taxonomy.jl
@@ -1,0 +1,96 @@
+"""
+Semantic error taxonomy contract (#231).
+
+Pins the SHAPE of the `PormGError` taxonomy — the abstract root, the `FieldAccessError`
+mid-node, subtype membership, the `get()`-cardinality reparenting, and the deliberate clean
+break (subtypes are NOT `<: ArgumentError`). A representative fluent-surface misuse per bucket
+confirms the right subtype is thrown; deeper behavioral coverage lives in the subsystem
+integration tests (test_row_and_get, test_cjoin, test_deletes, …).
+
+No database required: every assertion fires at query-build/validation time.
+"""
+# julia -t auto --project=. test/unit/test_error_taxonomy.jl
+
+using Test
+using PormG
+using PormG.Models
+using PormG.QueryBuilder: object, Q, Qor, With
+
+const QB = PormG.QueryBuilder
+
+# Every concrete member of the taxonomy (the two get()-cardinality types included).
+const TAXONOMY_TYPES = (
+    PormG.UnknownFieldError, PormG.LazyTraversalError, PormG.FilterError,
+    PormG.QueryBuildError, PormG.UnsafeMutationError, PormG.InvalidValueError,
+    PormG.PermissionError, PormG.UnsupportedConnectionError,
+    PormG.DoesNotExist, PormG.MultipleObjectsReturned,
+)
+
+@testset "Error taxonomy (#231)" begin
+
+    @testset "root and hierarchy" begin
+        @test PormG.PormGError <: Exception
+        @test PormG.FieldAccessError <: PormG.PormGError
+        # every concrete subtype is under the root
+        for T in TAXONOMY_TYPES
+            @test T <: PormG.PormGError
+        end
+        # the field-access mid-node groups the two field-lookup errors, so
+        # `catch FieldAccessError` catches both "no such field" and "no lazy traversal".
+        @test PormG.UnknownFieldError <: PormG.FieldAccessError
+        @test PormG.LazyTraversalError <: PormG.FieldAccessError
+        # get() cardinality errors were reparented from Exception to PormGError.
+        @test PormG.DoesNotExist <: PormG.PormGError
+        @test PormG.MultipleObjectsReturned <: PormG.PormGError
+    end
+
+    @testset "clean break — NOT <: ArgumentError" begin
+        # The whole point of #231: callers stop catching ArgumentError. Pin the clean break
+        # so a future accidental `PormGError <: ArgumentError` fails loudly here.
+        for T in TAXONOMY_TYPES
+            @test !(T <: ArgumentError)
+        end
+        @test !(PormG.PormGError <: ArgumentError)
+        @test !(PormG.FieldAccessError <: ArgumentError)
+    end
+
+    @testset "exported bare after `using PormG`" begin
+        # Each name resolves unqualified (exported) and points at the QueryBuilder binding.
+        @test PormGError === PormG.PormGError
+        @test FieldAccessError === PormG.FieldAccessError
+        @test UnknownFieldError === PormG.UnknownFieldError
+        @test LazyTraversalError === PormG.LazyTraversalError
+        @test FilterError === PormG.FilterError
+        @test QueryBuildError === PormG.QueryBuildError
+        @test UnsafeMutationError === PormG.UnsafeMutationError
+        @test InvalidValueError === PormG.InvalidValueError
+        @test PermissionError === PormG.PermissionError
+        @test UnsupportedConnectionError === PormG.UnsupportedConnectionError
+    end
+
+    # A model with no connection is enough — every assertion below fires at
+    # build/validation time, before any DB work.
+    taxo_model = Models.Model_Type(
+        name = "taxonomy_test",
+        fields = Dict("id" => Models.IDField(), "points" => Models.IntegerField()),
+        field_names = ["id", "points"],
+    )
+
+    @testset "representative misuse → specific subtype" begin
+        # FilterError: a bad filter argument (Int is not a Pair/Q/Qor/operator).
+        @test_throws PormG.FilterError object(taxo_model).filter(123)
+        # QueryBuildError: projection-shape misuse (operator suffix in a projection).
+        @test_throws PormG.QueryBuildError object(taxo_model).values("points__@gte")
+        # UnsupportedConnectionError: a connection that is neither PG nor SQLite.
+        @test_throws PormG.UnsupportedConnectionError QB._unsupported_conn("op", nothing)
+    end
+
+    @testset "showerror renders the message; catch the root works" begin
+        e = PormG.FilterError("bad filter arg")
+        @test occursin("bad filter arg", sprint(showerror, e))
+        # A caller can catch the abstract root regardless of the specific subtype.
+        caught = try; object(taxo_model).filter(123); catch err; err; end
+        @test caught isa PormG.PormGError
+        @test caught isa PormG.FilterError
+    end
+end

--- a/test/unit/test_execution_show.jl
+++ b/test/unit/test_execution_show.jl
@@ -1,5 +1,5 @@
 using Test
-using PormG: object, Q
+using PormG: object, Q, PormGError, PermissionError
 using PormG.Models: Model, CharField, IDField
 import PormG
 import DataFrames
@@ -93,7 +93,7 @@ end
     e
   end
 
-  @test err isa ArgumentError
+  @test err isa PormGError
 
   message = sprint(showerror, err)
   @test occursin("'id__@in' requires a subquery that returns exactly one column", message)
@@ -136,7 +136,7 @@ end
     e
   end
 
-  @test err isa ArgumentError
+  @test err isa PormGError
   message = sprint(showerror, err)
   @test occursin("'id__@in' requires a subquery that returns exactly one column", message)
 end
@@ -157,7 +157,7 @@ end
       e
     end
 
-    @test err isa ArgumentError
+    @test err isa PermissionError    # #231: write-blocked is a typed PermissionError
     # #205: unified write-disabled message names the op and points at the `config:` block.
     let m = lowercase(sprint(showerror, err))
       @test occursin("error in delete:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
@@ -181,7 +181,7 @@ end
       e
     end
 
-    @test err isa ArgumentError
+    @test err isa PermissionError    # #231: write-blocked is a typed PermissionError
     let m = lowercase(sprint(showerror, err))
       @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
     end
@@ -193,7 +193,7 @@ end
       e
     end
 
-    @test inspect_err isa ArgumentError
+    @test inspect_err isa PermissionError    # #231: write-blocked is a typed PermissionError
     let m = lowercase(sprint(showerror, inspect_err))
       @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
     end
@@ -227,7 +227,7 @@ end
   catch e
     e
   end
-  @test err_limit isa ArgumentError
+  @test err_limit isa PormGError
   @test occursin("limit", lowercase(sprint(showerror, err_limit)))
 
   # offset() must be rejected — fresh handler, no prior limit
@@ -237,7 +237,7 @@ end
   catch e
     e
   end
-  @test err_offset isa ArgumentError
+  @test err_offset isa PormGError
   @test occursin("offset", lowercase(sprint(showerror, err_offset)))
 
   # order_by() must be rejected — fresh handler, no prior limit or offset
@@ -247,7 +247,7 @@ end
   catch e
     e
   end
-  @test err_order isa ArgumentError
+  @test err_order isa PormGError
   @test occursin("order_by", lowercase(sprint(showerror, err_order)))
 
   # show_query=:dict must also be rejected (the guard fires before SQL dispatch)
@@ -257,7 +257,7 @@ end
   catch e
     e
   end
-  @test err_dry isa ArgumentError
+  @test err_dry isa PormGError
   @test occursin("limit", lowercase(sprint(showerror, err_dry)))
 end
 
@@ -293,9 +293,9 @@ end
       e
     end
 
-    # Must raise an ArgumentError with a message about not being allowed to
-    # insert (sequence allocation is an insert-class operation).
-    @test err isa ArgumentError
+    # Must raise a PermissionError with a message about not being allowed to
+    # write (sequence allocation is an insert-class operation).
+    @test err isa PermissionError
     @test occursin("not allowed", lowercase(sprint(showerror, err)))
 
     # The DataFrame must not have been mutated: no :id column should be present
@@ -358,7 +358,7 @@ end
     e
   end
 
-  @test err isa ArgumentError
+  @test err isa PormGError
   message = sprint(showerror, err)
   @test occursin("requires a subquery that returns exactly one column", message)
 end

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -51,7 +51,7 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         )
 
         @test validate_field_data(mock_int_model, "id", 10, "insert") === true
-        @test_throws ErrorException validate_field_data(mock_int_model, "id", "not-an-int", "insert")
+        @test_throws PormGError validate_field_data(mock_int_model, "id", "not-an-int", "insert")
         
         @test validate_field_data(mock_int_model, "age", 25, "insert") === true
         # Django accepts Decimal for IntegerField by coercing through int(value).
@@ -59,9 +59,9 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         # must still reject fractional Decimal values to avoid silent truncation.
         @test validate_field_data(mock_int_model, "age", parse(Decimal, "25"), "insert") === true
         @test validate_field_data(mock_int_model, "age", parse(Decimal, "25.0"), "insert") === true
-        @test_throws ErrorException validate_field_data(mock_int_model, "age", parse(Decimal, "25.5"), "insert")
+        @test_throws PormGError validate_field_data(mock_int_model, "age", parse(Decimal, "25.5"), "insert")
         @test Models.format2int64(parse(Decimal, "25.0")) == 25
-        @test_throws ErrorException validate_field_data(mock_int_model, "age", nothing, "insert")
+        @test_throws PormGError validate_field_data(mock_int_model, "age", nothing, "insert")
         
         @test validate_field_data(mock_int_model, "big_val", 9223372036854775807, "insert") === true
     end
@@ -91,7 +91,7 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
 
         @test validate_field_data(mock_str_model, "code", "abc", "insert") === true
         # Bounded CharField still enforces its limit (max_length=5).
-        @test_throws ErrorException validate_field_data(mock_str_model, "code", "toolong", "insert")
+        @test_throws PormGError validate_field_data(mock_str_model, "code", "toolong", "insert")
 
         @test validate_field_data(mock_str_model, "email", "test@example.com", "insert") === true
 
@@ -161,14 +161,14 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         
         # Test 10: Decimal respects decimal_places
         @test validate_field_data(mock_decimal_model, "price", "10.50", "insert") === true
-        @test_throws ErrorException validate_field_data(mock_decimal_model, "price", "10.123", "insert")
-        @test_throws ErrorException validate_field_data(mock_decimal_model, "score", 1.25, "insert")
+        @test_throws PormGError validate_field_data(mock_decimal_model, "price", "10.123", "insert")
+        @test_throws PormGError validate_field_data(mock_decimal_model, "score", 1.25, "insert")
 
         # Test 11: Decimal respects max_digits
-        @test_throws ErrorException validate_field_data(mock_decimal_model, "price", "12345678901", "insert")
+        @test_throws PormGError validate_field_data(mock_decimal_model, "price", "12345678901", "insert")
 
         # Test 12: Invalid Decimal - non-numeric string
-        @test_throws ErrorException validate_field_data(mock_decimal_model, "price", "not-a-number", "insert")
+        @test_throws PormGError validate_field_data(mock_decimal_model, "price", "not-a-number", "insert")
         
         # ===== FLOAT FIELD TESTS =====
         # Test 13: Float with integer input
@@ -203,18 +203,18 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         @test validate_field_data(mock_float_model, "percentage", missing, "insert") === true
         
         # Test 23: Float rejects non-finite values
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", Inf, "insert")
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", -Inf, "insert")
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", NaN, "insert")
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", "Inf", "insert")
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", "NaN", "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", Inf, "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", -Inf, "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", NaN, "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", "Inf", "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", "NaN", "insert")
 
         # Test 24: Float rejects invalid numeric strings during validation
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", "not-a-number", "insert")
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", "1,25", "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", "not-a-number", "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", "1,25", "insert")
 
         # Test 25: Invalid Float - non-nullable with nothing
-        @test_throws ErrorException validate_field_data(mock_float_model, "ratio", nothing, "insert")
+        @test_throws PormGError validate_field_data(mock_float_model, "ratio", nothing, "insert")
     end
 
     @testset "Numeric Formatter: Bool input converts to Int" begin
@@ -287,10 +287,10 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         @test validate_field_data(DateTimeModel, "scheduled_at", missing, "insert") === true
         
         # Test 3: Non-nullable field with nothing (should fail)
-        @test_throws ErrorException validate_field_data(DateTimeModel, "event_time", nothing, "insert")
+        @test_throws PormGError validate_field_data(DateTimeModel, "event_time", nothing, "insert")
         
         # Test 4: Non-nullable field with missing (should fail)
-        @test_throws ErrorException validate_field_data(DateTimeModel, "event_time", missing, "insert")
+        @test_throws PormGError validate_field_data(DateTimeModel, "event_time", missing, "insert")
         
         # --- VALID DATETIME VALUES ---
         
@@ -450,9 +450,9 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
         @test validate_field_data(DateModel, "inspection_day", nothing, "insert") === true
         @test validate_field_data(DateModel, "inspection_day", missing, "insert") === true
 
-        @test_throws ErrorException validate_field_data(DateModel, "race_day", nothing, "insert")
-        @test_throws ErrorException validate_field_data(DateModel, "race_day", "2024/07/28", "insert")
-        @test_throws ErrorException validate_field_data(DateModel, "race_day", 20240728, "insert")
+        @test_throws PormGError validate_field_data(DateModel, "race_day", nothing, "insert")
+        @test_throws PormGError validate_field_data(DateModel, "race_day", "2024/07/28", "insert")
+        @test_throws PormGError validate_field_data(DateModel, "race_day", 20240728, "insert")
 
         create_date = DateModel.objects.create(
             "race_day" => race_day,
@@ -525,11 +525,11 @@ end
         @test validate_field_data(ExtensiveModel, "email", "lewis@mercedes.com", "insert")
         
         # Invalid type checks
-        @test_throws ErrorException validate_field_data(ExtensiveModel, "age", 39.5, "insert")
+        @test_throws PormGError validate_field_data(ExtensiveModel, "age", 39.5, "insert")
         @test validate_field_data(ExtensiveModel, "salary", "5e7", "insert") === true
         
         # Nullability checks
-        @test_throws ErrorException validate_field_data(ExtensiveModel, "name", nothing, "insert")
+        @test_throws PormGError validate_field_data(ExtensiveModel, "name", nothing, "insert")
         @test validate_field_data(ExtensiveModel, "description", nothing, "insert")
         @test validate_field_data(ExtensiveModel, "ratio", nothing, "insert")
     end
@@ -587,31 +587,31 @@ end
         # --- EXCEED DECIMAL_PLACES (Should Fail) ---
         
         # Test 9: 3 decimal places (1 too many)
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 123.456, "insert")
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "123.456", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 123.456, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "123.456", "insert")
         
         # Test 10: 4 decimal places
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 99.9999, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 99.9999, "insert")
         
         # Test 11: Many decimal places
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 1.123456789, "insert")
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "1.123456789", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 1.123456789, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "1.123456789", "insert")
         
         # --- EXCEED MAX_DIGITS (Should Fail) ---
         
         # Test 12: 13 digits total (1 too many with 2 decimals)
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 99999999999.99, "insert")
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "99999999999.99", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 99999999999.99, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "99999999999.99", "insert")
         
         # Test 13: 14 digits total
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 999999999999.99, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 999999999999.99, "insert")
         
         # Test 14: Massive number
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 1e15, "insert")
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "1e15", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 1e15, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "1e15", "insert")
         
         # Test 15: Multiple violations (too many decimals AND too many digits)
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", 99999999999.999, "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", 99999999999.999, "insert")
         
         # --- EDGE CASES ---
         
@@ -622,10 +622,10 @@ end
         @test validate_field_data(BoundaryModel, "price", 123456789.1, "insert") === true
         
         # Test 18: Invalid string input (non-numeric)
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "not-a-number", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "not-a-number", "insert")
         
         # Test 19: Invalid notation
-        @test_throws ErrorException validate_field_data(BoundaryModel, "price", "12.34.56", "insert")
+        @test_throws PormGError validate_field_data(BoundaryModel, "price", "12.34.56", "insert")
         
         # --- USER OPERATIONS: CREATE, UPDATE, BULK ---
         
@@ -645,13 +645,13 @@ end
         @test create_scientific[:operation] === :insert
         
         # Test 22: Create with invalid scale (should fail before SQL)
-        @test_throws ErrorException BoundaryModel.objects.create(
+        @test_throws PormGError BoundaryModel.objects.create(
             "price" => 123.456,
             show_query=:inspection
         )
         
         # Test 23: Create exceeding max_digits (should fail before SQL)
-        @test_throws ErrorException BoundaryModel.objects.create(
+        @test_throws PormGError BoundaryModel.objects.create(
             "price" => 99999999999.99,
             show_query=:inspection
         )
@@ -678,7 +678,7 @@ end
         # Test 26: Update with invalid scale (should fail before SQL)
         update_bad_q = BoundaryModel.objects
         update_bad_q.filter("price__@gt" => 0)
-        @test_throws ErrorException update_bad_q.update(
+        @test_throws PormGError update_bad_q.update(
             "price" => 99.9999,
             show_query=:dict
         )
@@ -686,7 +686,7 @@ end
         # Test 27: Update exceeding max_digits (should fail before SQL)
         update_exceed_q = BoundaryModel.objects
         update_exceed_q.filter("price__@gt" => 0)
-        @test_throws ErrorException update_exceed_q.update(
+        @test_throws PormGError update_exceed_q.update(
             "price" => 99999999999.99,
             show_query=:dict
         )
@@ -763,8 +763,8 @@ end
         @test validate_field_data(ComplexModel, "salary", nothing, "insert") === true
         
         # Test: Non-nullable field validation
-        @test_throws ErrorException validate_field_data(ComplexModel, "username", nothing, "insert")
-        @test_throws ErrorException validate_field_data(ComplexModel, "email", nothing, "insert")
+        @test_throws PormGError validate_field_data(ComplexModel, "username", nothing, "insert")
+        @test_throws PormGError validate_field_data(ComplexModel, "email", nothing, "insert")
         
         # Test 5: Public API with show_query=:inspection (NO DB EXECUTION)
         q_handler = ComplexModel.objects
@@ -849,7 +849,7 @@ end
         @test create_scientific_decimal[:parameter_count] == 3
 
         # Float invalid strings are also rejected during validation now.
-        @test_throws ErrorException NumericApiModel.objects.create(
+        @test_throws PormGError NumericApiModel.objects.create(
             "label" => "bad_float_string",
             "amount" => "12.34",
             "ratio" => "not-a-number",
@@ -857,7 +857,7 @@ end
         )
 
         # Decimal scale enforcement must also trigger through the create() public API.
-        @test_throws ErrorException NumericApiModel.objects.create(
+        @test_throws PormGError NumericApiModel.objects.create(
             "label" => "bad_decimal_scale",
             "amount" => "10.123",
             "ratio" => "2.5",
@@ -893,7 +893,7 @@ end
         # Update rejects invalid float strings before building SQL.
         bad_float_update_q = NumericApiModel.objects
         bad_float_update_q.filter("id" => 1)
-        @test_throws ErrorException bad_float_update_q.update(
+        @test_throws PormGError bad_float_update_q.update(
             "ratio" => "NaN",
             show_query=:dict
         )
@@ -901,7 +901,7 @@ end
         # Decimal scale enforcement also applies on update.
         bad_scale_update_q = NumericApiModel.objects
         bad_scale_update_q.filter("id" => 1)
-        @test_throws ErrorException bad_scale_update_q.update(
+        @test_throws PormGError bad_scale_update_q.update(
             "amount" => "7.777",
             show_query=:dict
         )
@@ -990,11 +990,11 @@ end
         @test res_update[:parameters] == [1, false]  # filter value first, then update value
 
         # Direct validator coverage and public API coverage should both reject PK mutations.
-        @test_throws ErrorException validate_field_data(InspectModel, "id", 2, "update"; allow_primary_key=false)
+        @test_throws PormGError validate_field_data(InspectModel, "id", 2, "update"; allow_primary_key=false)
 
         pk_update_q = InspectModel.objects
         pk_update_q.filter("id" => 1)
-        @test_throws ErrorException pk_update_q.update("id" => 2, show_query=:dict)
+        @test_throws PormGError pk_update_q.update("id" => 2, show_query=:dict)
 
         # inspect_query has a dedicated delete branch that unwraps the inspection payload.
         q_delete = InspectModel.objects
@@ -1048,15 +1048,15 @@ end
         @test validate_field_data(TimeModel, "closing_hour", missing, "insert") === true
 
         # Test 7: Non-nullable TimeField with nothing (should fail)
-        @test_throws ErrorException validate_field_data(TimeModel, "opening_hour", nothing, "insert")
+        @test_throws PormGError validate_field_data(TimeModel, "opening_hour", nothing, "insert")
 
         # Test 8: Invalid input (DateTime instead of Time)
         invalid_time = DateTime(2024, 6, 15, 14, 30, 0)
-        @test_throws ErrorException validate_field_data(TimeModel, "opening_hour", invalid_time, "insert")
+        @test_throws PormGError validate_field_data(TimeModel, "opening_hour", invalid_time, "insert")
 
         # Test 9: Invalid input (Date instead of Time)
         invalid_date = Date(2024, 6, 15)
-        @test_throws ErrorException validate_field_data(TimeModel, "opening_hour", invalid_date, "insert")
+        @test_throws PormGError validate_field_data(TimeModel, "opening_hour", invalid_date, "insert")
 
         # Test 10: Invalid input (String time format not yet supported)
         @test validate_field_data(TimeModel, "opening_hour", "14:30:00", "insert") === true
@@ -1090,7 +1090,7 @@ end
         @test contains(update_time[:sql_text], "UPDATE")
 
         # TimeField should reject elapsed-duration strings such as F1 lap times.
-        @test_throws ErrorException validate_field_data(TimeModel, "opening_hour", "1:27.452", "insert")
+        @test_throws PormGError validate_field_data(TimeModel, "opening_hour", "1:27.452", "insert")
     end
 
     @testset "DurationField (Elapsed Time Values)" begin
@@ -1114,8 +1114,8 @@ end
         @test Models.format_duration_sql("1:27.452") == "00:01:27.452"
         @test Models.format_duration_sql(Minute(1) + Second(27) + Millisecond(452)) == "00:01:27.452"
 
-        @test_throws ErrorException validate_field_data(DurationModel, "lap_time", Time(1, 27, 45), "insert")
-        @test_throws ErrorException validate_field_data(DurationModel, "lap_time", "bad-duration", "insert")
+        @test_throws PormGError validate_field_data(DurationModel, "lap_time", Time(1, 27, 45), "insert")
+        @test_throws PormGError validate_field_data(DurationModel, "lap_time", "bad-duration", "insert")
     end
 
     @testset "DateTimeField Timezone Conversions & Round-Trip" begin
@@ -1300,25 +1300,25 @@ end
         @test validate_field_data(DateFormatModel, "event_date", ZonedDateTime(DateTime(2024, 6, 15, 14, 30, 0), TimeZone("UTC")), "insert") === true
 
         # Test 5: Invalid DD-MM-YYYY format (should fail)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "15-06-2024", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "15-06-2024", "insert")
 
         # Test 6: Invalid MM/DD/YYYY format (should fail)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "06/15/2024", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "06/15/2024", "insert")
 
         # Test 7: Invalid YYYY/MM/DD format (should fail)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "2024/06/15", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "2024/06/15", "insert")
 
         # Test 8: Invalid ISO format with time (should fail because DateField is date-only)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "2024-06-15T14:30:00", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "2024-06-15T14:30:00", "insert")
 
         # Test 9: Invalid malformed string (should fail)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "2024-6-15", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "2024-6-15", "insert")
 
         # Test 10: Invalid malformed string (not a date at all)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "not-a-date", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "not-a-date", "insert")
 
         # Test 11: Invalid numeric input (should fail)
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", 20240615, "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", 20240615, "insert")
 
         # Test 12: Valid edge case - Jan 1 (year boundary)
         @test validate_field_data(DateFormatModel, "event_date", "2024-01-01", "insert") === true
@@ -1331,7 +1331,7 @@ end
 
         # Test 15: Invalid non-leap year Feb 29 (should fail)
         # Note: Base.Date(2023, 2, 29) throws ArgumentError, validate_field_data catches it
-        @test_throws ErrorException validate_field_data(DateFormatModel, "event_date", "2023-02-29", "insert")
+        @test_throws PormGError validate_field_data(DateFormatModel, "event_date", "2023-02-29", "insert")
 
         # Test 16: Nullable field with nothing
         @test validate_field_data(DateFormatModel, "optional_date", nothing, "insert") === true
@@ -1391,7 +1391,7 @@ end
                 "15-06-2024"  # Invalid format
             ]
         )
-        @test_throws ArgumentError bulk_insert(DateFormatModel.objects, df_invalid_dates, show_query=:dict)
+        @test_throws PormGError bulk_insert(DateFormatModel.objects, df_invalid_dates, show_query=:dict)
 
         # Test 23: Bulk update with valid string dates
         df_bulk_update_dates = DataFrame(
@@ -1409,7 +1409,7 @@ end
         @test contains(res_bulk_update_dates[:sql_text], "UPDATE")
 
         # Test 24: Verify that invalid string format fails before SQL generation
-        @test_throws ErrorException DateFormatModel.objects.create(
+        @test_throws PormGError DateFormatModel.objects.create(
             "event_date" => "2024/06/15",
             show_query=:inspection
         )
@@ -1447,16 +1447,16 @@ end
         @test validate_field_data(PostModel, "author", 9223372036854775807, "insert") === true
 
         # Test 2: ForeignKey rejects non-integer values
-        @test_throws ErrorException validate_field_data(PostModel, "author", "not-an-id", "insert")
-        @test_throws ErrorException validate_field_data(PostModel, "author", 1.5, "insert")
+        @test_throws PormGError validate_field_data(PostModel, "author", "not-an-id", "insert")
+        @test_throws PormGError validate_field_data(PostModel, "author", 1.5, "insert")
 
         # Test 3: Nullable ForeignKey accepts nothing/missing
         @test validate_field_data(PostModel, "editor", nothing, "insert") === true
         @test validate_field_data(PostModel, "editor", missing, "insert") === true
 
         # Test 4: Non-nullable ForeignKey rejects nothing/missing
-        @test_throws ErrorException validate_field_data(PostModel, "author", nothing, "insert")
-        @test_throws ErrorException validate_field_data(PostModel, "author", missing, "insert")
+        @test_throws PormGError validate_field_data(PostModel, "author", nothing, "insert")
+        @test_throws PormGError validate_field_data(PostModel, "author", missing, "insert")
 
         # Test 5: ForeignKey field contains on_delete information
         author_field = PostModel.fields["author"]
@@ -1607,8 +1607,8 @@ end
         @test validate_field_data(UniqueModel, "firstname", "Alice", "insert") === true  # Duplicate is OK at validation level
 
         # Test 5: Unique field rejects null for non-nullable unique fields
-        @test_throws ErrorException validate_field_data(UniqueModel, "email", nothing, "insert")
-        @test_throws ErrorException validate_field_data(UniqueModel, "username", nothing, "insert")
+        @test_throws PormGError validate_field_data(UniqueModel, "email", nothing, "insert")
+        @test_throws PormGError validate_field_data(UniqueModel, "username", nothing, "insert")
 
         # Test 6: Create with unique fields
         create_unique = UniqueModel.objects.create(
@@ -1676,20 +1676,20 @@ end
         @test validate_field_data(StringModel, "title", "A" ^ 100, "insert") === true
 
         # Test 2: CharField exceeds max_length
-        @test_throws ErrorException validate_field_data(StringModel, "code", "ABCDEF", "insert")
-        @test_throws ErrorException validate_field_data(StringModel, "code", "A" ^ 10, "insert")
-        @test_throws ErrorException validate_field_data(StringModel, "title", "A" ^ 101, "insert")
+        @test_throws PormGError validate_field_data(StringModel, "code", "ABCDEF", "insert")
+        @test_throws PormGError validate_field_data(StringModel, "code", "A" ^ 10, "insert")
+        @test_throws PormGError validate_field_data(StringModel, "title", "A" ^ 101, "insert")
 
         # Test 3: CharField with empty string (should be OK)
         @test validate_field_data(StringModel, "code", "", "insert") === true
 
         # Test 4: CharField with whitespace (counts toward max_length)
         @test validate_field_data(StringModel, "code", "A B C", "insert") === true
-        @test_throws ErrorException validate_field_data(StringModel, "code", "A B C D E", "insert")
+        @test_throws PormGError validate_field_data(StringModel, "code", "A B C D E", "insert")
 
         # Test 5: CharField with special characters (counts toward max_length)
         @test validate_field_data(StringModel, "code", "A-BC!", "insert") === true
-        @test_throws ErrorException validate_field_data(StringModel, "code", "A-BC!!", "insert")
+        @test_throws PormGError validate_field_data(StringModel, "code", "A-BC!!", "insert")
 
         # Test 6: TextField has no max_length (very large strings OK)
         large_text = "X" ^ 10000
@@ -1702,7 +1702,7 @@ end
         # Test 8: Slug field with alphanumeric and hyphen
         @test validate_field_data(StringModel, "slug", "my-great-post-2024", "insert") === true
         @test validate_field_data(StringModel, "slug", "s" ^ 50, "insert") === true
-        @test_throws ErrorException validate_field_data(StringModel, "slug", "s" ^ 51, "insert")
+        @test_throws PormGError validate_field_data(StringModel, "slug", "s" ^ 51, "insert")
 
         # Test 9: Create with max_length string
         create_max = StringModel.objects.create(
@@ -1714,7 +1714,7 @@ end
         @test create_max[:operation] === :insert
 
         # Test 10: Create with string exceeding max_length (should fail)
-        @test_throws ErrorException StringModel.objects.create(
+        @test_throws PormGError StringModel.objects.create(
             "code" => "ABCDEF",
             "title" => "X" ^ 100,
             "slug" => "my-slug",
@@ -1733,7 +1733,7 @@ end
         # Test 12: Update with string exceeding max_length (should fail)
         update_bad_q = StringModel.objects
         update_bad_q.filter("id" => 1)
-        @test_throws ErrorException update_bad_q.update(
+        @test_throws PormGError update_bad_q.update(
             "code" => "ABCDEF",
             show_query=:dict
         )
@@ -1763,7 +1763,7 @@ end
 
         # Test 15: Unicode strings (count as characters, not bytes)
         @test validate_field_data(StringModel, "code", "你好世", "insert") === true
-        @test_throws ErrorException validate_field_data(StringModel, "code", "你好世界中国", "insert")
+        @test_throws PormGError validate_field_data(StringModel, "code", "你好世界中国", "insert")
     end
 
 end
@@ -2012,9 +2012,9 @@ end
         @test validate_field_data(PriceModel, "price", "-1234.56", "insert") === true
         @test validate_field_data(PriceModel, "price", 3.14,       "insert") === true
 
-        @test_throws ErrorException validate_field_data(PriceModel, "price", "99.999",       "insert")
-        @test_throws ErrorException validate_field_data(PriceModel, "price", 9.141,          "insert")
-        @test_throws ErrorException validate_field_data(PriceModel, "price", "12345678901",  "insert")
+        @test_throws PormGError validate_field_data(PriceModel, "price", "99.999",       "insert")
+        @test_throws PormGError validate_field_data(PriceModel, "price", 9.141,          "insert")
+        @test_throws PormGError validate_field_data(PriceModel, "price", "12345678901",  "insert")
     end
 
     @testset "SQL function helpers preserve advanced constructor inputs" begin

--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -354,7 +354,7 @@ PormG.config["default"] = MockSettings
       catch e
         e
       end
-      @test err isa ArgumentError
+      @test err isa PormGError
       msg = sprint(showerror, err)
       # Discriminating: names the offending column, the DISTINCT context, and the .values() fix —
       # not a bare @test_throws that any ArgumentError would satisfy.
@@ -376,7 +376,7 @@ PormG.config["default"] = MockSettings
       catch e
         e
       end
-      @test err isa ArgumentError
+      @test err isa PormGError
       msg = sprint(showerror, err)
       @test occursin("created_at", msg)   # names the offending order term
       @test occursin("DISTINCT", msg)
@@ -438,7 +438,7 @@ PormG.config["default"] = MockSettings
     @test (q.list(show_query=:none)) === nothing
     
     # Invalid mode should throw
-    @test_throws ArgumentError (q.list(show_query=:invalid))
+    @test_throws PormGError (q.list(show_query=:invalid))
   end
 
   # ===== Section 14: Comparison: inspect_query vs show_query =====
@@ -643,7 +643,7 @@ PormG.config["default"] = MockSettings
     )
 
     # inspect_query on the raw subquery (no Exists wrapper, no outer) must error
-    @test_throws ArgumentError inspect_query(note_query)
+    @test_throws PormGError inspect_query(note_query)
   end
 
   # ───────────────────────────────────────────────────────────────────────────
@@ -890,14 +890,14 @@ PormG.config["default"] = MockSettings
     excl_err = try
       DriverModel.objects.select_for_update(nowait = true, skip_locked = true); nothing
     catch e; e end
-    @test excl_err isa ArgumentError && occursin("mutually exclusive", excl_err.msg)
+    @test excl_err isa PormGError && occursin("mutually exclusive", excl_err.msg)
 
     # FOR UPDATE + DISTINCT is invalid on PostgreSQL → friendly error at render time.
     q = DriverModel.objects
     q.distinct(true)
     q.select_for_update()
     dist_err = try inspect_query(q); nothing catch e; e end
-    @test dist_err isa ArgumentError && occursin("distinct", dist_err.msg)
+    @test dist_err isa PormGError && occursin("distinct", dist_err.msg)
   end
 
 end

--- a/test/unit/test_json_operators.jl
+++ b/test/unit/test_json_operators.jl
@@ -108,7 +108,7 @@ _pg(q) = inspect_query(q; connection = _JO_PG)
     q = JO.Json_op_scratch.objects
     q.filter("name__@has_key" => "x")          # `name` is a CharField
     q.values("id")
-    @test_throws ArgumentError _pg(q)
+    @test_throws PormGError _pg(q)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -118,7 +118,7 @@ _pg(q) = inspect_query(q; connection = _JO_PG)
     q = JO.Json_op_scratch.objects
     q.filter("payload__meta__@has_key" => "x")
     q.values("id")
-    @test_throws ArgumentError _pg(q)
+    @test_throws PormGError _pg(q)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -130,7 +130,7 @@ _pg(q) = inspect_query(q; connection = _JO_PG)
       q = JO.Json_op_scratch.objects
       q.filter("payload__@$(suffix)" => "single")   # scalar, not a vector
       q.values("id")
-      @test_throws ArgumentError _pg(q)
+      @test_throws PormGError _pg(q)
     end
   end
 

--- a/test/unit/test_new_field_types.jl
+++ b/test/unit/test_new_field_types.jl
@@ -105,13 +105,13 @@ end
             @test validate_field_data(mock_model, "token", "550e8400-e29b-41d4-a716-446655440000", "insert") === true
 
             # Invalid string
-            @test_throws ErrorException validate_field_data(mock_model, "token", "bad-uuid", "insert")
+            @test_throws PormGError validate_field_data(mock_model, "token", "bad-uuid", "insert")
 
             # Wrong type
-            @test_throws ErrorException validate_field_data(mock_model, "token", 42, "insert")
+            @test_throws PormGError validate_field_data(mock_model, "token", 42, "insert")
 
             # Null handling
-            @test_throws ErrorException validate_field_data(mock_model, "token", nothing, "insert")
+            @test_throws PormGError validate_field_data(mock_model, "token", nothing, "insert")
             @test validate_field_data(mock_model, "nullable_token", nothing, "insert") === true
         end
     end
@@ -154,7 +154,7 @@ end
 
             # Max length enforcement: a URL exceeding max_length should fail
             long_url = "https://example.com/" * repeat("a", 50)
-            @test_throws ErrorException validate_field_data(mock_model, "website", long_url, "insert")
+            @test_throws PormGError validate_field_data(mock_model, "website", long_url, "insert")
         end
     end
 
@@ -197,7 +197,7 @@ end
             @test validate_field_data(mock_model, "slug", "test_slug_123", "insert") === true
 
             # Max length enforcement
-            @test_throws ErrorException validate_field_data(mock_model, "slug", repeat("a", 21), "insert")
+            @test_throws PormGError validate_field_data(mock_model, "slug", repeat("a", 21), "insert")
         end
     end
 
@@ -278,10 +278,10 @@ end
             @test validate_field_data(mock_model, "data", true, "insert") === true
 
             # Invalid JSON string
-            @test_throws ErrorException validate_field_data(mock_model, "data", "{bad json", "insert")
+            @test_throws PormGError validate_field_data(mock_model, "data", "{bad json", "insert")
 
             # Null handling
-            @test_throws ErrorException validate_field_data(mock_model, "data", nothing, "insert")
+            @test_throws PormGError validate_field_data(mock_model, "data", nothing, "insert")
             @test validate_field_data(mock_model, "nullable_data", nothing, "insert") === true
         end
     end

--- a/test/unit/test_operators.jl
+++ b/test/unit/test_operators.jl
@@ -508,7 +508,7 @@ const _E = _OperTestEvent
 
     # --- vector value, UNKNOWN operator: the exact @notin → @nin typo from #98 ---
     e_vec = grab(() -> _D.objects.filter("id__@notin" => [1, 2]))
-    @test e_vec isa ArgumentError
+    @test e_vec isa PormGError
     m_vec = e_vec.msg
     @test occursin("is not a valid operator", m_vec)  # unknown-operator branch
     @test occursin("Did you mean", m_vec)             # nearest-match suggestion offered
@@ -518,7 +518,7 @@ const _E = _OperTestEvent
 
     # --- vector value, KNOWN but shape-incompatible operator (@gte with a vector) ---
     e_known = grab(() -> _D.objects.filter("id__@gte" => [1, 2]))
-    @test e_known isa ArgumentError
+    @test e_known isa PormGError
     m_known = e_known.msg
     @test occursin("not valid with a vector value", m_known)  # distinct from the typo branch
     @test !occursin("Did you mean", m_known)                  # no suggestion for a real operator
@@ -527,7 +527,7 @@ const _E = _OperTestEvent
 
     # --- tuple value, unknown operator: message names the shape and its valid op ---
     e_tup = grab(() -> _D.objects.filter("id__@betwen" => (1, 2)))
-    @test e_tup isa ArgumentError
+    @test e_tup isa PormGError
     m_tup = e_tup.msg
     @test occursin("is not a valid operator", m_tup)
     @test occursin("tuple", m_tup)
@@ -536,7 +536,7 @@ const _E = _OperTestEvent
     # --- subquery value, unknown operator: same treatment, shape = "subquery" ---
     sub = _D.objects.values("id")
     e_sub = grab(() -> _D.objects.filter("id__@notin" => sub))
-    @test e_sub isa ArgumentError
+    @test e_sub isa PormGError
     m_sub = e_sub.msg
     @test occursin("is not a valid operator", m_sub)
     @test occursin("@nin", m_sub)
@@ -546,7 +546,7 @@ const _E = _OperTestEvent
     # Reaches the length(field_path) < 2 branch: the message must name the field
     # and show actionable examples, not treat the field name as a bogus operator.
     e_bare = grab(() -> _D.objects.filter("id" => [1, 2]))
-    @test e_bare isa ArgumentError
+    @test e_bare isa PormGError
     m_bare = e_bare.msg
     @test occursin("was given a vector value but no operator", m_bare)
     @test occursin("id__@in", m_bare)   # actionable example uses the real field name
@@ -555,7 +555,7 @@ const _E = _OperTestEvent
     # @xy is exactly 2 edits from @in/@ne/@gt (the whole word), so the relative
     # threshold must refuse a "did you mean"; the old floor-of-2 threshold would not.
     e_garb = grab(() -> _D.objects.filter("id__@xy" => [1, 2]))
-    @test e_garb isa ArgumentError
+    @test e_garb isa PormGError
     @test occursin("is not a valid operator", e_garb.msg)
     @test !occursin("Did you mean", e_garb.msg)
 
@@ -563,7 +563,7 @@ const _E = _OperTestEvent
     # A valid operator on the right shape, but @range requires exactly 2 bounds; the
     # error must state that (and the count) rather than a generic "invalid operator".
     e_range = grab(() -> _D.objects.filter("id__@range" => [1, 2, 3]))
-    @test e_range isa ArgumentError
+    @test e_range isa PormGError
     @test occursin("requires exactly 2 values", e_range.msg)
     @test occursin("got 3", e_range.msg)
 
@@ -680,7 +680,7 @@ end  # end "PormGsuffix — Operator SQL Generation"
     catch e
       e
     end
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("requires a DATE/TIMESTAMP field", err.msg)
     @test occursin("surname", err.msg)
   end

--- a/test/unit/test_order_by_nulls.jl
+++ b/test/unit/test_order_by_nulls.jl
@@ -68,7 +68,7 @@ PormG.config["order_nulls_pg"] = PormG.Configuration.Settings(
     catch e
       e
     end
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin(":first", string(err))
     @test occursin(":last", string(err))
   end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -20,6 +20,9 @@ const EXPECTED_TOPLEVEL = Set([
     :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Subquery, :Interval, :show_query, :inspect_query,
     # Rows & exceptions
     :PormGRow, :pk, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :PoolConnectError, :pool_stats,
+    # Semantic error taxonomy (#231): PormGError root + query-builder subtypes
+    :PormGError, :FieldAccessError, :UnknownFieldError, :LazyTraversalError, :FilterError,
+    :QueryBuildError, :UnsafeMutationError, :InvalidValueError, :PermissionError, :UnsupportedConnectionError,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API

--- a/test/unit/test_sqlorder_orientation.jl
+++ b/test/unit/test_sqlorder_orientation.jl
@@ -58,9 +58,9 @@ PormG.config["orientation_guard_pg"] = PormG.Configuration.Settings(
   @testset "injection-shaped orientations raise at construction" begin
     for bad in ("ASC; DROP TABLE drivers --", "DESC --", "ASC, (SELECT 1)", "")
       # Keyword constructor (the direct-construction path the issue flags).
-      @test_throws ArgumentError SQLOrder(SQLField("surname", "surname"); orientation=bad)
+      @test_throws PormGError SQLOrder(SQLField("surname", "surname"); orientation=bad)
       # Positional constructor (deepcopy's path) is guarded by the same whitelist.
-      @test_throws ArgumentError SQLOrder(SQLField("surname", "surname"), nothing, bad, "surname", nothing)
+      @test_throws PormGError SQLOrder(SQLField("surname", "surname"), nothing, bad, "surname", nothing)
     end
 
     # The rejection must fail loudly and name the valid options — not silently default.
@@ -71,7 +71,7 @@ PormG.config["orientation_guard_pg"] = PormG.Configuration.Settings(
     catch e
       e
     end
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("ASC", string(err))
     @test occursin("DESC", string(err))
   end
@@ -106,7 +106,7 @@ PormG.config["orientation_guard_pg"] = PormG.Configuration.Settings(
     catch e
       e
     end
-    @test err isa ArgumentError
+    @test err isa PormGError
     @test occursin("DESC", string(err))   # the whitelist error, naming the valid options
 
     # Sanity (negative case): the same query shape with a valid order renders fine.

--- a/test/unit/test_typed_exceptions.jl
+++ b/test/unit/test_typed_exceptions.jl
@@ -1,12 +1,16 @@
 """
-Typed-exception contract tests for the public query surface (#197).
+Typed-exception contract tests for the public query surface (#197, taxonomy #231).
 
 This file tests:
 - Representative fluent-surface misuse (filter, values, order_by, distinct, update kwargs,
-  With/CTE names, Q/Qor construction) throws a typed `ArgumentError` — previously many of
-  these sites threw raw Strings, which are NOT `Exception`s and escape every
-  `catch e; e isa Exception` handler a package user can write
-- Internal dispatch fallbacks throw `ErrorException` (via `_unsupported_conn`)
+  With/CTE names, Q/Qor construction) throws the RIGHT `PormGError` subtype — previously many
+  of these sites threw raw Strings (not `Exception`s), then bare `ArgumentError` (#197); #231
+  gives each a semantic type so callers `catch` a type instead of matching a message string.
+- The internal dispatch fallback (`_unsupported_conn`) throws `UnsupportedConnectionError`
+  (a `PormGError`), not the old `ErrorException`.
+
+Every subtype below is `<: PormG.PormGError`, so `catch PormGError` still catches them all;
+the specific-subtype/hierarchy contract lives in `test/unit/test_error_taxonomy.jl`.
 
 No database is required: every assertion fires at query-build/validation time.
 """
@@ -32,114 +36,114 @@ typed_errs_model = Models.Model_Type(
 )
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: filter() misuse
-# A non-Pair/non-Q filter argument must raise ArgumentError. This site was the
-# #197 poster child: filter() threw ErrorException while its values()/order_by()
-# siblings threw ArgumentError — same surface, different types.
+# filter() misuse → FilterError
+# This site was the #197 poster child: filter() threw ErrorException while its
+# values()/order_by() siblings threw ArgumentError. #231 gives it FilterError.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "filter() misuse is ArgumentError" begin
+@testset "filter() misuse is FilterError" begin
     q = object(typed_errs_model)
     # An Int is neither a Pair nor a Q/Qor/operator object.
-    @test_throws ArgumentError q.filter(123)
+    @test_throws PormG.FilterError q.filter(123)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: values() misuse
-# Three rejection paths in up_values!/_up_values, all previously raw-String throws:
-# a non-String pair key, an operator suffix inside a projection, and (pre-typed
-# since #92, pinned here) a value of an unsupported type.
+# values() misuse → QueryBuildError (projection-shape misuse)
+# Three rejection paths in up_values!/_up_values: a non-String pair key, an
+# operator suffix inside a projection, and a value of an unsupported type.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "values() misuse is ArgumentError" begin
+@testset "values() misuse is QueryBuildError" begin
     q = object(typed_errs_model)
     # Pair key must be a String alias.
-    @test_throws ArgumentError q.values(1 => "points")
+    @test_throws PormG.QueryBuildError q.values(1 => "points")
     # Operator suffixes belong in filter(), never in a projection.
-    @test_throws ArgumentError q.values("points__@gte")
-    # Unsupported bare value type (already typed by #92 — regression pin).
-    @test_throws ArgumentError q.values(3.14)
+    @test_throws PormG.QueryBuildError q.values("points__@gte")
+    # Unsupported bare value type.
+    @test_throws PormG.QueryBuildError q.values(3.14)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: order_by() misuse
+# order_by() misuse → QueryBuildError
 # Both order_by! rejection paths: an operator suffix inside an ordering field,
 # and an argument that is neither String nor SQLTypeOrder.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "order_by() misuse is ArgumentError" begin
+@testset "order_by() misuse is QueryBuildError" begin
     q = object(typed_errs_model)
     # Operator suffixes are meaningless in ORDER BY.
-    @test_throws ArgumentError q.order_by("points__@gte")
+    @test_throws PormG.QueryBuildError q.order_by("points__@gte")
     # An Int can't name an ordering column (hits the generic fallback method).
-    @test_throws ArgumentError q.order_by(1)
+    @test_throws PormG.QueryBuildError q.order_by(1)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: distinct() misuse
+# distinct() misuse → QueryBuildError
 # distinct() accepts only Bool (or no argument); anything else hits the typed
 # fallback method.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "distinct() misuse is ArgumentError" begin
+@testset "distinct() misuse is QueryBuildError" begin
     q = object(typed_errs_model)
-    @test_throws ArgumentError q.distinct("yes")
+    @test_throws PormG.QueryBuildError q.distinct("yes")
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: update() keyword misuse
+# update() keyword misuse → QueryBuildError
 # up_update! validates keywords BEFORE any build/DB work, so a typo'd kwarg
-# (only :show_query is supported) is a pure ArgumentError — no settings needed.
+# (only :show_query is supported) is rejected with no settings needed.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "update() bad keyword is ArgumentError" begin
+@testset "update() bad keyword is QueryBuildError" begin
     q = object(typed_errs_model)
-    @test_throws ArgumentError q.update("points" => 1, show_querys = :sql)
+    @test_throws PormG.QueryBuildError q.update("points" => 1, show_querys = :sql)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: Q / Qor construction and push!
+# Q / Qor construction and push! → FilterError
 # The Q/Qor constructors and Base.push! on Q objects validate their arguments;
-# all four rejection paths were raw-String throws before #197.
+# a non-Pair/non-filter entry is a filter-shape error.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "Q/Qor misuse is ArgumentError" begin
-    @test_throws ArgumentError Q(123)
-    @test_throws ArgumentError Qor(123)
+@testset "Q/Qor misuse is FilterError" begin
+    @test_throws PormG.FilterError Q(123)
+    @test_throws PormG.FilterError Qor(123)
     # push! onto an existing Q/Qor rejects non-Pair/non-filter entries too.
-    @test_throws ArgumentError push!(Q("points" => 1), 123)
-    @test_throws ArgumentError push!(Qor("points" => 1, "points" => 2), 123)
+    @test_throws PormG.FilterError push!(Q("points" => 1), 123)
+    @test_throws PormG.FilterError push!(Qor("points" => 1, "points" => 2), 123)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: duplicate CTE name via With()
+# Duplicate CTE name via With() → QueryBuildError
 # Registering two CTEs under one alias would render invalid SQL; With() rejects
 # the second registration at the call site (integration twin lives in
 # test/integration/test_cte.jl "With() duplicate CTE name is rejected").
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "With() duplicate CTE name is ArgumentError" begin
+@testset "With() duplicate CTE name is QueryBuildError" begin
     q = object(typed_errs_model)
     sub = object(typed_errs_model)
     With(q, "dup", sub)
-    @test_throws ArgumentError With(q, "dup", sub)
+    @test_throws PormG.QueryBuildError With(q, "dup", sub)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: ISNULL guard
+# ISNULL guard → FilterError
 # ISNULL refuses a function expression as its column operand.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "ISNULL on function expression is ArgumentError" begin
-    @test_throws ArgumentError QB.ISNULL("lower(points)", true)
+@testset "ISNULL on function expression is FilterError" begin
+    @test_throws PormG.FilterError QB.ISNULL("lower(points)", true)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Typed exceptions: internal dispatch fallback helper
+# Internal dispatch fallback helper → UnsupportedConnectionError
 # _unsupported_conn is the shared fallback for execution paths reached with a
-# connection that is neither PostgreSQL nor SQLite. It must throw a REAL
-# exception (ErrorException) naming the operation and the offending type —
-# these sites were raw "Unsupported connection type" String throws before #197.
+# connection that is neither PostgreSQL nor SQLite. #231 upgrades it from a bare
+# ErrorException to the catchable UnsupportedConnectionError, still naming the
+# operation and the offending type.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "_unsupported_conn is ErrorException with context" begin
+@testset "_unsupported_conn is UnsupportedConnectionError with context" begin
     err = try
         QB._unsupported_conn("unit-test-op", nothing)
     catch e
         e
     end
-    @test err isa ErrorException
-    @test occursin("unit-test-op", err.msg)     # names the operation
-    @test occursin("Nothing", err.msg)          # names the offending type
+    @test err isa PormG.UnsupportedConnectionError
+    @test err isa PormG.PormGError               # still under the taxonomy root
+    @test !(err isa ErrorException)              # #231: no longer a bare ErrorException
+    @test occursin("unit-test-op", err.msg)      # names the operation
+    @test occursin("Nothing", err.msg)           # names the offending type
 end

--- a/test/unit/test_update_or_create.jl
+++ b/test/unit/test_update_or_create.jl
@@ -110,7 +110,7 @@ function _uoc_error(f)
   catch e
     e
   end
-  @test err isa ArgumentError
+  @test err isa PormGError
   # Strip ANSI so the content assertions are color-agnostic: CI runs --color=yes, which bakes the
   # field-name highlight (\e[4m\e[31m…\e[0m) into the message via _argerr/_emsg. Reuse the repo's own
   # stripper so the assertions still check the message TEXT (incl. the offending field name), not TTY state.

--- a/test/unit/test_window_functions.jl
+++ b/test/unit/test_window_functions.jl
@@ -127,7 +127,7 @@ end
     "row_number" => RowNumber(over=WindowOver(order_by=["resultid"], frame="ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"))
   )
 
-  @test_throws ArgumentError q.list(show_query=:dict)
+  @test_throws PormGError q.list(show_query=:dict)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Today PormG signals *every* distinct query-builder failure with a bare `ArgumentError` carrying a human-readable string, so a consuming app that wants to react programmatically has **no handle except the message string** — brittle, wording-coupled, un-localizable (this is exactly what forced #204's regression test to `occursin(...)` on the message).

This introduces a **semantic error taxonomy**: an abstract `PormGError <: Exception` plus catchable subtypes. Callers `catch` a **type**, not a string. The subtypes are deliberately **NOT** `<: ArgumentError` — a clean pre-publish break. Extends the #197 typed-exception lineage.

## The taxonomy

| Type | Raised when |
|------|-------------|
| `UnknownFieldError` / `LazyTraversalError` (both `<: FieldAccessError`) | field/column/`__`-path not found; or an unprojected FK read off a fetched row (#204) |
| `FilterError` | invalid filter argument/shape; operator misuse on a JSON/subquery column |
| `QueryBuildError` | structural/API misuse (joins, CTEs, projection, ordering, window/bulk config) — the long-tail default |
| `UnsafeMutationError` | `update()`/`delete()` without a filter (or another unsafe shape) |
| `InvalidValueError` | value coercion/type mismatch on insert/update; identifier-safety guard; interval/duration parse |
| `PermissionError` | connection not allowed to insert/update/delete (`change_data=false`) |
| `UnsupportedConnectionError` | connection is neither PostgreSQL nor SQLite, or a model isn't bound to a connection |
| `DoesNotExist` / `MultipleObjectsReturned` | `get()` cardinality — reparented under `PormGError` |

`catch PormGError` catches all; a specific subtype for a specific reaction.

## Mechanic

Retype the throw-site funnels (`_argerr → QueryBuildError`, `_validation_error → InvalidValueError`, `_unsupported_conn → UnsupportedConnectionError`, `_write_not_allowed` [#205] `→ PermissionError`), then reclassify the sharper sites per file across `src/querybuilder/*.jl`. A single `Base.showerror(io, ::PormGError)` covers the msg-carrying subtypes; each constructor applies `_emsg` once so ANSI degrades off-TTY.

**Scope: query builder only.** `src/models/fields.jl` and `src/Models.jl` still throw `ArgumentError` (follow-up issue). The endangered internal catch in `many_to_many.jl` is widened to `isa PormGError`; the `save()` pk-catch is intentionally kept as `isa ArgumentError` (it wraps the out-of-scope `Models.get_model_pk_field`).

## Convergence with #205

#205 (merged) refactored the `change_data=false` write guards into a shared `_write_not_allowed(op, conn_key)` helper. This PR makes that helper **return `PermissionError`**, so #205's unified message and #231's semantic type combine — all 12 write-guard sites route through it.

## Versioning

Per the release-trains model (#235): **no `Project.toml` bump** (stays `0.2.3`); the migration entry is added under `## Unreleased` in `UPGRADING.md`, and it notes that it **supersedes the error type** in the #205 entry (write-disabled error is now `PermissionError`).

## Testing

- New `test/unit/test_error_taxonomy.jl` — hierarchy, clean-break (`!(T <: ArgumentError)`), exports, representative misuse.
- Migrated the typed-exception, ANSI, #204 row-and-get, and blast-radius assertions to type checks; `docs/src/api.md` updated.
- **Unit 4314/4314**, **SQLite integration green**, **PG integration green** (one PG-only `select_for_update` assertion migrated to the typed error).
- Independent code review: clean.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
