### PR TITLE
chore(test): make the integration suite runnable again

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -80,6 +80,8 @@ The subsystem map below is also the review **architecture checkpoint**: when a n
 
 - Run the narrowest relevant test slice first; broaden only after green.
 - PostgreSQL integration: `db_2`. SQLite: `PORMG_DB="db_sl"`.
+- **Integration runs in its own environment (`test/integration/Project.toml`)** — it carries `LibPQ` + `SQLite`, which the package env cannot (they are `[weakdeps]` by design, and `Manifest.toml` is gitignored so a checkout has no installed copy). `common_setup.jl` redirects the package env and "no project" to it automatically, so `--project=.` still works; on a fresh clone run `julia --project=test/integration -e 'using Pkg; Pkg.instantiate()'` once. An explicit `--project=<other>` is left alone.
+- **Local green ≠ CI green.** `Manifest.toml` is gitignored, so a local run reuses whatever versions were resolved once, while CI resolves fresh and lands on the newest versions `[compat]` allows. That is how OrderedCollections 2 broke CI for a day while every local suite passed (#263). Before claiming a change is green, check the CI run — or resolve into a scratch env to reproduce what CI will see.
 - Docs: `julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` (the main project env has no Documenter — `--project=.` fails)
 
 ## Tool notes

--- a/test/integration/Project.toml
+++ b/test/integration/Project.toml
@@ -1,0 +1,19 @@
+[deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Decimals = "abce61dc-4473-55a0-ba07-351d65e31d42"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+PormG = "7d8d7541-4d3d-4580-80a2-17064efb0993"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
+
+[sources]
+PormG = {path = "../.."}

--- a/test/integration/common_setup.jl
+++ b/test/integration/common_setup.jl
@@ -1,5 +1,22 @@
 using Pkg
-Pkg.activate(".") # Or the correct relative path
+# The integration suite needs the LibPQ/SQLite driver extensions loaded. The package env cannot
+# carry them — they are `[weakdeps]` by design (#34) and `Manifest.toml` is gitignored, so a
+# checkout has no installed copy to `Base.require`. `test/integration/Project.toml` is the
+# environment that does carry them; it resolves PormG through `[sources]`, so a fresh clone needs
+# only `Pkg.instantiate()`.
+#
+# This used to be an unconditional `Pkg.activate(".")`, which silently discarded whatever the
+# caller passed to `--project=` and forced the driver-less package env — making the suite
+# unrunnable regardless of how it was invoked. Now the package env and "no project" both redirect
+# here, while an explicit third-party environment is left alone.
+let _pkg_env = normpath(joinpath(@__DIR__, "..", "..", "Project.toml")),
+    _int_env = normpath(joinpath(@__DIR__, "Project.toml")),
+    _active  = Base.active_project()
+
+    if _active === nothing || normpath(_active) in (_pkg_env, _int_env)
+        Pkg.activate(@__DIR__)
+    end
+end
 ENV["PORMG_ENV"] = "dev"
 
 using Revise


### PR DESCRIPTION
The integration suite could not be run **at all** in a fresh checkout, and hadn't been for weeks. #255–#258 each shipped saying "integration not verified", and #259 shipped an integration test file that had never once been executed.

Two causes, both fixed here.

## 1. `common_setup.jl` discarded your `--project=`

Line 2 was an unconditional `Pkg.activate(".")`. Whatever environment you passed, it was thrown away and replaced with the package env. So **no invocation could work** — not the documented one, not a hand-built env, nothing.

Now it redirects only the package env and the no-project case; an explicit `--project=<other>` is left alone.

## 2. The package env structurally cannot carry the drivers

`LibPQ`/`SQLite` are `[weakdeps]` by design (#34), and `Manifest.toml` is gitignored — so a checkout has no installed copy for `load_drivers.jl`'s `Base.require` fallback to find. It failed before the first test:

```
ArgumentError: Package LibPQ [194296ae-...] is required but does not seem to be installed
```

Adds **`test/integration/Project.toml`** carrying `LibPQ`, `SQLite` and the 13 packages the suite actually loads (enumerated from its own `using`/`import` lines, not guessed).

It resolves PormG through **`[sources] = {path = "../.."}`** rather than a `dev` entry, because `Manifest.toml` is gitignored — without `[sources]` a fresh clone could not locate PormG at all. Verified by deleting the manifest and instantiating from scratch.

## Verification

```
PORMG_DB=db_sl julia -t 1 --project=. test/integration/runtests.jl
→ PormG Test Suite (db_sl) | 1849 pass | 1 broken | 0 fail | 4m15.9s
```

First green integration run since the suite became unrunnable. It also finally exercises `test/integration/test_docs_error_types.jl` — **12/12** — the file #259 shipped blind.

**Not verified:** PostgreSQL (`db_2`) needs live credentials this environment doesn't have. The change is backend-agnostic (environment resolution only), so exposure is low, but it is unrun.

## Also: documenting the trap that caused #263

`general.instructions.md` now states that **local green ≠ CI green**. `Manifest.toml` is gitignored, so a local run reuses previously resolved versions while CI resolves fresh and takes the newest versions `[compat]` allows. That gap is exactly what let OrderedCollections 2 redden CI for a day while every local suite passed.

## Related, not in this PR

`main` has **no branch protection** (`gh api .../branches/main/protection` → 404), so PRs merge into a red build without resistance — that is how #255–#259 all landed on top of a CI failure that had been visible since #245. The README badge was already there and red; visibility wasn't the gap, a gate was. Repo-settings change, so it's a maintainer call rather than something a PR can carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
