### PR TITLE
feat: fluent parity gaps — get_or_create, last/earliest/latest, aggregate, row.delete (#208)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -55,17 +55,22 @@ These methods finalize the query and execute it against the database:
 | `.list(:json)` | `String` | Returns results as a JSON string. |
 | `query \|> DataFrame` | `DataFrame` | Pipe to `DataFrame` for tabular output. |
 | `.count()` | `Int` | Runs `SELECT COUNT(*)` and returns the count. |
+| `.aggregate(alias => Agg(...), ...)` | `NamedTuple` | Whole-queryset aggregation (no `GROUP BY`); returns one named tuple of scalars. See [Aggregation](read/filters_and_aggregates.md). |
 | `.exists()` | `Bool` | Returns `true` if at least one row matches. |
 | `.first()` | `PormGRow` or `nothing` | Returns the first matching record or `nothing`. |
+| `.last()` | `PormGRow` or `nothing` | Returns the last matching record; inverts `order_by`, or falls back to primary-key descending when unset. |
+| `.earliest(fields...)` | `PormGRow` | Earliest row ordered by `fields` (ascending; `"-field"` flips); raises `DoesNotExist` when empty. |
+| `.latest(fields...)` | `PormGRow` | Latest row ordered by `fields` (descending; `"-field"` flips); raises `DoesNotExist` when empty. |
 | `.get(filters...)` | `PormGRow` | Returns exactly one row, or raises `DoesNotExist` / `MultipleObjectsReturned`. |
 | `.create(key => value, ...)` | `PormGRow` | Inserts a single record and returns it as a row (dot-access + `.save()`). |
 | `.update(key => value, ...)` | — | Updates all matching records. |
+| `.get_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Fetch-or-insert, never updates a match; returns `(row, created)`. See [Get or Create](write/create.md#get-or-create). |
 | `.update_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Row-level upsert: inserts on a fresh lookup or updates `defaults` on conflict; returns `(row, created)`. See [Update or Create](write/create.md#update-or-create). |
 | `.delete()` | — | Deletes all matching records. |
 
 ### `PormGRow` Instance Methods
 
-Rows returned by `.list()`, `.first()`, `.get()`, `.create()`, and `.update_or_create()` expose model-aware property access and instance-level persistence:
+Rows returned by `.list()`, `.first()`, `.last()`, `.earliest()`, `.latest()`, `.get()`, `.create()`, `.get_or_create()`, and `.update_or_create()` expose model-aware property access and instance-level persistence:
 
 | Method | Return Type | Description |
 | :--- | :--- | :--- |
@@ -76,6 +81,7 @@ Rows returned by `.list()`, `.first()`, `.get()`, `.create()`, and `.update_or_c
 | `row.relationship` | `ManyToManyManager` | Accesses a many-to-many relationship manager when the model defines one. |
 | `row.save()` | `PormGRow` | Persists fields assigned on the row and clears its dirty state. |
 | `row.save(show_query=:sql)` | `Vector` | Returns planned `UPDATE` inspection payloads without executing or clearing dirty state. |
+| `row.delete()` | `(Int, Dict)` | Deletes this row through the shared deletion collector (cascades like `query.delete()`); returns `(total, per-table counts)`. |
 
 ```julia
 driver = M.Driver.objects.get("driverref" => "hamilton")

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -541,6 +541,26 @@ On SQLite builds older than 3.30.0 (which lack `NULLS FIRST/LAST` syntax) PormG 
     than let SQLite return nondeterministic rows. Add the exact ordering expression to `values(...)`,
     or drop `distinct()`.
 
+### First, last, earliest, and latest
+
+`first()` and `last()` return a single row (or `nothing`) for the current query. `last()` returns the row `first()` would return under the **reversed** ordering — direction *and* NULL placement invert together. With no `order_by` set, `last()` falls back to **primary-key descending**, so it is always well-defined:
+
+```julia
+standings = M.Driver_standings.objects.filter("raceid" => 1)
+
+standings.order_by("points").first()   # fewest points
+standings.order_by("points").last()    # most points (ORDER BY points DESC, one row)
+
+M.Driver.objects.last()                # highest driverid (pk-descending fallback)
+```
+
+`earliest(fields...)` / `latest(fields...)` order by the field(s) you name (ascending / descending; a leading `-` flips a term, so `latest("dob") == earliest("-dob")`) and return the extreme row. Unlike `first`/`last`, they **raise `DoesNotExist`** on an empty queryset — they are the extreme-row counterpart of `get()`:
+
+```julia
+M.Driver.objects.earliest("dob")   # oldest driver
+M.Driver.objects.latest("dob")     # youngest driver
+```
+
 ---
 
 ## Counting
@@ -615,10 +635,23 @@ You do **not** write `GROUP BY` manually — PormG handles it.
 
 ### Aggregating Without Grouping
 
-When **every** column in `values()` is an aggregate, there are no non-aggregate columns to group by — so PormG emits **no `GROUP BY`** and the query collapses to a single summary row over the whole (optionally filtered) table. This is the equivalent of Django's `.aggregate()`.
+To compute one or more aggregates over the whole (optionally filtered) queryset — with **no `GROUP BY`** — use the `aggregate(...)` terminal. It is Django's `.aggregate()`: pass `"alias" => AggregateFunction(...)` pairs and it returns a single-row **`NamedTuple`** of scalars with dot-access.
 
 ```julia
 # Highest score, lowest score, and number of results for one constructor
+agg = M.Result.objects.filter("constructorid" => 131).aggregate(
+    "max_points"    => Max("points"),
+    "min_points"    => Min("points"),
+    "total_results" => Count("resultid"),
+)
+agg.max_points      # e.g. 25.0
+agg.total_results   # e.g. 412
+```
+
+`aggregate()` computes over the entire queryset, so it **cannot** be combined with `values()` grouping columns — call it on an unprojected (optionally filtered) queryset. For grouped aggregation, use `values(...)` (see [above](#Aggregations-and-Grouping)); PormG also emits **no `GROUP BY`** when *every* projected column is an aggregate, so the equivalent `values()` form returns the same single summary row when you want a `DataFrame`:
+
+```julia
+# Same numbers as a one-row DataFrame, via the values() projection path
 query = M.Result.objects
 query.filter("constructorid" => 131)
 query.values(

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -29,8 +29,12 @@ PormG provides several terminal methods to execute a query and return data in di
 | `.list(:json)` | `String` | Returns results as a JSON string for API responses. |
 | `query \|> DataFrame` | `DataFrame` | Pipe to `DataFrame` for tabular output (recommended for analysis). |
 | `.first()` | `PormGRow` or `nothing` | Returns the first matching row. |
+| `.last()` | `PormGRow` or `nothing` | Returns the last matching row (inverts `order_by`; falls back to primary-key descending when no ordering is set). |
+| `.earliest(fields...)` | `PormGRow` | Returns the earliest row ordered by `fields`; raises `DoesNotExist` when empty. |
+| `.latest(fields...)` | `PormGRow` | Returns the latest row ordered by `fields`; raises `DoesNotExist` when empty. |
 | `.get(filters...)` | `PormGRow` | Returns exactly one row, or raises a typed exception. |
 | `.count()` | `Int` | Runs `SELECT COUNT(*)` and returns the count. |
+| `.aggregate(pairs...)` | `NamedTuple` | Computes whole-queryset aggregates (no `GROUP BY`) and returns them as a single-row named tuple. |
 | `.exists()` | `Bool` | Returns `true` if at least one row matches. |
 
 ### Choosing an Output Format
@@ -62,7 +66,7 @@ n = query.count()      # => 42
 has_any = query.exists()  # => true
 ```
 
-Rows returned by `.list()`, `.first()`, `.get()`, `.create()`, and `.update_or_create()` are `PormGRow` values. They support property access, indexed access, many-to-many relationship accessors, and dirty tracking for `row.save()`:
+Rows returned by `.list()`, `.first()`, `.last()`, `.earliest()`, `.latest()`, `.get()`, `.create()`, `.get_or_create()`, and `.update_or_create()` are `PormGRow` values. They support property access, indexed access, many-to-many relationship accessors, and dirty tracking for `row.save()` and `row.delete()`:
 
 ```julia
 driver = M.Driver.objects.get("driverref" => "hamilton")

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -207,10 +207,41 @@ RETURNING *, (xmax = 0) AS "__pormg_created"
 ### Rules and behavior
 
 - **Lookup → conflict target.** The lookup pair(s) identify the row and become the `ON CONFLICT (...)` columns. A composite key is fully supported — pass several lookup pairs: `update_or_create("year" => 2024, "round" => 8; defaults = [...])`. The target must be backed by a real UNIQUE/PRIMARY KEY constraint in the database (PormG does not require it to be declared on the model — the database is the source of truth; a missing constraint surfaces as the backend's own error).
-- **`defaults` is required** and is the DO UPDATE `SET`. Fields in `defaults` are also merged into the INSERT. `update_or_create` always updates on conflict; a no-update *get-or-create* is a planned follow-up.
+- **`defaults` is required** and is the DO UPDATE `SET`. Fields in `defaults` are also merged into the INSERT. `update_or_create` always updates on conflict; when you want to *keep* an existing row untouched, use [`get_or_create`](#get-or-create) instead.
 - **Lookup and `defaults` must not overlap** — each field is either a match key or an updated value, never both.
 - **`auto_now` fields refresh on the update arm.** Any field with `auto_now = true` is appended to the SET so a conflict updates its timestamp (matching `.save()`/`.update()`); `auto_now_add` fields are create-only and are not refreshed.
 - **Field names are logical.** `db_column` mappings are resolved to the physical column names in the rendered SQL.
+
+## Get or Create
+
+`get_or_create` is the no-update sibling of `update_or_create`: it returns an existing row when the lookup matches, or inserts a new one when it doesn't — and **never modifies a matching row**. It returns the same `(row, created)` tuple, where `row` is a [`PormGRow`](../read/index.md) and `created` is `true` only when a new row was inserted.
+
+```julia
+# First call for this status → inserted.
+row, created = M.Status.objects.get_or_create(
+    "statusid" => 200; defaults = ["status" => "Provisional Classification"])
+# created == true, row.status == "Provisional Classification"
+
+# Second call with the same lookup → the existing row is returned unchanged.
+# The new defaults are IGNORED (get_or_create never updates on a hit).
+row, created = M.Status.objects.get_or_create(
+    "statusid" => 200; defaults = ["status" => "Something Else"])
+# created == false, row.status == "Provisional Classification"  (still the original)
+```
+
+### `get_or_create` vs `update_or_create`
+
+| | On a match | `defaults` |
+|---|---|---|
+| `get_or_create` | returns it **unchanged** | optional — create-only extras used only when inserting |
+| `update_or_create` | **updates** it with `defaults` | required — becomes the `SET` |
+
+### Rules and behavior
+
+- **Lookup → conflict target.** As with `update_or_create`, the lookup pair(s) identify the row and, on the create path, become the `ON CONFLICT (...)` columns. The lookup **must be backed by a real UNIQUE/PRIMARY KEY constraint** so a concurrent insert of the same key is a safe no-op rather than a duplicate-key error. A non-unique lookup raises an actionable error pointing you at `filter(...).first()` + `create(...)`.
+- **`defaults` is optional** — a bare `get_or_create("statusid" => 200)` is a valid pure get-or-create. `defaults` supplies extra columns applied **only** when a row is inserted.
+- **Non-lookup `NOT NULL` columns are needed only on insert.** `get_or_create` runs the `SELECT` first; on a match it returns immediately, so a matching row is returned even if you didn't supply every required column. On a miss the insert must satisfy every `NOT NULL` column (via the lookup, `defaults`, or a model default), exactly like `create`.
+- **Race-safe.** The create path runs `INSERT ... ON CONFLICT (lookup) DO NOTHING`, so if a competing writer inserts the same key first, PormG re-reads the winner and returns `created = false` — no duplicate-key crash.
 
 ## Creating with Relationships
 

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -26,6 +26,18 @@ The function returns a tuple containing the total count of deleted rows and a di
 (1, Dict{String, Integer}("just_a_test_deletion" => 1))
 ```
 
+### Deleting a Fetched Row
+
+A `PormGRow` you already have in hand — from `get()`, `first()`, `last()`, or `list()` — can delete itself with `row.delete()`. It is located by its primary key and routed through the **same** deletion collector as `query.delete()`, so cascade / `on_delete` handling is identical. It returns the same `(total, per-table counts)` tuple.
+
+```julia
+status = M.Status.objects.get("statusid" => 200)
+total, counts = status.delete()
+# (1, Dict{String, Integer}("status" => 1))
+```
+
+The row must have had its primary key projected (rows from `get()`/`first()`/`last()`/`list()` always do). The in-memory `row` is not mutated — its field data is stale after the delete.
+
 ### Deletion with Conditions
 
 ```julia

--- a/docs/src/write/index.md
+++ b/docs/src/write/index.md
@@ -18,7 +18,10 @@ PormG is designed as **Async-First**. All database operations must utilize non-b
 | Operation | Best For | Speed | Protocol |
 | :--- | :--- | :--- | :--- |
 | `create()` | Single rows | Standard | SQL INSERT |
+| `get_or_create()` | Fetch-or-insert, keep existing | Standard | SELECT + INSERT ON CONFLICT |
+| `update_or_create()` | Insert-or-update (upsert) | Standard | INSERT ON CONFLICT DO UPDATE |
 | `row.save()` | Persisting one fetched row | Standard | SQL UPDATE |
+| `row.delete()` | Deleting one fetched row | Standard | SQL DELETE (+ cascade) |
 | `bulk_insert()` | Medium datasets (< 10k rows) | Fast | Multi-row INSERT |
 | `bulk_copy()` ⭐ | Massive datasets | Ultra-Fast | Postgres COPY |
 | `update()` | Selective updates | Standard | SQL UPDATE |

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -18,7 +18,7 @@ import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, tra
 	in_transaction_context,
 	get_settings as get_configuration_settings
 import PormG: @pormg_debug
-import Base: first, get
+import Base: first, last, get
 
 #
 # SQL Sanitization

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -401,6 +401,49 @@ function do_count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} =
   end
 end
 
+# Whole-queryset aggregation (#208). Django's aggregate(): compute one or more aggregate scalars
+# over the ENTIRE queryset (no GROUP BY) and return them as a single-row NamedTuple keyed by alias.
+# Built on the same column-form path as do_count() — inject the aggregate projections via values(),
+# read the single row back — but generalized to multiple aggregates and a dot-accessible result.
+function do_aggregate(oq::SQLObjectHandler; pairs, show_query::Symbol = :execute)
+  isempty(pairs) &&
+    throw(_argerr("aggregate() requires at least one \"alias\" => AggregateFunction(...) pair, e.g. aggregate(\"total\" => Sum(\"points\"))."))
+  # aggregate() is whole-queryset only. If the caller already projected grouping columns via
+  # values(), that is a DIFFERENT operation (grouped aggregation) — refuse rather than silently
+  # discard their grouping. Steer them to values(...) + list() for the grouped form.
+  isempty(oq.object.values) ||
+    throw(_argerr("aggregate() computes a single whole-queryset result and cannot combine with values() grouping columns. Use values(...) + list() for grouped aggregation, or call aggregate() on an unprojected queryset."))
+
+  aliases = Symbol[]
+  for p in pairs
+    (p isa Pair && p.first isa AbstractString) ||
+      throw(_argerr("aggregate() arguments must be \"alias\" => AggregateFunction(...) pairs; got $(typeof(p))."))
+    val = p.second
+    (val isa SQLTypeFunction && hasproperty(val, :aggregate) && getproperty(val, :aggregate) === true) ||
+      throw(_argerr("aggregate() value for \"$(p.first)\" must be an aggregate function (Sum/Avg/Count/Max/Min); got $(typeof(val)). For per-row expressions use values(...)."))
+    push!(aliases, Symbol(p.first))
+  end
+
+  cq = deepcopy(oq)
+  cq.object.order = []
+  cq.object.limit = 0
+  cq.object.offset = 0
+  cq.object.distinct = false
+  # Inject the aggregate projections through the shared values() path (column resolution, joins and
+  # dialect rendering stay identical to values(Sum(...))). With ONLY aggregates projected, no
+  # non-aggregate column is present, so the builder emits no GROUP BY (same as do_count).
+  up_values!(cq.object, collect(Any, pairs))
+
+  if show_query !== :execute
+    return query(cq; show_query=show_query)
+  end
+
+  rows = list(cq, Val(:dict))
+  # A SQL aggregate over an empty set still returns one row (COUNT→0, others→NULL); guard anyway.
+  row = isempty(rows) ? Dict{Symbol,Any}() : Base.first(rows)
+  return NamedTuple{Tuple(aliases)}(Tuple(get(row, a, nothing) for a in aliases))
+end
+
 function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
   try
     # Resolve settings
@@ -723,6 +766,135 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
   else
     _unsupported_conn("update_or_create()", connection)
   end
+end
+
+# A missing unique constraint on the ON CONFLICT target surfaces as a driver error at execution
+# ("no unique or exclusion constraint matching the ON CONFLICT specification" on PostgreSQL; "ON
+# CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint" on SQLite). Re-raise it as an
+# actionable PormGError — this is the one place a Django user is surprised, because Django's
+# get_or_create does SELECT-then-INSERT and needs no unique constraint (#208).
+function _rethrow_conflict_target_error(e, model::PormGModel, target_fields::Vector{String})
+  msg = sprint(showerror, e)
+  low = lowercase(msg)
+  if occursin("on conflict", low) && (occursin("unique", low) || occursin("exclusion", low) ||
+      occursin("does not match", low) || occursin("no primary key", low))
+    throw(QueryBuildError(
+      "get_or_create on $(model.name) requires a UNIQUE constraint on the lookup field(s) " *
+      "(\e[4m\e[31m$(join(target_fields, ", "))\e[0m) — they are the ON CONFLICT target. Add a unique " *
+      "constraint/index on them, or for non-unique lookups use filter(...).first() then create(...)."))
+  end
+  rethrow(e)
+end
+
+# Django-style get_or_create (#208): match-or-insert with NO update on a hit. This is Django's own
+# algorithm — get() FIRST, and only on a miss build+run the INSERT — so that columns beyond the
+# lookup (NOT NULL fields with no default) are required ONLY when a row is actually created, never
+# on a plain hit. `ON CONFLICT (target) DO NOTHING` on the create path is the concurrency guard: if
+# a competing writer inserts the same key between our SELECT and INSERT, the insert is skipped (no
+# duplicate-key crash) and we re-read the winner. Returns `(PormGRow, created::Bool)`. The lookup
+# must be a UNIQUE constraint for the create path to be safe — `_rethrow_conflict_target_error`
+# turns the missing-constraint driver error into an actionable message.
+function _get_or_create(objct::SQLObject; target_fields::Vector{String}, show_query::Symbol = :execute)
+  real_obj = objct isa SQLObjectHandler ? objct.object : objct
+  model = real_obj.model
+  ensure_model_transaction_scope(model)
+
+  settings, connection, conn_key = get_settings(objct)
+  !settings.change_data && throw(_write_not_allowed("get_or_create", conn_key))
+
+  # Capture the raw lookup values BEFORE any INSERT marshalling mutates real_obj.insert.
+  target_values = Dict{String,Any}(f => real_obj.insert[f] for f in target_fields)
+
+  # get() by the conflict target through the fluent builder — dialect-correct binding for free, and
+  # inside a transaction it uses the pinned connection (same pattern as save()).
+  fetch_by_target = () -> begin
+    q = object(model)
+    for f in target_fields
+      q.filter(f => target_values[f])
+    end
+    q.first()
+  end
+
+  # Build the `INSERT ... ON CONFLICT (target) DO NOTHING` a MISS would run. `_prepare_row_insert!`
+  # validates/fills the row and requires every NOT NULL column — so this fires (create-time) only
+  # when we actually insert. Returns (insert_sql, pk_exist, pk_field).
+  build_insert = (parameters) -> begin
+    set_context!(parameters, :select)
+    quoted_field_columns, param_values, pk_exist, pk_field =
+      _prepare_row_insert!(real_obj, model, settings, connection, parameters)
+    safe_table_name = safe_table_identifier(string(model.name), connection)
+    qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
+    clause  = Dialect.on_conflict_clause(:nothing, qtarget, String[], connection)
+    sql = """
+    INSERT INTO $(safe_table_name) (
+      $(join(quoted_field_columns, ", "))
+    ) VALUES (
+      $(join(param_values, ", "))
+    )
+    $(clause)"""
+    (sql, pk_exist, pk_field)
+  end
+
+  if show_query !== :execute
+    # Honest to what a miss executes: the INSERT + ON CONFLICT DO NOTHING (the get() + read-back are
+    # out-of-band SELECTs). Mirrors _update_or_create's inspect contract.
+    parameters = get_parameter(connection)
+    insert_sql, _, _ = build_insert(parameters)
+    return _show_query_result(show_query, insert_sql, connection, model.name, :insert; parameters = parameters)
+  end
+
+  do_goc = () -> begin
+    # Hit → return the existing row WITHOUT building an INSERT (no NOT NULL columns needed).
+    existing = fetch_by_target()
+    existing !== nothing && return (existing, false)
+
+    # Miss → create, guarded by ON CONFLICT DO NOTHING against a concurrent insert of the same key.
+    parameters = get_parameter(connection)
+    insert_sql, pk_exist, pk_field = build_insert(parameters)
+
+    if connection isa PormGPostgres
+      exec_sql = insert_sql * " RETURNING *;"
+      result = try
+        fetch(settings, exec_sql, parameters)
+      catch e
+        _rethrow_conflict_target_error(e, model, target_fields)
+      end
+      rows = Tables.rowtable(result)
+      if !isempty(rows)
+        dict = _row_to_field_keyed_dict(Base.first(rows), model)
+        pk_exist && _update_sequence(model, connection, pk_field, settings)
+        return (PormGRow(dict, model), true)
+      end
+      # Lost the insert race → the row exists now; return the winner, created == false.
+      raced = fetch_by_target()
+      raced === nothing &&
+        throw(QueryBuildError("get_or_create: ON CONFLICT DO NOTHING skipped the insert but the existing $(model.name) row could not be read back."))
+      return (raced, false)
+
+    elseif connection isa PormGSQLite
+      try
+        fetch(settings, insert_sql, parameters)         # INSERT ... ON CONFLICT DO NOTHING
+      catch e
+        _rethrow_conflict_target_error(e, model, target_fields)
+      end
+      row = fetch_by_target()
+      row === nothing &&
+        throw(QueryBuildError("get_or_create: insert reported success but the $(model.name) row could not be read back."))
+      # Under the serialized write lock (the transaction below) no writer can interleave between the
+      # miss-check and this insert, so a fetched-nothing-then-insert is always a real creation.
+      pk_exist && _update_sequence(model, connection, pk_field, settings)
+      return (row, true)
+    else
+      _unsupported_conn("get_or_create()", connection)
+    end
+  end
+
+  # SQLite: serialize get + insert + read-back so `created` is correct and the create race-guard
+  # holds. PostgreSQL's ON CONFLICT is atomic on its own; running inside an ambient tx is fine.
+  if connection isa PormGSQLite
+    return transaction_connection_for(settings) !== nothing ? do_goc() : run_in_transaction(do_goc, settings)
+  end
+  return do_goc()
 end
 
 function _get_owned_sequence_name(connection::PormGPostgres, model::PormGModel, field::String; ignore_tx::Bool = false)
@@ -1554,6 +1726,113 @@ end
 # test/unit/test_public_exports.jl. (`delete`/`inspect_query` keep their curried forms — those
 # functions are package-owned, so a kwargs-only method on them is not piracy.)
 
+# Reverse a single ORDER BY term in place — the reverse of an ORDER BY yields the last row (#208).
+# Flip ASC↔DESC, and any EXPLICIT nulls placement (an unset `nothing` stays default so the
+# renderer keeps its orientation-derived NULLS placement). Non-SQLOrder ordering terms are left
+# as-is (best effort).
+function _invert_order!(o::SQLOrder)
+  o.orientation = o.orientation == "DESC" ? "ASC" : "DESC"
+  # if/elseif, NOT two `&&` statements: sequential flips would swap :first→:last→:first (no-op).
+  if o.nulls === :first
+    o.nulls = :last
+  elseif o.nulls === :last
+    o.nulls = :first
+  end
+  return o
+end
+_invert_order!(o) = o
+
+"""
+    last(objct::SQLObjectHandler; show_query::Symbol = :execute)
+
+Return the last `PormGRow` matching the current query, or `nothing` if no records match.
+
+The mirror of [`first`](@ref): it inverts the query's ordering and takes one row. When an
+`order_by(...)` is set, `last()` returns the row that `first()` would return under the reversed
+ordering. When **no** ordering is set, it falls back to **primary-key descending**, so `last()`
+is always well-defined (matching Django). Like every read terminal, it runs on an internal copy —
+the inverted ordering and `limit(1)` never leak into the caller's handler.
+"""
+function last(objct::SQLObjectHandler; show_query::Symbol = :execute)
+  # #199: copy-first like first/count/list — the ordering flip and limit(1) apply to the copy only.
+  q = deepcopy(objct)
+  if isempty(q.object.order)
+    # No ordering: fall back to primary-key DESC so last() is meaningful (Django parity).
+    model = q.object.model
+    pk_sym = try
+      Models.get_model_pk_field(model)
+    catch e
+      # get_model_pk_field lives in Models and still throws ArgumentError on a composite pk
+      # (mirrors save()/pk()). Re-home it as an actionable QueryBuildError.
+      e isa ArgumentError || rethrow(e)
+      throw(QueryBuildError("last() with no order_by() needs a single-column primary key to order by, but $(model.name) has none — add an explicit order_by(...)."))
+    end
+    pk_sym === nothing &&
+      throw(QueryBuildError("last() with no order_by() needs a single-column primary key to order by, but $(model.name) has none — add an explicit order_by(...)."))
+    q.order_by("-" * String(pk_sym))
+  else
+    # Reverse the existing ordering; the reversed ORDER BY's first row is the original's last.
+    for o in q.object.order
+      _invert_order!(o)
+    end
+  end
+  q.limit(1)
+  res = list(q, show_query=show_query)
+  if show_query !== :execute
+    return res
+  end
+  return isempty(res) ? nothing : res[1]
+end
+
+# Shared body for earliest()/latest(): apply the (already-oriented) ordering fields, take one row,
+# and raise DoesNotExist on an empty queryset (Django parity — these behave like get(), not first()).
+function _extreme(objct::SQLObjectHandler, order_fields, opname::String; show_query::Symbol)
+  q = deepcopy(objct)
+  q.order_by(order_fields...)
+  q.limit(1)
+  if show_query !== :execute
+    return list(q, show_query=show_query)
+  end
+  rows = list(q)
+  if isempty(rows)
+    model_name = q.object.model.name
+    filter_repr = isempty(q.object.filter) ? "(none)" : join(_get_filter_repr.(q.object.filter), ", ")
+    throw(DoesNotExist(model_name, "$(opname): $(filter_repr)"))
+  end
+  return rows[1]
+end
+
+# Flip a single order token's direction for latest() (the ASC↔DESC inverse of what the user wrote):
+# "field" → "-field" (DESC), "-field" → "field" (ASC). Matches Django's latest("-f") == earliest("f").
+_invert_order_token(f::AbstractString) = startswith(f, "-") ? String(f[2:end]) : "-" * String(f)
+_invert_order_token(f) = throw(_argerr("earliest()/latest() fields must be field-name Strings (\"-field\" for the opposite direction); got $(typeof(f))."))
+
+"""
+    earliest(objct::SQLObjectHandler, fields...; show_query = :execute) -> PormGRow
+
+Return the earliest row ordered by `fields` (ascending; a `"-field"` flips that term to
+descending). Requires at least one field and raises `DoesNotExist` when no rows match — the
+extreme-row counterpart of [`get`](@ref), matching Django's `earliest()`.
+"""
+function earliest(objct::SQLObjectHandler, fields...; show_query::Symbol = :execute)
+  isempty(fields) &&
+    throw(_argerr("earliest() requires at least one field to order by, e.g. earliest(\"dob\")."))
+  return _extreme(objct, fields, "earliest"; show_query=show_query)
+end
+
+"""
+    latest(objct::SQLObjectHandler, fields...; show_query = :execute) -> PormGRow
+
+Return the latest row ordered by `fields` (descending; a `"-field"` flips that term to
+ascending). Requires at least one field and raises `DoesNotExist` when no rows match. Django's
+`latest()`; `latest("f") == earliest("-f")`.
+"""
+function latest(objct::SQLObjectHandler, fields...; show_query::Symbol = :execute)
+  isempty(fields) &&
+    throw(_argerr("latest() requires at least one field to order by, e.g. latest(\"dob\")."))
+  return _extreme(objct, _invert_order_token.(fields), "latest"; show_query=show_query)
+end
+
 function _get_filter_repr(filter::SQLTypeOper)::String
   column = filter.column isa SQLTypeField ? filter.column.field : filter.column
   return "$(column) $(filter.operator) $(filter.values)"
@@ -1722,4 +2001,36 @@ function save(row::PormGRow; show_query::Symbol = :execute)
 
   empty!(dirty)
   return row
+end
+
+"""
+    delete(row::PormGRow; show_query=:execute) -> (total::Int, Dict{String,Integer})
+
+Delete this fetched row from its table, cascading through the **same** `DeletionCollector` as
+`Model.objects.filter(...).delete()` — so `on_delete` behaviour (CASCADE / SET_NULL / PROTECT)
+is identical whether you delete one fetched row or a filtered set. Returns the
+`(total_deleted, per-model counts)` tuple of the underlying queryset delete.
+
+The row is located by its primary key, which must have been projected onto the row (it is, for
+rows from `list()`/`first()`/`get()`). The in-memory `row` is not mutated — its data becomes
+stale after the delete.
+"""
+function delete(row::PormGRow; show_query::Symbol = :execute)
+  model = getfield(row, :_model)
+  pk_sym = try
+    Models.get_model_pk_field(model)
+  catch e
+    # get_model_pk_field still throws ArgumentError on a composite pk (mirrors save()/pk()).
+    e isa ArgumentError || rethrow(e)
+    throw(QueryBuildError("delete() requires exactly one primary key field; $(model.name) is not supported."))
+  end
+  pk_sym === nothing &&
+    throw(QueryBuildError("delete() requires exactly one primary key field; $(model.name) is not supported."))
+
+  data = getfield(row, :_data)
+  haskey(data, pk_sym) ||
+    throw(QueryBuildError("Cannot delete() this $(model.name) row: its primary-key column '$(pk_sym)' was not projected. Select it before deleting the row."))
+
+  # Route the single pk through the queryset delete — one collector/cascade path, no drift (#208).
+  return object(model).filter(String(pk_sym) => data[pk_sym]).delete(show_query=show_query)
 end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -107,12 +107,12 @@ end
 
 # Coerce a lookup/defaults argument into a Vector{Pair}, tolerating a tuple (positional args),
 # a vector, or a single bare Pair; reject any non-Pair element with an actionable error.
-function _normalize_uoc_pairs(x, what::AbstractString)
+function _normalize_uoc_pairs(x, what::AbstractString; op::AbstractString = "update_or_create")
   items = x isa Pair ? (x,) : x
   out = Pair[]
   for item in items
     item isa Pair ||
-      throw(_argerr("Error in update_or_create, each $what entry must be a `field => value` pair, got $(typeof(item))"))
+      throw(_argerr("Error in $op, each $what entry must be a `field => value` pair, got $(typeof(item))"))
     push!(out, item)
   end
   return out
@@ -130,7 +130,7 @@ function up_update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_quer
   isempty(lookup_pairs) &&
     throw(_argerr("Error in update_or_create, at least one lookup pair is required (it becomes the ON CONFLICT target)"))
   isempty(default_pairs) &&
-    throw(_argerr("Error in update_or_create, `defaults` must be non-empty — ON CONFLICT DO UPDATE needs a SET; a no-update get_or_create is a planned follow-up (#30)"))
+    throw(_argerr("Error in update_or_create, `defaults` must be non-empty — ON CONFLICT DO UPDATE needs a SET. For a no-update match-or-insert, use get_or_create(...) instead."))
 
   lookup_keys  = String[string(k) for (k, _) in lookup_pairs]
   default_keys = String[string(k) for (k, _) in default_pairs]
@@ -166,6 +166,49 @@ function up_update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_quer
   set_fields = vcat(default_keys, auto_now_fields)
 
   return _update_or_create(q; target_fields = target_fields, set_fields = set_fields, show_query = show_query)
+end
+
+# Django-style get_or_create (#208, deferred from #30). The no-update sibling of update_or_create:
+# `lookup` pairs identify the row; `defaults` are create-only extras applied ONLY when a row is
+# inserted — never on a hit (that's the whole point of "no update"). So unlike update_or_create,
+# `defaults` is OPTIONAL. Returns `(PormGRow, created::Bool)`. `_get_or_create` does get()-first and
+# only creates on a miss (so non-lookup NOT NULL columns are needed only when actually creating);
+# the create path uses `ON CONFLICT (lookup) DO NOTHING` as its concurrency guard, so the lookup
+# fields must be a unique constraint for it to be race-safe (re-raised as an actionable error
+# otherwise). All validation fires here, before any DB work, so `show_query=:dict` surfaces it.
+function up_get_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
+  model = q.model
+  lookup_pairs  = _normalize_uoc_pairs(lookup, "lookup"; op = "get_or_create")
+  default_pairs = _normalize_uoc_pairs(defaults, "defaults"; op = "get_or_create")
+
+  isempty(lookup_pairs) &&
+    throw(_argerr("Error in get_or_create, at least one lookup pair is required (it becomes the ON CONFLICT target)"))
+
+  lookup_keys  = String[string(k) for (k, _) in lookup_pairs]
+  default_keys = String[string(k) for (k, _) in default_pairs]
+
+  for k in lookup_keys
+    haskey(model.fields, k) ||
+      throw(_argerr("Error in get_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+  end
+  for k in default_keys
+    haskey(model.fields, k) ||
+      throw(_argerr("Error in get_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+  end
+  length(unique(lookup_keys)) == length(lookup_keys) ||
+    throw(_argerr("Error in get_or_create, duplicate lookup field(s)"))
+  length(unique(default_keys)) == length(default_keys) ||
+    throw(_argerr("Error in get_or_create, duplicate defaults field(s)"))
+  overlap = intersect(Set(lookup_keys), Set(default_keys))
+  isempty(overlap) ||
+    throw(_argerr("Error in get_or_create, field(s) $(join(sort(collect(overlap)), ", ")) appear in both lookup and defaults; put each in one (lookup = match key, defaults = create-only extras applied on insert)"))
+
+  # Merge into the insert map (lookup then defaults; order preserved for deterministic SQL, #97).
+  q.insert = OrderedCollections.OrderedDict{String,Any}()
+  for (k, v) in lookup_pairs;  q.insert[string(k)] = v; end
+  for (k, v) in default_pairs; q.insert[string(k)] = v; end
+
+  return _get_or_create(q; target_fields = lookup_keys, show_query = show_query)
 end
 
 """
@@ -360,6 +403,11 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     # show_query=:sql/:dict/:params return the inspection shape (String/Dict/Vector), same dual
     # contract as :create/:update. `args` = lookup pairs; `defaults=`/`show_query=` via kwargs.
     return (args...; kwargs...) -> up_update_or_create!(q.object, args; kwargs...)
+  elseif sym === :get_or_create
+    # Django-style match-or-insert (#208), no update on a hit. Execute path returns
+    # (row::PormGRow, created::Bool); show_query=:sql/:dict/:params return the inspection shape.
+    # `args` = lookup pairs; `defaults=`/`show_query=` via kwargs.
+    return (args...; kwargs...) -> up_get_or_create!(q.object, args; kwargs...)
   elseif sym === :count
     # count()                         -> COUNT(*)              (total rows)
     # count(distinct=true)            -> distinct rows         (subquery COUNT(*) over SELECT DISTINCT *)
@@ -367,10 +415,27 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     # count("col", distinct=true)     -> COUNT(DISTINCT "col") (distinct values of a column, scalar)
     return (column=nothing; distinct::Bool=false, show_query::Symbol=:execute) ->
       do_count(q; column=column, distinct=distinct, show_query=show_query)
+  elseif sym === :aggregate
+    # Whole-queryset aggregation with NO GROUP BY (#208). aggregate("total" => Sum("points"), …)
+    # returns a single-row NamedTuple of scalars (dot-access r.total). Errors if the queryset
+    # already carries values() grouping columns.
+    return (pairs...; show_query::Symbol=:execute) -> do_aggregate(q; pairs=pairs, show_query=show_query)
   elseif sym === :exists
     return (; show_query=:execute) -> do_exists(q; show_query=show_query)
   elseif sym === :first
     return (; kwargs...) -> first(q; kwargs...)
+  elseif sym === :last
+    # Mirror of first() with inverted ordering (#208); with no order_by set, falls back to
+    # primary-key DESC so last() is always well-defined. Returns a PormGRow or nothing.
+    return (; kwargs...) -> last(q; kwargs...)
+  elseif sym === :earliest
+    # earliest(fields...) — order by the given field(s) ASC, return the first; raises
+    # DoesNotExist on an empty queryset (Django parity, unlike first/last).
+    return (fields...; kwargs...) -> earliest(q, fields...; kwargs...)
+  elseif sym === :latest
+    # latest(fields...) — order by the given field(s) DESC, return the first; raises
+    # DoesNotExist on an empty queryset.
+    return (fields...; kwargs...) -> latest(q, fields...; kwargs...)
   elseif sym === :get
     return (args...; show_query=:execute) -> get(q, args...; show_query=show_query)
   elseif sym === :list

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -896,6 +896,7 @@ function Base.getproperty(row::PormGRow, sym::Symbol)
   sym === :_model && return getfield(row, :_model)
   sym === :_dirty && return getfield(row, :_dirty)
   sym === :save && return (; show_query::Symbol=:execute) -> save(row; show_query=show_query)
+  sym === :delete && return (; show_query::Symbol=:execute) -> delete(row; show_query=show_query)
 
   data = getfield(row, :_data)
   model = getfield(row, :_model)
@@ -990,6 +991,7 @@ end
 function Base.propertynames(row::PormGRow, private::Bool = false)
   cols = collect(keys(getfield(row, :_data)))
   push!(cols, :save)
+  push!(cols, :delete)
   private && append!(cols, (:_data, :_model, :_dirty))
   return Tuple(cols)
 end

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -35,6 +35,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Field Expressions"            begin include("test_field_expressions.jl")  end
     @testset "Updates"                      begin include("test_updates.jl")            end
     @testset "Deletes"                      begin include("test_deletes.jl")            end
+    @testset "Fluent parity (#208)"         begin include("test_fluent_parity_208.jl")  end
     @testset "Bulk copy"                    begin include("test_bulk_copy.jl")          end
     @testset "SQL Functions"                begin include("test_sql_functions.jl")      end
     @testset "Window Functions"             begin include("test_window_functions.jl")   end

--- a/test/integration/test_fluent_parity_208.jl
+++ b/test/integration/test_fluent_parity_208.jl
@@ -1,0 +1,138 @@
+# test/integration/test_fluent_parity_208.jl
+#
+# End-to-end coverage for the #208 fluent parity terminals against real adapters (db_2 =
+# PostgreSQL, db_sl = SQLite). Row correctness — the questions the unit SQL-rendering tests
+# cannot answer: does get_or_create actually match-or-insert without updating on a hit; does
+# last()/earliest()/latest() return the right extreme row; does aggregate() compute the right
+# scalars; does row.delete() actually remove the row through the shared collector.
+#
+# Ordering is asserted only on NUMERIC columns (points / integer pk) — never on text — because
+# PostgreSQL's locale collation and SQLite's BINARY collation disagree on string order.
+
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+@testset "get_or_create (#208)" begin
+    # M.Status: pk `statusid` is UNIQUE (the ON CONFLICT target); `status` is a plain, non-unique
+    # column used below to prove the missing-unique-constraint guard. High pk avoids seeded data.
+    sid = 360001
+    cleanup() = (q = M.Status.objects.filter("statusid" => sid); q.exists() && q.delete())
+    cleanup()
+    try
+        # 1. Miss → INSERT, created == true, PormGRow carries the inserted values.
+        row, created = M.Status.objects.get_or_create("statusid" => sid; defaults = ["status" => "First"])
+        @test created === true
+        @test row isa PormG.QueryBuilder.PormGRow
+        @test row.statusid == sid
+        @test row.status == "First"
+        @test M.Status.objects.filter("statusid" => sid).count() == 1
+
+        # 2. Hit → NO update (the defining difference from update_or_create). New defaults are
+        #    ignored; the existing row is returned unchanged, count is unchanged.
+        row2, created2 = M.Status.objects.get_or_create("statusid" => sid; defaults = ["status" => "Second"])
+        @test created2 === false
+        @test row2.status == "First"          # unchanged — NOT "Second"
+        @test M.Status.objects.filter("statusid" => sid).count() == 1
+        persisted = M.Status.objects.filter("statusid" => sid).values("status").list() |> first
+        @test persisted[:status] == "First"
+
+        # 3. Pure get-or-create (no defaults) on a hit also returns the existing row.
+        row3, created3 = M.Status.objects.get_or_create("statusid" => sid)
+        @test created3 === false
+        @test row3.status == "First"
+    finally
+        cleanup()
+    end
+end
+
+@testset "get_or_create requires a unique constraint on the lookup (#208)" begin
+    # `status` has no unique constraint, so ON CONFLICT (status) has no matching target — PormG
+    # re-raises the driver error as an actionable PormGError (the Django-divergence edge). The
+    # statement is rejected before inserting, so nothing is created; clean up defensively anyway.
+    marker = "pormg_no_unique_status_208"
+    err = try
+        M.Status.objects.get_or_create("status" => marker); nothing
+    catch e
+        e
+    end
+    @test err isa PormGError
+    @test occursin("unique constraint", PormG._emsg(sprint(showerror, err); color = false))
+    residual = M.Status.objects.filter("status" => marker)
+    residual.exists() && residual.delete()
+end
+
+@testset "last / earliest / latest (#208)" begin
+    # A populated, bounded subset: one race's results, ordered by the numeric `points` column.
+    raceid = (M.Result.objects.values("raceid").list() |> first)[:raceid]
+    fresh() = M.Result.objects.filter("raceid" => raceid)
+
+    pts = [r[:points] for r in fresh().values("points").list()]
+    @test !isempty(pts)
+    lo, hi = minimum(pts), maximum(pts)
+
+    # first()/last() under an explicit ordering are exact mirrors: last() == first() reversed.
+    @test fresh().order_by("points").first().points == lo
+    @test fresh().order_by("points").last().points == hi     # last() inverts ASC → DESC
+
+    # earliest()/latest() order by the given field; a leading "-" flips it (latest("f")==earliest("-f")).
+    @test fresh().earliest("points").points == lo
+    @test fresh().latest("points").points == hi
+    @test fresh().latest("points").points == fresh().earliest("-points").points
+
+    # last() with NO order_by falls back to primary-key (resultid) DESC → the max-pk row.
+    max_pk = maximum(r[:resultid] for r in fresh().values("resultid").list())
+    @test fresh().last().resultid == max_pk
+
+    # Empty queryset: earliest/latest RAISE (like get()); first/last RETURN nothing.
+    empty = M.Result.objects.filter("raceid" => -999_999)
+    @test empty.last() === nothing
+    @test empty.first() === nothing
+    @test_throws PormG.DoesNotExist M.Result.objects.filter("raceid" => -999_999).earliest("points")
+    @test_throws PormG.DoesNotExist M.Result.objects.filter("raceid" => -999_999).latest("points")
+end
+
+@testset "aggregate (#208)" begin
+    raceid = (M.Result.objects.values("raceid").list() |> first)[:raceid]
+    fresh() = M.Result.objects.filter("raceid" => raceid)
+
+    # Whole-queryset aggregation → a single-row NamedTuple with dot-access.
+    agg = fresh().aggregate(
+        "total" => Sum("points"),
+        "n"     => Count("resultid"),
+        "avg"   => Avg("points"),
+    )
+    raw = [r[:points] for r in fresh().values("points").list()]
+    @test agg.total ≈ sum(raw)
+    @test agg.n == length(raw)
+    @test agg.avg ≈ sum(raw) / length(raw)
+
+    # aggregate() must match the blessed values()+single-row list() workaround it sugars over.
+    viaValues = fresh().values("total" => Sum("points"), "n" => Count("resultid")).list() |> first
+    @test agg.total ≈ viaValues[:total]
+    @test agg.n == viaValues[:n]
+
+    # Refuses to silently discard values() grouping columns.
+    @test_throws PormGError fresh().values("driverid").aggregate("total" => Sum("points"))
+end
+
+@testset "row.delete() (#208)" begin
+    # Create a disposable Status row, fetch it, and delete THROUGH the row — the same collector
+    # path as queryset delete, so it returns the (total, per-model counts) tuple. High pk keeps it
+    # clear of both seeded data and the get_or_create block above.
+    sid = 360002
+    cleanup() = (q = M.Status.objects.filter("statusid" => sid); q.exists() && q.delete())
+    cleanup()
+    try
+        M.Status.objects.create("statusid" => sid, "status" => "ToDelete")
+        row = M.Status.objects.get("statusid" => sid)
+        @test row isa PormG.QueryBuilder.PormGRow
+
+        total, counts = row.delete()
+        @test total >= 1
+        @test counts isa AbstractDict
+        @test M.Status.objects.filter("statusid" => sid).exists() == false
+    finally
+        cleanup()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")
     @testset "update_or_create (#30)" include("unit/test_update_or_create.jl")
+    @testset "Fluent parity: get_or_create/last/aggregate (#208)" include("unit/test_fluent_parity_208.jl")
     @testset "create() returns PormGRow (#166)" include("unit/test_create_returns_pormgrow.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")

--- a/test/unit/test_fluent_parity_208.jl
+++ b/test/unit/test_fluent_parity_208.jl
@@ -1,0 +1,151 @@
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, IntegerField
+using PormG.Functions: Sum, Count, Avg
+using PormG.QueryBuilder: SQLOrder, SQLField
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fluent parity gaps (#208): get_or_create, last(), aggregate()
+#
+# DB-free: `show_query=:sql`/`:dict` render the full statement before any DB round-trip, so the
+# get_or_create ON CONFLICT DO NOTHING clause, the last() ORDER-BY inversion + pk fallback, the
+# aggregate() no-GROUP-BY projection, and every validation error are all assertable against bare
+# mock connections. Mirrors test_update_or_create.jl. (Row correctness lives in the integration
+# suite, which needs a live DB.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+struct MockPg208 <: PormG.PormGPostgres end
+struct MockSqlite208 <: PormG.PormGSQLite end
+PormG.backend_sqlite_version(::MockSqlite208) = 3045000
+
+PormG.config["p208_pg"] = PormG.Configuration.Settings(connections = MockPg208(), change_data = true)
+PormG.config["p208_sqlite"] = PormG.Configuration.Settings(connections = MockSqlite208(), change_data = true)
+
+# db_column-mapped field (surname -> family_name) proves the ON CONFLICT target renders the physical column.
+GocPg = Model("goc_driver",
+  id = IDField(),
+  code = CharField(),
+  surname = CharField(db_column = "family_name", null = true),
+  points = IntegerField(null = true),
+)
+GocPg.connect_key = "p208_pg"
+
+GocSl = Model("goc_driver",
+  id = IDField(),
+  code = CharField(),
+  surname = CharField(db_column = "family_name", null = true),
+  points = IntegerField(null = true),
+)
+GocSl.connect_key = "p208_sqlite"
+
+# Runs a terminal with :dict (validation fires before any DB call) and returns the stripped message.
+function _p208_error(f)
+  err = try
+    f(); nothing
+  catch e
+    e
+  end
+  @test err isa PormGError
+  return err === nothing ? "" : PormG._emsg(sprint(showerror, err); color = false)
+end
+
+@testset "get_or_create SQL rendering (PostgreSQL mock)" begin
+  # No-update match-or-insert: DO NOTHING (never DO UPDATE), and the :sql form has no RETURNING
+  # (the created-flag + read-back are out-of-band on the execute path).
+  sql = GocPg.objects.get_or_create("code" => "HAM"; defaults = ["surname" => "Hamilton"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"code\") DO NOTHING", sql)
+  @test !occursin("DO UPDATE", sql)
+  @test !occursin("RETURNING", sql)
+  # defaults are create-only extras merged into the INSERT column list (physical db_column name).
+  @test occursin("\"family_name\"", sql)
+
+  # Multi-column lookup → composite conflict target; db_column field resolves physically.
+  sql_multi = GocPg.objects.get_or_create("code" => "HAM", "surname" => "Hamilton"; show_query = :sql)
+  @test occursin("ON CONFLICT (\"code\", \"family_name\") DO NOTHING", sql_multi)
+
+  # defaults are OPTIONAL for get_or_create (unlike update_or_create) — pure get-or-create renders fine.
+  sql_nodef = GocPg.objects.get_or_create("code" => "HAM"; show_query = :sql)
+  @test occursin("ON CONFLICT (\"code\") DO NOTHING", sql_nodef)
+end
+
+@testset "get_or_create SQLite avoids RETURNING" begin
+  sql = GocSl.objects.get_or_create("code" => "HAM"; defaults = ["surname" => "Hamilton"], show_query = :sql)
+  @test occursin("ON CONFLICT (\"code\") DO NOTHING", sql)
+  @test !occursin("RETURNING", sql)
+  @test !occursin("DO UPDATE", sql)
+end
+
+@testset "get_or_create validation errors" begin
+  @test occursin("at least one lookup pair",
+    _p208_error(() -> GocPg.objects.get_or_create(; defaults = ["surname" => "x"], show_query = :dict)))
+  @test occursin("must be a `field => value` pair",
+    _p208_error(() -> GocPg.objects.get_or_create("code"; show_query = :dict)))
+  @test occursin("lookup field nope is not a field",
+    _p208_error(() -> GocPg.objects.get_or_create("nope" => 1; show_query = :dict)))
+  @test occursin("defaults field nope is not a field",
+    _p208_error(() -> GocPg.objects.get_or_create("code" => "x"; defaults = ["nope" => 1], show_query = :dict)))
+  @test occursin("appear in both lookup and defaults",
+    _p208_error(() -> GocPg.objects.get_or_create("code" => "x"; defaults = ["code" => "y"], show_query = :dict)))
+  @test occursin("duplicate lookup field",
+    _p208_error(() -> GocPg.objects.get_or_create("code" => "x", "code" => "y"; show_query = :dict)))
+  # Error messages are attributed to get_or_create, not update_or_create.
+  @test occursin("Error in get_or_create",
+    _p208_error(() -> GocPg.objects.get_or_create("nope" => 1; show_query = :dict)))
+end
+
+@testset "last() inverts ordering and falls back to primary key" begin
+  # Explicit ASC ordering → last() renders DESC + LIMIT 1.
+  q = GocPg.objects
+  q.order_by("points")
+  sql = q.last(show_query = :sql)
+  @test occursin("DESC", sql)
+  @test occursin("LIMIT 1", sql)
+
+  # Explicit DESC ordering ("-points") → last() renders ASC.
+  q2 = GocPg.objects
+  q2.order_by("-points")
+  @test occursin("ASC", q2.last(show_query = :sql))
+
+  # No ordering → falls back to primary-key DESC so last() is well-defined (Django parity).
+  sql_pk = GocPg.objects.last(show_query = :sql)
+  @test occursin("\"id\" DESC", sql_pk)
+  @test occursin("LIMIT 1", sql_pk)
+
+  # NULLS placement must invert together with the direction: ASC NULLS FIRST → DESC NULLS LAST.
+  # (Guards the _invert_order! bug where two sequential `&&` swaps left :first unchanged.)
+  qn = GocPg.objects
+  qn.order_by(SQLOrder(SQLField("points", "points"); orientation = "ASC", nulls = :first))
+  sqln = qn.last(show_query = :sql)
+  @test occursin("DESC", sqln)
+  @test occursin("NULLS LAST", sqln)
+  @test !occursin("NULLS FIRST", sqln)
+
+  # last() does NOT leak its ordering flip / limit into the caller's handler (#199 copy-first).
+  q3 = GocPg.objects
+  q3.order_by("points")
+  q3.last(show_query = :sql)
+  @test isempty(q3.object.filter)          # untouched
+  @test q3.object.limit == 0               # limit(1) applied only to the internal copy
+  @test length(q3.object.order) == 1 && q3.object.order[1].orientation == "ASC"  # still ASC
+end
+
+@testset "aggregate() renders a whole-queryset aggregate with no GROUP BY" begin
+  sql = GocPg.objects.aggregate("total" => Sum("points"), "n" => Count("id"), show_query = :sql)
+  @test occursin("SUM(", sql)
+  @test occursin("COUNT(", sql)
+  @test occursin("total", sql) && occursin("n", sql)   # aliases present
+  @test !occursin("GROUP BY", sql)                     # whole-queryset: no grouping
+end
+
+@testset "aggregate() validation errors" begin
+  @test occursin("requires at least one",
+    _p208_error(() -> GocPg.objects.aggregate(show_query = :dict)))
+  # A non-aggregate value is rejected (would otherwise return N rows, not one scalar row).
+  @test occursin("must be an aggregate function",
+    _p208_error(() -> GocPg.objects.aggregate("x" => 5, show_query = :dict)))
+  # Refuses to silently discard values() grouping columns.
+  qv = GocPg.objects
+  qv.values("code")
+  @test occursin("cannot combine with values() grouping",
+    _p208_error(() -> qv.aggregate("total" => Sum("points"), show_query = :dict)))
+end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -115,6 +115,17 @@ const EXPECTED_FUNCTIONS = Set([
         @test hasmethod(first, Tuple{PormG.QueryBuilder.SQLObjectHandler})
     end
 
+    # Same contract for Base.last (#208): last() mirrors first() and is allowed to extend Base.last
+    # ONLY through the typed `last(::SQLObjectHandler; …)` method (nargs==2). A nullary kwargs-only
+    # method would be the same global piracy the #200 guard above forbids for first.
+    @testset "no Base.last type piracy — nullary kwargs method (#208)" begin
+        pormg_nullary_last = filter(methods(last)) do m
+            occursin("PormG", string(parentmodule(m))) && m.nargs == 1
+        end
+        @test isempty(pormg_nullary_last)
+        @test hasmethod(last, Tuple{PormG.QueryBuilder.SQLObjectHandler})
+    end
+
     # `close_pool!` was exported by BOTH Configuration and ConnectionPool as *different*
     # functions, which made `PormG.close_pool!` ambiguous (undefined). The dedup leaves
     # Configuration's full-featured version (pool OR db-name String) as the single one.


### PR DESCRIPTION
Closes #208.

Adds the four small, **additive, non-breaking** fluent-surface terminals the pre-publish audit flagged as things Django users reach for early. Each is a thin terminal over existing machinery — no new subsystems.

## What's new

| Terminal | Behavior |
|---|---|
| `get_or_create(lookup...; defaults=())` | Django's **SELECT-first** match-or-insert → `(row, created)`; **never updates a match**. Create path uses `INSERT … ON CONFLICT (lookup) DO NOTHING` as a concurrency guard, so a non-unique lookup raises an actionable error. `defaults` are optional create-only extras. |
| `last()` | Mirrors `first()` with inverted ordering (direction **and** NULLS); falls back to **primary-key DESC** when no `order_by` is set. |
| `earliest(fields...)` / `latest(fields...)` | Order by an explicit field; **raise `DoesNotExist`** on empty (Django parity, unlike `first`/`last`). |
| `aggregate("alias" => Sum(...), ...)` | Whole-queryset aggregation, no `GROUP BY` → single-row **`NamedTuple`**; errors rather than silently discard `values()` grouping. |
| `row.delete()` | Deletes a fetched `PormGRow` through the **same `DeletionCollector`** as `query.delete()` — cascade/`on_delete` parity. |

## Design note — get_or_create is SELECT-first

The initial plan was an atomic single-statement `INSERT … ON CONFLICT`, but that requires **all** NOT NULL columns even on a *hit* (`get_or_create("statusid"=>x)` failed when the row already existed) — a Django-incompatibility that defeats the "first impressions" goal of #208. Switched to Django's own algorithm: **get() first, create only on a miss**, with `ON CONFLICT DO NOTHING` guarding the create path against concurrent inserts (race-safe). A matching row is returned even when non-lookup columns aren't supplied.

## Tests (all green, both backends)

- **Unit** (`test/unit/test_fluent_parity_208.jl`, DB-free): SQL rendering + validation, incl. a NULLS-inversion assertion for `last()`.
- **Integration** (`test/integration/test_fluent_parity_208.jl`): PostgreSQL (`db_2`) and SQLite (`db_sl`) — created flag, no-update-on-hit, unique-constraint error, extreme-row correctness, aggregate values vs. raw scan, row.delete cascade. Ordering asserted only on numeric columns (PG locale ≠ SQLite BINARY).
- Existing `test_update_or_create` and `test_public_exports` still pass; added a `Base.last` piracy guard mirroring `first`'s.

## Notes

- All terminals are **fluent-only** (no new exports) — consistent with `update_or_create`.
- Refreshes the stale `update_or_create` "no-update get-or-create is a planned follow-up (#30)" message now that `get_or_create` exists.
- Docs updated: `write/create.md` (get_or_create), `write/delete.md` + `write/index.md` (row.delete), `read/index.md` + `api.md` (new terminals), `read/filters_and_aggregates.md` (aggregate + first/last/earliest/latest). Docs build passes.
- Additive/non-breaking → **no `Project.toml` bump** (release-train rule); no `UPGRADING.md` migration entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)