### PR TITLE
feat: retype field-constructor validation to FieldValidationError (#239 slice 3)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,13 +43,13 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 ## The `PormGError` taxonomy now covers all of PormG — not just the query builder (#239)
 
 - **Version**: Unreleased
-- **PormG ref**: issue #239 ; `src/exceptions.jl` (the taxonomy), `src/Models.jl`, `src/Dialect.jl`,
-  `src/Configuration.jl`, `src/ConnectionPool.jl`, `src/migrations/*`, `src/PormG.jl`,
-  `src/querybuilder/execution.jl`, `docs/src/api.md`
+- **PormG ref**: issue #239 ; `src/exceptions.jl` (the taxonomy), `src/models/fields.jl`,
+  `src/Models.jl`, `src/Dialect.jl`, `src/Configuration.jl`, `src/ConnectionPool.jl`,
+  `src/migrations/*`, `src/PormG.jl`, `src/querybuilder/execution.jl`, `docs/src/api.md`
 - **Recorded**: 2026-07-28
-- **Severity**: **breaking (error contract)** — completes what #231 started. Model definition, field
-  defaults, configuration, the SQL dialect, the connection pool and the migration engine now raise
-  `PormGError` subtypes instead of bare `ArgumentError`. Part of the `0.3.x` pre-publish wave.
+- **Severity**: **breaking (error contract)** — completes what #231 started. Field constructors,
+  model definition, configuration, the SQL dialect, the connection pool and the migration engine now
+  raise `PormGError` subtypes instead of bare `ArgumentError`. Part of the `0.3.x` pre-publish wave.
 
 ### What changed
 
@@ -61,7 +61,7 @@ except two genuine Julia-level API misuses in `src/tools.jl` (a missing kwarg, a
 | Subtype | Now raised by |
 |---------|---------------|
 | `ModelDefinitionError` | model/schema definition — more than one primary key, duplicate `related_name`, illegal field name, a `UniqueConstraint` naming an unknown or M2M field, an unresolvable `ForeignKey`/`ManyToManyField` target, `Model(...)` given a non-`PormGField` |
-| `FieldValidationError` | a field's `default=` kwarg failing its own contract (`validate_default`, and the `UUIDField`/`JSONField` string-default paths) |
+| `FieldValidationError` | **every** field-constructor rejection — a kwarg of the wrong type (`unique="yes"`), an out-of-range `max_length`, a `default=` violating the field's own contract, a malformed `choices`, `decimal_places > max_digits`, or a `FloatField`/`DecimalField` used as a primary key |
 | `InvalidValueError` | the `Models.format_*_sql` coercion family — duration, UUID, JSON, number, bool, date, timezone, `yyyy_mm` — plus `Dialect`'s "the value must be a String" guards |
 | `ConfigurationError` *(abstract)* | umbrella; `InvalidConfigurationError` for an unsupported adapter, unknown connection key, malformed `extensions`, a pool that was never built; `MissingDatabaseConfigurationException` is now **inside** this bucket |
 | `MigrationError` *(abstract)* | umbrella; `InvalidMigrationError` for a duplicate index name, an invalid interactive `makemigrations` answer, an unimplemented `migrate_to(version)`; `DestructiveMigrationError` is now **inside** this bucket |
@@ -69,7 +69,7 @@ except two genuine Julia-level API misuses in `src/tools.jl` (a missing kwarg, a
 | `QueryBuildError` | `on_conflict_clause` argument shape; `atomic(durable=true)` nested inside another transaction |
 
 **Definition-time vs value-time.** `FieldValidationError` fires while *defining* a model
-(`UUIDField(default="nope")`); `InvalidValueError` fires while coercing a *value* on the insert/update
+(`IntegerField(unique="yes")`, `UUIDField(default="nope")`); `InvalidValueError` fires while coercing a *value* on the insert/update
 path (`Models.format_uuid_sql("nope")`). Both were `ArgumentError` before, so an app that lumped them
 together must now decide which it meant.
 
@@ -82,6 +82,16 @@ rg -n 'catch|@test_throws|isa' <app> | rg 'ArgumentError|ErrorException'
 After #231 you were told to leave field- and model-definition catches alone. **Revisit exactly those** —
 they are what changed here. Also check `catch` blocks around `Configuration.load`, `register_connection`,
 `makemigrations`/`migrate`, `import_models_from_*`, `pool_stats`, and any model-definition module.
+
+Field constructors are the largest single group (248 throw sites across the 26 `*Field` types), so any
+app that builds models dynamically and guards the call is affected:
+
+```julia
+# ✗ before
+try; Models.CharField(max_length = user_supplied); catch e; e isa ArgumentError && fallback(); end
+# ✓ after
+try; Models.CharField(max_length = user_supplied); catch e; e isa PormG.FieldValidationError && fallback(); end
+```
 
 ### Migrate your app
 

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -1,3 +1,17 @@
+# ── Field-validation throw funnel (#239) ────────────────────────────────────
+# Every failure in this file is one category: the caller got a field CONSTRUCTOR argument wrong —
+# a kwarg of the wrong type, an out-of-range `max_length`, a `default` that violates the field's
+# own contract, a malformed `choices`, or a field type that cannot serve as a primary key. So a
+# call site changes only `ArgumentError(` → `_fielderr(` and lands on `FieldValidationError`
+# (mirrors `_argerr` in querybuilder/exceptions.jl). The subtype's constructor applies `_emsg`, so
+# messages degrade correctly off-TTY without a second wrap.
+#
+# NOT for value coercion: `Models.format_*_sql` raises `InvalidValueError`, because there the
+# caller is inserting a bad *value* rather than defining a bad *field*. Where a constructor calls
+# one of those helpers on a `default=` (UUIDField/JSONField/DurationField), it re-raises as
+# FieldValidationError so the whole constructor surface reports one category.
+_fielderr(msg::AbstractString) = FieldValidationError(msg)
+
 
 struct sIDField <: PormGField
   verbose_name::Union{String, Nothing}
@@ -100,18 +114,18 @@ function IDField(; kwargs...)
   generated_always = get(kwargs, :generated_always, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate other parameters
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
-  !(auto_increment isa Bool) && throw(ArgumentError("The 'auto_increment' must be a Boolean"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(generated isa Bool) && throw(ArgumentError("The 'generated' must be a Boolean"))
-  !(generated_always isa Bool) && throw(ArgumentError("The 'generated_always' must be a Boolean"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
+  !(auto_increment isa Bool) && throw(_fielderr("The 'auto_increment' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(generated isa Bool) && throw(_fielderr("The 'generated' must be a Boolean"))
+  !(generated_always isa Bool) && throw(_fielderr("The 'generated_always' must be a Boolean"))
   # Validate default
   default = validate_default(default, Union{Int64, Nothing}, "IDField", format2int64)
   # Return the field instance
@@ -278,33 +292,33 @@ function ForeignKey(to::Union{String, PormGModel}; kwargs...)
   db_constraint = get(kwargs, :db_constraint, true)
 
   # Validate 'to' parameter
-  !(to isa Union{String, PormGModel}) && throw(ArgumentError("The 'to' parameter must be a String or PormGModel"))
+  !(to isa Union{String, PormGModel}) && throw(_fielderr("The 'to' parameter must be a String or PormGModel"))
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
 
   # Validate boolean parameters
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(deferrable isa Bool) && throw(ArgumentError("The 'deferrable' must be a Boolean"))
-  !(initially_deferred isa Bool) && throw(ArgumentError("The 'initially_deferred' must be a Boolean"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(deferrable isa Bool) && throw(_fielderr("The 'deferrable' must be a Boolean"))
+  !(initially_deferred isa Bool) && throw(_fielderr("The 'initially_deferred' must be a Boolean"))
 
   # Validate default
   default = validate_default(default, Union{Int64, Nothing}, "ForeignKey", format2int64)
 
   # Validate optional string parameters
   !(pk_field isa Union{Nothing, AbstractString, Symbol}) &&
-    throw(ArgumentError("The 'pk_field' must be a String, Symbol, or nothing"))
+    throw(_fielderr("The 'pk_field' must be a String, Symbol, or nothing"))
   on_delete = _get_on_delete_mode(on_delete)
-  !(on_update isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'on_update' must be a String or nothing"))
-  !(how isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'how' must be a String or nothing"))
-  !(related_name isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'related_name' must be a String or nothing"))
-  !(db_constraint isa Bool) && throw(ArgumentError("The 'db_constraint' must be a Boolean"))
+  !(on_update isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'on_update' must be a String or nothing"))
+  !(how isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'how' must be a String or nothing"))
+  !(related_name isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'related_name' must be a String or nothing"))
+  !(db_constraint isa Bool) && throw(_fielderr("The 'db_constraint' must be a Boolean"))
 
   # Resolve db_index based on db_constraint
   db_index = db_index || !db_constraint 
@@ -355,14 +369,14 @@ function _get_on_delete_mode(on_delete::AbstractString)
   elseif contains(on_delete, "PROTECT")
     return PROTECT
   else
-    throw(ArgumentError("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
+    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
   end
 end
 function _get_on_delete_mode(on_delete::Function)
   # check if the function is one of the valid functions
   check_function = on_delete |> string |> uppercase
   if !(check_function in ["CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "SET", "DO_NOTHING", "PROTECT"])
-    throw(ArgumentError("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
+    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
   end
   return on_delete
 end
@@ -413,13 +427,13 @@ function ManyToManyField(to::Union{String, PormGModel}; kwargs...)
   source_field = get(kwargs, :source_field, nothing)
   target_field = get(kwargs, :target_field, nothing)
 
-  !(to isa Union{String, PormGModel}) && throw(ArgumentError("The 'to' parameter must be a String or PormGModel"))
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
-  !(through isa Union{Nothing, String, PormGModel}) && throw(ArgumentError("The 'through' parameter must be a String, PormGModel, or nothing"))
-  !(related_name isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'related_name' must be a String or nothing"))
-  !(db_table isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'db_table' must be a String or nothing"))
-  !(source_field isa Union{Nothing, AbstractString, Symbol}) && throw(ArgumentError("The 'source_field' must be a String, Symbol, or nothing"))
-  !(target_field isa Union{Nothing, AbstractString, Symbol}) && throw(ArgumentError("The 'target_field' must be a String, Symbol, or nothing"))
+  !(to isa Union{String, PormGModel}) && throw(_fielderr("The 'to' parameter must be a String or PormGModel"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
+  !(through isa Union{Nothing, String, PormGModel}) && throw(_fielderr("The 'through' parameter must be a String, PormGModel, or nothing"))
+  !(related_name isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'related_name' must be a String or nothing"))
+  !(db_table isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'db_table' must be a String or nothing"))
+  !(source_field isa Union{Nothing, AbstractString, Symbol}) && throw(_fielderr("The 'source_field' must be a String, Symbol, or nothing"))
+  !(target_field isa Union{Nothing, AbstractString, Symbol}) && throw(_fielderr("The 'target_field' must be a String, Symbol, or nothing"))
 
   return sManyToManyField(
     verbose_name,
@@ -615,31 +629,31 @@ function OneToOneField(to::Union{String, PormGModel}; kwargs...)
   db_constraint = get(kwargs, :db_constraint, true)
 
   # Validate 'to' parameter
-  !(to isa Union{String, PormGModel}) && throw(ArgumentError("The 'to' parameter must be a String or PormGModel"))
+  !(to isa Union{String, PormGModel}) && throw(_fielderr("The 'to' parameter must be a String or PormGModel"))
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
 
   # Validate boolean parameters
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(deferrable isa Bool) && throw(ArgumentError("The 'deferrable' must be a Boolean"))
-  !(initially_deferred isa Bool) && throw(ArgumentError("The 'initially_deferred' must be a Boolean"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(deferrable isa Bool) && throw(_fielderr("The 'deferrable' must be a Boolean"))
+  !(initially_deferred isa Bool) && throw(_fielderr("The 'initially_deferred' must be a Boolean"))
 
   # Validate default
   default = validate_default(default, Union{Int64, Nothing}, "OneToOneField", format2int64)
 
   # Validate optional string parameters
-  !(pk_field isa Union{Nothing, String, Symbol}) && throw(ArgumentError("The 'pk_field' must be a String, Symbol, or nothing"))
-  !(on_update isa Union{Nothing, AbstractString}) && throw(ArgumentError("The 'on_update' must be a String or nothing"))
-  !(how isa Union{Nothing, String}) && throw(ArgumentError("The 'how' must be a String or nothing"))
-  !(related_name isa Union{Nothing, String}) && throw(ArgumentError("The 'related_name' must be a String or nothing"))
-  !(db_constraint isa Bool) && throw(ArgumentError("The 'db_constraint' must be a Boolean"))
+  !(pk_field isa Union{Nothing, String, Symbol}) && throw(_fielderr("The 'pk_field' must be a String, Symbol, or nothing"))
+  !(on_update isa Union{Nothing, AbstractString}) && throw(_fielderr("The 'on_update' must be a String or nothing"))
+  !(how isa Union{Nothing, String}) && throw(_fielderr("The 'how' must be a String or nothing"))
+  !(related_name isa Union{Nothing, String}) && throw(_fielderr("The 'related_name' must be a String or nothing"))
+  !(db_constraint isa Bool) && throw(_fielderr("The 'db_constraint' must be a Boolean"))
 
   # Resolve on_delete using similar logic as ForeignKey
   on_delete = _get_on_delete_mode(on_delete)
@@ -763,16 +777,16 @@ function AutoField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate other parameters
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
-  !(auto_increment isa Bool) && throw(ArgumentError("The 'auto_increment' must be a Boolean"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
+  !(auto_increment isa Bool) && throw(_fielderr("The 'auto_increment' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Validate default
   default = validate_default(default, Union{Int64, Nothing}, "AutoField", format2int64)
   # Return the field instance
@@ -810,7 +824,7 @@ function parse_choices(choices_str::String)
       value = strip(values[2]) |> string
       choices = (choices..., (key, value))
     else
-      throw(ArgumentError("Invalid choices format"))
+      throw(_fielderr("Invalid choices format"))
     end
   end
   return choices
@@ -998,45 +1012,45 @@ function CharField(; kwargs...)
   choices = get(kwargs, :choices, nothing)
   editable = get(kwargs, :editable, true)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
   max_length isa AbstractString && (max_length = parse(Int, max_length))
-  max_length isa Int || throw(ArgumentError("The max_length must be an integer"))
-  max_length > 255 && throw(ArgumentError("The max_length must be less than or equal to 255"))
-  max_length < 1 && throw(ArgumentError("The max_length must be greater than 1"))
+  max_length isa Int || throw(_fielderr("The max_length must be an integer"))
+  max_length > 255 && throw(_fielderr("The max_length must be less than or equal to 255"))
+  max_length < 1 && throw(_fielderr("The max_length must be greater than 1"))
   default isa Int && (default = string(default))
   if !(default isa Nothing) && !(default isa AbstractString) 
-    throw(ArgumentError("The default value must be a string, but got $(default) ($(typeof(default)))"))
+    throw(_fielderr("The default value must be a string, but got $(default) ($(typeof(default)))"))
   end
   if !(default isa Nothing) && length(default) > max_length
-    throw(ArgumentError("The default value exceeds the max_length, but got $(length(default)) and max_length is $(max_length)"))
+    throw(_fielderr("The default value exceeds the max_length, but got $(length(default)) and max_length is $(max_length)"))
   end
-  !(unique isa Bool) && throw(ArgumentError("The unique must be a boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The blank must be a boolean"))
-  !(null isa Bool) && throw(ArgumentError("The null must be a boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The db_index must be a boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The db_column must be a string or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The editable must be a boolean"))  
+  !(unique isa Bool) && throw(_fielderr("The unique must be a boolean"))
+  !(blank isa Bool) && throw(_fielderr("The blank must be a boolean"))
+  !(null isa Bool) && throw(_fielderr("The null must be a boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The db_index must be a boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The db_column must be a string or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The editable must be a boolean"))  
   if choices isa AbstractString
     choices = parse_choices(choices)
   elseif !(choices isa Union{Nothing, NTuple{N, Tuple{AbstractString, AbstractString}} where N })
     println(choices)
     println(choices |> typeof)
-    throw(ArgumentError("The 'choices' must be a String or Tuple{Tuple{String,String}}, but got $(choices) ($(typeof(choices)))"))
+    throw(_fielderr("The 'choices' must be a String or Tuple{Tuple{String,String}}, but got $(choices) ($(typeof(choices)))"))
   end
   if choices !== nothing
     for choice in choices
       if !(choice[1] isa AbstractString)
-        throw(ArgumentError("Choice values must be strings"))
+        throw(_fielderr("Choice values must be strings"))
       end
       if count_just_strings(choice[1]) > max_length
-        throw(ArgumentError("Choices cannot exceed max_length"))
+        throw(_fielderr("Choices cannot exceed max_length"))
       end
     end
     if default !== nothing
       valid_defaults = choices isa Vector{String} ? return_just_strings(choices) : [return_just_strings(c[1]) for c in choices]
       if !(default in valid_defaults)
-        throw(ArgumentError("The default value must be one of the choices"))
+        throw(_fielderr("The default value must be one of the choices"))
       end
     end
   end
@@ -1141,18 +1155,18 @@ function IntegerField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
 
   # Validate default using validate_default
   default = validate_default(default, Union{Int64, Nothing}, "IntegerField", format2int64)
   
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Booleadn"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sIntegerField(
     verbose_name,
@@ -1247,21 +1261,21 @@ function PositiveSmallIntegerField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
 
   # Validate default using validate_default, then enforce the non-negative range
   default = validate_default(default, Union{Int64, Nothing}, "PositiveSmallIntegerField", format2int64)
   if default !== nothing && !(0 <= default <= POSITIVE_SMALL_INTEGER_MAX)
-    throw(ArgumentError("The default value for PositiveSmallIntegerField must be between 0 and $(POSITIVE_SMALL_INTEGER_MAX), got: $default"))
+    throw(_fielderr("The default value for PositiveSmallIntegerField must be between 0 and $(POSITIVE_SMALL_INTEGER_MAX), got: $default"))
   end
 
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sPositiveSmallIntegerField(
     verbose_name,
@@ -1356,21 +1370,21 @@ function PositiveIntegerField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
 
   # Validate default using validate_default, then enforce the non-negative range
   default = validate_default(default, Union{Int64, Nothing}, "PositiveIntegerField", format2int64)
   if default !== nothing && !(0 <= default <= POSITIVE_INTEGER_MAX)
-    throw(ArgumentError("The default value for PositiveIntegerField must be between 0 and $(POSITIVE_INTEGER_MAX), got: $default"))
+    throw(_fielderr("The default value for PositiveIntegerField must be between 0 and $(POSITIVE_INTEGER_MAX), got: $default"))
   end
 
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sPositiveIntegerField(
     verbose_name,
@@ -1493,18 +1507,18 @@ function BigIntegerField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
 
   # Validate default using validate_default
   default = validate_default(default, Union{Int64, Nothing}, "BigIntegerField", format2int64)
   
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sBigIntegerField(
     verbose_name,
@@ -1594,16 +1608,16 @@ function BooleanField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{Bool, Nothing}, "BooleanField", x -> parse(Bool, string(x)))
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sBooleanField(
     verbose_name,
@@ -1738,18 +1752,18 @@ function DateField(; kwargs...)
   auto_now_add = get(kwargs, :auto_now_add, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{Date, Nothing}, "DateField", format_date_sql)
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(auto_now isa Bool) && throw(ArgumentError("The 'auto_now' must be a Boolean"))
-  !(auto_now_add isa Bool) && throw(ArgumentError("The 'auto_now_add' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(auto_now isa Bool) && throw(_fielderr("The 'auto_now' must be a Boolean"))
+  !(auto_now_add isa Bool) && throw(_fielderr("The 'auto_now_add' must be a Boolean"))
   # Return the field instance
   return sDateField(
     verbose_name,
@@ -1866,26 +1880,26 @@ function DateTimeField(; kwargs...)
         end
       end
     else
-      throw(ArgumentError("Invalid default value for DateTimeField. Expected a DateTime, ZonedDateTime, or parseable datetime string."))
+      throw(_fielderr("Invalid default value for DateTimeField. Expected a DateTime, ZonedDateTime, or parseable datetime string."))
     end
   end
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{ZonedDateTime, DateTime, Nothing}, "DateTimeField", normalize_datetime_default)
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(auto_now isa Bool) && throw(ArgumentError("The 'auto_now' must be a Boolean"))
-  !(auto_now_add isa Bool) && throw(ArgumentError("The 'auto_now_add' must be a Boolean"))
-  !(type isa String) && throw(ArgumentError("The 'type' must be a String"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(auto_now isa Bool) && throw(_fielderr("The 'auto_now' must be a Boolean"))
+  !(auto_now_add isa Bool) && throw(_fielderr("The 'auto_now_add' must be a Boolean"))
+  !(type isa String) && throw(_fielderr("The 'type' must be a String"))
   if type != "TIMESTAMPTZ" && type != "TIMESTAMP"
-    throw(ArgumentError("The 'type' must be either 'TIMESTAMPTZ' or 'TIMESTAMP'"))
+    throw(_fielderr("The 'type' must be either 'TIMESTAMPTZ' or 'TIMESTAMP'"))
   end
   # Return the field instance
   return sDateTimeField(
@@ -1991,11 +2005,11 @@ function DecimalField(; kwargs...)
 
   # Validate primary_key rejection for Decimal (Best practice)
   if primary_key === true
-    throw(ArgumentError("DecimalField cannot be used as a Primary Key due to precision comparison risks. Use IDField or CharField instead."))
+    throw(_fielderr("DecimalField cannot be used as a Primary Key due to precision comparison risks. Use IDField or CharField instead."))
   end
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
   
   # Validate default using validate_default
   default = validate_default(default, Union{Float64, Nothing}, "DecimalField", format2float64)
@@ -2004,16 +2018,16 @@ function DecimalField(; kwargs...)
   
   # Validate scale vs precision
   if decimal_places > max_digits
-    throw(ArgumentError("DecimalField 'decimal_places' ($decimal_places) cannot be greater than 'max_digits' ($max_digits)"))
+    throw(_fielderr("DecimalField 'decimal_places' ($decimal_places) cannot be greater than 'max_digits' ($max_digits)"))
   end
 
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sDecimalField(
     verbose_name,
@@ -2103,16 +2117,16 @@ function EmailField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{String, Nothing}, "EmailField", x -> parse(String, x))
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sEmailField(
     verbose_name,
@@ -2231,15 +2245,15 @@ function PasswordField(; kwargs...)
   db_column = get(kwargs, :db_column, nothing)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate other parameters
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(max_length isa Int) && throw(ArgumentError("The 'max_length' must be an Integer"))
-  max_length < 64 && throw(ArgumentError("The 'max_length' must be at least 64 to store password hashes"))
-  !(auto_hash isa Bool) && throw(ArgumentError("The 'auto_hash' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(max_length isa Int) && throw(_fielderr("The 'max_length' must be an Integer"))
+  max_length < 64 && throw(_fielderr("The 'max_length' must be at least 64 to store password hashes"))
+  !(auto_hash isa Bool) && throw(_fielderr("The 'auto_hash' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
   
   # Return the field instance
   return sPasswordField(
@@ -2323,22 +2337,22 @@ function FloatField(; kwargs...)
 
   # Validate primary_key rejection for Float (Best practice)
   if primary_key === true
-    throw(ArgumentError("FloatField cannot be used as a Primary Key due to precision comparison risks. Use IDField or CharField instead."))
+    throw(_fielderr("FloatField cannot be used as a Primary Key due to precision comparison risks. Use IDField or CharField instead."))
   end
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The verbose_name must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The verbose_name must be a String or nothing"))
   
   # Validate default using validate_default
   default = validate_default(default, Union{Float64, Nothing}, "FloatField", format2float64)
   
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' parameter must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' parameter must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' parameter must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' parameter must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' parameter must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' parameter must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' parameter must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' parameter must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' parameter must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' parameter must be a Boolean"))
 
   return sFloatField(
     verbose_name,
@@ -2426,16 +2440,16 @@ function ImageField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{String, Nothing}, "ImageField", x -> parse(String, x))
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sImageField(
     verbose_name,
@@ -2477,14 +2491,14 @@ function FileField(; kwargs...)
   default      = get(kwargs, :default, nothing)
   editable     = get(kwargs, :editable, true)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   default = validate_default(default, Union{String, Nothing}, "FileField", x -> parse(String, x))
-  !(unique   isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank    isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null     isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique   isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank    isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null     isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
 
   return sImageField(
     verbose_name,
@@ -2569,16 +2583,16 @@ function TextField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{String, Nothing}, "TextField", x -> parse(String, x))
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sTextField(
     verbose_name,
@@ -2631,16 +2645,16 @@ function TimeField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{Time, Nothing}, "TimeField", x -> Time(x))
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sTimeField(
     verbose_name,
@@ -2695,7 +2709,7 @@ function BinaryField(; kwargs...)
   max_length = get(kwargs, :max_length, nothing)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default
   default = validate_default(default, Union{Vector{UInt8}, Nothing}, "BinaryField", x -> Base64.decode(x))
   if max_length isa AbstractString
@@ -2706,17 +2720,17 @@ function BinaryField(; kwargs...)
     end
   end
   if !(max_length isa Union{Nothing, Int})
-    throw(ArgumentError("The 'max_length' must be an integer or nothing"))
+    throw(_fielderr("The 'max_length' must be an integer or nothing"))
   elseif max_length isa Int && max_length <= 0
-    throw(ArgumentError("The 'max_length' must be a positive integer"))
+    throw(_fielderr("The 'max_length' must be a positive integer"))
   end
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sBinaryField(
     verbose_name,
@@ -2770,7 +2784,7 @@ function DurationField(; kwargs...)
   editable = get(kwargs, :editable, false)
 
   # Validate verbose_name
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   # Validate default. `format_duration_sql` raises InvalidValueError — correct on the insert/update
   # path, but here the caller's mistake is the `default=` kwarg at model-definition time. Re-raise as
   # FieldValidationError so every field constructor reports the same category (#239), matching the
@@ -2786,12 +2800,12 @@ function DurationField(; kwargs...)
     end
   end
   # Validate other parameters
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
   # Return the field instance
   return sDurationField(
     verbose_name,
@@ -2881,15 +2895,15 @@ function UUIDField(; kwargs...)
   editable = get(kwargs, :editable, true)
   auto_add = get(kwargs, :auto_add, false)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
-  !(primary_key isa Bool) && throw(ArgumentError("The 'primary_key' must be a Boolean"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
-  !(auto_add isa Bool) && throw(ArgumentError("The 'auto_add' must be a Boolean"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
+  !(primary_key isa Bool) && throw(_fielderr("The 'primary_key' must be a Boolean"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
+  !(auto_add isa Bool) && throw(_fielderr("The 'auto_add' must be a Boolean"))
 
   # Validate UUID format for string defaults (validate_default won't invoke the
   # converter when the value already matches Union{String, Nothing})
@@ -2993,16 +3007,16 @@ function URLField(; kwargs...)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   max_length isa AbstractString && (max_length = parse(Int, max_length))
-  max_length isa Int || throw(ArgumentError("The max_length must be an integer"))
-  max_length < 1 && throw(ArgumentError("The max_length must be greater than 0"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  max_length isa Int || throw(_fielderr("The max_length must be an integer"))
+  max_length < 1 && throw(_fielderr("The max_length must be greater than 0"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
 
   default = validate_default(default, Union{String, Nothing}, "URLField", x -> string(x))
 
@@ -3092,17 +3106,17 @@ function SlugField(; kwargs...)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
   max_length isa AbstractString && (max_length = parse(Int, max_length))
-  max_length isa Int || throw(ArgumentError("The max_length must be an integer"))
-  max_length > 255 && throw(ArgumentError("The max_length must be less than or equal to 255"))
-  max_length < 1 && throw(ArgumentError("The max_length must be greater than 0"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  max_length isa Int || throw(_fielderr("The max_length must be an integer"))
+  max_length > 255 && throw(_fielderr("The max_length must be less than or equal to 255"))
+  max_length < 1 && throw(_fielderr("The max_length must be greater than 0"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
 
   default = validate_default(default, Union{String, Nothing}, "SlugField", x -> string(x))
 
@@ -3194,13 +3208,13 @@ function JSONField(; kwargs...)
   default = get(kwargs, :default, nothing)
   editable = get(kwargs, :editable, true)
 
-  !(verbose_name isa Union{Nothing, String}) && throw(ArgumentError("The 'verbose_name' must be a String or nothing"))
-  !(unique isa Bool) && throw(ArgumentError("The 'unique' must be a Boolean"))
-  !(blank isa Bool) && throw(ArgumentError("The 'blank' must be a Boolean"))
-  !(null isa Bool) && throw(ArgumentError("The 'null' must be a Boolean"))
-  !(db_index isa Bool) && throw(ArgumentError("The 'db_index' must be a Boolean"))
-  !(db_column isa Union{Nothing, String}) && throw(ArgumentError("The 'db_column' must be a String or nothing"))
-  !(editable isa Bool) && throw(ArgumentError("The 'editable' must be a Boolean"))
+  !(verbose_name isa Union{Nothing, String}) && throw(_fielderr("The 'verbose_name' must be a String or nothing"))
+  !(unique isa Bool) && throw(_fielderr("The 'unique' must be a Boolean"))
+  !(blank isa Bool) && throw(_fielderr("The 'blank' must be a Boolean"))
+  !(null isa Bool) && throw(_fielderr("The 'null' must be a Boolean"))
+  !(db_index isa Bool) && throw(_fielderr("The 'db_index' must be a Boolean"))
+  !(db_column isa Union{Nothing, String}) && throw(_fielderr("The 'db_column' must be a String or nothing"))
+  !(editable isa Bool) && throw(_fielderr("The 'editable' must be a Boolean"))
 
   # Validate JSON format for string defaults (validate_default won't invoke the
   # converter when the value already matches Union{String, Nothing})

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -68,11 +68,11 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
 
     @testset "Constructor Hardening" begin
         # Decimal places > max_digits should fail at construction
-        @test_throws ArgumentError Models.DecimalField(max_digits=5, decimal_places=6)
+        @test_throws PormG.FieldValidationError Models.DecimalField(max_digits=5, decimal_places=6)
         
         # primary_key=true should fail at construction for both
-        @test_throws ArgumentError Models.DecimalField(primary_key=true)
-        @test_throws ArgumentError Models.FloatField(primary_key=true)
+        @test_throws PormG.FieldValidationError Models.DecimalField(primary_key=true)
+        @test_throws PormG.FieldValidationError Models.FloatField(primary_key=true)
         
         # FloatField default should now use format2float64 logic (more robust)
         f_field = Models.FloatField(default="123.45")

--- a/test/unit/test_new_field_types.jl
+++ b/test/unit/test_new_field_types.jl
@@ -135,8 +135,8 @@ end
         end
 
         @testset "Construction rejects invalid max_length" begin
-            @test_throws ArgumentError Models.URLField(max_length=0)
-            @test_throws ArgumentError Models.URLField(max_length=-1)
+            @test_throws PormG.FieldValidationError Models.URLField(max_length=0)
+            @test_throws PormG.FieldValidationError Models.URLField(max_length=-1)
         end
 
         @testset "validate_field_data with URLField" begin
@@ -179,8 +179,8 @@ end
         end
 
         @testset "Construction rejects invalid max_length" begin
-            @test_throws ArgumentError Models.SlugField(max_length=0)
-            @test_throws ArgumentError Models.SlugField(max_length=256)
+            @test_throws PormG.FieldValidationError Models.SlugField(max_length=0)
+            @test_throws PormG.FieldValidationError Models.SlugField(max_length=256)
         end
 
         @testset "validate_field_data with SlugField" begin

--- a/test/unit/test_positive_small_integer_check.jl
+++ b/test/unit/test_positive_small_integer_check.jl
@@ -83,8 +83,8 @@ end
   @testset "constructor enforces the non-negative range" begin
     @test Models.PositiveIntegerField(default=0).default == 0
     @test Models.PositiveIntegerField(default=2147483647).default == 2147483647
-    @test_throws ArgumentError Models.PositiveIntegerField(default=-1)
-    @test_throws ArgumentError Models.PositiveIntegerField(default=2147483648)
+    @test_throws PormG.FieldValidationError Models.PositiveIntegerField(default=-1)
+    @test_throws PormG.FieldValidationError Models.PositiveIntegerField(default=2147483648)
   end
 
   # ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Slice 3 of #239 — the last one. **Breaking (error contract).**

All 248 throw sites in `src/models/fields.jl` now raise `FieldValidationError` instead of `ArgumentError`. After this, `src/` contains **no** `throw(ArgumentError(` at all except two genuine Julia-level API misuses in `tools.jl` (a missing kwarg, a missing path).

`catch PormGError` now means *"PormG rejected this"* across the whole package — which was the point of #239.

## The change

Adds `_fielderr(msg) = FieldValidationError(msg)`, mirroring `_argerr` in `querybuilder/exceptions.jl`. Every failure in this file is one category — the caller got a field **constructor** argument wrong — so a call site changes only `ArgumentError(` → `_fielderr(`.

### It is provably mechanical

Reconstructing `HEAD`'s `fields.jl` by inverting the transform on the result yields a **byte-identical** file. The change is exactly: the funnel block, 248 constructor swaps, and one typo fix (`"must be a Booleadn"` → `"Boolean"`, pre-existing). Nothing else in the file moved.

Safe as a mechanical pass because `grep -c 'ArgumentError('` and `grep -c 'throw(ArgumentError('` **both return 248** — every occurrence is a throw, so there is no `isa`/`catch` site to mis-hit. Verified before and after the slice-2 merge. No message contains ANSI escapes, so nothing needs wrapping beyond what the subtype constructor already does with `_emsg`.

### Every distinct message was read, not just the repeated guards

~200 of the 248 are per-constructor kwarg type guards. The long tail is `max_length` bounds, `choices` format/limits, default-vs-choices checks, `decimal_places > max_digits`, and the `FloatField`/`DecimalField` primary-key restrictions. All field-constructor validation; none is value coercion.

Spot-verified one of each category actually retypes:

```
kwarg type guard      FieldValidationError   isa PormGError=true   isa ArgumentError=false
max_length bound      FieldValidationError   isa PormGError=true   isa ArgumentError=false
PK restriction        FieldValidationError   isa PormGError=true   isa ArgumentError=false
decimal places        FieldValidationError   isa PormGError=true   isa ArgumentError=false
bad default           FieldValidationError   isa PormGError=true   isa ArgumentError=false
positive range        FieldValidationError   isa PormGError=true   isa ArgumentError=false
```

## Tests

The last 9 field-constructor assertions migrate from `ArgumentError` to `FieldValidationError` — strictly stronger. What remains in `test/` is exactly the two intentional keeps: `test_upgrade_guide.jl`'s missing-kwarg assertion, and `test_execution_show.jl`'s `!(err isa ArgumentError)` clean-break assertion.

## `UPGRADING.md`

The entry's `FieldValidationError` row now covers **every** field-constructor rejection rather than just the `default=` paths, and gains a before/after for apps that build models dynamically.

⚠️ Correcting myself: the entry's claim that *"every `throw(ArgumentError(...))` in `src/` is now a semantic type"* was written in **slice 2 and was not yet true then** — `fields.jl` still held all 248. It is true as of this commit. The overstatement lived only inside `## Unreleased` and was never cut into a release, but it was inaccurate in `main` between #257 and this PR.

## Known gap — deliberately not fixed here

**26 stale `ArgumentError` claims across 14 user-facing pages in `docs/src/`** (FK traversal, subqueries, update/create/delete, m2m, window functions, filters, bulk). Most broke when **#231** shipped in `0.3.0`, not in this slice. Each type has been resolved against its actual throw site; they land in a **separate docs-accuracy PR** so this one stays a reviewable mechanical swap.

Worth noting for release planning: #239 is technically complete after this, but the docs still teach the old rule — which is what blocks #253's `errors.md`. I'd hold #239 open until the docs PR lands rather than empty the `pre-publish` label on a taxonomy nobody can correctly read about.

## Verification

- **`Pkg.test()` — 4449/4449 pass**
- **Docs build exits 0**

**Not verified:** integration suites still cannot run locally (weakdep drivers absent from the package env, see #255). `fields.jl` is backend-agnostic, so PG/SQLite exposure here is low.

Refs #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
