### PR TITLE
fix(upgrade_guide): stop leaking the Unreleased sentinel and the release marker

### DIFF
--- a/.github/skills/pormg-cut-release/SKILL.md
+++ b/.github/skills/pormg-cut-release/SKILL.md
@@ -46,6 +46,16 @@ outside this skill.
      `## <new> — <YYYY-MM-DD>`.
    - Insert a **fresh empty** `## Unreleased — next \`<next-y>\`` block at the very top of the entries
      (above the just-stamped section), carrying the same placeholder note the previous one had.
+   - **Sweep the prose.** Stamping the `- **Version**:` bullet does *not* fix an entry **body** that
+     refers to itself as unreleased. Grep the just-stamped section for `Unreleased` and rewrite every
+     prose hit — "Part of the current `## Unreleased` wave … when the train is cut" is false the
+     moment it ships, and points readers at a section that is now empty:
+     ```bash
+     awk '/^## <new> —/,/^## [0-9]/' UPGRADING.md | grep -n 'Unreleased'   # expect: no prose hits
+     ```
+     Prefer version-neutral phrasing when *writing* an entry (`Part of the `<y>.x` pre-publish wave —
+     roll it forward with the other `<y>.*` entries`) so there is nothing to sweep. Caught in #201,
+     which shipped in 0.3.0 still telling apps to wait for a cut that had already happened.
    - Leave already-stamped (older) entries untouched.
 
 5. **Verify the parser.** Run `julia --project=. test/unit/test_upgrade_guide.jl` (via a runner that

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -191,9 +191,11 @@ default_env: dev
 # If you relied on load() creating the skeleton, be explicit:
 PormG.Configuration.load("db"; scaffold=true)      # or: PormG.setup("db")
 
-# A catch that keyed on the old per-op write message → match the type + the new stable phrase:
+# A catch that keyed on the old per-op write message → match the TYPE. #231 (same 0.3.0 train)
+# retyped this error to `PormG.PermissionError`, which is deliberately NOT <: ArgumentError —
+# so an `e isa ArgumentError` catch here would silently stop matching. No message check needed.
 catch e
-    e isa ArgumentError && occursin("not allowed to write", e.msg) && handle()
+    e isa PormG.PermissionError && handle()
 ```
 
 The recommended server pattern is unchanged and preferred: let the host resolve its environment and
@@ -209,8 +211,7 @@ environments. `default_env:` is a convenience for scripts/single-env apps.
   `src/PormG.jl` exports, `docs/src/{api,many_to_many,import_django}.md`
 - **Recorded**: 2026-07-24
 - **Severity**: **breaking (renames)** — pre-publish naming pass; every rename is old-name-gone, no aliases.
-  Part of the current `## Unreleased` wave: roll an app forward by applying **all** Unreleased entries
-  together when the train is cut.
+  Part of the `0.3.x` pre-publish wave — roll it forward together with the other `0.3.*` entries.
 
 ### What changed
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -173,7 +173,20 @@ const _UNSTAMPED_VERSION = v"0.2.0-"
 # `/pormg-cut-release` command later rewrites `Unreleased` to the assigned release number.
 const _UNRELEASED_VERSION = v"1000000.0.0"
 
+# `_UNRELEASED_VERSION` is an internal sort key, never a user-facing version. Render it as the
+# literal `UPGRADING.md` token so output reads "0.3.0 → Unreleased" and not "0.3.0 → 1000000.0.0".
+_version_label(v::VersionNumber) = v == _UNRELEASED_VERSION ? "Unreleased" : string(v)
+
 const _UpgradeEntry = @NamedTuple{version::VersionNumber, title::String, body::String}
+
+# A release marker heading — `## 0.3.0 — 2026-07-24` or `## Unreleased — next \`0.4.0\``, both
+# written by `/pormg-cut-release`. It groups the entries of one release; it is NOT an entry title.
+#
+# The em-dash separator is REQUIRED, not decoration: without it this also matches a real entry whose
+# title merely starts with a version (`## 0.5.0 config format is now strict`), and the parser then
+# finds no other `##` in that block and drops the entry SILENTLY — it just disappears from the
+# guide. Both forms `/pormg-cut-release` writes carry the separator, so requiring it costs nothing.
+const _RELEASE_MARKER = r"^(?:Unreleased|\d+\.\d+\.\d+)\s+—"
 
 _asver(v::VersionNumber) = v
 _asver(v::AbstractString) = VersionNumber(v)
@@ -214,9 +227,20 @@ function _parse_upgrading(text::AbstractString)
 
     entries = _UpgradeEntry[]
     for block in split(text, r"(?m)^---[ \t]*$")
-        # A real change entry has a `## ` heading AND a `- **Recorded**:` bullet — this rejects
-        # the header/recipe prose and any stray section, regardless of `---` placement.
-        title_m = match(r"(?m)^##[ \t]+(.+)$", block)
+        # `/pormg-cut-release` writes the release marker (`## 0.3.0 — 2026-07-24`) directly above
+        # the first entry of that release with NO `---` between them, so the first `##` in a block
+        # is not necessarily the entry's own heading. Take the first non-marker heading instead —
+        # otherwise the first entry of every release is titled with the release date and its real
+        # title is lost (visible via `structured = true`).
+        title_m = nothing
+        for h in eachmatch(r"(?m)^##[ \t]+(.+)$", block)
+            occursin(_RELEASE_MARKER, strip(h[1])) && continue
+            title_m = h
+            break
+        end
+
+        # A real change entry has a non-marker `## ` heading AND a `- **Recorded**:` bullet — this
+        # rejects the header/recipe prose and any stray section, regardless of `---` placement.
         (title_m === nothing || !occursin(r"(?m)^-[ \t]+\*\*Recorded\*\*:", block)) && continue
 
         ver_m = match(r"(?m)^-[ \t]+\*\*Version\*\*:[ \t]*(\S+)", block)
@@ -224,9 +248,14 @@ function _parse_upgrading(text::AbstractString)
                   ver_m[1] == "Unreleased" ? _UNRELEASED_VERSION :
                                              VersionNumber(ver_m[1])
 
+        # Start the body at the entry's own heading. This drops a leading release marker, so every
+        # entry renders identically — previously only the first entry of a release carried the
+        # `## <ver> — <date>` line, making later entries from *other* releases look like they
+        # belonged to it. Each entry states its own `- **Version**:`, so nothing is lost.
+        body = block[title_m.offset:end]
+
         # Trim the internal per-app rollout table (which of PormG's own apps adopted it) —
         # noise for a consuming app, which only needs the porting work.
-        body = block
         roll = findfirst("### Per-app rollout", body)
         roll === nothing || (body = body[1:prevind(body, first(roll))])
 
@@ -281,11 +310,11 @@ function upgrade_guide(io::IO = stdout; from = nothing, to = _UNRELEASED_VERSION
     structured && return entries
 
     if isempty(entries)
-        println(io, "# PormG: nothing to port between $from_v and $to_v.")
+        println(io, "# PormG: nothing to port between $(_version_label(from_v)) and $(_version_label(to_v)).")
         return nothing
     end
 
-    println(io, "# Porting a PormG consumer from $from_v → $to_v")
+    println(io, "# Porting a PormG consumer from $(_version_label(from_v)) → $(_version_label(to_v))")
     println(io, "# Work newest-first; for each entry run its \"How to find the calls to migrate\"")
     println(io, "# grep, apply before → after, then run your app's tests.")
     for e in entries

--- a/test/unit/test_upgrade_guide.jl
+++ b/test/unit/test_upgrade_guide.jl
@@ -94,6 +94,25 @@ using PormG
         @test occursin("nothing to port", out)
     end
 
+    # `to` defaults to _UNRELEASED_VERSION — an internal sort key (v"1000000.0.0"), not a real
+    # version. It must render as the literal "Unreleased" token on BOTH output paths; leaking the
+    # raw sentinel reads as a bug to the consumer running the command.
+    @testset "printed guide: the Unreleased sentinel never reaches output" begin
+        # populated path — the scope header, with `to` defaulted
+        full = sprint(io -> PormG.upgrade_guide(io; from = v"0.1.0"))
+        @test occursin("→ Unreleased", full)
+        @test !occursin("1000000", full)
+
+        # empty path — from == to == sentinel is an empty range by construction
+        empty = sprint(io -> PormG.upgrade_guide(io; from = PormG._UNRELEASED_VERSION))
+        @test occursin("nothing to port between Unreleased and Unreleased.", empty)
+        @test !occursin("1000000", empty)
+
+        # a real version still renders normally — the label must not swallow ordinary versions
+        real = sprint(io -> PormG.upgrade_guide(io; from = v"0.1.0", to = v"0.2.0"))
+        @test occursin("0.1.0 → 0.2.0", real)
+    end
+
     # ── argument handling ──────────────────────────────────────────────────────
     @testset "from is required" begin
         @test_throws ArgumentError PormG.upgrade_guide()
@@ -146,5 +165,62 @@ using PormG
                   filter(e -> v"0.1.0" < e.version <= PormG._UNRELEASED_VERSION, parsed))
         @test !any(e -> occursin("(#9001)", e.title),
                    filter(e -> v"0.1.0" < e.version <= v"0.2.0", parsed))
+    end
+
+    # ── `/pormg-cut-release` writes the release marker (`## 0.8.0 — <date>`) directly above the
+    #    FIRST entry of that release with no `---` between them, so the block's first `##` is the
+    #    marker, not the entry heading. Hand-fed so the test does not depend on which releases the
+    #    live file happens to contain. ──────────────────────────────────────────────────────────
+    @testset "release-marker heading is not mistaken for the entry title" begin
+        text = "# UPGRADING (fixture)\n\n---\n\n" *
+               "## Unreleased — next `0.9.0`\n\n" *
+               "## An uncut change (#9101)\n\n" *
+               "- **Version**: Unreleased\n- **Recorded**: 2026-02-02\n\nUncut body.\n\n---\n\n" *
+               "## 0.8.0 — 2026-01-15\n\n" *
+               "## First entry of the release (#9100)\n\n" *
+               "- **Version**: 0.8.0\n- **Recorded**: 2026-01-15\n\nFirst body.\n\n---\n\n" *
+               "## Second entry of the same release (#9099)\n\n" *
+               "- **Version**: 0.8.0\n- **Recorded**: 2026-01-14\n\nSecond body.\n"
+        parsed = PormG._parse_upgrading(text)
+        @test length(parsed) == 3
+
+        # the title is the entry's OWN heading — never the release marker above it
+        @test parsed[1].title == "An uncut change (#9101)"
+        @test parsed[2].title == "First entry of the release (#9100)"
+        @test parsed[3].title == "Second entry of the same release (#9099)"
+
+        # the version still comes from the `- **Version**:` bullet, not the marker's date
+        @test parsed[1].version == PormG._UNRELEASED_VERSION
+        @test parsed[2].version == v"0.8.0"
+
+        # the marker is stripped from the body so entries render uniformly: without this, only the
+        # first entry of a release carries a `## <ver> — <date>` line and later entries from OTHER
+        # releases read as if they belonged to it.
+        @test startswith(parsed[2].body, "## First entry of the release (#9100)")
+        @test !occursin("## 0.8.0 — 2026-01-15", parsed[2].body)
+        @test !occursin("## Unreleased — next", parsed[1].body)
+        @test occursin("First body.", parsed[2].body)   # the entry's own content still survives
+    end
+
+    # A marker is recognized by the `<token> — ` shape, NOT by "starts with a version". Without the
+    # em-dash requirement a real entry titled `## 0.5.0 config format …` is skipped as a marker, the
+    # block then has no other `##`, and the entry is dropped SILENTLY — no error, it just vanishes
+    # from every guide that should have listed it. That is the worst failure mode this parser has.
+    @testset "an entry whose title starts with a version is NOT treated as a marker" begin
+        text = "# fixture\n\n---\n\n" *
+               "## 0.5.0 config format is now strict (#9200)\n\n" *
+               "- **Version**: 0.5.0\n- **Recorded**: 2026-03-03\n\nImportant body.\n"
+        parsed = PormG._parse_upgrading(text)
+        @test length(parsed) == 1                                        # not swallowed
+        @test parsed[1].title == "0.5.0 config format is now strict (#9200)"
+        @test parsed[1].version == v"0.5.0"
+        @test occursin("Important body.", parsed[1].body)
+
+        # …while a genuine marker sharing a block with its first entry is still stripped.
+        marked = PormG._parse_upgrading(
+            "# fixture\n\n---\n\n## 0.5.0 — 2026-03-03\n\n## A real change (#9201)\n\n" *
+            "- **Version**: 0.5.0\n- **Recorded**: 2026-03-03\n\nBody.\n")
+        @test length(marked) == 1
+        @test marked[1].title == "A real change (#9201)"
     end
 end


### PR DESCRIPTION
## Why

Running the documented command surfaced three defects in the `UPGRADING.md` emitter — all user-visible, one of which can silently drop an entry.

## 1 — The `Unreleased` sentinel reached the output

`to` defaults to `_UNRELEASED_VERSION` (`v"1000000.0.0"`), an internal sort key, and both printed paths interpolated it raw:

```
# PormG: nothing to port between 0.3.0 and 1000000.0.0.
# Porting a PormG consumer from 0.2.3 → 1000000.0.0
```

The header path is the worse one — it hits every HEAD consumer with pending entries. Now:

```
# Porting a PormG consumer from 0.2.3 → Unreleased
```

## 2 — The release marker was parsed as the entry title

`/pormg-cut-release` writes `## 0.3.0 — 2026-07-24` directly above the first entry of that release with **no `---` between them**, so both land in one block and the block's first `##` is the marker. Two symptoms:

- `structured = true` returned `"0.3.0 — 2026-07-24"` as the **title of the #231 entry**; its real title was lost. Any programmatic consumer got that.
- The marker printed above only the *first* entry of a release. The `#199` entry is **0.2.3**, but got no heading of its own — so it read as though it belonged to 0.3.0.

Title selection now skips markers, and the body starts at the entry's own heading. Every entry renders identically; each still states its own `- **Version**:`.

## 3 — The marker pattern was too loose (silent entry loss)

`^(?:Unreleased|\d+\.\d+\.\d+)\b` also matches a real entry whose title merely *starts* with a version. Caught in review:

```julia
"## 0.5.0 config format is now strict (#9200)"  →  entries parsed: 0
```

The heading is skipped as a marker, the block has no other `##`, and the entry is dropped **silently** — no error, it just never appears in any guide. Requiring the `—` separator that both real marker forms carry removes the risk at no cost.

## Also — two `UPGRADING.md` content bugs this surfaced

- **#205's migration snippet was wrong.** It still prescribed `e isa ArgumentError && occursin("not allowed to write", e.msg)`, but #231 (same 0.3.0 train) retyped that error to `PormG.PermissionError`, deliberately **not** `<: ArgumentError`. An app applying #205 literally writes a catch that matches nothing — silently, since a catch that never fires doesn't error. Only #231's cross-reference saved a reader working newest-first.
- **#201 shipped stale.** It went out in 0.3.0 still saying *"Part of the current `## Unreleased` wave … when the train is cut"* — pointing at a section that is now empty, and at a cut that already happened. Root cause: `/pormg-cut-release` stamps the `- **Version**:` bullet and the heading, never prose. Added a **Sweep the prose** step with an inline check, plus guidance to prefer version-neutral phrasing when *writing* entries so there's nothing to sweep.

## Verification

Tests **38 → 54**. Each new assertion fails if its fix is reverted — `!occursin("1000000", …)` on both output paths, the title/`startswith` assertions for the marker, and the swallow case. The parser tests are hand-fed rather than reading the live file, so they won't rot when a train empties `## Unreleased`.

Real `UPGRADING.md` still parses **21 entries** with no marker-shaped titles.

No `UPGRADING.md` entry for the fix itself: display/parse corrections, no API or contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)