### PR TITLE
feat: PoolError umbrella + uniform error_message accessor (#261)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,6 +41,7 @@ Dates = "1"
 Decimals = "0.4, 0.5"
 FlameGraphs = "1.1.0"
 Infiltrator = "1"
+InteractiveUtils = "1"
 JSON = "1"
 LibPQ = "1"
 Logging = "1"
@@ -67,6 +68,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LibPQ = "194296ae-ab2e-5f79-8cd4-7183a0a5a0d1"
 ProfileView = "c46f51b8-102a-5cf2-8d2c-8597cb0e0da7"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
@@ -76,4 +78,4 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "Infiltrator", "LibPQ", "SQLite", "SafeTestsets", "Test"]
+test = ["Aqua", "BenchmarkTools", "Infiltrator", "InteractiveUtils", "LibPQ", "SQLite", "SafeTestsets", "Test"]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,82 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Read a caught `PormGError` with `error_message`, not `e.msg` (#261)
+
+- **Version**: Unreleased
+- **PormG ref**: issue #261 ; `src/exceptions.jl` (`error_message`, `PoolError`), `src/Kernel.jl`
+  and `src/PormG.jl` (exports), `src/ConnectionPool.jl` (reparenting), `docs/src/api.md`
+- **Recorded**: 2026-07-29
+- **Severity**: **corrective** — no PormG behavior changed, so nothing that worked before stops
+  working. It is logged here rather than treated as an additive feature (which this file excludes)
+  because **apps that followed #239's advice may already carry a latent bug**: #239 told you to
+  `catch PormGError`, and the natural next line, `e.msg`, throws a `FieldError` on four of the
+  sixteen subtypes. Fixing that is a real app edit, which is what this entry exists to prompt.
+
+### What changed
+
+**1. `error_message(e)` is the uniform way to read any PormG error.**
+
+#239 told you to `catch PormGError`. The obvious next line is `e.msg` — and that works for 12 of
+the 16 concrete subtypes, then throws a `FieldError` on the four built from structured fields:
+`DoesNotExist`, `MultipleObjectsReturned`, `PoolTimeoutError`, `PoolConnectError`. Those four
+carry richer data (`model_name`, `adapter`, `pool_size`, `attempts`, …) instead of a flat string,
+which is better design — there was just no uniform way to get text out of them.
+
+`error_message` is defined through `showerror`, which every subtype implements, so it also stays
+correct for subtypes added later. It never returns less than `e.msg` did: for most subtypes it is
+exactly that field, and for the few with their own `showerror` it returns the richer rendering.
+
+**2. `PoolError` is the new abstract umbrella over `PoolTimeoutError` / `PoolConnectError`.**
+
+Matching `ConfigurationError` and `MigrationError`. `catch PoolError` now handles pool saturation
+and connect failure without naming both; catching either concrete type still works unchanged.
+
+### How to find the calls to migrate
+
+```
+rg -n '\.msg' <app> | rg -i 'catch|err|exception'
+```
+
+Look for anything reading `.msg` off a **caught** PormG error. A site that catches a specific
+`msg`-carrying subtype (`FilterError`, `QueryBuildError`, …) is fine as-is; the risk is a site that
+catches the broad `PormGError` and then reads `.msg`, because that path can now receive one of the
+four structured types.
+
+### Migrate your app
+
+```julia
+# ✗ before — throws FieldError if `e` is a pool/cardinality error
+try
+    M.Result.objects.filter("driverid__surname" => "Senna").update("points" => 25)
+catch e
+    e isa PormGError && @error "write failed" msg=e.msg
+    rethrow()
+end
+
+# ✓ after — one accessor, every subtype
+try
+    M.Result.objects.filter("driverid__surname" => "Senna").update("points" => 25)
+catch e
+    e isa PormGError && @error "write failed" msg=error_message(e) type=typeof(e)
+    rethrow()
+end
+```
+
+And, optionally, collapse a two-branch pool catch:
+
+```julia
+# ✗ before
+catch e
+    (e isa PoolTimeoutError || e isa PoolConnectError) && back_off()
+
+# ✓ after
+catch e
+    e isa PoolError && back_off()
+```
+
+---
+
 ## The `PormGError` taxonomy now covers all of PormG — not just the query builder (#239)
 
 - **Version**: Unreleased

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -657,11 +657,31 @@ Every PormG misuse raises a subtype of `PormGError` (`<: Exception`) so callers 
 **type** instead of matching on a message string. Catch `PormGError` for any PormG failure, or a
 specific subtype for a specific reaction (#231, completed in #239):
 
-`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `PermissionError`, `UnsupportedConnectionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`
+`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `PermissionError`, `UnsupportedConnectionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`, `PoolError`, `error_message`
 
 !!! warning "These are not `ArgumentError`s"
     The subtypes are deliberately **not** `<: ArgumentError`. A `catch ArgumentError` block around a
     PormG call will not match — catch `PormGError` (or a specific subtype) instead.
+
+### Reading a caught error
+
+Use `error_message(e)`, **not** `e.msg`. Most subtypes carry a `msg::String`, but the ones built
+from structured fields — `DoesNotExist`, `MultipleObjectsReturned`, `PoolTimeoutError`,
+`PoolConnectError` — do not, so `e.msg` throws on exactly the errors you are least likely to have
+tested against.
+
+```julia
+try
+    M.Result.objects.filter("driverid__surname" => "Senna").update("points" => 25)
+catch e
+    e isa PormGError || rethrow()
+    @error "PormG rejected the write" msg=error_message(e) type=typeof(e)
+end
+```
+
+`error_message` is defined through `showerror`, which every subtype implements, so it stays correct
+for subtypes added later. It never returns *less* than `e.msg`: for most subtypes it is exactly that
+field, and for the few with their own `showerror` it returns the richer rendering.
 
 **Querying**
 
@@ -698,9 +718,10 @@ specific subtype for a specific reaction (#231, completed in #239):
 | `MigrationError` *(abstract)* | Umbrella for migration-engine failures — `catch` it to get both cases below. |
 | `InvalidMigrationError` | A duplicate index name in a plan, an invalid answer to an interactive `makemigrations` prompt, or an unimplemented `migrate_to(version)` path. |
 | `DestructiveMigrationError` | A destructive plan was applied non-interactively without `destructive=true`. |
-| `PoolTimeoutError` / `PoolConnectError` | The pool is saturated / a physical connection could not be opened. |
+| `PoolError` *(abstract)* | Umbrella for connection-pool failures — `catch` it to get both cases below. |
+| `PoolTimeoutError` / `PoolConnectError` | The pool is saturated / a physical connection could not be opened. Both carry structured fields (`adapter`, `pool_size`, `attempts`, …) rather than a `msg` — read them with `error_message`. |
 
-The two abstract umbrellas exist so the buckets have **no holes**: `catch ConfigurationError` also
+The abstract umbrellas exist so the buckets have **no holes**: `catch ConfigurationError` also
 catches a missing `connection.yml`, and `catch MigrationError` also catches a refused destructive
 migration.
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -7,7 +7,9 @@ import Logging
 import Base: fetch
 import PormG: PormGSettings, PormGPostgres, PormGPostgresParam, PormGSQLite, PormGSQLiteParam, AbstractPormGParam, config, PormGModel, DEFAULT_POOL_TIMEOUT
 import PormG: @pormg_debug
-import PormG: PormGError  # taxonomy root — PoolTimeoutError / PoolConnectError are reparented under it
+# `PoolError` is the taxonomy's connection-pool umbrella; it lives in Kernel (layer 1) so that
+# modules included before this one can name it (#261). PormGError comes along for `catch` sites.
+import PormG: PormGError, PoolError
 # Throw sites (#239): a bad acquire mode is a value error, an unresolvable pool is a config error,
 # and misuse of atomic() nesting lands on the long-tail QueryBuildError bucket.
 import PormG: InvalidValueError, InvalidConfigurationError, QueryBuildError
@@ -61,7 +63,7 @@ i.e. the pool is saturated at its ceiling (`pool_size * POOL_EXPANSION_FACTOR`).
 Reparented from `Exception` to `PormGError` (#239), so `catch PormGError` covers connection
 saturation too. Catching `PoolTimeoutError` specifically is unaffected.
 """
-struct PoolTimeoutError <: PormGError
+struct PoolTimeoutError <: PoolError
   adapter::String        # "PostgreSQL" | "SQLite"
   pool_size::Int
   max_size::Int
@@ -86,7 +88,7 @@ redacted connection string; catchable so apps can translate it distinctly (e.g. 
 Reparented from `Exception` to `PormGError` (#239), so `catch PormGError` covers connection failures
 too. Catching `PoolConnectError` specifically is unaffected.
 """
-struct PoolConnectError <: PormGError
+struct PoolConnectError <: PoolError
   adapter::String        # "PostgreSQL" | "SQLite"
   cause                  # underlying driver exception (untyped: a driver may throw a non-Exception)
   connection::String     # redacted connection string

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -164,7 +164,8 @@ export PormGError,
        DoesNotExist, MultipleObjectsReturned,
        FieldValidationError, ModelDefinitionError,
        ConfigurationError, InvalidConfigurationError,
-       MigrationError, InvalidMigrationError
+       MigrationError, InvalidMigrationError,
+       PoolError, error_message
 
 # Shared state / generics
 export config, get_constraints_pk, get_constraints_unique, get_constraints_check

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -148,6 +148,10 @@ export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, Filt
 export FieldValidationError, ModelDefinitionError,
   ConfigurationError, InvalidConfigurationError,   # ConfigurationError is the abstract umbrella
   MigrationError, InvalidMigrationError            # MigrationError likewise
+# Taxonomy edges (#261). `PoolError` is the connection-pool umbrella — the pool errors were the
+# only concrete subtypes with neither a Kernel home nor an abstract one. `error_message` is the
+# uniform way to read a caught PormGError: the structured subtypes have no `.msg` field.
+export PoolError, error_message
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -127,6 +127,27 @@ struct MultipleObjectsReturned <: PormGError
   filters::String
 end
 
+"""
+    PoolError <: PormGError
+
+Abstract umbrella for connection-pool failures — `catch PoolError` to handle both saturation and
+connect failure without naming each. Subtypes: `ConnectionPool.PoolTimeoutError` (no connection
+became available in time) and `ConnectionPool.PoolConnectError` (the backend refused or dropped
+the connection).
+
+Both concrete types keep their structured fields (`adapter`, `pool_size`, `attempts`, …) and their
+own `showerror`, so they do not use the uniform `msg::String` shape — read them with
+[`error_message`](@ref).
+
+The umbrella lives here rather than in `ConnectionPool` on purpose (#261). The taxonomy's rule is
+that a concrete subtype either lives in `Kernel` or has a *dedicated* Kernel-owned abstract
+umbrella above it — the root `PormGError` does not count, or the rule would be vacuous. The pool
+errors were the only pair satisfying neither, which is the same mid-include-chain trap that made
+#239 need the `Kernel` extraction (#255). `Configuration` is included *before* `ConnectionPool`
+and already reasons about pool failure, so it could not have named those types.
+"""
+abstract type PoolError <: PormGError end
+
 # ── Schema, configuration and migration errors (#239) ───────────────────────
 
 """
@@ -212,6 +233,35 @@ end
 # reparented types that carry their own structured fields (PoolTimeoutError, PoolConnectError,
 # MissingDatabaseConfigurationException, DestructiveMigrationError), each next to its definition.
 Base.showerror(io::IO, e::PormGError) = print(io, e.msg)
+
+"""
+    error_message(e::PormGError) -> String
+
+The text of any PormG error, as a `String`.
+
+Use this instead of `e.msg`. Four subtypes are built from structured fields and have **no `msg`
+field at all** — `DoesNotExist`, `MultipleObjectsReturned`, `ConnectionPool.PoolTimeoutError`,
+`ConnectionPool.PoolConnectError` — so `e.msg` throws a `FieldError` on exactly the errors a caller
+is least likely to have tested against (#261).
+
+```julia
+try
+    M.Result.objects.values("bad alias!" => "points").list()
+catch e
+    e isa PormGError || rethrow()
+    @error "PormG rejected the query" msg=error_message(e) type=typeof(e)
+end
+```
+
+Defined via `showerror`, which every subtype implements, so it stays correct for subtypes added
+later without needing a new method. For subtypes that use the generic `showerror` above, the result
+is exactly `e.msg` (it prints that field verbatim, and `_emsg` has already normalized any ANSI at
+construction). Subtypes with their own `showerror` return that richer rendering instead — e.g.
+`Configuration.MissingDatabaseConfigurationException` and `Migrations.DestructiveMigrationError`
+both carry a `msg` yet prefix it with the error name, so `error_message` is a superset of `.msg`,
+never a subset.
+"""
+error_message(e::PormGError)::String = sprint(showerror, e)
 
 Base.showerror(io::IO, e::DoesNotExist) =
   print(io, "$(e.model_name).DoesNotExist: No record found matching filters: $(e.filters)")

--- a/test/unit/test_error_taxonomy.jl
+++ b/test/unit/test_error_taxonomy.jl
@@ -36,6 +36,9 @@ const TAXONOMY_TYPES = (
 # The abstract mid-nodes. Each groups its concrete leaves so `catch <node>` has no holes.
 const TAXONOMY_ABSTRACT = (
     PormG.FieldAccessError, PormG.ConfigurationError, PormG.MigrationError,
+    # #261: the pool errors were the only concrete subtypes with neither a Kernel home nor an
+    # abstract supertype in Kernel. `PoolError` closes that gap.
+    PormG.PoolError,
 )
 
 @testset "Error taxonomy (#231, #239)" begin
@@ -71,9 +74,16 @@ const TAXONOMY_ABSTRACT = (
         @test PormG.InvalidMigrationError <: PormG.MigrationError
         @test PormG.Migrations.DestructiveMigrationError <: PormG.MigrationError
 
-        # Reparented from bare `Exception` (#239) so `catch PormGError` covers the pool too.
+        # Reparented from bare `Exception` (#239) so `catch PormGError` covers the pool too,
+        # then grouped under the `PoolError` umbrella (#261) so `catch PoolError` handles
+        # saturation and connect failure without naming each.
         @test PormG.PoolTimeoutError <: PormG.PormGError
         @test PormG.PoolConnectError <: PormG.PormGError
+        @test PormG.PoolTimeoutError <: PormG.PoolError
+        @test PormG.PoolConnectError <: PormG.PoolError
+        # …and PoolError stays disjoint from the other umbrellas.
+        @test !(PormG.PoolError <: PormG.ConfigurationError)
+        @test !(PormG.InvalidConfigurationError <: PormG.PoolError)
 
         # …and the buckets stay disjoint: a config error is not a migration error.
         @test !(PormG.InvalidConfigurationError <: PormG.MigrationError)
@@ -112,6 +122,8 @@ const TAXONOMY_ABSTRACT = (
         @test InvalidConfigurationError === PormG.InvalidConfigurationError
         @test MigrationError === PormG.MigrationError
         @test InvalidMigrationError === PormG.InvalidMigrationError
+        @test PoolError === PormG.PoolError
+        @test error_message === PormG.error_message
 
         # QueryBuilder must see the SAME objects it imported, not redefinitions.
         @test QB.QueryBuildError === PormG.QueryBuildError
@@ -133,6 +145,63 @@ const TAXONOMY_ABSTRACT = (
         @test_throws PormG.QueryBuildError object(taxo_model).values("points__@gte")
         # UnsupportedConnectionError: a connection that is neither PG nor SQLite.
         @test_throws PormG.UnsupportedConnectionError QB._unsupported_conn("op", nothing)
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # error_message: one accessor for every subtype (#261)
+    # `api.md` and `UPGRADING.md` both tell callers to `catch PormGError`. The obvious next line
+    # is `e.msg`, which throws on the four subtypes built from structured fields. `error_message`
+    # is the uniform reader; this pins that it works for EVERY concrete member, so a subtype added
+    # later cannot quietly reintroduce the gap.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "error_message covers every concrete subtype (#261)" begin
+        # A representative instance per concrete type. The four structured ones are constructed
+        # through their real field signatures precisely because they have no `msg`.
+        samples = Any[
+            PormG.DoesNotExist("Driver", "(driverref = \"senna\")"),
+            PormG.MultipleObjectsReturned("Driver", 3, "(nationality = \"British\")"),
+            PormG.PoolTimeoutError("SQLite", 1, 10, 3, 1.5),
+            PormG.PoolConnectError("SQLite", "disk I/O error", "f1.sqlite", 2, 0.5),
+            # carries the blocked statements alongside its message
+            PormG.Migrations.DestructiveMigrationError("boom", ["DROP TABLE \"drivers\""]),
+        ]
+        for T in TAXONOMY_TYPES
+            # the msg-carrying majority share one constructor shape
+            T in (PormG.DoesNotExist, PormG.MultipleObjectsReturned,
+                  PormG.PoolTimeoutError, PormG.PoolConnectError,
+                  PormG.Migrations.DestructiveMigrationError) && continue
+            push!(samples, T("boom"))
+        end
+
+        for e in samples
+            msg = PormG.error_message(e)
+            @test msg isa String
+            @test !isempty(msg)
+        end
+
+        # For the structured types `.msg` does not exist — that is the whole reason this accessor
+        # exists. Assert the failure mode directly so the motivation cannot rot.
+        @test_throws Exception PormG.PoolTimeoutError("SQLite", 1, 10, 3, 1.5).msg
+        @test_throws Exception PormG.DoesNotExist("Driver", "(id = 1)").msg
+
+        # For subtypes using the GENERIC showerror it is exactly `e.msg` — the accessor is a
+        # drop-in replacement, not a reformatting.
+        e = PormG.FilterError("bad filter arg")
+        @test PormG.error_message(e) == e.msg
+
+        # For subtypes with their OWN showerror it is a superset: they carry a `msg` but render it
+        # with the error name prefixed. Pinned because the docs promise `error_message` never
+        # returns *less* than `.msg` — a future showerror that dropped the message would break that
+        # promise silently.
+        for e2 in (PormG.Configuration.MissingDatabaseConfigurationException("no connection.yml"),
+                   PormG.Migrations.DestructiveMigrationError("refused", ["DROP TABLE \"drivers\""]))
+            @test occursin(e2.msg, PormG.error_message(e2))
+            @test length(PormG.error_message(e2)) >= length(e2.msg)
+        end
+
+        # And it reflects the structured fields rather than a placeholder.
+        @test occursin("SQLite", PormG.error_message(PormG.PoolTimeoutError("SQLite", 1, 10, 3, 1.5)))
+        @test occursin("Driver", PormG.error_message(PormG.DoesNotExist("Driver", "(id = 1)")))
     end
 
     @testset "showerror renders the message; catch the root works" begin

--- a/test/unit/test_error_taxonomy.jl
+++ b/test/unit/test_error_taxonomy.jl
@@ -12,6 +12,7 @@ No database required: every assertion fires at query-build/validation time.
 # julia -t auto --project=. test/unit/test_error_taxonomy.jl
 
 using Test
+using InteractiveUtils: subtypes   # walk the taxonomy by TYPE, not by export list
 using PormG
 using PormG.Models
 using PormG.QueryBuilder: object, Q, Qor, With
@@ -41,7 +42,24 @@ const TAXONOMY_ABSTRACT = (
     PormG.PoolError,
 )
 
+# Walk the real type tree. `names(PormG)` only sees EXPORTED names, which silently omits
+# `Configuration.MissingDatabaseConfigurationException` and `Migrations.DestructiveMigrationError` —
+# the two types that live mid-include-chain, i.e. exactly the ones a placement guard must inspect.
+function _concrete_pormg_errors(T = PormG.PormGError, acc = Any[])
+    for S in subtypes(T)
+        isabstracttype(S) ? _concrete_pormg_errors(S, acc) : push!(acc, S)
+    end
+    return acc
+end
+
 @testset "Error taxonomy (#231, #239)" begin
+
+    # TAXONOMY_TYPES is hand-maintained, and every testset below iterates it — so if it drifts out
+    # of sync with the real hierarchy, all of them narrow silently instead of failing. Pin it to the
+    # type tree so adding a subtype without listing it here is a test failure, not a coverage hole.
+    @testset "TAXONOMY_TYPES is the whole taxonomy (#262)" begin
+        @test Set(TAXONOMY_TYPES) == Set(_concrete_pormg_errors())
+    end
 
     @testset "root and hierarchy" begin
         @test PormG.PormGError <: Exception
@@ -179,10 +197,24 @@ const TAXONOMY_ABSTRACT = (
             @test !isempty(msg)
         end
 
+        # Shape-only checks above would survive an `error_message` that returned, say, the type
+        # name. Assert the actual text reaches the caller for every sample built from a known
+        # message — that is the contract, and it is knowable.
+        for T in TAXONOMY_TYPES
+            T in (PormG.DoesNotExist, PormG.MultipleObjectsReturned,
+                  PormG.PoolTimeoutError, PormG.PoolConnectError,
+                  PormG.Migrations.DestructiveMigrationError) && continue
+            @test occursin("boom", PormG.error_message(T("boom")))
+        end
+
         # For the structured types `.msg` does not exist — that is the whole reason this accessor
-        # exists. Assert the failure mode directly so the motivation cannot rot.
-        @test_throws Exception PormG.PoolTimeoutError("SQLite", 1, 10, 3, 1.5).msg
-        @test_throws Exception PormG.DoesNotExist("Driver", "(id = 1)").msg
+        # exists. Assert on the FIELD SET rather than `@test_throws Exception …msg`: the latter also
+        # matches a MethodError from a changed constructor arity, so it could pass while the thing
+        # it documents had moved.
+        for T in (PormG.PoolTimeoutError, PormG.PoolConnectError,
+                  PormG.DoesNotExist, PormG.MultipleObjectsReturned)
+            @test :msg ∉ fieldnames(T)
+        end
 
         # For subtypes using the GENERIC showerror it is exactly `e.msg` — the accessor is a
         # drop-in replacement, not a reformatting.
@@ -195,8 +227,8 @@ const TAXONOMY_ABSTRACT = (
         # promise silently.
         for e2 in (PormG.Configuration.MissingDatabaseConfigurationException("no connection.yml"),
                    PormG.Migrations.DestructiveMigrationError("refused", ["DROP TABLE \"drivers\""]))
+            # `occursin` already implies the result is no shorter, so one assertion suffices.
             @test occursin(e2.msg, PormG.error_message(e2))
-            @test length(PormG.error_message(e2)) >= length(e2.msg)
         end
 
         # And it reflects the structured fields rather than a placeholder.

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -31,6 +31,52 @@ using PormG
         @test !isdefined(PormG.Kernel, :PormG)
     end
 
+    # ─────────────────────────────────────────────────────────────────────────
+    # The layering RULE, not today's inventory (#261, #262)
+    # The assertions above pin four names by hand, so they only catch a regression in those four.
+    # This derives the check from the export list instead, so a taxonomy type added later is
+    # covered without anyone remembering to extend a list — the same "assert the invariant, not
+    # the inventory" approach as the #259 drift guards.
+    #
+    # The rule: every concrete PormGError subtype either lives in Kernel, or has a DEDICATED
+    # Kernel-owned abstract umbrella above it. Nothing may sit mid-include-chain as a bare child
+    # of the root — that is exactly the shape that made #239 need the Kernel extraction, and it
+    # recurred with PoolTimeoutError / PoolConnectError until #261 added `PoolError`.
+    #
+    # "Dedicated" is load-bearing: `PormGError` itself is always Kernel-owned, so accepting any
+    # Kernel-parented supertype would make this check vacuous — it would pass for every subtype
+    # ever, including the violation it exists to catch. Verified by mutation: reverting
+    # PoolTimeoutError to `<: PormGError` must fail this testset.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "every taxonomy type is reachable from Kernel (#261)" begin
+        offenders = String[]
+        checked = 0
+        for n in names(PormG)
+            T = try getfield(PormG, n) catch; continue end
+            (T isa Type && T <: Exception && !isabstracttype(T)) || continue
+            checked += 1
+            parentmodule(T) === PormG.Kernel && continue
+            S = supertype(T)
+            (S !== PormG.PormGError && parentmodule(S) === PormG.Kernel) && continue
+            push!(offenders, "$(n): defined in $(parentmodule(T)), supertype $(S) " *
+                             "in $(parentmodule(S))")
+        end
+
+        if !isempty(offenders)
+            @error """
+            Exported exception type(s) reachable from neither Kernel nor a Kernel-owned umbrella.
+            Define the type in src/exceptions.jl (Kernel), or give it an abstract supertype there —
+            the pattern ConfigurationError / MigrationError / PoolError already follow. A type left
+            mid-include-chain cannot be named by any submodule included before it.
+            """ offenders
+        end
+        @test isempty(offenders)
+
+        # Guard the guard: if the export list or the filter ever stops matching anything, the loop
+        # above passes vacuously. There are 16 concrete exported exception types as of #261.
+        @test checked >= 16
+    end
+
     @testset "backend generics stay owned by PormG (layer 2)" begin
         # ext/PormGLibPQExt.jl and ext/PormGSQLiteExt.jl define their methods as
         # `PormG.backend_execute(...) = ...`. Julia only accepts a qualified method definition

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -11,6 +11,7 @@ No database required.
 # julia -t auto --project=. test/unit/test_kernel_layering.jl
 
 using Test
+using InteractiveUtils: subtypes   # walk the taxonomy by TYPE, not by export list
 using PormG
 
 @testset "Kernel layering" begin
@@ -43,22 +44,35 @@ using PormG
     # of the root — that is exactly the shape that made #239 need the Kernel extraction, and it
     # recurred with PoolTimeoutError / PoolConnectError until #261 added `PoolError`.
     #
-    # "Dedicated" is load-bearing: `PormGError` itself is always Kernel-owned, so accepting any
-    # Kernel-parented supertype would make this check vacuous — it would pass for every subtype
-    # ever, including the violation it exists to catch. Verified by mutation: reverting
-    # PoolTimeoutError to `<: PormGError` must fail this testset.
+    # Two things are load-bearing here, both learned the hard way:
+    #
+    #   • "Dedicated" excludes the root. `PormGError` is always Kernel-owned, so accepting ANY
+    #     Kernel-parented supertype made this check vacuous — it passed for every subtype ever,
+    #     including the violation it exists to catch.
+    #   • The walk is over `subtypes(PormGError)`, not `names(PormG)`. An export-list walk sees only
+    #     exported types, which silently omits `MissingDatabaseConfigurationException` and
+    #     `DestructiveMigrationError` — the two that actually live mid-include-chain, i.e. precisely
+    #     the ones this rule is about. Reparenting either to a bare `<: PormGError` must fail here.
+    #
+    # Both mutations are verified to fail this testset.
     # ─────────────────────────────────────────────────────────────────────────
     @testset "every taxonomy type is reachable from Kernel (#261)" begin
+        # Recursive walk of the real type tree — exported or not.
+        function _concrete_errors(T = PormG.PormGError, acc = Any[])
+            for S in subtypes(T)
+                isabstracttype(S) ? _concrete_errors(S, acc) : push!(acc, S)
+            end
+            return acc
+        end
+
         offenders = String[]
         checked = 0
-        for n in names(PormG)
-            T = try getfield(PormG, n) catch; continue end
-            (T isa Type && T <: Exception && !isabstracttype(T)) || continue
+        for T in _concrete_errors()
             checked += 1
             parentmodule(T) === PormG.Kernel && continue
             S = supertype(T)
             (S !== PormG.PormGError && parentmodule(S) === PormG.Kernel) && continue
-            push!(offenders, "$(n): defined in $(parentmodule(T)), supertype $(S) " *
+            push!(offenders, "$(nameof(T)): defined in $(parentmodule(T)), supertype $(S) " *
                              "in $(parentmodule(S))")
         end
 
@@ -72,9 +86,10 @@ using PormG
         end
         @test isempty(offenders)
 
-        # Guard the guard: if the export list or the filter ever stops matching anything, the loop
-        # above passes vacuously. There are 16 concrete exported exception types as of #261.
-        @test checked >= 16
+        # Guard the guard: if the walk or the filter ever stops matching anything, the loop above
+        # passes vacuously. 18 concrete subtypes as of #261 — 16 exported plus the two that are
+        # reached only by qualified name.
+        @test checked >= 18
     end
 
     @testset "backend generics stay owned by PormG (layer 2)" begin

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -28,6 +28,9 @@ const EXPECTED_TOPLEVEL = Set([
     :FieldValidationError, :ModelDefinitionError,
     :ConfigurationError, :InvalidConfigurationError,
     :MigrationError, :InvalidMigrationError,
+    # Taxonomy edges (#261): PoolError is the connection-pool umbrella; error_message is the
+    # uniform way to read a caught PormGError (the structured subtypes have no `.msg`).
+    :PoolError, :error_message,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API


### PR DESCRIPTION
Closes #261. Two seams found by auditing the **assembled** result of #255–#259 rather than the individual PRs — both public-API/layering commitments that get materially more expensive after publish.

## 1. `error_message(e)` — one way to read any PormG error

#239 told callers to `catch PormGError`. The obvious next line is `e.msg` — and it works for **12 of 16** concrete exported subtypes, then throws a `FieldError` on the four built from structured fields:

| Type | Fields | `.msg` |
|---|---|---|
| `DoesNotExist` | `model_name`, `filters` | ❌ |
| `MultipleObjectsReturned` | `model_name`, `count`, `filters` | ❌ |
| `PoolTimeoutError` | `adapter`, `pool_size`, `max_size`, `attempts`, `elapsed_seconds` | ❌ |
| `PoolConnectError` | `adapter`, `cause`, `connection`, `attempts`, `elapsed_seconds` | ❌ |

Those four carrying structured data is the **better** design — there was just no uniform way to get text out of them. Easy to hit: PormG's own tests already reach for `err.msg` (`test_subqueries.jl:106`), and they pass only because those happen to be `QueryBuildError`.

```julia
catch e
    e isa PormGError || rethrow()
    @error "PormG rejected the write" msg=error_message(e) type=typeof(e)
end
```

Defined through `showerror`, which every subtype implements, so it stays correct for subtypes added later without a new method. It **never returns less** than `.msg` did — exactly that field for the generic-`showerror` types, and the richer rendering for the few with their own (`MissingDatabaseConfigurationException`, `DestructiveMigrationError`). Both directions are pinned by tests.

Named `error_message`, not `message`: `using PormG` puts it in the caller's scope, and a name that common would clash with user code for no benefit.

## 2. `PoolError` — the umbrella the pool errors never had

The taxonomy follows a consistent rule — a concrete subtype either lives in `Kernel`, or has a **dedicated** Kernel-owned abstract umbrella above it:

| Pattern | Types |
|---|---|
| Concrete leaf in `Kernel` | `FilterError`, `QueryBuildError`, … (14) |
| Leaf in subsystem, umbrella in `Kernel` | `MissingDatabaseConfigurationException` → `ConfigurationError`; `DestructiveMigrationError` → `MigrationError` |
| **Leaf in subsystem, no umbrella** | **`PoolTimeoutError`, `PoolConnectError`** ← the only violation |

Both were defined in `ConnectionPool` (**include step 6**) as bare children of the root. Same mid-include-chain trap that made #239 need the `Kernel` extraction (#255) — and already half-live: `Configuration` is step **4** and already reasons about raising a `PoolConnectError` in a comment, so it could never have named the type.

**Non-breaking**: catching either concrete type still works, `catch PormGError` still works, and `catch PoolError` becomes possible.

## Also: #262's derived layering assertion

Included here because it is the regression guard for the placement fix above, and can only pass once `PoolError` exists. It replaces a hardcoded four-name check with one derived from the export list, so a type added later is covered without anyone extending a list.

⚠️ **It nearly shipped vacuous.** The first version accepted *any* Kernel-parented supertype — but `PormGError` is always Kernel-parented, so it passed for every subtype, including the violation it exists to catch. Only a mutation test found it. It now requires a *dedicated* umbrella (root excluded), and the mutation is verified to fail:

```
revert PoolTimeoutError <: PoolError → <: PormGError
  → exit 1: "PoolTimeoutError: defined in PormG.ConnectionPool, supertype PormGError in PormG.Kernel"
```

## Verification

| | |
|---|---|
| `Pkg.test()` | **4539 / 4539** |
| Docs build | exit 0 |
| SQLite integration | **1849 pass / 1 broken / 0 fail** |

The integration run is the notable one: this is the **first** taxonomy PR able to exercise the pool hierarchy for real, now that #264 made the suite runnable. #255–#258 each shipped saying integration was unverified.

**Not verified:** PostgreSQL (`db_2`) needs live credentials this environment lacks.

## `UPGRADING.md`

Logged as **corrective**, not additive — the file excludes additive features, but apps that followed #239's `catch PormGError` advice and then read `.msg` carry a latent `FieldError`. Fixing that is a real app edit, which is what the entry exists to prompt.

## After this

`#262` remains, reshaped by the same audit: two of its four "funnels" (`_argerr`, `_fielderr`) turn out to be pure type aliases left over from #231's mechanical swap, not abstractions — so the fix is to delete `_argerr` rather than unify four conventions. `_fielderr` waits for #260, which rewrites ~187 of its sites anyway.

**Merging this empties the `pre-publish` gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
