### PR TITLE
fix(test): unbreak CI under OrderedCollections 2

### DIFF
--- a/test/unit/test_inspect_query.jl
+++ b/test/unit/test_inspect_query.jl
@@ -150,14 +150,18 @@ PormG.config["default"] = MockSettings
     
     # Test: Auto-detect :update (has insert data + filters)
     q_up = DriverModel.objects.filter("id" => 1)
-    # Manually populate insert field for the test
-    q_up.object.insert = Dict("forename" => "Ayrton")
+    # Manually populate insert field for the test. It must be an OrderedDict — that is the
+    # declared field type (types.jl: `insert::OrderedDict{String,Any}`, ordered so INSERT/UPDATE
+    # column lists follow call order, #97). OrderedCollections 2 removed the implicit
+    # Dict→OrderedDict conversion (ordering would be undefined), so a plain Dict now throws here.
+    q_up.object.insert = PormG.QueryBuilder.OrderedCollections.OrderedDict{String,Any}("forename" => "Ayrton")
     res_up = inspect_query(q_up)
     @test res_up[:operation] === :update
     
     # Test: Auto-detect :insert (has insert data, no filters)
     q_in = DriverModel.objects.copy()
-    q_in.object.insert = Dict("forename" => "Ayrton", "surname" => "Senna")
+    q_in.object.insert = PormG.QueryBuilder.OrderedCollections.OrderedDict{String,Any}(
+        "forename" => "Ayrton", "surname" => "Senna")
     res_in = inspect_query(q_in)
     @test res_in[:operation] === :insert
     


### PR DESCRIPTION
**`main` has been red since #245** — the CompatHelper `OrderedCollections 1 → 2` bump on 2026-07-28, *before* the #239 slice series started. Every CI run since has failed identically on all four matrix legs. This is two lines.

## What breaks

```
Heuristic Operation Detection: Error During Test at test/unit/test_inspect_query.jl:145
  ArgumentError: Cannot convert unordered `AbstractDict`s into `OrderedDicts`
    convert(::Type{OrderedDict{String,Any}}, ::Dict{String,String})
    setproperty!(::SQLObjectQuery, :insert, ::Dict{String,String})
```

OrderedCollections 2 removed the implicit `Dict → OrderedDict` conversion — the resulting order would be undefined. Two lines in `test_inspect_query.jl` assign a plain `Dict` straight into `SQLObjectQuery.insert`, declared `OrderedDict{String,Any}` (ordered so INSERT/UPDATE column lists follow call order, #97). Both now construct the declared type.

## `src/` is unaffected — no user was exposed

All four assignments to `.insert` (`querybuilder/object_manager.jl:79, 100, 155, 207`) already build a real `OrderedDict`. **PormG itself is compatible with OrderedCollections 2.** Only the test reached into an internal typed field with the wrong dict type, which is also why the fix is to construct the right type rather than to loosen anything.

## Why this stayed invisible locally

`Manifest.toml` is gitignored. In a local checkout `DataStructures` and `Tables` cap OrderedCollections at `<2.0.1`, so every local run resolves 1.8.x and passes. CI checks out fresh with no manifest and resolves 2.0.1.

**Local green and CI green are not the same thing here, and nothing surfaces the difference.** That is the more valuable finding than the bug itself — it is why four merged PRs each reported a green local suite while `main` was red.

## Verification

Reproduced in a fresh-resolve environment pinned to the CI version:

| | Result |
|---|---|
| Before, under v2.0.1 | `201 passed, 1 errored` — matches CI exactly |
| After, under v2.0.1 | **4483/4483** |
| After, under local v1.8.2 | 4483/4483 |

Test-only change; no `UPGRADING.md` entry.

## Follow-ups I'd suggest separately

- A checked-in `test/integration/Project.toml` so the integration suite is runnable at all — `common_setup.jl:2`'s unconditional `Pkg.activate(".")` currently discards any `--project=` you pass, forcing the driver-less package env.
- A CI leg that resolves at the **minimum** compat bound, since resolve-fresh-vs-local-manifest is a standing trap rather than a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
