### PR TITLE
refactor: extract PormG.Kernel — declare the core layer

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -58,10 +58,15 @@ Cross-cutting changes: public-API skill + the most specific subsystem skill. Rev
 
 The subsystem map below is also the review **architecture checkpoint**: when a new subsystem file appears in `src/` that is not listed here, flag it and add it.
 
+**Layering (enforced by include order in `src/PormG.jl`).** `Kernel` is layer 1 and imports nothing from `PormG`; `Backend.jl` is layer 2 (behavior `PormG` must own — see below); the submodules are layer 3; `tools.jl` is layer 4. Shared vocabulary — an abstract type, a constant, an exception type — belongs in `Kernel`, **not** part-way down the chain, or the submodules included before it cannot name it. That is not hypothetical: the #231 error taxonomy was defined at include step 11, which is why `Models`/`Configuration`/`Dialect` could not use a single one of its types (#239).
+
+`Backend.jl` stays in `PormG` on purpose. The weakdep extensions define `PormG.backend_execute(…) = …`, and Julia only accepts a qualified method definition on the module that *owns* the binding — moving those generics into `Kernel` breaks every extension method, and it fails at `using LibPQ` / `using SQLite`, not at `using PormG`, so precompiling the package does not catch it. **Kernel holds the nouns; `PormG` keeps the verbs.**
+
 | Path | Role |
 |------|------|
-| `src/PormG.jl` | Package root (config, models, QueryBuilder, dialects, migrations) |
-| `src/Configuration.jl`, `src/constants.jl` | Config, `DB_PATH`, `PORMG_ENV`, transactions |
+| `src/PormG.jl` | Package root — include chain and the public `export` surface |
+| `src/Kernel.jl`, `src/constants.jl` | Layer 1: shared vocabulary — abstract types, constants, `PormGError` root, `_emsg`, `config`. Imports nothing from `PormG` |
+| `src/Configuration.jl` | Config, `DB_PATH`, `PORMG_ENV`, transactions |
 | `src/ConnectionPool.jl` | `fetch`, pool lock, transaction context (driver-agnostic; untyped connection storage) |
 | `src/Backend.jl`, `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl` | Backend interface: `backend_*` generics + friendly fallbacks; driver bodies live in the weakdep extensions (`LibPQ`/`SQLite`). Core never names a concrete driver type |
 | `src/Models.jl`, `src/models/` | Models and fields |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(
     
     modules = [
         PormG,
+        PormG.Kernel,
         PormG.Functions,
         PormG.QueryBuilder,
         PormG.Models,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -769,6 +769,7 @@ The following section contains auto-generated documentation from docstrings in t
 ```@autodocs
 Modules = [
     PormG,
+    PormG.Kernel,
     PormG.Functions,
     PormG.QueryBuilder,
     PormG.Models,

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -1,0 +1,175 @@
+"""
+    PormG.Kernel
+
+**Layer 1 — the shared vocabulary.** Everything in here is a *noun*: abstract types, constants,
+the error taxonomy root, and the two dependency-free helpers (`_emsg`, `config`) that the rest of
+the package needs before it can define anything of its own.
+
+## The invariant
+
+`Kernel` imports **nothing** from `PormG`. Every other submodule may import from `Kernel`, and
+`Kernel` is included first, so "may I use this name?" stops depending on where a file happens to sit
+in `PormG.jl`'s include chain.
+
+That ordering used to be implicit, and it bit: the `#231` error taxonomy was defined in
+`src/querybuilder/exceptions.jl` (included at step 11), so `Models`, `Configuration`, `Dialect` and
+`ConnectionPool` — all included earlier — could not name a single one of its types. Each submodule
+resolves `import PormG: …` at include time, so "defined later in the module body" means "does not
+exist yet".
+
+## What does NOT belong here
+
+**Behavior.** In particular `Backend.jl` stays in `PormG`, even though it looks like core: the weakdep
+extensions define their methods as `PormG.backend_execute(…) = …`, and Julia only accepts a qualified
+method definition on the module that *owns* the binding. Moving those generics here would break every
+extension method with `function Kernel.backend_execute must be explicitly imported to be extended` —
+and it would fail at `using LibPQ` / `using SQLite`, not at `using PormG`, so precompiling the package
+would not catch it. The generics dispatch on the `PormGPostgres` / `PormGSQLite` markers defined below,
+which works fine from where they are.
+
+Rule of thumb: **Kernel holds the nouns, `PormG` keeps the verbs.**
+"""
+module Kernel
+
+#═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Type hierarchy
+#═══════════════════════════════════════════════════════════════════════════════
+
+abstract type PormGAbstractType end
+abstract type PormGSettings <: PormGAbstractType end
+# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: PormGSettings —
+# PormGSettings is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
+# PostgresConnectionPool <: PormGPostgres and SQLiteConnectionPool <: PormGSQLite.
+abstract type PormGBackend <: PormGAbstractType end
+abstract type PormGPostgres <: PormGBackend end
+abstract type PormGSQLite <: PormGBackend end
+abstract type AbstractPormGParam <: PormGAbstractType end  # Base type for all parameterized queries
+abstract type PormGPostgresParam <: AbstractPormGParam end  # PostgreSQL numbered params ($1, $2...)
+abstract type PormGSQLiteParam <: AbstractPormGParam end    # SQLite positional params with contextual buckets
+abstract type SQLObject <: PormGAbstractType end
+abstract type SQLObjectHandler <: SQLObject end
+abstract type SQLTableAlias <: SQLObject end # Manage the name from table alias
+abstract type SQLInstruction <: PormGAbstractType end # instruction to build a query
+abstract type SQLType <: PormGAbstractType end
+abstract type SQLTypeQ <: SQLType end
+abstract type SQLTypeQor <: SQLType end
+abstract type SQLTypeF <: SQLType end
+abstract type SQLTypeFunction <: SQLType end # Function to be used in the query
+abstract type SQLTypeOper <: SQLType end
+abstract type SQLTypeText <: SQLType end # raw texgt to be used in the query
+abstract type SQLTypeArrays <: SQLType end # Arrays to orgnize the query informations
+abstract type SQLTypeField <: SQLType end # Field to be used in the query (values, filters, etc)
+abstract type SQLTypeOrder <: SQLTypeField end # Order to be used in the query
+abstract type SQLTypeCTE <: SQLType end # Common Table Expression (WITH clause)
+
+
+abstract type PormGModel <: PormGAbstractType end
+# A field is a COMPONENT of a model, not a kind of model — a sibling, not a subtype, so it does not
+# satisfy ::PormGModel signatures (which all read model-only attributes) (#186).
+abstract type PormGField <: PormGAbstractType end # define the type of the column from the model
+
+abstract type Migration <: PormGAbstractType end
+
+# Root of the semantic error taxonomy (#231). Subtypes <: Exception (NOT <: ArgumentError — a
+# clean break, so callers catch a type instead of string-matching a message). It lives in Kernel
+# precisely so every submodule can reach it and its concrete subtypes; see the module docstring
+# for why "defined later in PormG.jl" was not good enough. Extends the #197 typed-exception lineage.
+abstract type PormGError <: Exception end
+
+#═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Shared state
+#═══════════════════════════════════════════════════════════════════════════════
+
+const config::Dict{String,PormGSettings} = Dict()
+
+# Introspection/DDL constraint readers. Declared here as empty generics because `Dialect` and
+# `Migrations` both extend AND call them, so neither can own the binding.
+function get_constraints_pk end
+function get_constraints_unique end
+function get_constraints_check end
+
+#═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Error-message helper
+#═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _emsg(msg; color = (Base.have_color === true))
+
+TTY-aware error-message colorizer. Many PormG error strings embed ANSI SGR codes
+(`\\e[31m…\\e[0m`) to highlight the offending token in the REPL. Those codes are
+helpful on a color terminal but leak as raw `\\e[..m` noise into non-TTY sinks
+(CI output, file logs, `sprint(showerror, e)`, structured logging).
+
+`_emsg` keeps the codes when `color` is true and strips every `\\e[..m` sequence
+otherwise. The default tracks `Base.have_color` — the same flag Julia consults to
+colorize its own error displays, so it honors the `--color` flag and `NO_COLOR`.
+The `color` keyword exists so tests can exercise both branches deterministically.
+
+This is the single shared definition. It lives in `Kernel` rather than `tools.jl`
+because the error taxonomy's constructors call it, and the taxonomy has to be
+available to every submodule — see the `PormG.Kernel` docstring.
+"""
+_emsg(msg::AbstractString; color::Bool = (Base.have_color === true)) =
+  color ? String(msg) : replace(msg, r"\e\[[0-9;]*m" => "")
+
+"""
+    _emsg(io, msg)
+
+IO-aware variant of [`_emsg`](@ref) for use inside `show` / `print(io, …)` methods:
+it keeps ANSI only when the destination stream advertises color via its `:color`
+IOContext property. This is the correct signal for rendered output, because a
+non-color buffer (`sprint`, `repr`, a captured string, a file) must stay ANSI-free
+even when the process itself is attached to a color terminal.
+"""
+_emsg(io::IO, msg::AbstractString) = _emsg(msg; color = get(io, :color, false))
+
+#═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Constants
+#═══════════════════════════════════════════════════════════════════════════════
+
+include("constants.jl")
+
+#═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Exports
+#
+# Kernel exports its whole vocabulary — that is the module's entire purpose. `PormG` does
+# `using .Kernel`, which BINDS these names in `PormG` (so `PormG.PormGModel` keeps resolving)
+# without re-exporting them; `PormG`'s own `export` list stays the single definition of the
+# public surface. Underscore-private names are deliberately NOT exported and are imported
+# explicitly by the few places that need them.
+#═══════════════════════════════════════════════════════════════════════════════
+
+# Type hierarchy
+export PormGAbstractType, PormGSettings, PormGBackend, PormGPostgres, PormGSQLite,
+       AbstractPormGParam, PormGPostgresParam, PormGSQLiteParam,
+       SQLObject, SQLObjectHandler, SQLTableAlias, SQLInstruction,
+       SQLType, SQLTypeQ, SQLTypeQor, SQLTypeF, SQLTypeFunction, SQLTypeOper,
+       SQLTypeText, SQLTypeArrays, SQLTypeField, SQLTypeOrder, SQLTypeCTE,
+       PormGModel, PormGField, Migration, PormGError
+
+# Shared state / generics
+export config, get_constraints_pk, get_constraints_unique, get_constraints_check
+
+# Paths and file-name constants
+export DBDF_FOLDER_NAME, CONFIG_PATH, ENV_PATH, LOG_PATH, APP_PATH, RESOURCES_PATH,
+       TEST_PATH, DB_PATH, MODEL_PATH, MODEL_FILE, DBDF_PATH,
+       PORMG_DB_CONFIG_FILE_NAME, TEST_FILE_IDENTIFIER
+
+# Behavior constants
+export DEFAULT_POOL_TIMEOUT, LAST_INSERT_ID_LABEL, DATETIME_FORMAT, UTC_TIMEZONE,
+       reserved_words
+
+# Query-builder vocabulary
+export PormGsuffix, PormGtransform, PormGTypeField, JSON_CONTAINMENT_OPERATORS
+
+# Type maps and introspection ignore lists
+export sqlite_type_map, postgres_type_map, sqlite_type_map_reverse, postgres_type_map_reverse,
+       sqlite_date_format_map, sqlite_ignore_schema, postgres_ignore_table
+
+# on_delete handlers
+export CASCADE, RESTRICT, PROTECT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING
+
+# `register_ignore_tables!` is exported by constants.jl itself (it is part of the documented
+# downstream-extension surface), so it needs no re-listing here.
+
+end # module Kernel

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -36,67 +36,35 @@ import DataFrames, OrderedCollections, Dates, Logging, YAML
 # `Backend.jl`, whose methods live in `ext/PormGLibPQExt.jl` / `ext/PormGSQLiteExt.jl`
 # and load on `using LibPQ` / `using SQLite`.
 
-abstract type PormGAbstractType end
-abstract type PormGSettings <: PormGAbstractType end
-# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: PormGSettings —
-# PormGSettings is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
-# PostgresConnectionPool <: PormGPostgres and SQLiteConnectionPool <: PormGSQLite.
-abstract type PormGBackend <: PormGAbstractType end
-abstract type PormGPostgres <: PormGBackend end
-abstract type PormGSQLite <: PormGBackend end
-abstract type AbstractPormGParam <: PormGAbstractType end  # Base type for all parameterized queries
-abstract type PormGPostgresParam <: AbstractPormGParam end  # PostgreSQL numbered params ($1, $2...)
-abstract type PormGSQLiteParam <: AbstractPormGParam end    # SQLite positional params with contextual buckets
-abstract type SQLObject <: PormGAbstractType end
-abstract type SQLObjectHandler <: SQLObject end
-abstract type SQLTableAlias <: SQLObject end # Manage the name from table alias
-abstract type SQLInstruction <: PormGAbstractType end # instruction to build a query
-abstract type SQLType <: PormGAbstractType end
-abstract type SQLTypeQ <: SQLType end
-abstract type SQLTypeQor <: SQLType end
-abstract type SQLTypeF <: SQLType end
-abstract type SQLTypeFunction <: SQLType end # Function to be used in the query
-abstract type SQLTypeOper <: SQLType end
-abstract type SQLTypeText <: SQLType end # raw texgt to be used in the query
-abstract type SQLTypeArrays <: SQLType end # Arrays to orgnize the query informations 
-abstract type SQLTypeField <: SQLType end # Field to be used in the query (values, filters, etc)
-abstract type SQLTypeOrder <: SQLTypeField end # Order to be used in the query
-abstract type SQLTypeCTE <: SQLType end # Common Table Expression (WITH clause)
+# ── Layer 1: shared vocabulary ───────────────────────────────────────────────
+# Abstract types, constants, the `PormGError` root, `_emsg` and `config`. Kernel imports nothing
+# from PormG and is included first, so every submodule below can name any of it regardless of its
+# own position in this chain. See the `PormG.Kernel` docstring for why that ordering is load-bearing.
+#
+# `using .Kernel` BINDS Kernel's exports here (so `PormG.PormGModel`, `PormG.config`, … keep
+# resolving) but does NOT re-export them — this module's own `export` lines below remain the single
+# definition of the public surface.
+include("Kernel.jl")
+using .Kernel
+# Underscore-private members are not exported by Kernel; import the two that are reached as
+# `PormG._emsg` / `PormG._EXTRA_IGNORE_TABLES` (both pinned by tests).
+import .Kernel: _emsg, _EXTRA_IGNORE_TABLES
+# Part of the documented downstream-extension surface (Nitro et al. call it from an ext `__init__`).
+export register_ignore_tables!
 
-
-abstract type PormGModel <: PormGAbstractType end
-# A field is a COMPONENT of a model, not a kind of model — a sibling, not a subtype, so it does not
-# satisfy ::PormGModel signatures (which all read model-only attributes) (#186).
-abstract type PormGField <: PormGAbstractType end # define the type of the column from the model
-
-abstract type Migration <: PormGAbstractType end
-
-# Root of the semantic error taxonomy (#231). Subtypes <: Exception (NOT <: ArgumentError — a
-# clean break, so callers catch a type instead of string-matching a message). Declared at the top
-# module level so every submodule can `import PormG: PormGError`; the concrete query-builder
-# subtypes live in `src/querybuilder/exceptions.jl`. Extends the #197 typed-exception lineage.
-abstract type PormGError <: Exception end
-
-const config::Dict{String,PormGSettings} = Dict()
-
-include("constants.jl")
-
+# ── Layer 2: behavior owned by PormG ─────────────────────────────────────────
 # Backend interface (empty generics + friendly fallbacks); driver bodies live in the
 # weakdep extensions. Must precede Configuration/ConnectionPool, which call the generics.
+# Deliberately NOT in Kernel: the extensions define `PormG.backend_*(…) = …`, and Julia only
+# accepts a qualified method definition on the module that owns the binding.
 include("Backend.jl")
 
-# upper functions
-function get_constraints_pk end
-function get_constraints_unique end
-function get_constraints_check end
-
+# ── Layer 3: submodules ──────────────────────────────────────────────────────
 include("Generator.jl")
 using .Generator
 
 include("Configuration.jl")
 using .Configuration
-
-include("tools.jl")
 
 include("ConnectionPool.jl")
 using .ConnectionPool
@@ -187,6 +155,12 @@ export upgrade_guide  # version-scoped UPGRADING.md emitter (#216)
 
 include("Migrations.jl")
 using .Migrations
+
+# ── Layer 4: user-facing lifecycle helpers ───────────────────────────────────
+# `setup`, `install_ai_skills`, `upgrade_guide` — consumers of everything above, depended on by
+# nothing. (It used to sit between Configuration and ConnectionPool purely because it also held
+# `_emsg`; that helper now lives in Kernel, so this file is free to land where it belongs.)
+include("tools.jl")
 
 include("precompile.jl")
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,33 +1,10 @@
 
-"""
-    _emsg(msg; color = (Base.have_color === true))
-
-TTY-aware error-message colorizer. Many PormG error strings embed ANSI SGR codes
-(`\\e[31m…\\e[0m`) to highlight the offending token in the REPL. Those codes are
-helpful on a color terminal but leak as raw `\\e[..m` noise into non-TTY sinks
-(CI output, file logs, `sprint(showerror, e)`, structured logging).
-
-`_emsg` keeps the codes when `color` is true and strips every `\\e[..m` sequence
-otherwise. The default tracks `Base.have_color` — the same flag Julia consults to
-colorize its own error displays, so it honors the `--color` flag and `NO_COLOR`.
-The `color` keyword exists so tests can exercise both branches deterministically.
-
-This is the single shared definition; `QueryBuilder` (`_argerr`) and `Models` both
-import it rather than re-embedding the strip logic.
-"""
-_emsg(msg::AbstractString; color::Bool = (Base.have_color === true)) =
-  color ? String(msg) : replace(msg, r"\e\[[0-9;]*m" => "")
-
-"""
-    _emsg(io, msg)
-
-IO-aware variant of [`_emsg`](@ref) for use inside `show` / `print(io, …)` methods:
-it keeps ANSI only when the destination stream advertises color via its `:color`
-IOContext property. This is the correct signal for rendered output, because a
-non-color buffer (`sprint`, `repr`, a captured string, a file) must stay ANSI-free
-even when the process itself is attached to a color terminal.
-"""
-_emsg(io::IO, msg::AbstractString) = _emsg(msg; color = get(io, :color, false))
+# User-facing lifecycle helpers: `setup`, `install_ai_skills`, `upgrade_guide`. Included last in
+# PormG.jl — this file consumes the layers above and nothing depends on it.
+#
+# `_emsg` used to live here, which forced this file to be included before Models/QueryBuilder even
+# though nothing else in it is infrastructure. It now lives in `Kernel`, next to the `PormGError`
+# root — the error types whose constructors call it need it available from layer 1.
 
 """
     setup(path::String = DB_PATH)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Typed Exceptions on Query Surface (#197)" include("unit/test_typed_exceptions.jl")
     @testset "Semantic Error Taxonomy (#231)" include("unit/test_error_taxonomy.jl")
+    @testset "Kernel Layering" include("unit/test_kernel_layering.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")
     @testset "Configuration API" include("unit/test_configuration_api.jl")

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -1,0 +1,58 @@
+"""
+Kernel layering contract.
+
+Pins the two structural facts the `PormG.Kernel` extraction exists to guarantee. Both are
+invisible to every other test in the suite — the failure modes they guard show up as a
+mysterious `UndefVarError` during precompilation, or as an error that only fires when a user
+runs `using LibPQ`.
+
+No database required.
+"""
+# julia -t auto --project=. test/unit/test_kernel_layering.jl
+
+using Test
+using PormG
+
+@testset "Kernel layering" begin
+
+    @testset "shared vocabulary is owned by Kernel (layer 1)" begin
+        # The whole point of the extraction: vocabulary is defined BEFORE any submodule is
+        # included, so `Models` / `Configuration` / `Dialect` can name it regardless of their
+        # own position in the include chain. If someone moves these back into the PormG module
+        # body, they land after Configuration(4)/ConnectionPool(6)/Models(7) again and the next
+        # shared-vocabulary addition breaks with an UndefVarError at precompile time.
+        @test parentmodule(PormG.PormGError) === PormG.Kernel
+        @test parentmodule(PormG.PormGModel) === PormG.Kernel
+        @test parentmodule(PormG.PormGField) === PormG.Kernel
+        @test parentmodule(PormG._emsg) === PormG.Kernel
+
+        # Kernel must not reach back into PormG — that is what makes it safe to include first.
+        # `using PormG` inside Kernel would create the cycle this design removes.
+        @test !isdefined(PormG.Kernel, :PormG)
+    end
+
+    @testset "backend generics stay owned by PormG (layer 2)" begin
+        # ext/PormGLibPQExt.jl and ext/PormGSQLiteExt.jl define their methods as
+        # `PormG.backend_execute(...) = ...`. Julia only accepts a qualified method definition
+        # on the module that OWNS the binding, so moving these generics into Kernel breaks every
+        # extension method with "function Kernel.backend_execute must be explicitly imported to
+        # be extended" — and it fails at `using LibPQ` / `using SQLite`, NOT at `using PormG`,
+        # so precompiling the package would not catch it. This assertion would.
+        for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
+                   :backend_execute, :backend_execute_async, :backend_is_connection_error,
+                   :backend_is_permanent_connect_error, :backend_num_affected_rows,
+                   :backend_num_rows, :backend_copy_in!, :backend_sqlite_version)
+            @test parentmodule(getfield(PormG, fn)) === PormG
+        end
+    end
+
+    @testset "public surface is unaffected by where a name is defined" begin
+        # `using .Kernel` binds Kernel's exports in PormG without re-exporting them, so PormG's
+        # own `export` list stays the single definition of the public surface. Spot-check the
+        # one public name that actually moved modules (it is defined in constants.jl, which
+        # Kernel now includes) — it must still be exported bare by `using PormG`.
+        @test :register_ignore_tables! in names(PormG)
+        @test parentmodule(PormG.register_ignore_tables!) === PormG.Kernel
+    end
+
+end


### PR DESCRIPTION
Closes #254. Unblocks #239.

## Why

PormG had a core layer that was never declared. `Backend.jl`'s own header already calls itself *"the seam between **core** and the SQL-driver extensions"*, and the abstract-type block, `constants.jl` and `_emsg` are all pure vocabulary — but they sat interleaved with submodules in `src/PormG.jl`'s include chain, so *"may I use this name?"* was answered by accident of line order.

`tools.jl`, which held `_emsg`, sat at include step 5 — **after** two submodules — for no reason other than history.

**This blocks #239.** The #231 error taxonomy is defined in `src/querybuilder/exceptions.jl`, included at step 11. Every subsystem #239 needs to retype is included earlier — `Configuration` (4), `ConnectionPool` (6), `Models` + `models/fields` (7), `Dialect` (9) — and each resolves `import PormG: …` at include time. `Models.jl` physically cannot write `import PormG: InvalidValueError` today. That is **358 untyped `ArgumentError` sites** that cannot be migrated until the layering is fixed.

## What changed

- **New `src/Kernel.jl` (layer 1)** — abstract types incl. the `PormGError` root, `config`, `_emsg` + its `IO` variant (moved from `tools.jl`, still exactly one definition), the `get_constraints_*` generics, and `include("constants.jl")`. Imports nothing from `PormG`.
- `PormG` does `include("Kernel.jl"); using .Kernel`, which **binds** Kernel's exports without re-exporting them — so `PormG.PormGModel`, `PormG.config`, and **every existing `import PormG: …` in the submodules keep resolving unchanged**. `PormG`'s own `export` list stays the single definition of the public surface. *(This is why the diff is 8 files and not 20: no submodule import rewrite was needed.)*
- `tools.jl` moves to layer 4 — once `_emsg` leaves it, `setup` / `install_ai_skills` / `upgrade_guide` are user-facing consumers, depended on by nothing.

### Two constraints that shaped the design

**Not named `Core`.** `src/Utils.jl` (×2) and `src/Models.jl` call `Core.eval` on the `@import_models` / `set_models` world-age path — the code the Julia 1.12 floor exists for (#211). A `PormG.Core` submodule would shadow Julia's `Core` inside the package.

**`Backend.jl` stays in `PormG`.** The weakdep extensions define `PormG.backend_execute(…) = …`, and Julia only accepts a qualified method definition on the module that *owns* the binding. Moving those generics into `Kernel` breaks every extension method — and it fails at `using LibPQ` / `using SQLite`, **not** at `using PormG`, so precompiling the package would not catch it.

**Kernel holds the nouns; `PormG` keeps the verbs.**

## Verification

- **`Pkg.test()` — 4410/4410 pass** (Aqua included; +18 is the new layering test)
- **Docs build exits 0**
- **Public surface byte-identical** to the pre-refactor baseline: exported-name list (47), backend generics' ownership and method counts *with both drivers loaded*, taxonomy hierarchy, submodule reachability
- **`test/unit/test_public_exports.jl` passes unmodified** — the acceptance criterion for this refactor
- Only intended observable change: types display as `PormG.Kernel.PormGModel`. Verified nothing string-matches those qualified names.

`test/unit/test_kernel_layering.jl` pins both invariants. The backend-ownership assertion was **mutation-tested** — defining `backend_execute` in `Kernel` and removing it from `Backend.jl`'s generic list makes it fail. That is the regression that would otherwise only surface at driver load. (A first, unfaithful mutation passed 18/18; the test was kept only after the faithful one failed it.)

`docs/make.jl` and the `api.md` `@autodocs` block gain `PormG.Kernel`: with `checkdocs = :exports`, the relocated `register_ignore_tables!` docstring and the `Kernel` module docstring were otherwise unreachable and `makedocs` failed on `[:missing_docs]`.

No `UPGRADING.md` entry — nothing consumer-visible changes.

## Not verified

**The PG/SQLite integration suites did not run.** `test/integration/common_setup.jl:2` calls `Pkg.activate(".")`, which overrides `--project` onto the package env, where the weakdep drivers are not installed (they live only in `[extras]`/`[targets].test`). I reproduced the identical failure on unmodified `main`, so it is environmental rather than a regression from this change — but real PG/SQLite round-trips are unverified here. The extension-seam risk specifically *is* covered, since the seam probe loads both drivers and confirms method binding.

Related: the `Verification Commands` section of `.github/skills/pormg-public-api-development/SKILL.md` lists `julia --project=. test/runtests.jl`, which fails for the same weakdep reason. CI uses `Pkg.test()`. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
