### PR TITLE
docs: name the real PormGError subtype at every documented throw site (#239)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -171,7 +171,10 @@ rg -n 'catch|@test_throws|isa' <app> | rg 'ArgumentError|ErrorException'
 ```
 
 Focus on blocks wrapping PormG query calls (`filter`/`values`/`update`/`delete`/`get`/row access/`bulk_*`).
-Field-definition and model-definition errors still throw `ArgumentError` — leave those.
+Field-definition and model-definition errors still throw `ArgumentError` — leave those. ⚠️ **This is no
+longer true** — #239 retyped them to `FieldValidationError` / `ModelDefinitionError`. If you already
+migrated on this instruction, revisit exactly those catches; see *"The `PormGError` taxonomy now covers
+all of PormG"* above.
 
 ### Migrate your app
 

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -914,7 +914,7 @@ driver_rows = manager.all().values("surname", "nationality").list()
 Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table.
 
 !!! warning
-    **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add`, `remove`, `clear`, and `set`) will raise an `ArgumentError`. Create or delete custom through model objects directly using the through model's objects manager instead.
+    **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add`, `remove`, `clear`, and `set`) will raise a `QueryBuildError`. Create or delete custom through model objects directly using the through model's objects manager instead.
 
 ---
 

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -85,7 +85,7 @@ This pattern matches Django exactly and keeps your model definitions clean and r
 ### Relationship Mutator Limitations on Custom Through Tables
 
 !!! warning
-    **Django-Style Strict Mutators**: If your custom intermediate `through` model contains *any extra fields* beyond the two relationship foreign keys (like the `joined_year` field in `M2m_membership_scratch` above), all direct manager mutators (`add`, `remove`, `clear`, and `set`) are disabled and will raise an `ArgumentError`.
+    **Django-Style Strict Mutators**: If your custom intermediate `through` model contains *any extra fields* beyond the two relationship foreign keys (like the `joined_year` field in `M2m_membership_scratch` above), all direct manager mutators (`add`, `remove`, `clear`, and `set`) are disabled and will raise a `QueryBuildError`.
 
 This constraint prevents silent failures or incomplete rows, as PormG cannot determine appropriate values to insert for your custom fields. 
 

--- a/docs/src/read/custom_joins.md
+++ b/docs/src/read/custom_joins.md
@@ -473,7 +473,7 @@ query = M.Result.objects.
 # This raises an error: driverid points to Driver, not Constructor
 query = M.Result.objects.
     cjoin("driverid" => "Constructor", filters=["name" => "Ferrari"])  
-# ArgumentError: Field 'driverid' is already a ForeignKey pointing to 'Driver', 
+# QueryBuildError: Field 'driverid' is already a ForeignKey pointing to 'Driver', 
 # but `.cjoin()` attempted to join with 'Constructor'...
 # Use query.cjoin("driverid" => "Driver", filters=[...]) instead.
 ```

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -163,7 +163,7 @@ M.Driver.objects.filter("surname__@iunaccent_contains" => "raikkonen")
 M.Driver.objects.filter("surname__@iunaccent_exact" => "RAIKKONEN")
 ```
 
-They require the `unaccent` extension and its `immutable_unaccent` helper, declared once in `connection.yml` and installed by `migrate()` — see [PostgreSQL Extensions](../configuration/connection_yml.md#PostgreSQL-Extensions). On SQLite these lookups raise an `ArgumentError`.
+They require the `unaccent` extension and its `immutable_unaccent` helper, declared once in `connection.yml` and installed by `migrate()` — see [PostgreSQL Extensions](../configuration/connection_yml.md#PostgreSQL-Extensions). On SQLite these lookups raise an `UnsupportedConnectionError`.
 
 There is no `@iunaccent_in`; OR the equality lookup with [`Qor`](q_objects.md) for accent-insensitive set membership:
 
@@ -215,7 +215,7 @@ Supported comparisons on a path lookup: `=` (default), `@ne`, `@gt`, `@gte`, `@l
 
 !!! note
     Keys must be simple (letters, digits, underscore) or an integer array index — a key with
-    spaces, dots, or quotes is not addressable via the `__` path and raises an `ArgumentError`.
+    spaces, dots, or quotes is not addressable via the `__` path and raises an `InvalidValueError`.
     Extraction is text-based: comparisons are string comparisons unless you use a numeric operator
     (`@gte` etc.), which casts to numeric on PostgreSQL. Equality against a numeric JSON value
     (`"metadata__wins" => 121`) works on both backends.
@@ -228,7 +228,7 @@ Supported comparisons on a path lookup: `=` (default), `@ne`, `@gt`, `@gte`, `@l
 ### Containment and key-existence operators (PostgreSQL only)
 
 These map to the PostgreSQL JSONB operators and apply to a JSON **column** (not a nested path).
-On SQLite they raise an `ArgumentError`:
+On SQLite they raise an `UnsupportedConnectionError`:
 
 | Lookup | JSONB operator | Meaning | Example |
 | :--- | :--- | :--- | :--- |
@@ -522,7 +522,7 @@ M.Driver.objects.values("surname", "nationality").order_by(
 ```
 
 `orientation` must be `"ASC"` or `"DESC"` (case-insensitive); any other value — including a
-user-supplied sort-direction string forwarded as-is — raises an `ArgumentError` at construction
+user-supplied sort-direction string forwarded as-is — raises a `QueryBuildError` at construction
 instead of reaching the SQL.
 
 On SQLite builds older than 3.30.0 (which lack `NULLS FIRST/LAST` syntax) PormG emits the portable
@@ -686,7 +686,7 @@ Joining a **to-many** relation — a reverse foreign key (one parent → many ch
 query = M.Driver.objects
 query.values("nationality", "n" => Count("driverid"))
 query.filter("driver_standings__position__@gte" => 1)
-query |> DataFrame   # ArgumentError: PormG fan-out guard (#74): the aggregate n is inflated because …
+query |> DataFrame   # QueryBuildError: PormG fan-out guard (#74): the aggregate n is inflated because …
 ```
 
 The legitimate case — aggregating the **related** table's own column (e.g. counting the related rows) — is exactly the intended fan-out and works normally:

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -82,7 +82,7 @@ For framework integrations that require plain dictionaries, use `.list(:dict)`. 
 !!! warning "No lazy FK traversal — project related columns up front"
     PormG never lazily loads a related row. Accessing a ForeignKey you did not
     project (`row.driverid`, or traversing further with `row.driverid.forename`)
-    raises an `ArgumentError`. Project what you need up front with `values(...)`,
+    raises a `LazyTraversalError`. Project what you need up front with `values(...)`,
     then read it off the row by its key:
 
     ```julia

--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -35,10 +35,10 @@ WHERE "Tb"."statusid" IN (SELECT "Tb"."statusid" FROM "status" as "Tb" WHERE "Tb
 
 ## Subquery Column Constraint
 
-An `@in` subquery **must project exactly one column**. PormG validates this before generating SQL and throws an `ArgumentError` if the subquery selects more than one field.
+An `@in` subquery **must project exactly one column**. PormG validates this before generating SQL and throws a `FilterError` if the subquery selects more than one field.
 
 ```julia
-# Wrong — two columns will throw ArgumentError
+# Wrong — two columns will throw FilterError
 bad_sub = M.Status.objects.values("statusid", "status")
 query.filter("statusid__@in" => bad_sub)
 # ERROR: 'statusid__@in' requires a subquery that returns exactly one column
@@ -186,7 +186,7 @@ For an outer row with **no** related rows, an aggregate scalar returns its natur
 
 ### Rules and limitations
 
-- **Exactly one column.** The inner query must project exactly one column via `.values(...)` (the inner alias is cosmetic). Zero or several columns raise an `ArgumentError` at build time — the same one-column rule as `@in` subqueries.
+- **Exactly one column.** The inner query must project exactly one column via `.values(...)` (the inner alias is cosmetic). Zero or several columns raise a `QueryBuildError` at build time. The same one-column rule applies to `@in` subqueries, where it surfaces as a `FilterError` — the type names which argument you got wrong (a projection here, a filter there). Catch `PormGError` to handle both.
 - **The alias is mandatory.** Always project as a pair: `"alias" => Subquery(...)`. A bare `Subquery(...)` inside `values()` raises.
 - **At most one row.** The database requires a scalar subquery to return ≤ 1 row ("more than one row returned by a subquery used as an expression" at execution otherwise). An aggregate always satisfies this; for a plain column add `order_by` + `limit(1)` — PormG emits a build-time warning for the non-aggregate/no-limit case but does not block it.
 - **One level of correlation.** `OuterRef` resolves against the immediately enclosing query only, so a `Subquery`/`Exists` projected *inside another subquery* raises rather than risk silently correlating to the wrong level. Multi-level correlation is a possible future extension.

--- a/docs/src/read/values_and_joins.md
+++ b/docs/src/read/values_and_joins.md
@@ -72,7 +72,7 @@ WHERE "Tb_3"."status" = $1
 !!! warning "No lazy FK traversal — project related columns up front"
     PormG never lazily loads a related row. Accessing a ForeignKey you did not
     project (`row.driverid`, or traversing further with `row.driverid.forename`)
-    raises an `ArgumentError`. Project what you need up front with `values(...)`,
+    raises a `LazyTraversalError`. Project what you need up front with `values(...)`,
     then read it off the row by its key:
 
     ```julia
@@ -254,7 +254,7 @@ df = M.Driver.objects.filter("driverref" => "hamilton").
 ```
 
 !!! note
-    Alias identifiers must start with a Unicode letter or underscore, followed by letters, combining marks, digits, or underscores. Aliases containing spaces, punctuation, or other special characters throw an `ArgumentError` at query-build time.
+    Alias identifiers must start with a Unicode letter or underscore, followed by letters, combining marks, digits, or underscores. Aliases containing spaces, punctuation, or other special characters throw an `InvalidValueError` at query-build time.
 
 !!! tip
     Aliasing happens at the SQL level (`SELECT "field" AS "alias"`). This is more efficient than renaming columns in a Julia DataFrame after the query.

--- a/docs/src/read/window_functions.md
+++ b/docs/src/read/window_functions.md
@@ -376,7 +376,7 @@ ORDER BY "constructorid" ASC, "positionorder" ASC
 ```
 
 !!! warning
-    Explicit frame strings are PostgreSQL-only. Passing `frame=` on a SQLite connection throws `ArgumentError` with a helpful message.
+    Explicit frame strings are PostgreSQL-only. Passing `frame=` on a SQLite connection throws a `QueryBuildError` with a helpful message.
 
 **Frame unit — `ROWS` vs `RANGE`**
 
@@ -803,12 +803,12 @@ PormG quotes the alias in `ORDER BY` and never adds it to `GROUP BY`.
 
 ## SQLite Support
 
-All window functions work on SQLite **3.25.0 and later** (released 2018-09-15). PormG checks the SQLite library version at query time and throws a clear `ArgumentError` if the library is too old.
+All window functions work on SQLite **3.25.0 and later** (released 2018-09-15). PormG checks the SQLite library version at query time and throws a clear `UnsupportedConnectionError` if the library is too old.
 
 ```julia
 # SQLite version check happens automatically — you do not need to call it yourself.
 # If the library is too old, you will see:
-# ArgumentError: SQLite window functions require SQLite >= 3.25.0; current SQLite library is 3.24.0.
+# UnsupportedConnectionError: SQLite window functions require SQLite >= 3.25.0; current SQLite library is 3.24.0.
 ```
 
 The only SQLite limitation is **explicit frame specifications** (`frame=` argument). These are PostgreSQL-only for now.
@@ -832,7 +832,7 @@ The only SQLite limitation is **explicit frame specifications** (`frame=` argume
 
 - **Aggregate-over-window** (`SUM(...) OVER (...)`) is not yet implemented. Use a CTE to aggregate first, then apply the window in the outer query.
 - **Named `WINDOW` clauses** (`WINDOW w AS (...)`) are not supported. Each function carries its own inline `OVER`.
-- **SQLite explicit frame specs** throw `ArgumentError`. Use PostgreSQL for frame-bound queries.
+- **SQLite explicit frame specs** throw a `QueryBuildError`. Use PostgreSQL for frame-bound queries.
 
 ---
 

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -436,7 +436,7 @@ WHERE "Tb"."id" = source."id"::bigint
 - **Case-sensitive DataFrame matching**: PormG resolves `columns` and `match_on` against `DataFrame` column names **exactly**. A name that differs only in case from the model field (e.g. `ID` vs `id`) is rejected with an error that names the candidate column and suggests the fix — either `rename!(df, lowercase.(names(df)))` or an explicit `"DF_COL" => "field"` mapping in `columns=`. (An explicit `columns=` mapping is always honored, even when its source column differs in case from the field name.)
 - **Mapping-first match keys**: A `match_on` field with a `columns=` mapping always uses that mapping as its source. If the `DataFrame` *also* carries a column with the field's own name, the mapping still wins and the same-named column is ignored — with a warning, so the ambiguity is visible.
 - **Primary key fallback**: If you omit `match_on=`, `bulk_update()` infers the model primary key column(s) and expects those columns to be present in the `DataFrame` (or mapped in `columns=`).
-- **Missing column errors**: A `match_on` field with no source — no `columns=` mapping and no same-named `DataFrame` column — raises an `ArgumentError` rather than silently degrading to a constant filter. An explicit `columns=` mapping (`"df_col" => "field"`) whose source column is absent likewise raises — it is never silently bound to a non-existent column.
+- **Missing column errors**: A `match_on` field with no source — no `columns=` mapping and no same-named `DataFrame` column — raises an `UnknownFieldError` rather than silently degrading to a constant filter. An explicit `columns=` mapping (`"df_col" => "field"`) whose source column is absent likewise raises — it is never silently bound to a non-existent column.
 - **Handler filters are rebuilt**: `bulk_update()` clears any filters already attached to the query handler and rebuilds the `WHERE` clause from `match_on=` and `filters=`. Pass every predicate you need through those arguments rather than relying on prior `query.filter(...)` state.
 - **Dry-run support**: `show_query=:dict` and `show_query=:inspection` return metadata, `:sql` returns SQL text, `:params` returns the bound parameter list, and `:none` builds the statement and returns `nothing` without executing.
 - **Empty input is a no-op**: An empty `DataFrame` returns `nothing` after logging a warning.
@@ -467,13 +467,13 @@ each call by splitting `filters=` into **`match_on=`** (row-matching keys) and
 
 **How to update your apps:** search each project for `bulk_update(` and inspect its
 `filters=`. The fastest path is to **run the app or its tests** — every old per-row
-key still passed in `filters=` now raises an `ArgumentError` that names the offending
+key still passed in `filters=` now raises a `QueryBuildError` that names the offending
 key and tells you to move it to `match_on=`. Fix them one at a time until the errors
 stop. Calls that only ever passed constant `field => value` predicates (or no
 `filters=` at all) need no change.
 
 !!! warning "The migration error is temporary"
-    The `ArgumentError` that detects the old per-row-key-in-`filters=` usage is a
+    The `QueryBuildError` that detects the old per-row-key-in-`filters=` usage is a
     transitional aid for updating existing call sites. Once your applications are
     migrated it can be removed from PormG (see the `DEPRECATION SHIM` block in
     `src/querybuilder/execution_bulk.jl`); after removal, the same mistake surfaces

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -107,7 +107,7 @@ RETURNING *
 
 ### Validation
 
-PormG validates that all non-nullable fields are provided. If a required field is missing, it will raise an `ArgumentError`.
+PormG validates that all non-nullable fields are provided. If a required field is missing, it will raise an `InvalidValueError`.
 
 ```julia
 # This will fail because the 'driverref' field is required (NOT NULL)
@@ -122,7 +122,7 @@ driver = M.Driver.objects.create(
 
 **Error:**
 ```julia
-ERROR: ArgumentError: Error in insert, the field driverref not allow null
+ERROR: InvalidValueError: Error in insert, the field driverref not allow null
 ```
 
 ### Default Values

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -64,7 +64,7 @@ sql = delete(query, show_query=:sql)
 
 ### `change_data` Guard
 
-If the connection is configured with `change_data: false`, any call to `delete()` raises an `ArgumentError` at the ORM layer before generating SQL.
+If the connection is configured with `change_data: false`, any call to `delete()` raises a `PermissionError` at the ORM layer before generating SQL.
 
 ```julia
 # connection.yml: change_data: false

--- a/docs/src/write/update.md
+++ b/docs/src/write/update.md
@@ -138,10 +138,10 @@ All updates pass through a centralized validation engine that enforces:
 
 ### Pagination Guard
 
-Standard SQL `UPDATE` does not support `LIMIT`, `OFFSET`, or `ORDER BY`. If any of these are set on the query handler when `.update()` is called, PormG throws an `ArgumentError` immediately — before any SQL is generated — so the developer gets a clear error rather than silently mutating the wrong rows.
+Standard SQL `UPDATE` does not support `LIMIT`, `OFFSET`, or `ORDER BY`. If any of these are set on the query handler when `.update()` is called, PormG throws an `UnsafeMutationError` immediately — before any SQL is generated — so the developer gets a clear error rather than silently mutating the wrong rows.
 
 ```julia
-# These all raise ArgumentError before any SQL is sent
+# These all raise UnsafeMutationError before any SQL is sent
 q = M.Driver.objects.filter("nationality" => "British")
 q.limit(5).update("nationality" => "English")   # ERROR: UPDATE with LIMIT is not supported
 q.offset(2).update("nationality" => "English")  # ERROR: UPDATE with OFFSET is not supported
@@ -163,7 +163,7 @@ update_q.update("nationality" => "English")
 
 ### `change_data` Guard
 
-If the connection is configured with `change_data: false`, any call to `.update()` raises an `ArgumentError` at the ORM layer before generating SQL. This applies to both normal execution and `show_query=:dict` dry-runs.
+If the connection is configured with `change_data: false`, any call to `.update()` raises a `PermissionError` at the ORM layer before generating SQL. This applies to both normal execution and `show_query=:dict` dry-runs.
 
 ```julia
 # connection.yml: change_data: false

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -46,6 +46,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "Many-to-Many"                 begin include("test_many_to_many.jl")       end
     @testset "CTEs (with)"                  begin include("test_cte.jl")                end
     @testset "Subqueries"                   begin include("test_subqueries.jl")         end
+    @testset "Documented Error Types (#239)" begin include("test_docs_error_types.jl")  end
     @testset "Correlated EXISTS"            begin include("test_exists_correlated.jl")  end
     @testset "Custom Joins (cjoin)"         begin include("test_cjoin.jl")              end    
     @testset "Cached Joins"                 begin include("test_cache_join.jl")         end

--- a/test/integration/test_docs_error_types.jl
+++ b/test/integration/test_docs_error_types.jl
@@ -1,0 +1,84 @@
+# julia -t auto --project=. test/integration/test_docs_error_types.jl
+
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
+"""
+Documented error types that need live data (#239).
+
+Companion to `test/unit/test_docs_error_types.jl`, which pins every `docs/src` "this raises `X`"
+claim that fires at query-build time against mock connections — that file is the CI-enforced half,
+since `test/integration/` is excluded from CI (it needs a live PostgreSQL).
+
+What lands here is only what a mock genuinely cannot reach: a claim needing a *fetched row*, a
+real *insert* path, or a real *reverse relation*. Three of them.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# read/index.md + read/values_and_joins.md — unprojected ForeignKey read
+# Both pages promise a LazyTraversalError when a FK that was not projected is read off a fetched
+# row. Needs a real row, so it cannot move to the unit half.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "docs: unprojected FK read raises LazyTraversalError" begin
+    row = M.Result.objects.values("resultid", "points").first()
+    # Guard the fixture, not the contract: an empty results table would make the assertion below
+    # vacuous, so fail on the fixture rather than pass silently.
+    @test row !== nothing
+
+    err = try
+        row.driverid
+        nothing
+    catch e
+        e
+    end
+    @test err !== nothing
+    @test err isa LazyTraversalError
+    @test !(err isa ArgumentError)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# write/create.md — create() rejects a missing NOT NULL field
+# The page prints the exact message, so assert the text as well as the type: a different
+# InvalidValueError (a coercion failure, say) would otherwise satisfy the type check and let the
+# documented message rot. Validation fires before any SQL, so nothing is inserted and there is
+# nothing to clean up.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "docs: create() missing required field raises InvalidValueError" begin
+    err = try
+        M.Driver.objects.create(
+            "forename" => "Docs", "surname" => "Guard", "nationality" => "British")
+        nothing
+    catch e
+        e
+    end
+    @test err !== nothing
+    @test err isa InvalidValueError
+    @test !(err isa ArgumentError)
+    # docs/src/write/create.md shows: "Error in insert, the field driverref not allow null"
+    @test occursin("driverref", err.msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# read/filters_and_aggregates.md — #74 fan-out guard refuses an inflated aggregate
+# Needs a real reverse relation (driver_standings), which a synthetic mock model set does not
+# provide. Existing coverage in test_sql_functions.jl / test_subqueries.jl asserts
+# `isa PormGError` + the message; this pins the concrete subtype the docs now name.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "docs: fan-out guard raises QueryBuildError" begin
+    query = M.Driver.objects
+    query.values("nationality", "n" => Count("driverid"))
+    query.filter("driver_standings__position__@gte" => 1)
+
+    err = try
+        query.list()
+        nothing
+    catch e
+        e
+    end
+    @test err !== nothing
+    @test err isa QueryBuildError
+    @test !(err isa ArgumentError)
+    # Confirm it is the fan-out guard, not an unrelated QueryBuildError from the same call.
+    @test occursin("fan-out", err.msg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,8 @@ end
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Typed Exceptions on Query Surface (#197)" include("unit/test_typed_exceptions.jl")
     @testset "Semantic Error Taxonomy (#231)" include("unit/test_error_taxonomy.jl")
+    @testset "Error-contract Drift Guard (#239)" include("unit/test_docs_error_type_drift.jl")
+    @testset "Documented Error Types (#239)" include("unit/test_docs_error_types.jl")
     @testset "Kernel Layering" include("unit/test_kernel_layering.jl")
     @testset "DateTime UTC Canonicalization (#79)" include("unit/test_datetime_canonicalization.jl")
     @testset "Reload Regressions" include("unit/test_reload.jl")

--- a/test/unit/test_docs_error_type_drift.jl
+++ b/test/unit/test_docs_error_type_drift.jl
@@ -1,0 +1,123 @@
+"""
+Error-contract drift guard (#239).
+
+Two invariants that #239 established and nothing else enforces:
+
+1. **`docs/src` must never tell a user to expect `ArgumentError` from a PormG call.** Every PormG
+   domain error is a `PormGError` subtype; a page that still names `ArgumentError` teaches a
+   `catch` block that silently stops matching.
+2. **`src/` must not raise `ArgumentError` for a PormG domain error.** Only genuine Julia-level
+   API misuse (a missing kwarg, a missing path) may still use it.
+
+This is a static text scan — no database, no query execution. It exists because 26 stale doc
+claims survived an entire release (most broke when #231 shipped in `0.3.0`) with nothing to
+catch them, which is what blocked #253's `errors.md`.
+
+Scope note: this file only proves no page names the **wrong** type. The companion
+`test/integration/test_docs_error_types.jl` proves the **right** type is actually raised for each
+documented scenario — that is the check a plausible-but-wrong type would slip past here.
+"""
+# julia --project=. test/unit/test_docs_error_type_drift.jl
+
+using Test
+
+const DRIFT_REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const DRIFT_DOCS_SRC = joinpath(DRIFT_REPO_ROOT, "docs", "src")
+const DRIFT_SRC_DIR = joinpath(DRIFT_REPO_ROOT, "src")
+
+# `.md` is not pinned to LF in `.gitattributes`, so a Windows checkout yields CRLF (#216, #228).
+# Normalize before matching or every assertion below becomes platform-dependent.
+_drift_lines(path) = split(replace(read(path, String), "\r\n" => "\n"), '\n')
+
+_drift_files(dir, ext) = sort!([joinpath(root, f)
+                                for (root, _, files) in walkdir(dir)
+                                for f in files if endswith(f, ext)])
+
+# Render a repo-relative path so failure output is copy-pasteable.
+_drift_rel(path) = replace(relpath(path, DRIFT_REPO_ROOT), '\\' => '/')
+
+# The ONLY legitimate reasons a `docs/src` page may name `ArgumentError`. Each entry is a
+# *pattern*, never a line number — line numbers drift on every unrelated doc edit and would make
+# this guard a nuisance rather than a signal.
+const ALLOWED_DOC_MENTIONS = [
+    # DataFrames.jl raises this itself on a bare `SELECT *` across joined tables. It is not a
+    # PormG error, so it correctly stays `ArgumentError`.
+    ("DataFrames.jl's own duplicate-column error", r"Duplicate variable names"),
+    # api.md's warning that the taxonomy is deliberately NOT `<: ArgumentError` (the #231/#239
+    # clean break). Naming the type is the entire point of the warning.
+    ("the deliberate clean-break warning", r"These are not `ArgumentError`s"),
+    ("the deliberate clean-break warning", r"deliberately \*\*not\*\* `<: ArgumentError`"),
+]
+
+# `src/tools.jl`'s two deliberate keeps: `upgrade_guide(from=…)` missing its required kwarg, and a
+# missing path. Both are Julia-level API misuse, not a PormG domain error.
+const ALLOWED_SRC_ARGUMENTERROR = Dict("src/tools.jl" => 2)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Docs error-type drift: no user-facing page may promise `ArgumentError`
+# Scans every `docs/src/**/*.md` line naming `ArgumentError` and requires it to match one of the
+# allow-listed reasons above. A page that says "raises an `ArgumentError`" for a PormG failure
+# hands the reader a `catch` block that cannot fire — the exact defect #239 exists to remove.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "docs/src names no stale ArgumentError" begin
+    @test isdir(DRIFT_DOCS_SRC)
+
+    # Collect every offending (file, line) so one run reports all of them, not just the first.
+    offenders = Tuple{String,Int,String}[]
+    allowed_hits = 0
+
+    for path in _drift_files(DRIFT_DOCS_SRC, ".md")
+        for (lineno, line) in enumerate(_drift_lines(path))
+            occursin("ArgumentError", line) || continue
+            if any(pat -> occursin(pat, line), last.(ALLOWED_DOC_MENTIONS))
+                allowed_hits += 1
+            else
+                push!(offenders, (_drift_rel(path), lineno, strip(line)))
+            end
+        end
+    end
+
+    if !isempty(offenders)
+        @error """
+        $(length(offenders)) docs/src line(s) still promise `ArgumentError`.
+        Every PormG domain error is a `PormGError` subtype (#231, #239). Resolve each against its
+        real throw site in src/ and name that subtype instead — do not add it to the allow-list
+        unless the error genuinely is not PormG's (e.g. DataFrames.jl's own).
+        """ offenders
+    end
+    @test isempty(offenders)
+
+    # The allow-list must stay *earned*: if a documented DataFrames.jl caveat or the clean-break
+    # warning is deleted, this drops and the list should shrink with it.
+    @test allowed_hits == 4
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Source error-type drift: `src/` raises no `ArgumentError` for a PormG domain error
+# #239 retyped all 358 sites; only `src/tools.jl`'s two Julia-level API misuses remain. A new
+# `throw(ArgumentError(...))` anywhere else re-splits the taxonomy that #239 closed, and
+# `catch PormGError` silently stops covering it.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "src/ raises no stale ArgumentError" begin
+    @test isdir(DRIFT_SRC_DIR)
+
+    found = Dict{String,Int}()
+    for path in _drift_files(DRIFT_SRC_DIR, ".jl")
+        n = count(l -> occursin("throw(ArgumentError(", l), _drift_lines(path))
+        n > 0 && (found[_drift_rel(path)] = n)
+    end
+
+    unexpected = filter(p -> get(ALLOWED_SRC_ARGUMENTERROR, p.first, 0) != p.second, found)
+    if !isempty(unexpected)
+        @error """
+        `throw(ArgumentError(...))` found in src/ outside the deliberate keeps.
+        Use a `PormGError` subtype — `FieldValidationError` for a field constructor,
+        `ModelDefinitionError` for a schema definition, `_argerr` (→ `QueryBuildError`) for
+        query-builder misuse. `ArgumentError` is correct ONLY for Julia-level API misuse.
+        """ unexpected expected = ALLOWED_SRC_ARGUMENTERROR
+    end
+    @test isempty(unexpected)
+
+    # Pin the keeps positively too, so deleting them silently doesn't loosen the guard.
+    @test found == ALLOWED_SRC_ARGUMENTERROR
+end

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -1,0 +1,138 @@
+"""
+Documented error types are the public contract (#239) — CI-enforced half.
+
+Every user-facing *"this raises `X`"* claim in `docs/src` that can be triggered at query-build
+time is asserted here by running the documented failure and checking the type actually raised.
+
+Why this exists: 26 such claims went stale and shipped in `0.3.0` because the only thing tying a
+doc sentence to a throw site was someone remembering. Its sibling
+`test/unit/test_docs_error_type_drift.jl` catches a page naming the *retired* `ArgumentError`;
+it cannot catch a page naming a plausible-but-wrong `PormGError` subtype. This file can.
+
+Deliberately a **unit** test: `test/integration/` is excluded from CI (see `.github/workflows/CI.yml`
+— it needs a live PostgreSQL), so a guard placed there would never run automatically. Mock
+`Settings` give a real dialect with no database, the same pattern as `test_complex_queries.jl`.
+
+Claims that genuinely need live data — the unprojected-FK read, `create()` validation, and the
+#74 fan-out guard's reverse relation — are asserted in
+`test/integration/test_docs_error_types.jl` instead.
+"""
+# julia --project=. test/unit/test_docs_error_types.jl
+
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, JSONField
+
+# Mock backends: dialect dispatch is by connection TYPE, so a bare subtype is enough to render
+# SQL and to fire the backend-capability guards. No DB, no pool.
+struct DocErrMockPostgres <: PormG.PormGPostgres end
+struct DocErrMockSQLite <: PormG.PormGSQLite end
+
+PormG.config["docerr_pg"] = PormG.Configuration.Settings(
+    connections = DocErrMockPostgres(), change_data = true)
+PormG.config["docerr_sl"] = PormG.Configuration.Settings(
+    connections = DocErrMockSQLite(), change_data = true)
+
+# One model set per backend. Table/related names are suffixed so the two sets never collide in the
+# shared model registry when the whole unit suite runs in one session.
+function _docerr_models(key::String)
+    status = Model("docerr_status_$key", statusid = IDField(), status = CharField())
+    status.connect_key = key; status._module = Main
+
+    driver = Model("docerr_driver_$key",
+        driverid = IDField(), surname = CharField(), nationality = CharField())
+    driver.connect_key = key; driver._module = Main
+
+    result = Model("docerr_result_$key",
+        resultid = IDField(),
+        points   = IntegerField(),
+        payload  = JSONField(null = true),
+        statusid = ForeignKey(status, pk_field = "statusid", null = true),
+        driverid = ForeignKey(driver, pk_field = "driverid", null = true,
+                              related_name = "results_$key"))
+    result.connect_key = key; result._module = Main
+
+    (status, driver, result)
+end
+
+const DOCERR_STATUS_PG, DOCERR_DRIVER_PG, DOCERR_RESULT_PG = _docerr_models("docerr_pg")
+const DOCERR_STATUS_SL, DOCERR_DRIVER_SL, DOCERR_RESULT_SL = _docerr_models("docerr_sl")
+
+# (docs claim this test pins, expected type, the call that must raise it).
+# Keep the doc reference exact — it is how a maintainer finds the sentence to update when a type
+# legitimately changes.
+const DOCERR_CASES = [
+    (
+        "read/subqueries_and_ctes.md — `@in` subquery must project exactly one column",
+        FilterError,
+        () -> begin
+            bad_sub = DOCERR_STATUS_PG.objects.values("statusid", "status")
+            DOCERR_RESULT_PG.objects.filter("statusid__@in" => bad_sub).list(show_query = :dict)
+        end,
+    ),
+    (
+        "read/subqueries_and_ctes.md — scalar `Subquery(...)` must project exactly one column",
+        QueryBuildError,
+        () -> begin
+            inner = DOCERR_STATUS_PG.objects.values("statusid", "status")
+            DOCERR_RESULT_PG.objects.values("resultid", "x" => Subquery(inner)).
+                list(show_query = :dict)
+        end,
+    ),
+    (
+        "read/values_and_joins.md — alias identifiers reject spaces and punctuation",
+        InvalidValueError,
+        () -> DOCERR_RESULT_PG.objects.values("bad alias!" => "points").list(show_query = :dict),
+    ),
+    (
+        "write/update.md — UPDATE cannot carry LIMIT/OFFSET/ORDER BY",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.filter("resultid" => 1).limit(5).
+            update("points" => 0, show_query = :dict),
+    ),
+    (
+        "read/filters_and_aggregates.md — a JSON path key with spaces is not addressable",
+        InvalidValueError,
+        () -> DOCERR_RESULT_PG.objects.filter("payload__bad key" => 1).list(show_query = :dict),
+    ),
+    # Intentional PG/SQLite divergence: these pages tell the reader the lookup is PostgreSQL-only
+    # and raises on SQLite. Asserting it on the SQLite mock keeps the documented divergence honest.
+    (
+        "read/filters_and_aggregates.md — iunaccent_* lookups require PostgreSQL",
+        UnsupportedConnectionError,
+        () -> DOCERR_DRIVER_SL.objects.filter("surname__@iunaccent_contains" => "sena").
+            list(show_query = :dict),
+    ),
+    (
+        "read/filters_and_aggregates.md — JSONB key-existence operators require PostgreSQL",
+        UnsupportedConnectionError,
+        () -> DOCERR_RESULT_SL.objects.filter("payload__@has_key" => "wins").
+            list(show_query = :dict),
+    ),
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Documented error types: every build-time claim raises the type its page names
+# Runs each documented failure and asserts the raised type. The `!isa ArgumentError` assertion is
+# independent rather than redundant: it pins the #231/#239 clean break that both `api.md` and
+# `UPGRADING.md` promise, and would fail if a subtype were reparented under `ArgumentError` to
+# soften the break.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Documented error types (build-time)" begin
+    for (doc_ref, expected, call) in DOCERR_CASES
+        @testset "$doc_ref" begin
+            err = try
+                call()
+                nothing
+            catch e
+                e
+            end
+            # A doc that promises an error for something which now succeeds is drift too, and
+            # would otherwise pass silently — so assert the failure happens before its type.
+            @test err !== nothing
+            @test err isa expected
+            @test err isa PormGError
+            @test !(err isa ArgumentError)
+        end
+    end
+end


### PR DESCRIPTION
The docs-accuracy follow-up flagged in #258, plus the CI backstop this drift class never had.

**27 claims across 12 `docs/src` pages** still told users to expect `ArgumentError` from calls that have not raised one since **#231 shipped in `0.3.0`** — not since these slices. Until this lands, the documentation teaches exactly the rule #239 exists to kill, which is what blocks #253's `errors.md`.

## Every type resolved against its actual throw site

Not inferred from the sentence — read from `src/`:

| Doc pages | Correct type | Throw site |
|---|---|---|
| `read/index.md`, `read/values_and_joins.md` | `LazyTraversalError` | `types.jl:917` |
| `subqueries_and_ctes.md` ×2 (`@in`) | `FilterError` | `build_helpers.jl:357` |
| `subqueries_and_ctes.md` (scalar `Subquery`) | `QueryBuildError` | `build_helpers.jl:802` |
| `write/update.md` ×2 | `UnsafeMutationError` | `execution.jl:1372` |
| `write/update.md`, `write/delete.md` | `PermissionError` | `exceptions.jl:24` |
| `write/create.md` ×2 | `InvalidValueError` | `execution.jl:539` |
| `many_to_many.md`, `fields.md`, `custom_joins.md` | `QueryBuildError` | `many_to_many.jl:128`, `ctes.jl:337` |
| `filters_and_aggregates.md` ×5 | `UnsupportedConnectionError` ×2, `InvalidValueError`, `QueryBuildError` ×2 | Dialect / build_joins / types |
| `window_functions.md` ×4 | `QueryBuildError` ×2, `UnsupportedConnectionError` ×2 | `build_helpers.jl:618`, `Dialect.jl:137` |
| `bulk.md` ×3 | `UnknownFieldError`, `QueryBuildError` ×2 | `execution_bulk.jl:629`, `:51` |

**27, not the 26 estimated in #258** — that count was one low.

Four `ArgumentError` mentions deliberately remain, each re-verified: two are DataFrames.jl's own `Duplicate variable names` (not PormG's error), two are `api.md`'s warning that the taxonomy is deliberately **not** `<: ArgumentError`. `api.md`'s taxonomy table needed nothing — slices 1–3 already updated it.

## `UPGRADING.md` — a stale *instruction*, not just a description

The #231 entry's *"Field-definition and model-definition errors still throw `ArgumentError` — leave those"* was falsified by #239 and never corrected, while the **identical claim 12 lines above it was**. It is an imperative, so a consumer following it keeps a `catch` block that no longer matches — the exact silent miss #239 exists to remove. And `upgrade_guide()` prints it into consuming apps.

Annotated in place, matching the treatment already used above it. `upgrade_guide(from=v"0.2.0")` renders it correctly; `test_upgrade_guide.jl` 54/54.

## The CI backstop

**`.github/workflows/CI.yml` excludes `test/integration/`** (it needs live PostgreSQL). A guard placed there is not a backstop — it only runs when someone remembers. So everything reachable at query-build time went into the **unit** suite against mock `Settings`, the same no-DB pattern as `test_complex_queries.jl`:

- **`test/unit/test_docs_error_type_drift.jl`** — static scan. No `docs/src` page may name `ArgumentError` outside 4 allow-listed reasons, and `src/` must hold exactly the 2 deliberate `tools.jl` keeps. Keyed on **patterns, never line numbers** (those drift on every doc edit), and CRLF-normalized for the Windows CI leg (#216, #228).
- **`test/unit/test_docs_error_types.jl`** — runs 7 documented failures and asserts the raised type, including both PG/SQLite divergence claims.
- **`test/integration/test_docs_error_types.jl`** — the 3 claims that genuinely need live data.

### Mutation-tested, not assumed

- Reintroduce a stale docs claim → docs guard fails.
- Revert `_argerr` to `throw(ArgumentError(...))` → src guard fails on 2 assertions.

Neither is green-theater. The first guard catches a page naming the *retired* type; the second catches a page naming a *plausible-but-wrong* subtype — which is the failure mode that let all 27 through.

## Verification

- **`Pkg.test()` — 4483/4483** (+34), the same environment CI uses
- **Docs build exits 0**
- Each documented type reproduced live against the F1 SQLite dataset

**Not verified:** `test/integration/test_docs_error_types.jl` has never been executed. `common_setup.jl:2` calls `Pkg.activate(".")` unconditionally, overriding any environment passed in, and this checkout's `Manifest.toml` records no installed `LibPQ` entry — so `load_drivers.jl` fails before any test runs. Its three assertions were each confirmed live via scratch scripts; the file *inside the harness* is untested. Worth a look on a machine where the integration suite runs.

⚠️ Correcting the record: PRs #255–#258 each said integration suites "cannot run locally (weakdep drivers absent)". I claimed that was avoidable. **It wasn't** — `common_setup.jl` discards any environment you give it, so the workaround I had in mind does not apply to the harness.

## No `UPGRADING.md` entry

This corrects documentation of an already-recorded behavior change; the slice-2/3 entry covers the break itself. The `UPGRADING.md` edit here is an in-place correction to that existing entry, not a new one.

## After this

#239 is closable, which empties the `pre-publish` label. The remaining follow-up from #258 is the dedup issue for the ~200 repeated kwarg guards in `fields.jl`.

Refs #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
