### PR TITLE
docs: collapse sidebar sections and group loose pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,10 +25,12 @@ makedocs(
     
     pages = [
         "Home" => "index.md",
-        "Models" => "models.md",
-        "Fields" => "fields.md",
-        "Schema Conventions" => "schema_conventions.md",
-        "Many-to-Many" => "many_to_many.md",
+        "Data Modeling" => [
+            "Models" => "models.md",
+            "Fields" => "fields.md",
+            "Schema Conventions" => "schema_conventions.md",
+            "Many-to-Many" => "many_to_many.md",
+        ],
         "Configuration" => [
             "Overview" => "configuration/index.md",
             "Setup" => "configuration/setup.md",
@@ -36,7 +38,7 @@ makedocs(
             "Server Patterns" => "configuration/server.md",
             "Dynamic & Multi-Tenancy" => "configuration/dynamic.md",
             "Advanced" => "configuration/advanced.md",
-        ],        
+        ],
         "Migrations" => [
             "Overview" => "migrations/index.md",
             "Workflow" => "migrations/workflow.md",
@@ -62,14 +64,17 @@ makedocs(
             "Window Functions" => "read/window_functions.md",
             "Q Objects" => "read/q_objects.md",
         ],
-        "Import from Django" => "import_django.md",
-
-        "PostgreSQL Guide" => "postgres.md",
-        "Async & Concurrency" => "async.md",
-        "Architecture" => "architecture.md",
-        "Advisory Locks" => "advisory_lock.md",
-        "Extending PormG" => "extending.md",
-        "Contributing" => "contributing.md",
+        "Guides" => [
+            "PostgreSQL Guide" => "postgres.md",
+            "Async & Concurrency" => "async.md",
+            "Advisory Locks" => "advisory_lock.md",
+            "Import from Django" => "import_django.md",
+        ],
+        "Internals" => [
+            "Architecture" => "architecture.md",
+            "Extending PormG" => "extending.md",
+            "Contributing" => "contributing.md",
+        ],
         "API" => "api.md"
     ],
     
@@ -81,6 +86,12 @@ makedocs(
         # Canonical: Defines the official URL for Google to avoid duplicate content
         canonical = "https://pingolee.github.io/PormG.jl",
         
+        # collapselevel = 1: every top-level section (Configuration, Migrations, Reading, ...)
+        # renders as a collapsed, chevron-toggled group instead of dumping all ~30 child pages
+        # into the sidebar at once. Documenter auto-expands the section containing the current
+        # page, so navigation stays one click deep.
+        collapselevel = 1,
+
         assets = String[],
         size_threshold = 600 * 1024, # api.md is one comprehensive auto-generated page (~340 KiB); headroom for growth
     ),


### PR DESCRIPTION
## Problem

The Documenter sidebar rendered **every** section fully expanded at once — Documenter's default `collapselevel = 2` only collapses *second*-level groups, so `Configuration`, `Migrations`, `Writing` and `Reading` dumped all ~30 child pages into the sidebar on every page. Six ungrouped pages (PostgreSQL Guide, Async, Architecture, Advisory Locks, Extending, Contributing) trailed below them.

## Changes

Both in `docs/make.jl`:

1. **`collapselevel = 1`** — top-level sections render as chevron-toggled groups, collapsed by default. Documenter auto-expands the section containing the current page (`configuration/setup.html` renders `menuitem-3` with `checked`), so navigation stays one click deep.
2. **Grouped the loose pages** so the collapsed top level is short and scannable:
   - `Data Modeling` ← Models, Fields, Schema Conventions, Many-to-Many
   - `Guides` ← PostgreSQL Guide, Async & Concurrency, Advisory Locks, Import from Django
   - `Internals` ← Architecture, Extending PormG, Contributing

Top level goes from 12 rows + 25 always-open children to 9 collapsible rows:

```
Home · Data Modeling ▸ · Configuration ▸ · Migrations ▸ · Writing ▸
Reading ▸ · Guides ▸ · Internals ▸ · API
```

**Page URLs are unchanged** — only sidebar nesting and breadcrumbs move, so no links break.

## Verification

Full docs build green (`julia --project=docs … include("docs/make.jl")`, exit 0) with only the two pre-existing size warnings (`api.md`, search index). Built sidebar HTML inspected: all eight groups render `ul.collapsed` with a `collapse-toggle` checkbox; the active section auto-expands.

No API or behavior change for consuming apps, so no `UPGRADING.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)