### PR TITLE
chore(release): pin the tag convention to annotated v-prefixed tags

### DIFF
--- a/.github/skills/pormg-cut-release/SKILL.md
+++ b/.github/skills/pormg-cut-release/SKILL.md
@@ -55,8 +55,18 @@ outside this skill.
 6. **Commit** (respect the commit gate — show the diff, get explicit approval):
    `chore(release): cut <new>` with the entry titles in the body.
 
-7. **Tag** (confirm first — tagging/pushing is a separate outward step):
-   `git tag <new>` (annotated, message = the release title). Push the tag with the branch/PR.
+7. **Tag** (confirm first — tagging/pushing is a separate outward step). Tag the commit on `main`
+   that carries the new `Project.toml` version — the merge commit of the release PR, not the branch
+   commit:
+   `git tag -a v<new> <sha> -m "PormG v<new>"` + the entry titles in the body, then
+   `git push origin v<new>` (a plain `git push` does **not** carry tags).
+
+   The **`v` prefix is required**: once PormG is registered in General, `JuliaRegistries/TagBot`
+   (already wired in `.github/workflows/TagBot.yml`) takes over tagging and emits `vX.Y.Z`. Matching
+   it now keeps one continuous series instead of two parallel ones. Pre-publish, TagBot never fires —
+   nothing comments as `JuliaTagBot` — so tags are manual until then. Tag history starts at `v0.3.0`;
+   earlier versions are deliberately untagged (per-PR bumps, and `0.3.0`–`0.3.3` were burned and
+   reclaimed before the release-train policy landed).
 
 8. **Roll it out.** The reason you cut: work each consuming app through the newly-stamped entries
    (`PormG.upgrade_guide(from = v"<app's pinned version>")`), then bump that app's PormG dependency


### PR DESCRIPTION
## Why

The cut-release skill's step 7 said `git tag <new>` and nothing else. The result: **no version tag has ever existed in this repo.** 0.2.0 through 0.3.0 were all cut and rolled out untagged — the only tag on `origin` was `stable-pre-big-update`.

`v0.3.0` has now been tagged manually at `b96ecae` (the merge commit of #242, where `Project.toml` first reads `0.3.0` on `main`). This PR fixes the skill so the next train doesn't repeat the miss.

## What changed

`.github/skills/pormg-cut-release/SKILL.md` step 7 only:

- **`v` prefix.** `JuliaRegistries/TagBot` is already wired in `.github/workflows/TagBot.yml` and emits `vX.Y.Z` once PormG is registered in General. Tagging bare `0.3.0` now would start a second, parallel series that never reconciles.
- **Annotated + explicit push.** `git tag -a` (real object with tagger/date/message), and a spelled-out `git push origin v<new>` — a plain `git push` does not carry tags, which is a reliable way to think you've tagged when you haven't.
- **Which commit.** The merge commit on `main` carrying the bumped `Project.toml`, not the release-branch commit.
- **Why the series starts at v0.3.0.** Recorded inline so a future cut doesn't try to backfill: 0.2.1–0.2.3 were per-PR bumps under the old policy, and 0.3.0–0.3.3 were burned and then reclaimed by `a816518` when release trains landed — two different commits have claimed `0.3.0`, so tagging them would be actively ambiguous.

## Notes

Skill-only; no `src/` or test changes, so no `UPGRADING.md` entry (nothing user-facing changed). Registration is unaffected either way — Registrator reads `Project.toml` at a commit and records a tree hash, never tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)