### PR TITLE
refactor: error-contract final pass — naming, capability split, closed escapes

### DIFF
--- a/.github/instructions/general.instructions.md
+++ b/.github/instructions/general.instructions.md
@@ -72,6 +72,7 @@ The subsystem map below is also the review **architecture checkpoint**: when a n
 | `src/Models.jl`, `src/models/` | Models and fields |
 | `src/QueryBuilder.jl`, `src/querybuilder/` | Query builder (incl. `many_to_many.jl`) |
 | `src/Dialect.jl` | Backend SQL rendering |
+| `src/AdvisoryLock.jl` | `with_advisory_lock` — cross-process advisory locking (migrations serialize on it) |
 | `src/Migrations.jl`, `src/migrations/` | State-based schema reconciliation |
 | `test/integration/` | DB integration tests (`db_2` = PostgreSQL, `db_sl` = SQLite via `PORMG_DB`) |
 | `docs/src/` | User documentation |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,92 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Error contract, final pass: renames, capability split, and closed escape hatches (audit / #268)
+
+- **Version**: Unreleased
+- **PormG ref**: the 2026-07-30 taxonomy audit; `src/exceptions.jl`, `src/Backend.jl`,
+  `src/Configuration.jl`, `src/ConnectionPool.jl`, `src/Dialect.jl`, `src/migrations/*`,
+  `src/querybuilder/*`, `docs/src/api.md`; boundary decision deferred to #268
+- **Recorded**: 2026-07-30
+- **Severity**: **breaking (error contract)** — the last pre-publish pass over error types. Three
+  renames, one type split, two new types, one umbrella, and ~20 formerly-untyped escape hatches now
+  raise taxonomy types. Part of the `0.3.x` pre-publish wave.
+
+### Renames (mechanical)
+
+| Before | After | Why |
+|---|---|---|
+| `PermissionError` | `WritesDisabledError` (now `<: ConfigurationError`) | The old name read as OS/file permissions or DB GRANTs; it means PormG's own `change_data: false` switch, and its remedy is a `connection.yml` edit |
+| `MissingDatabaseConfigurationException` | `MissingConfigurationError` | The sole `*Exception` that survived the #231 clean break |
+| `UnsupportedConnectionError` (capability cases) | `BackendCapabilityError` | See the split below |
+
+### The `UnsupportedConnectionError` split
+
+One type covered three disjoint remedies, distinguishable only by message text:
+
+- **Backend capability limits** → **`BackendCapabilityError`** (new): JSONB / `iunaccent_*` lookups
+  on SQLite, window `frame=` on SQLite (was `QueryBuildError`), `bulk_copy` on SQLite, too-old
+  SQLite library, an importer pointed at the wrong backend.
+- **Model not bound to a connection** → **`InvalidConfigurationError`** (whose docstring always
+  claimed this case). All three former entry-path variants now agree, and a fourth path that
+  produced a raw `MethodError` (config entry present but pool never built) is typed too.
+- **Internal dispatch bugs** keep `UnsupportedConnectionError` — "please report" cases only.
+
+### New types and umbrella
+
+- **`ProtectedError`** (new): `delete()` refused because rows reference the target via
+  `on_delete = PROTECT`/`RESTRICT`. Was the long-tail `QueryBuildError`, which made "the data
+  forbids this" indistinguishable from "your delete call is malformed". Mirrors Django.
+- **`DefinitionError`** (new abstract): umbrella over `FieldValidationError` +
+  `ModelDefinitionError` — one `include("models.jl")` can raise either. Non-breaking to catch.
+
+### Formerly untyped escapes — `catch PormGError` now actually covers these
+
+- **Bulk row validation** (`bulk_insert`/`bulk_copy`/`bulk_update`): a failing row now rethrows
+  PormG's own error (e.g. `InvalidValueError`) instead of stringifying it into `ErrorException` —
+  `catch InvalidValueError` now behaves the same for `insert()` and `bulk_insert()`.
+- **Missing driver** (`using SQLite`/`using LibPQ` forgotten): all backend generics now raise
+  `InvalidConfigurationError` instead of `ErrorException` (message unchanged).
+- **Migration engine**: no-pending-plan, SQLite PK-column deletion, missing models file
+  (`MissingConfigurationError`), unparseable introspected DDL, importer field failures — all typed
+  (`InvalidMigrationError` unless noted); a wrapped `FieldValidationError` now rethrows as itself.
+- **`before_connect` hook abort** → `PoolConnectError` (so `catch PoolError` covers it).
+- **`get_or_create` unknown lookup/defaults field** → `UnknownFieldError`, matching
+  `update_or_create` (they disagreed).
+- **`SET_NULL` on a `null=false` FK** → `ModelDefinitionError` (schema self-contradiction; was
+  `InvalidValueError`).
+
+**Still outside the taxonomy, deliberately:** runtime database failures (constraint violations,
+rejected SQL, dropped connections) still propagate as raw driver exceptions — that boundary is the
+open pre-publish decision in **#268**, now stated honestly in `api.md`. `with_advisory_lock`'s
+timeout stays `ErrorException` pending the same decision.
+
+### How to find the calls to migrate
+
+```
+rg -n 'PermissionError|MissingDatabaseConfigurationException' <app>
+rg -n 'UnsupportedConnectionError' <app>   # decide per site: capability → BackendCapabilityError
+rg -n 'catch|@test_throws|isa' <app> | rg 'ErrorException'   # bulk/migration/driver-hint catches
+```
+
+### Migrate your app
+
+```julia
+# ✗ before
+catch e
+    e isa PermissionError && fall_back_to_readonly()
+
+# ✓ after
+catch e
+    e isa WritesDisabledError && fall_back_to_readonly()
+```
+
+A `catch UnsupportedConnectionError` around a query that might hit a backend limit must become
+`catch BackendCapabilityError`; one guarding against a missing driver becomes
+`catch InvalidConfigurationError`.
+
+---
+
 ## Read a caught `PormGError` with `error_message`, not `e.msg` (#261)
 
 - **Version**: Unreleased

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -657,7 +657,15 @@ Every PormG misuse raises a subtype of `PormGError` (`<: Exception`) so callers 
 **type** instead of matching on a message string. Catch `PormGError` for any PormG failure, or a
 specific subtype for a specific reaction (#231, completed in #239):
 
-`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `PermissionError`, `UnsupportedConnectionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`, `PoolError`, `error_message`
+`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `WritesDisabledError`, `UnsupportedConnectionError`, `BackendCapabilityError`, `ProtectedError`, `DefinitionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`, `PoolError`, `error_message`
+
+!!! note "Database-level errors are not (yet) wrapped"
+    The taxonomy covers *misuse of PormG*. Once a statement reaches the database, failures —
+    a constraint violation, SQL the backend rejects, a connection dropped mid-query — currently
+    propagate as the **driver's own exception types** (`SQLite.SQLiteException`,
+    `LibPQ.Errors.*`), *not* as `PormGError`. Connect-time failures are the exception: they
+    arrive as `PoolConnectError`. Whether to wrap the rest is an open pre-publish decision —
+    see [#268](https://github.com/PingoLee/PormG.jl/issues/268).
 
 !!! warning "These are not `ArgumentError`s"
     The subtypes are deliberately **not** `<: ArgumentError`. A `catch ArgumentError` block around a
@@ -693,15 +701,18 @@ field, and for the few with their own `showerror` it returns the richer renderin
 | `FilterError` | Invalid filter argument/shape, or an operator misused on a JSON/subquery column. |
 | `QueryBuildError` | Structural/API misuse while building a query (joins, CTEs, projection, ordering, window/bulk config). **The long-tail default** — it is the bucket for query-shape misuse that isn't one of the sharper categories, so `catch QueryBuildError` says little beyond "PormG rejected the query shape". Catch a sharper subtype when you need to branch on the cause. |
 | `UnsafeMutationError` | An `update()`/`delete()` was requested without a filter (or another unsafe shape). |
+| `ProtectedError` | A `delete()` was refused because rows reference the target through a `ForeignKey` with `on_delete = PROTECT`/`RESTRICT` — the data forbids it; delete or reassign the referencing rows first. |
+| `BackendCapabilityError` | The active backend cannot do this: PG-only lookups on SQLite (JSONB, `iunaccent_*`), explicit window `frame=` on SQLite, `bulk_copy` on SQLite, or a too-old SQLite library. Change the query or the backend. |
 | `InvalidValueError` | A **value** failed coercion/type validation on insert/update, an identifier failed the safety check, or an interval/duration could not be parsed. |
-| `PermissionError` | The connection is not permitted to insert/update/delete (`change_data=false`). |
-| `UnsupportedConnectionError` | A connection is neither PostgreSQL nor SQLite, a model is not bound to a connection, or a lookup requires a backend this connection is not. |
+| `WritesDisabledError` | The connection is not permitted to insert/update/delete — `change_data: false` in `connection.yml`, which is why it lives under `ConfigurationError`. (Renamed from `PermissionError` in the pre-publish naming pass.) |
+| `UnsupportedConnectionError` | A connection object that is neither PostgreSQL nor SQLite reached an execution path — an internal PormG dispatch bug; please report it. (Capability limits are `BackendCapabilityError`; an unbound model is `InvalidConfigurationError`.) |
 | `DoesNotExist` / `MultipleObjectsReturned` | `get()` found zero / more than one row. |
 
 **Defining models**
 
 | Type | Raised when |
 | :--- | :--- |
+| `DefinitionError` *(abstract)* | Umbrella for definition-time failures — `catch` it to get both cases below. One `include("models.jl")` can raise either, so a handler naming only one silently misses the other. |
 | `FieldValidationError` | A field constructor got an invalid argument — a kwarg of the wrong type, an out-of-range `max_length`, a `default` that violates the field's own contract, or a field type that cannot be a primary key. |
 | `ModelDefinitionError` | A model/schema definition is invalid — more than one primary key, a duplicate `related_name`, an illegal field name, a `UniqueConstraint` naming an unknown field, or an unresolvable `ForeignKey` target. |
 
@@ -712,9 +723,9 @@ field, and for the few with their own `showerror` it returns the richer renderin
 
 | Type | Raised when |
 | :--- | :--- |
-| `ConfigurationError` *(abstract)* | Umbrella for connection-configuration failures — `catch` it to get both cases below. |
-| `InvalidConfigurationError` | Configuration is present but unusable — unsupported adapter, unknown connection key, malformed `extensions`, or an attempt to overwrite a static connection. |
-| `MissingDatabaseConfigurationException` | No configuration folder / `connection.yml`, or the selected environment has no matching block. |
+| `ConfigurationError` *(abstract)* | Umbrella for configuration failures — covers `InvalidConfigurationError`, `MissingConfigurationError`, **and** `WritesDisabledError` (listed in the Querying table above, where users meet it). |
+| `InvalidConfigurationError` | Configuration is present but unusable — unsupported adapter, unknown connection key, malformed `extensions`, a model not bound to a connection (or bound to an entry whose pool was never built), a missing driver package, or an attempt to overwrite a static connection. |
+| `MissingConfigurationError` | No configuration folder / `connection.yml`, or the selected environment has no matching block. |
 | `MigrationError` *(abstract)* | Umbrella for migration-engine failures — `catch` it to get both cases below. |
 | `InvalidMigrationError` | A duplicate index name in a plan, an invalid answer to an interactive `makemigrations` prompt, or an unimplemented `migrate_to(version)` path. |
 | `DestructiveMigrationError` | A destructive plan was applied non-interactively without `destructive=true`. |
@@ -730,7 +741,7 @@ try
     M.Result.objects.update("points" => 25)   # no filter → refused, protects every row
 catch e
     e isa PormG.UnsafeMutationError && @warn "add a filter before update()"
-    e isa PormG.PermissionError    && @warn "this connection is read-only"
+    e isa PormG.WritesDisabledError    && @warn "this connection is read-only"
     rethrow(e)
 end
 ```

--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -4,7 +4,7 @@ PormG uses a centralized YAML configuration file—typically located at `db/conn
 
 ## Creating `connection.yml`
 
-During standard initialization, `PormG.Configuration.load(path)` reads a `connection.yml` from `path` (default `DB_PATH`). If the folder or file is missing it **throws** a `MissingDatabaseConfigurationException` that points you at `PormG.setup(path)` (interactive) or `load(path; scaffold=true)` (writes an editable skeleton) — it no longer silently scaffolds a file and returns.
+During standard initialization, `PormG.Configuration.load(path)` reads a `connection.yml` from `path` (default `DB_PATH`). If the folder or file is missing it **throws** a `MissingConfigurationError` that points you at `PormG.setup(path)` (interactive) or `load(path; scaffold=true)` (writes an editable skeleton) — it no longer silently scaffolds a file and returns.
 
 To scaffold it programmatically, you can run:
 

--- a/docs/src/read/filters_and_aggregates.md
+++ b/docs/src/read/filters_and_aggregates.md
@@ -163,7 +163,7 @@ M.Driver.objects.filter("surname__@iunaccent_contains" => "raikkonen")
 M.Driver.objects.filter("surname__@iunaccent_exact" => "RAIKKONEN")
 ```
 
-They require the `unaccent` extension and its `immutable_unaccent` helper, declared once in `connection.yml` and installed by `migrate()` — see [PostgreSQL Extensions](../configuration/connection_yml.md#PostgreSQL-Extensions). On SQLite these lookups raise an `UnsupportedConnectionError`.
+They require the `unaccent` extension and its `immutable_unaccent` helper, declared once in `connection.yml` and installed by `migrate()` — see [PostgreSQL Extensions](../configuration/connection_yml.md#PostgreSQL-Extensions). On SQLite these lookups raise a `BackendCapabilityError`.
 
 There is no `@iunaccent_in`; OR the equality lookup with [`Qor`](q_objects.md) for accent-insensitive set membership:
 
@@ -228,7 +228,7 @@ Supported comparisons on a path lookup: `=` (default), `@ne`, `@gt`, `@gte`, `@l
 ### Containment and key-existence operators (PostgreSQL only)
 
 These map to the PostgreSQL JSONB operators and apply to a JSON **column** (not a nested path).
-On SQLite they raise an `UnsupportedConnectionError`:
+On SQLite they raise a `BackendCapabilityError`:
 
 | Lookup | JSONB operator | Meaning | Example |
 | :--- | :--- | :--- | :--- |

--- a/docs/src/read/window_functions.md
+++ b/docs/src/read/window_functions.md
@@ -376,7 +376,7 @@ ORDER BY "constructorid" ASC, "positionorder" ASC
 ```
 
 !!! warning
-    Explicit frame strings are PostgreSQL-only. Passing `frame=` on a SQLite connection throws a `QueryBuildError` with a helpful message.
+    Explicit frame strings are PostgreSQL-only. Passing `frame=` on a SQLite connection throws a `BackendCapabilityError` with a helpful message.
 
 **Frame unit — `ROWS` vs `RANGE`**
 
@@ -803,12 +803,12 @@ PormG quotes the alias in `ORDER BY` and never adds it to `GROUP BY`.
 
 ## SQLite Support
 
-All window functions work on SQLite **3.25.0 and later** (released 2018-09-15). PormG checks the SQLite library version at query time and throws a clear `UnsupportedConnectionError` if the library is too old.
+All window functions work on SQLite **3.25.0 and later** (released 2018-09-15). PormG checks the SQLite library version at query time and throws a clear `BackendCapabilityError` if the library is too old.
 
 ```julia
 # SQLite version check happens automatically — you do not need to call it yourself.
 # If the library is too old, you will see:
-# UnsupportedConnectionError: SQLite window functions require SQLite >= 3.25.0; current SQLite library is 3.24.0.
+# BackendCapabilityError: SQLite window functions require SQLite >= 3.25.0; current SQLite library is 3.24.0.
 ```
 
 The only SQLite limitation is **explicit frame specifications** (`frame=` argument). These are PostgreSQL-only for now.
@@ -832,7 +832,7 @@ The only SQLite limitation is **explicit frame specifications** (`frame=` argume
 
 - **Aggregate-over-window** (`SUM(...) OVER (...)`) is not yet implemented. Use a CTE to aggregate first, then apply the window in the outer query.
 - **Named `WINDOW` clauses** (`WINDOW w AS (...)`) are not supported. Each function carries its own inline `OVER`.
-- **SQLite explicit frame specs** throw a `QueryBuildError`. Use PostgreSQL for frame-bound queries.
+- **SQLite explicit frame specs** throw a `BackendCapabilityError`. Use PostgreSQL for frame-bound queries.
 
 ---
 

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -64,7 +64,7 @@ sql = delete(query, show_query=:sql)
 
 ### `change_data` Guard
 
-If the connection is configured with `change_data: false`, any call to `delete()` raises a `PermissionError` at the ORM layer before generating SQL.
+If the connection is configured with `change_data: false`, any call to `delete()` raises a `WritesDisabledError` at the ORM layer before generating SQL.
 
 ```julia
 # connection.yml: change_data: false

--- a/docs/src/write/update.md
+++ b/docs/src/write/update.md
@@ -163,7 +163,7 @@ update_q.update("nationality" => "English")
 
 ### `change_data` Guard
 
-If the connection is configured with `change_data: false`, any call to `.update()` raises a `PermissionError` at the ORM layer before generating SQL. This applies to both normal execution and `show_query=:dict` dry-runs.
+If the connection is configured with `change_data: false`, any call to `.update()` raises a `WritesDisabledError` at the ORM layer before generating SQL. This applies to both normal execution and `show_query=:dict` dry-runs.
 
 ```julia
 # connection.yml: change_data: false

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -45,7 +45,10 @@ for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
            :backend_sqlite_version)
   @eval begin
     function $fn end
-    $fn(pool::PormGPostgres, args...; kwargs...) = error(_PG_DRIVER_HINT)
-    $fn(pool::PormGSQLite, args...; kwargs...) = error(_SQLITE_DRIVER_HINT)
+    # InvalidConfigurationError, not ErrorException: forgetting `using LibPQ`/`using SQLite` is a
+    # setup mistake the docs' `catch PormGError` recipe must cover (audit finding — this fires from
+    # ALL backend generics, i.e. the first thing a consumer hits with a missing driver).
+    $fn(pool::PormGPostgres, args...; kwargs...) = throw(InvalidConfigurationError(_PG_DRIVER_HINT))
+    $fn(pool::PormGSQLite, args...; kwargs...) = throw(InvalidConfigurationError(_SQLITE_DRIVER_HINT))
   end
 end

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -70,18 +70,20 @@ const TEST  = "test"
 
 # Raised when configuration cannot be loaded: a missing folder/yml (`load` no longer silently
 # scaffolds + returns `nothing` — #205) or a selected environment with no matching block in the
-# yaml. Typed so callers can `catch e; e isa MissingDatabaseConfigurationException`. Previously the
+# yaml. Typed so callers can `catch e; e isa MissingConfigurationError`. Renamed from
+# `MissingDatabaseConfigurationException` in the pre-publish naming pass — the sole `*Exception`
+# that survived the #231 clean break in an otherwise uniform `*Error` taxonomy. Previously the
 # "no matching block" path referenced this name without defining it, so it threw an `UndefVarError`
 # instead of the intended message.
 #
 # Reparented from `Exception` to `ConfigurationError <: PormGError` (#239): catching the specific
 # type still works, it is merely ALSO catchable as `ConfigurationError` / `PormGError`. It keeps
 # its own `showerror` below (a more specific method wins over the taxonomy's shared one).
-struct MissingDatabaseConfigurationException <: ConfigurationError
+struct MissingConfigurationError <: ConfigurationError
   msg::String
 end
-Base.showerror(io::IO, e::MissingDatabaseConfigurationException) =
-  print(io, "MissingDatabaseConfigurationException: ", e.msg)
+Base.showerror(io::IO, e::MissingConfigurationError) =
+  print(io, "MissingConfigurationError: ", e.msg)
 
 #
 # Thread-Local Transaction Context
@@ -575,7 +577,7 @@ function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{
   # No block for the selected env — list the available ones so the fix is obvious (#205).
   available = sort!(String[string(k) for (k, v) in db_conn_data if v isa AbstractDict])
   avail_str = isempty(available) ? "(none defined)" : join(available, ", ")
-  throw(MissingDatabaseConfigurationException(
+  throw(MissingConfigurationError(
     "environment \"$(settings.app_env)\" not found in $(db_settings_file); available: $(avail_str). " *
     "Select one with `load(...; env=\"…\")`, `ENV[\"PORMG_ENV\"]`, or a top-level `default_env:` in the yaml."))
 end
@@ -601,7 +603,7 @@ function load(path::Union{String,Nothing} = nothing; context::Union{Module,Nothi
     end
     missing_what = !isdir(path) ? "the folder \"$(path)\" does not exist" :
                                   "no \"$(PORMG_DB_CONFIG_FILE_NAME)\" was found in \"$(path)\""
-    throw(MissingDatabaseConfigurationException(
+    throw(MissingConfigurationError(
       "cannot load PormG configuration: $(missing_what). Create it interactively with " *
       "`PormG.setup(\"$(path)\")`, or call `PormG.Configuration.load(\"$(path)\"; scaffold=true)` " *
       "to write a skeleton to edit."))

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -105,7 +105,11 @@ Base.showerror(io::IO, e::PoolConnectError) = print(io,
 function _run_before_connect!(pool::Union{PormGPostgres, PormGSQLite})
   if !ensure_before_connect!(pool)
     key = something(connection_key_for_pool(pool), "?")
-    throw(ErrorException("before_connect hook aborted the connection for '$(key)'"))
+    # PoolConnectError, not ErrorException: a hook refusing the connection is a connect-time
+    # failure like any other, and `catch PoolError` must cover it (audit finding). The hook is the
+    # documented downstream-extension seam (Nitro), so this is consumer-reachable.
+    throw(PoolConnectError(pool isa PormGPostgres ? "PostgreSQL" : "SQLite",
+                           "before_connect hook aborted the connection", key, 1, 0.0))
   end
   return nothing
 end

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -6,10 +6,10 @@ import PormG: PormGSettings, SQLType, SQLInstruction, SQLTypeQ, SQLTypeQor, SQLT
 import PormG: backend_sqlite_version  # SQLite library-version probe (driver body in the weakdep extension)
 # Semantic error taxonomy (#239). Dialect raises three categories:
 #   InvalidValueError          — a rendered value has the wrong Julia type ("must be a String").
-#   UnsupportedConnectionError — the active backend cannot do this (a PG-only JSONB/unaccent
+#   BackendCapabilityError — the active backend cannot do this (a PG-only JSONB/unaccent
 #                                lookup, an extract part SQLite lacks, too old a SQLite library).
 #   QueryBuildError            — the caller passed an impossible argument shape (on_conflict_clause).
-import PormG: InvalidValueError, UnsupportedConnectionError, QueryBuildError
+import PormG: InvalidValueError, BackendCapabilityError, QueryBuildError
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse
 import PormG: get_constraints_pk, get_constraints_unique, get_constraints_check
@@ -134,7 +134,7 @@ function _assert_sqlite_window_support(conn::PormGSQLite)
     # Reconstruct M.mm.pp from the packed version integer (e.g. 3039000 -> "3.39.0").
     major, rem = divrem(version_number, 1_000_000)
     minor, patch = divrem(rem, 1_000)
-    throw(UnsupportedConnectionError("SQLite window functions require SQLite >= 3.25.0; current SQLite library is $major.$minor.$patch."))
+    throw(BackendCapabilityError("SQLite window functions require SQLite >= 3.25.0; current SQLite library is $major.$minor.$patch."))
   end
   return nothing
 end
@@ -263,7 +263,7 @@ function EXTRACT(column::String, format::Dict{String,Any}, conn::PormGSQLite)
   elseif part == "DOY"
     "%j"
   else
-    throw(UnsupportedConnectionError("Unsupported extract part for SQLite: $part"))
+    throw(BackendCapabilityError("Unsupported extract part for SQLite: $part"))
   end
 
   return "CAST(strftime('$(strftime_format)', $(column)) AS INTEGER)"
@@ -1098,40 +1098,40 @@ function jcontains(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) @> $(value)"                    # jsonb contains the given document
 end
 function jcontains(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
 end
 function jcontains(conn::PormGAbstractType, column::String, value)
-  throw(UnsupportedConnectionError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @jcontains lookup (JSONB @>) requires PostgreSQL"))
 end
 
 function has_key(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ? $(value)"                     # top-level key exists
 end
 function has_key(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
 end
 function has_key(conn::PormGAbstractType, column::String, value)
-  throw(UnsupportedConnectionError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_key lookup (JSONB ?) requires PostgreSQL"))
 end
 
 function has_any_keys(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ?| $(value)"                    # any of the given keys exists
 end
 function has_any_keys(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
 end
 function has_any_keys(conn::PormGAbstractType, column::String, value)
-  throw(UnsupportedConnectionError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_any_keys lookup (JSONB ?|) requires PostgreSQL"))
 end
 
 function has_keys(conn::PormGPostgres, column::String, value::String)::String
   return "$(column) ?& $(value)"                    # all of the given keys exist
 end
 function has_keys(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
 end
 function has_keys(conn::PormGAbstractType, column::String, value)
-  throw(UnsupportedConnectionError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
+  throw(BackendCapabilityError("The @has_keys lookup (JSONB ?&) requires PostgreSQL"))
 end
 
 function contains(conn::PormGPostgres, column::String, value::String)::String
@@ -1164,7 +1164,7 @@ function iunaccent_contains(conn::PormGPostgres, column::String, value::String):
   return "public.immutable_unaccent($(column)) ILIKE public.immutable_unaccent($(value))$(_like_escape_clause())"
 end
 function iunaccent_contains(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The iunaccent_contains lookup requires PostgreSQL and the unaccent extension"))
+  throw(BackendCapabilityError("The iunaccent_contains lookup requires PostgreSQL and the unaccent extension"))
   return nothing
 end
 function iunaccent_contains(conn::PormGAbstractType, column::String, value)
@@ -1179,7 +1179,7 @@ function iunaccent_exact(conn::PormGPostgres, column::String, value::String)::St
   return "LOWER(public.immutable_unaccent($(column))) = LOWER(public.immutable_unaccent($(value)))"
 end
 function iunaccent_exact(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The iunaccent_exact lookup requires PostgreSQL and the unaccent extension"))
+  throw(BackendCapabilityError("The iunaccent_exact lookup requires PostgreSQL and the unaccent extension"))
   return nothing
 end
 function iunaccent_exact(conn::PormGAbstractType, column::String, value)
@@ -1268,7 +1268,7 @@ function niunaccent_contains(conn::PormGPostgres, column::String, value::String)
   return "public.immutable_unaccent($(column)) NOT ILIKE public.immutable_unaccent($(value))$(_like_escape_clause())"
 end
 function niunaccent_contains(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The niunaccent_contains lookup requires PostgreSQL and the unaccent extension"))
+  throw(BackendCapabilityError("The niunaccent_contains lookup requires PostgreSQL and the unaccent extension"))
   return nothing
 end
 function niunaccent_contains(conn::PormGAbstractType, column::String, value)
@@ -1280,7 +1280,7 @@ function niunaccent_exact(conn::PormGPostgres, column::String, value::String)::S
   return "LOWER(public.immutable_unaccent($(column))) <> LOWER(public.immutable_unaccent($(value)))"
 end
 function niunaccent_exact(conn::PormGSQLite, column::String, value::String)
-  throw(UnsupportedConnectionError("The niunaccent_exact lookup requires PostgreSQL and the unaccent extension"))
+  throw(BackendCapabilityError("The niunaccent_exact lookup requires PostgreSQL and the unaccent extension"))
   return nothing
 end
 function niunaccent_exact(conn::PormGAbstractType, column::String, value)

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -161,12 +161,15 @@ export PormGAbstractType, PormGSettings, PormGBackend, PormGPostgres, PormGSQLit
 export PormGError,
        FieldAccessError, UnknownFieldError, LazyTraversalError,
        FilterError, QueryBuildError, UnsafeMutationError, InvalidValueError,
-       PermissionError, UnsupportedConnectionError,
+       WritesDisabledError, UnsupportedConnectionError,
        DoesNotExist, MultipleObjectsReturned,
        FieldValidationError, ModelDefinitionError,
        ConfigurationError, InvalidConfigurationError,
        MigrationError, InvalidMigrationError,
-       PoolError, error_message
+       PoolError, error_message,
+       # Pre-publish naming pass (#268-era audit): narrowed/added members (WritesDisabledError
+       # replaces PermissionError on the taxonomy line above).
+       BackendCapabilityError, ProtectedError, DefinitionError
 
 # Shared state / generics
 export config, get_constraints_pk, get_constraints_unique, get_constraints_check

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -21,10 +21,13 @@ using Logging
 
 import PormG: @pormg_debug
 import PormG: _emsg  # shared TTY-aware error/log-message strip helper (Kernel)
-import PormG: MigrationError, InvalidMigrationError  # semantic error taxonomy (#239); defined in Kernel
+import PormG: PormGError, MigrationError, InvalidMigrationError  # semantic error taxonomy (#239); defined in Kernel
 # importers.jl reports a wrong-backend connection with the precise type rather than folding it
 # into MigrationError — an unknown key already fails earlier as InvalidConfigurationError.
-import PormG: UnsupportedConnectionError
+import PormG: BackendCapabilityError
+# MissingConfigurationError lives in Configuration (its umbrella ConfigurationError is in Kernel);
+# it is NOT a PormG-level binding, so it must be imported from the owning module.
+import PormG.Configuration: MissingConfigurationError
 
 import PormG: Models, Migration, Dialect
 import PormG.Models: format_model_name

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -141,7 +141,7 @@ end
 # live in `PormG.Functions` and are reached via `using PormG.Functions` / `PormG.Functions.X`.
 export object, get, PormGRow, pk, DoesNotExist, MultipleObjectsReturned, Q, Qor, F, Exists, OuterRef, Subquery, Interval, show_query, inspect_query, bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 # Semantic error taxonomy (#231): catch `PormGError` for any query-builder misuse, or a specific subtype.
-export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError, QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError
+export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError, QueryBuildError, UnsafeMutationError, InvalidValueError, WritesDisabledError, UnsupportedConnectionError, BackendCapabilityError, ProtectedError
 # Schema / configuration / migration errors (#239). These complete the taxonomy: `catch PormGError`
 # now covers field-constructor and model-definition mistakes, connection config, and the migration
 # engine — not just the query builder.
@@ -151,7 +151,7 @@ export FieldValidationError, ModelDefinitionError,
 # Taxonomy edges (#261). `PoolError` is the connection-pool umbrella — the pool errors were the
 # only concrete subtypes with neither a Kernel home nor an abstract one. `error_message` is the
 # uniform way to read a caught PormGError: the structured subtypes have no `.msg` field.
-export PoolError, error_message
+export PoolError, error_message, DefinitionError
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -11,7 +11,8 @@ import PormG: SQLType, PormGSettings, PormGSQLite, PormGPostgres, PormGSQLitePar
 # `Kernel` (layer 1) so every subsystem can reach them; only the message-composing funnels
 # (`_unsupported_conn`, `_write_not_allowed`) live in `querybuilder/error_funnels.jl`.
 import PormG: PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError,
-  QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError,
+  QueryBuildError, UnsafeMutationError, InvalidValueError, WritesDisabledError, UnsupportedConnectionError, BackendCapabilityError, ProtectedError,
+  InvalidConfigurationError,   # thrown by the model-not-bound guards (audit: was UnsupportedConnectionError)
   DoesNotExist, MultipleObjectsReturned,
   # Not thrown here — CAUGHT here: last()/save()/delete() convert Models' composite-pk failure
   # into an actionable QueryBuildError (#239).
@@ -105,7 +106,7 @@ export get
 export PormGRow, pk, DoesNotExist, MultipleObjectsReturned
 # Semantic error taxonomy (#231): every query-builder misuse throws a PormGError subtype.
 export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError,
-  QueryBuildError, UnsafeMutationError, InvalidValueError, PermissionError, UnsupportedConnectionError
+  QueryBuildError, UnsafeMutationError, InvalidValueError, WritesDisabledError, UnsupportedConnectionError, BackendCapabilityError, ProtectedError
 # do_count and do_exists are now strictly used as functors (query.count(), query.exists())
 export bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -197,7 +197,10 @@ import .models as M
 macro import_models(path_expr, alias)
     source_file = string(__source__.file)
     if !(path_expr isa String)
-        error("@import_models requires a string literal path, got: $(typeof(path_expr))")
+        # ArgumentError, deliberately outside the taxonomy: a non-literal macro argument is
+        # Julia-level API misuse (same class as tools.jl's two keeps), not a PormG domain error.
+        # Pinned in test_docs_error_type_drift.jl's allowlist.
+        throw(ArgumentError("@import_models requires a string literal path, got: $(typeof(path_expr))"))
     end
 
     calling_module = __module__

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -109,35 +109,73 @@ struct InvalidValueError <: PormGError
 end
 
 """
-    PermissionError(msg) <: PormGError
-
-The connection is not permitted to insert/update/delete — its settings carry `change_data=false`.
-"""
-struct PermissionError <: PormGError
-  msg::String
-  PermissionError(msg::AbstractString) = new(_emsg(msg))
-end
-
-"""
     UnsupportedConnectionError(msg) <: PormGError
 
-A connection that is neither a PostgreSQL nor a SQLite pool (or a model not bound to a
-connection) reached an execution path, or a lookup/function requires a backend the active
-connection is not. The catchable replacement for the internal `ErrorException` from #197.
+A connection object that is neither a PostgreSQL nor a SQLite pool reached an execution path —
+a PormG internal dispatch bug; the message asks the user to report it. The catchable replacement
+for the internal `ErrorException` from #197.
+
+Narrowed in the pre-publish naming pass: it previously also covered backend capability limits
+(now [`BackendCapabilityError`](@ref)) and models not bound to a connection (now
+[`InvalidConfigurationError`](@ref), whose docstring always claimed that case) — three disjoint
+remedies distinguishable only by message text, which is the failure mode this taxonomy exists to
+remove.
 """
 struct UnsupportedConnectionError <: PormGError
   msg::String
   UnsupportedConnectionError(msg::AbstractString) = new(_emsg(msg))
 end
 
+"""
+    BackendCapabilityError(msg) <: PormGError
+
+The active backend cannot do this — a PostgreSQL-only lookup on SQLite (JSONB containment,
+`iunaccent_*`), an explicit window `frame=` on SQLite, `bulk_copy` on SQLite, or a SQLite library
+older than a feature requires. The query is well-formed and the configuration is fine; the remedy
+is to change the query or the backend. Split out of `UnsupportedConnectionError` in the pre-publish
+naming pass — capability limits are a user-facing contract, not an internal error.
+"""
+struct BackendCapabilityError <: PormGError
+  msg::String
+  BackendCapabilityError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    ProtectedError(msg) <: PormGError
+
+A `delete()` was refused because other rows reference the target through a `ForeignKey` declared
+with `on_delete = PROTECT` (or `RESTRICT`). Nothing about the call is malformed — the *data*
+forbids it, and the remedy is to delete or reassign the referencing rows first. Mirrors Django's
+`ProtectedError`/`RestrictedError`; previously filed under the long-tail `QueryBuildError`, which
+made this case indistinguishable from a malformed delete.
+"""
+struct ProtectedError <: PormGError
+  msg::String
+  ProtectedError(msg::AbstractString) = new(_emsg(msg))
+end
+
 # get() cardinality errors — reparented from `Exception` to `PormGError` (#231) so
 # `catch PormGError` catches them too. They keep their structured fields and field-built
 # `showerror` (below), which is why they don't use the uniform `msg::String` shape.
+"""
+    DoesNotExist <: PormGError
+
+`get()` matched zero rows. Carries `model_name` and the rendered `filters` (structured — no `msg`
+field; read it with [`error_message`](@ref)). Often normal control flow: catch it to implement
+get-or-create-style logic.
+"""
 struct DoesNotExist <: PormGError
   model_name::String
   filters::String
 end
 
+"""
+    MultipleObjectsReturned <: PormGError
+
+`get()` matched more than one row — usually a data-integrity surprise rather than control flow.
+Carries `model_name`, the offending `count`, and the rendered `filters` (structured — no `msg`
+field; read it with [`error_message`](@ref)).
+"""
 struct MultipleObjectsReturned <: PormGError
   model_name::String
   count::Int
@@ -168,7 +206,18 @@ abstract type PoolError <: PormGError end
 # ── Schema, configuration and migration errors (#239) ───────────────────────
 
 """
-    FieldValidationError(msg) <: PormGError
+    DefinitionError <: PormGError  (abstract)
+
+Umbrella for model-definition-time failures — `catch DefinitionError` covers both a bad field
+constructor argument ([`FieldValidationError`](@ref)) and a bad model/schema shape
+([`ModelDefinitionError`](@ref)). They almost always surface together: one `include("models.jl")`
+can raise either, and a handler that names only one silently misses the other — which is exactly
+what `UPGRADING.md`'s own #239 migration recipe did.
+"""
+abstract type DefinitionError <: PormGError end
+
+"""
+    FieldValidationError(msg) <: DefinitionError <: PormGError
 
 A field constructor was given an invalid argument — a kwarg of the wrong type, a `max_length`
 outside its permitted range, a `default` that does not satisfy the field's own contract, a
@@ -177,20 +226,20 @@ outside its permitted range, a `default` that does not satisfy the field's own c
 Raised while *defining* a model. Contrast [`InvalidValueError`](@ref), which is raised while
 coercing a *value* on the insert/update path.
 """
-struct FieldValidationError <: PormGError
+struct FieldValidationError <: DefinitionError
   msg::String
   FieldValidationError(msg::AbstractString) = new(_emsg(msg))
 end
 
 """
-    ModelDefinitionError(msg) <: PormGError
+    ModelDefinitionError(msg) <: DefinitionError <: PormGError
 
 A model or schema definition is invalid — more than one primary key, a duplicate `related_name`,
 an illegal field name, a `UniqueConstraint` that names an unknown or many-to-many field, an
 unresolvable `ForeignKey` / `ManyToManyField` target, or a `Model(...)` call given something
 that is not a `PormGField`.
 """
-struct ModelDefinitionError <: PormGError
+struct ModelDefinitionError <: DefinitionError
   msg::String
   ModelDefinitionError(msg::AbstractString) = new(_emsg(msg))
 end
@@ -200,11 +249,12 @@ end
 
 Umbrella for connection-configuration failures — `catch` it to get every case below. Like
 [`FieldAccessError`](@ref), this is an abstract mid-node rather than a throwable type, so the
-pre-existing `MissingDatabaseConfigurationException` can live *inside* the bucket instead of
+pre-existing `MissingConfigurationError` can live *inside* the bucket instead of
 beside it. `catch ConfigurationError` must not have holes; that class of surprise is the reason
 this taxonomy exists.
 
-Subtypes: [`InvalidConfigurationError`](@ref), and `Configuration.MissingDatabaseConfigurationException`
+Subtypes: [`InvalidConfigurationError`](@ref), [`WritesDisabledError`](@ref) (the `change_data:
+false` write switch — its remedy is a config edit), and `Configuration.MissingConfigurationError`
 (a missing folder/`connection.yml`, or a selected environment with no matching block).
 """
 abstract type ConfigurationError <: PormGError end
@@ -214,11 +264,27 @@ abstract type ConfigurationError <: PormGError end
 
 Connection configuration is present but unusable or inconsistent — an unsupported adapter, an
 unknown connection key, a malformed `extensions` setting, an unsupported PostgreSQL extension,
-a model not bound to a connection, or an attempt to overwrite a static connection.
+a model not bound to a connection (or bound to an entry whose pool was never built), a missing
+driver package (`using LibPQ` / `using SQLite` forgotten), or an attempt to overwrite a static
+connection.
 """
 struct InvalidConfigurationError <: ConfigurationError
   msg::String
   InvalidConfigurationError(msg::AbstractString) = new(_emsg(msg))
+end
+
+"""
+    WritesDisabledError(msg) <: ConfigurationError <: PormGError
+
+The connection is not permitted to insert/update/delete — its settings carry `change_data: false`.
+The remedy is a configuration edit (`connection.yml`), which is why this lives under
+[`ConfigurationError`](@ref). Renamed from `PermissionError` in the pre-publish naming pass: that
+name read as OS/file permissions to some audiences and database GRANTs to others, while the actual
+meaning is PormG's own write switch.
+"""
+struct WritesDisabledError <: ConfigurationError
+  msg::String
+  WritesDisabledError(msg::AbstractString) = new(_emsg(msg))
 end
 
 """
@@ -237,7 +303,9 @@ abstract type MigrationError <: PormGError end
 
 The migration engine refused or could not complete an operation — a duplicate index name in a
 plan, an invalid answer to an interactive `makemigrations` prompt, an unimplemented
-`migrate_to(version)` path, or an importer pointed at a non-SQLite connection.
+`migrate_to(version)` path, or a migration-engine step that cannot proceed (no pending plan,
+an unparseable introspected DDL statement, a missing model file). The importer-pointed-at-the-
+wrong-backend case is [`BackendCapabilityError`](@ref).
 """
 struct InvalidMigrationError <: MigrationError
   msg::String
@@ -248,7 +316,7 @@ end
 # One `showerror` covers every `msg`-carrying subtype. DoesNotExist / MultipleObjectsReturned
 # override with their field-built messages (a more specific method wins on dispatch); so do the
 # reparented types that carry their own structured fields (PoolTimeoutError, PoolConnectError,
-# MissingDatabaseConfigurationException, DestructiveMigrationError), each next to its definition.
+# MissingConfigurationError, DestructiveMigrationError), each next to its definition.
 Base.showerror(io::IO, e::PormGError) = print(io, e.msg)
 
 """
@@ -274,7 +342,7 @@ Defined via `showerror`, which every subtype implements, so it stays correct for
 later without needing a new method. For subtypes that use the generic `showerror` above, the result
 is exactly `e.msg` (it prints that field verbatim, and `_emsg` has already normalized any ANSI at
 construction). Subtypes with their own `showerror` return that richer rendering instead — e.g.
-`Configuration.MissingDatabaseConfigurationException` and `Migrations.DestructiveMigrationError`
+`Configuration.MissingConfigurationError` and `Migrations.DestructiveMigrationError`
 both carry a `msg` yet prefix it with the error name, so `error_message` is a superset of `.msg`,
 never a subset.
 """

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -49,7 +49,7 @@ function import_models_from_sqlite(db::String = "db";
   # output folder comes from the resolved connection's settings — never a hardcoded path.
   settings = Configuration.get_settings(db)
   conn = settings.connections
-  conn isa PormGSQLite || throw(UnsupportedConnectionError(
+  conn isa PormGSQLite || throw(BackendCapabilityError(
     "Connection '$(db)' is not a SQLite connection (got $(typeof(conn))). Use import_models_from_postgres for PostgreSQL."))
   model_path = settings.db_def_folder
 
@@ -444,8 +444,10 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
         end
       catch e
         @pormg_debug
-        error_msg = "Error processing field '$field_name' in class '$class_name': $(e)"
-        throw(ErrorException(error_msg))
+        # A FieldValidationError/InvalidValueError from field construction is already the right
+        # type — stringifying it into an ErrorException would eject it from the taxonomy (audit).
+        e isa PormGError && rethrow()
+        throw(InvalidMigrationError("Error processing field '$field_name' in class '$class_name': $(e)"))
       end
     end
   end

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -79,7 +79,8 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
 
   # Extract table name
   table_name_match = match(r"CREATE TABLE \"(.+?)\"", sql)
-  table_name = table_name_match !== nothing ? table_name_match.captures[1] : error("Table name not found")
+  table_name = table_name_match !== nothing ? table_name_match.captures[1] :
+    throw(InvalidMigrationError("Cannot introspect: CREATE TABLE statement has no double-quoted table name (table created outside PormG?): $(first(sql, 120))"))
 
   # Define a dictionary to map SQL types to Models.jl field types
   fk_map::Dict{String, Any} = Dict{String, Any}()

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -497,9 +497,9 @@ function _resolve_table_fields(
       for fsym in colect_deletion
         f = model.fields[model_fields_map[string(fsym)]]
         if hasfield(typeof(f), :primary_key) && f.primary_key
-          error("Cannot auto-migrate on SQLite: deleting primary-key column \"$(fsym)\" from table " *
+          throw(InvalidMigrationError("Cannot auto-migrate on SQLite: deleting primary-key column \"$(fsym)\" from table " *
                 "\"$(model_name)\" would leave it with no primary key. Declare a replacement primary key, " *
-                "or make this change manually.")
+                "or make this change manually."))
         end
       end
     end
@@ -779,7 +779,7 @@ end
 function makemigrations(db::String; config::Dict{String,PormGSettings} = config, interactive::Bool = true)
 settings = Configuration.get_settings(db)
 path = joinpath(db, settings.model_file)
-isfile(path) || error("The file $(path) does not exists")
+isfile(path) || throw(MissingConfigurationError("The models file $(path) does not exist for connection '$(db)'."))
 makemigrations(settings.connections, settings, path=path, interactive=interactive)
 end
 

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -495,7 +495,7 @@ Load and return all OrderedDicts from the pending_migrations.jl file.
 function _load_migration_plan(settings::PormGSettings)
   pending_path = joinpath(settings.db_def_folder, "migrations", "pending_migrations.jl")
   if !isfile(pending_path)
-    error("No pending migrations found at: $pending_path")
+    throw(InvalidMigrationError("No pending migrations found at: $pending_path"))
   end
   temp_migration_module = include(pending_path)
   return Base.invokelatest(get_all_dicts, temp_migration_module)
@@ -705,7 +705,7 @@ function _execute_statements_sqlite(connection::PormGSQLite, statements::Vector{
         result, _ = with_transaction(connection, trimmed, conn=conn)
         violations = DataFrame(result)
         if nrow(violations) > 0
-          error("Migration aborted: PRAGMA foreign_key_check found $(nrow(violations)) orphaned foreign-key row(s) after a SQLite table rebuild; rolling back.")
+          throw(InvalidMigrationError("Migration aborted: PRAGMA foreign_key_check found $(nrow(violations)) orphaned foreign-key row(s) after a SQLite table rebuild; rolling back."))
         end
       else
         with_transaction(connection, trimmed, conn=conn)

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -19,13 +19,19 @@ function get_settings(obj::Union{SQLObject,SQLObjectHandler}; connection::Union{
     if length(config) == 1
       conn_key = first(keys(config))
     else
-      throw(UnsupportedConnectionError("Model '$(q.model.name)' is not bound to a database connection key. " *
+      throw(InvalidConfigurationError("Model '$(q.model.name)' is not bound to a database connection key. " *
         "Call `set_models()` or `PormG.@import_models` to bind the model before querying."))
     end
   end
   settings = get_configuration_settings(conn_key)
 
   final_connection = connection === nothing ? settings.connections : connection
+  # A config entry can exist with no pool built yet (`connections === nothing`); letting that
+  # escape produced a raw `MethodError` at get_parameter downstream (audit probe). Same guard and
+  # wording as `pool_stats(key)` in PormG.jl.
+  final_connection === nothing && throw(InvalidConfigurationError(
+    "Connection '$(conn_key)' has no pool yet (not built / not connected). " *
+    "Call PormG.Configuration.load(...) so the pool exists before querying."))
   return settings, final_connection, conn_key
 end
 
@@ -558,7 +564,9 @@ function _get_select_query(v::String, instruc::SQLInstruction; _as::Union{Nothin
       return string(quoted_alias, ".*")
     end
     
-    if _as !== nothing && haskey(instruc.tab_field_cache, _as)
+    if _as !== nothing && haskey(instruc.tab_field_cache, _as) && haskey(instruc.object.model.fields, v)
+      # The fields haskey guard matters: an invalid `v` must fall through to _solve_field's
+      # UnknownFieldError below, not die here with a raw KeyError (audit finding).
       instruc.tab_field_cache[_as] = instruc.object.model.fields[v]
     end
     return string(quoted_alias, ".", _solve_field(v, instruc.object.model, instruc))
@@ -615,7 +623,7 @@ function _build_over_clause(over::WindowSpec, instruc::SQLInstruction)::String
   end
 
   if over.frame !== nothing
-    instruc.connection isa PormGSQLite && throw(QueryBuildError("SQLite window functions in PormG do not support explicit frame specifications yet. Remove frame=$(repr(over.frame)) or use PostgreSQL."))
+    instruc.connection isa PormGSQLite && throw(BackendCapabilityError("SQLite window functions in PormG do not support explicit frame specifications yet. Remove frame=$(repr(over.frame)) or use PostgreSQL."))
     frame = strip(over.frame)
     isempty(frame) && throw(QueryBuildError("Window frame cannot be empty"))
     push!(parts, frame)

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -344,13 +344,13 @@ function handle_on_delete!(collector::DeletionCollector, field_name::Union{Strin
   elseif field.on_delete in [PROTECT, RESTRICT]    
     # More descriptive error with field name, constraint type, and sample IDs
     constraint_type = field.on_delete == PROTECT ? "PROTECT" : "RESTRICT"
-    throw(QueryBuildError("Cannot delete \e[4m\e[31m$(model.name)\e[0m because it is referenced by \e[4m\e[31m$(related_model.name).$(field_name)\e[0m with ON DELETE \e[4m\e[31m$(constraint_type)\e[0m constraint"))
+    throw(ProtectedError("Cannot delete \e[4m\e[31m$(model.name)\e[0m because it is referenced by \e[4m\e[31m$(related_model.name).$(field_name)\e[0m with ON DELETE \e[4m\e[31m$(constraint_type)\e[0m constraint"))
   elseif field.on_delete == SET_NULL
     # TODO : I dont check if this works
     @pormg_debug false
     # check if the field allow null
     if !field.null
-      throw(InvalidValueError("Error in delete, the field \e[4m\e[31m$(field_name)\e[0m not allow null"))
+      throw(ModelDefinitionError("Error in delete: ON DELETE SET_NULL is declared on \e[4m\e[31m$(field_name)\e[0m, but the field has null=false — the schema contradicts itself. Declare the FK with null=true or use a different on_delete."))
     end
 
     # Add field update to set field to NULL

--- a/src/querybuilder/error_funnels.jl
+++ b/src/querybuilder/error_funnels.jl
@@ -25,20 +25,20 @@
 #
 # Scope, so a fifth funnel has an obvious home: **shared** funnels live here; a funnel used by
 # exactly one file lives beside its call sites. `_fielderr` in `src/models/fields.jl` is the latter
-# — 248 sites in one file, one category, documented where it is used.
+# — its call sites live in one file, one category, documented where it is used (#260 cut them from 248 to ~50).
 
 # Internal dispatch fallback (#197, retyped in #231): a connection object that is neither a
 # PostgreSQL nor a SQLite pool reached an execution path — a catchable `PormGError` subtype.
 _unsupported_conn(op::AbstractString, conn) = UnsupportedConnectionError(
-  "PormG internal error in $(op): unsupported connection type $(typeof(conn)) — expected a PostgreSQL or SQLite connection pool.")
+  "PormG internal error in $(op): unsupported connection type $(typeof(conn)) — expected a PostgreSQL or SQLite connection pool. This is a PormG bug; please report it.")
 
 # Standard actionable error for a write blocked by `change_data: false` (#205), typed as
-# `PermissionError` (#231). Every DML entry point (insert, update, delete, update_or_create,
+# `WritesDisabledError` (#231, renamed from `PermissionError` in the pre-publish naming pass). Every DML entry point (insert, update, delete, update_or_create,
 # bulk_*, many-to-many add/remove/clear, primary-key allocation) shares this one message so a user
 # hitting any of them gets the same fix — writes are disabled by default (safety-first, the common
 # first-`create` trap), and the message names where to fix it: the `config:` block of the active
 # environment in connection.yml.
-_write_not_allowed(operation::AbstractString, conn_key) = PermissionError(
+_write_not_allowed(operation::AbstractString, conn_key) = WritesDisabledError(
   "Error in $(operation): the connection \e[4m\e[31m$(conn_key)\e[0m is not allowed to write. " *
   "Writes are disabled by default — set \e[1mchange_data: true\e[0m under the `config:` block of the active " *
   "environment in connection.yml to enable creates, updates, and deletes.")

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -291,7 +291,7 @@ function allocate_primary_keys(objct::SQLObjectHandler, df_o::DataFrames.DataFra
       end
     end
   else
-    throw(UnsupportedConnectionError("allocate_primary_keys: unsupported connection type $(typeof(connection))"))
+    throw(_unsupported_conn("allocate_primary_keys", connection))
   end
 
   df[!, pk_field] = ids
@@ -908,7 +908,8 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
         # param_placeholders = add_parameter!(parameters, values)
       catch e
         _depuration_values_bulk_insert(fields_df, mapping, model, row, index, django_prefix)
-        throw(ErrorException("Error in bulk_insert, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
+        e isa PormGError && rethrow()   # keep the taxonomy type; the depuration log above carries the row context
+        throw(InvalidValueError("Error in bulk_insert, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
       end
       push!(rows, "($(join(param_placeholders, ", ")))")
       count += 1
@@ -982,7 +983,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   # Resolve settings
   settings, connection, conn_key = get_settings(objct)
 
-  !(connection isa PormGPostgres) && throw(UnsupportedConnectionError("bulk_copy is only supported for PostgreSQL. Use bulk_insert for SQLite."))
+  !(connection isa PormGPostgres) && throw(BackendCapabilityError("bulk_copy is only supported for PostgreSQL. Use bulk_insert for SQLite."))
 
   # check if is allowed to insert
   !settings.change_data && throw(_write_not_allowed("bulk_copy", conn_key))
@@ -1035,7 +1036,8 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
             validate_field_data(model, field, value, "bulk_copy"; allow_primary_key = true)
             model.fields[field].formatter(value)
           catch e
-            throw(ErrorException("Error in bulk_copy, row $(row_index) for model $(model.name) failed validation or formatting: $(e)"))
+            e isa PormGError && rethrow()   # keep the taxonomy type (bulk_copy logs no per-row depuration; the message below carries the row index only for the wrapped case)
+            throw(InvalidValueError("Error in bulk_copy, row $(row_index) for model $(model.name) failed validation or formatting: $(e)"))
           end
         end
       end
@@ -1404,7 +1406,8 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
         param_placeholders = [add_parameter!(instruction.parameters, model.fields[field].formatter(row[mapping[field]])) for field in joined_columns]
       catch e
         _depuration_values_bulk_insert(fields_df, mapping, model, row, index, settings.django_prefix !== nothing)
-        throw(ErrorException("Error in bulk_update, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
+        e isa PormGError && rethrow()   # keep the taxonomy type; the depuration log above carries the row context
+        throw(InvalidValueError("Error in bulk_update, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
       end
       push!(rows, "($(join(param_placeholders, ", ")))")
       count += 1

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -53,7 +53,7 @@ function _m2m_settings(manager::ManyToManyManager)
     if length(config) == 1
       conn_key = first(keys(config))
     else
-      throw(UnsupportedConnectionError("Model '$(manager.owner_model.name)' is not bound to a database connection key. Call set_models() before using a many-to-many manager."))
+      throw(InvalidConfigurationError("Model '$(manager.owner_model.name)' is not bound to a database connection key. Call set_models() before using a many-to-many manager."))
     end
   end
   settings = get_configuration_settings(conn_key)
@@ -111,7 +111,7 @@ end
 function (descriptor::ManyToManyDescriptor)(owner)
   owner_id = _m2m_extract_pk(owner, descriptor.relation.owner_pk)
   owner_module = descriptor.owner_model._module
-  owner_module === nothing && throw(QueryBuildError("Many-to-many descriptor $(descriptor.accessor) requires initialized models. Call set_models() before using it."))
+  owner_module === nothing && throw(InvalidConfigurationError("Many-to-many descriptor $(descriptor.accessor) requires initialized models. Call set_models() before using it."))
   related_model = _m2m_model_from_binding(owner_module, descriptor.relation.related_binding, descriptor.relation.related_model)
   return ManyToManyManager(descriptor.owner_model, related_model, descriptor.relation, owner_id)
 end
@@ -170,7 +170,7 @@ function add(manager::ManyToManyManager, targets...)
     sql = "INSERT OR IGNORE INTO $table_name ($owner_column, $related_column) VALUES $(join(groups, ", "));"
     fetch(settings, sql, parameters)
   else
-    throw(UnsupportedConnectionError("Unsupported connection type $(typeof(connection)) for many-to-many add"))
+    throw(_unsupported_conn("many-to-many add", connection))
   end
 
   return nothing

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -189,11 +189,11 @@ function up_get_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::
 
   for k in lookup_keys
     haskey(model.fields, k) ||
-      throw(QueryBuildError("Error in get_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+      throw(UnknownFieldError("Error in get_or_create, lookup field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
   end
   for k in default_keys
     haskey(model.fields, k) ||
-      throw(QueryBuildError("Error in get_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
+      throw(UnknownFieldError("Error in get_or_create, defaults field \e[4m\e[31m$(k)\e[0m is not a field of $(model.name)"))
   end
   length(unique(lookup_keys)) == length(lookup_keys) ||
     throw(QueryBuildError("Error in get_or_create, duplicate lookup field(s)"))

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -611,11 +611,13 @@ end
                 e
             end
 
-            @test err isa PormGError
+            # #268 audit: SET_NULL on a null=false FK is a schema self-contradiction — typed
+            # ModelDefinitionError, and the message names the contradiction rather than the row.
+            @test err isa ModelDefinitionError
             msg = _strip_ansi(lowercase(sprint(showerror, err)))
-            # The error must identify the field name and the null-constraint violation.
+            # The error must identify the field name and the schema contradiction.
             @test occursin("parent_id", msg)
-            @test occursin("not allow null", msg)
+            @test occursin("null=true", msg)
 
             # Both rows must be untouched.
             @test SetNullGuardM.Set_null_guard_parent_scratch.objects.filter("id" => parent_id).exists()
@@ -695,7 +697,10 @@ end
             e
         end
 
-        @test err isa PormGError
+        # #268 audit: PROTECT/RESTRICT refusal is ProtectedError — the data forbids the delete,
+        # distinct from a malformed call. A supertype assertion here would pass for the old
+        # QueryBuildError too, proving nothing about the retype.
+        @test err isa ProtectedError
         msg = _strip_ansi(lowercase(sprint(showerror, err)))
         # The error must name the parent table, the offending FK field,
         # and the on_delete constraint type.

--- a/test/integration/test_json_fields.jl
+++ b/test/integration/test_json_fields.jl
@@ -118,7 +118,7 @@ _json_backend_is_pg() = PormG.config[PORMG_DB_FOLDER].connections isa PormG.Porm
         else
             @testset "containment operators throw on SQLite" begin
                 q = base(); q.filter("payload__@has_key" => "driver")
-                @test_throws PormG.UnsupportedConnectionError q.count()
+                @test_throws PormG.BackendCapabilityError q.count()
             end
         end
     finally

--- a/test/integration/test_unaccent_extension.jl
+++ b/test/integration/test_unaccent_extension.jl
@@ -117,12 +117,12 @@ elseif _UNACCENT_ADAPTER == "SQLite"
     # ─────────────────────────────────────────────────────────────────────────────
     # iunaccent_contains is unsupported on SQLite and must fail loudly
     # The lookup requires the PostgreSQL unaccent extension; on SQLite the dialect raises a
-    # clear UnsupportedConnectionError (#239) rather than silently producing wrong SQL.
+    # clear BackendCapabilityError (#239) rather than silently producing wrong SQL.
     # ─────────────────────────────────────────────────────────────────────────────
     @testset "iunaccent_contains rejected on SQLite" begin
         conn = PormG.config[PORMG_DB_FOLDER].connections
-        @test_throws PormG.UnsupportedConnectionError PormG.Dialect.iunaccent_contains(conn, "surname", "raikkonen")
-        @test_throws PormG.UnsupportedConnectionError PormG.Dialect.iunaccent_exact(conn, "surname", "raikkonen")
+        @test_throws PormG.BackendCapabilityError PormG.Dialect.iunaccent_contains(conn, "surname", "raikkonen")
+        @test_throws PormG.BackendCapabilityError PormG.Dialect.iunaccent_exact(conn, "surname", "raikkonen")
     end
 
 else

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -220,7 +220,11 @@ end
             conn = PormG.ConnectionPool.acquire_connection(pool; mode=:read)
 
             PormG.Configuration.set_before_connect_hook((key, settings) -> false)
-            @test_throws ErrorException PormG.ConnectionPool.reconnect_db(pool, conn)
+            # #268 audit: a hook refusing the connection is a connect-time failure — typed
+            # PoolConnectError so `catch PoolError` covers it (this is the Nitro extension seam).
+            err = @test_throws PormG.PoolConnectError PormG.ConnectionPool.reconnect_db(pool, conn)
+            @test err.value isa PormG.PoolError
+            @test occursin("before_connect hook", PormG.error_message(err.value))
 
             _cleanup_configuration_test_keys([db_dir])
         end
@@ -447,7 +451,7 @@ end
 # and a missing env block reports the available ones. All DB-free (SQLite `:memory:`), isolated via
 # `mktempdir` + `_cleanup_configuration_test_keys`.
 @testset "config env selection + fail-loud load (#205)" begin
-    MDCE = PormG.Configuration.MissingDatabaseConfigurationException
+    MDCE = PormG.Configuration.MissingConfigurationError
 
     # dev (read-only) + prod (writable) blocks, so the selected env is identifiable by change_data.
     _dev_prod_blocks =

--- a/test/unit/test_date_functions_sql.jl
+++ b/test/unit/test_date_functions_sql.jl
@@ -58,7 +58,7 @@ const _EMPTY = Dict{String, Any}()
       @test Dialect.EXTRACT(_COL, fmt, _SL) == "CAST(strftime('$slcode', $(_COL)) AS INTEGER)"
     end
     # The SQLite whitelist is fail-closed: an unsupported part must throw, not emit garbage.
-    @test_throws PormG.UnsupportedConnectionError Dialect.EXTRACT(_COL, Dict{String, Any}("part" => "WEEK"), _SL)
+    @test_throws PormG.BackendCapabilityError Dialect.EXTRACT(_COL, Dict{String, Any}("part" => "WEEK"), _SL)
   end
 
   # ===========================================================================

--- a/test/unit/test_docs_error_type_drift.jl
+++ b/test/unit/test_docs_error_type_drift.jl
@@ -58,7 +58,10 @@ const ALLOWED_DOC_MENTIONS = [
 
 # `src/tools.jl`'s two deliberate keeps: `upgrade_guide(from=…)` missing its required kwarg, and a
 # missing path. Both are Julia-level API misuse, not a PormG domain error.
-const ALLOWED_SRC_ARGUMENTERROR = Dict("src/tools.jl" => 2)
+const ALLOWED_SRC_ARGUMENTERROR = Dict(
+    "src/tools.jl" => 2,   # upgrade_guide's missing kwarg / missing path — Julia-level misuse
+    "src/Utils.jl" => 1,   # @import_models non-literal path — macro (Julia-level) misuse
+)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Docs error-type drift: no user-facing page may promise `ArgumentError`
@@ -97,6 +100,74 @@ const ALLOWED_SRC_ARGUMENTERROR = Dict("src/tools.jl" => 2)
     # The allow-list must stay *earned*: if a documented DataFrames.jl caveat or the clean-break
     # warning is deleted, this drops and the list should shrink with it.
     @test allowed_hits == 4
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# src/ and ext/ raise no untyped errors (#268 audit)
+# `catch PormGError` is the documented contract, and the 2026-07-30 audit found it leaking through
+# exactly the patterns no guard policed: `throw(ErrorException(` and bare `error(` calls — 14 of
+# them user-reachable (bulk row validation, missing-driver hints, five migration-engine sites, the
+# before_connect hook, `with_advisory_lock`). Those are fixed; this pins the residue so the leak
+# class cannot regrow. `ext/` is scanned too — it previously had NO guard coverage at all.
+#
+# The allowlists are positive pins (== , not <=): every entry is a deliberate, commented keep, and
+# removing one from src/ must shrink the list here or the guard fails — same discipline as
+# ALLOWED_SRC_ARGUMENTERROR.
+# ─────────────────────────────────────────────────────────────────────────────
+const DRIFT_EXT_DIR = joinpath(DRIFT_REPO_ROOT, "ext")
+
+# Internal invariant violations ("should not happen; please report") — not PormG misuse, so they
+# stay ErrorException by design rather than polluting the taxonomy with an InternalError type.
+const ALLOWED_UNTYPED_ERROREXCEPTION = Dict(
+    "src/AdvisoryLock.jl"    => 1,  # lock-acquisition timeout — parked with the #268 boundary decision
+    "src/ConnectionPool.jl"  => 1,  # SQLite async worker returned a malformed payload (internal)
+)
+const ALLOWED_UNTYPED_BARE_ERROR = Dict(
+    "src/querybuilder/deletion.jl"      => 1,  # empty generated SQL — internal invariant
+    "src/querybuilder/build_joins.jl"   => 2,  # missing join alias / unmaterialized CTE — internal
+    "src/querybuilder/build_helpers.jl" => 2,  # duplicate dedup row / bad placeholder type — internal
+    "src/ConnectionPool.jl"             => 1,  # `error("validation failed")` inside atomic()'s DOCSTRING example
+)
+
+@testset "src/ and ext/ raise no untyped errors (#268)" begin
+    found_ee = Dict{String,Int}()
+    found_err = Dict{String,Int}()
+    for dir in (DRIFT_SRC_DIR, DRIFT_EXT_DIR)
+        isdir(dir) || continue
+        for path in _drift_files(dir, ".jl")
+            n_ee, n_err = 0, 0
+            for (_, line) in _drift_code_lines(path)
+                occursin("throw(ErrorException(", line) && (n_ee += 1)
+                # The negated class's `.` lets `Base.error(` through — the canonical qualified
+                # spelling of exactly what this hunts — so it gets its own pattern.
+                (occursin(r"(?:^|[^_\w!.@])error\(", line) || occursin("Base.error(", line)) && (n_err += 1)
+            end
+            n_ee  > 0 && (found_ee[_drift_rel(path)] = n_ee)
+            n_err > 0 && (found_err[_drift_rel(path)] = n_err)
+        end
+    end
+
+    for (label, found, allowed) in (("throw(ErrorException(", found_ee, ALLOWED_UNTYPED_ERROREXCEPTION),
+                                    ("bare error(",           found_err, ALLOWED_UNTYPED_BARE_ERROR))
+        unexpected = filter(p -> get(allowed, p.first, 0) != p.second, found)
+        if !isempty(unexpected)
+            @error """
+            Untyped $(label) found outside the allowlisted internal invariants.
+            An error a consumer can reach must be a PormGError subtype — see the taxonomy index in
+            src/exceptions.jl. A genuine internal invariant may stay untyped, but it must be added
+            here WITH its rationale.
+            """ unexpected expected = allowed
+        end
+        @test isempty(unexpected)
+        # Equality (not <=): a STALE allowlist entry — the keep was removed but the pin wasn't —
+        # must also fail, so the list stays earned. The printed dicts show which side drifted.
+        @test found == allowed
+    end
+
+    # ext/ must stay completely clean — it has no legitimate keeps.
+    @test isdir(DRIFT_EXT_DIR)
+    @test !any(startswith(k, "ext/") for k in keys(found_ee))
+    @test !any(startswith(k, "ext/") for k in keys(found_err))
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -99,13 +99,13 @@ const DOCERR_CASES = [
     # and raises on SQLite. Asserting it on the SQLite mock keeps the documented divergence honest.
     (
         "read/filters_and_aggregates.md — iunaccent_* lookups require PostgreSQL",
-        UnsupportedConnectionError,
+        BackendCapabilityError,
         () -> DOCERR_DRIVER_SL.objects.filter("surname__@iunaccent_contains" => "sena").
             list(show_query = :dict),
     ),
     (
         "read/filters_and_aggregates.md — JSONB key-existence operators require PostgreSQL",
-        UnsupportedConnectionError,
+        BackendCapabilityError,
         () -> DOCERR_RESULT_SL.objects.filter("payload__@has_key" => "wins").
             list(show_query = :dict),
     ),

--- a/test/unit/test_error_taxonomy.jl
+++ b/test/unit/test_error_taxonomy.jl
@@ -23,14 +23,17 @@ const QB = PormG.QueryBuilder
 const TAXONOMY_TYPES = (
     PormG.UnknownFieldError, PormG.LazyTraversalError, PormG.FilterError,
     PormG.QueryBuildError, PormG.UnsafeMutationError, PormG.InvalidValueError,
-    PormG.PermissionError, PormG.UnsupportedConnectionError,
+    PormG.WritesDisabledError, PormG.UnsupportedConnectionError,
+    # #268 audit: capability limits split out of UnsupportedConnectionError; PROTECT-delete refusal
+    # split out of the QueryBuildError long tail.
+    PormG.BackendCapabilityError, PormG.ProtectedError,
     PormG.DoesNotExist, PormG.MultipleObjectsReturned,
     # #239 completion: schema, configuration and migration errors, plus the four
     # pre-existing standalone types reparented under the taxonomy.
     PormG.FieldValidationError, PormG.ModelDefinitionError,
     PormG.InvalidConfigurationError, PormG.InvalidMigrationError,
     PormG.PoolTimeoutError, PormG.PoolConnectError,
-    PormG.Configuration.MissingDatabaseConfigurationException,
+    PormG.Configuration.MissingConfigurationError,
     PormG.Migrations.DestructiveMigrationError,
 )
 
@@ -40,10 +43,12 @@ const TAXONOMY_ABSTRACT = (
     # #261: the pool errors were the only concrete subtypes with neither a Kernel home nor an
     # abstract supertype in Kernel. `PoolError` closes that gap.
     PormG.PoolError,
+    # #268 audit: definition-time umbrella — one include("models.jl") can raise either member.
+    PormG.DefinitionError,
 )
 
 # Walk the real type tree. `names(PormG)` only sees EXPORTED names, which silently omits
-# `Configuration.MissingDatabaseConfigurationException` and `Migrations.DestructiveMigrationError` —
+# `Configuration.MissingConfigurationError` and `Migrations.DestructiveMigrationError` —
 # the two types that live mid-include-chain, i.e. exactly the ones a placement guard must inspect.
 function _concrete_pormg_errors(T = PormG.PormGError, acc = Any[])
     for S in subtypes(T)
@@ -88,9 +93,16 @@ end
         # surprise is what this taxonomy exists to remove. Concrete buckets would have made
         # these subtypings impossible ("can only subtype abstract types").
         @test PormG.InvalidConfigurationError <: PormG.ConfigurationError
-        @test PormG.Configuration.MissingDatabaseConfigurationException <: PormG.ConfigurationError
+        @test PormG.Configuration.MissingConfigurationError <: PormG.ConfigurationError
         @test PormG.InvalidMigrationError <: PormG.MigrationError
         @test PormG.Migrations.DestructiveMigrationError <: PormG.MigrationError
+
+        # #268 audit: the definition-time pair grouped under one umbrella, and the write-switch
+        # error reparented under ConfigurationError (its remedy is a connection.yml edit).
+        @test PormG.FieldValidationError <: PormG.DefinitionError
+        @test PormG.ModelDefinitionError <: PormG.DefinitionError
+        @test PormG.WritesDisabledError <: PormG.ConfigurationError
+        @test !(PormG.DefinitionError <: PormG.ConfigurationError)
 
         # Reparented from bare `Exception` (#239) so `catch PormGError` covers the pool too,
         # then grouped under the `PoolError` umbrella (#261) so `catch PoolError` handles
@@ -132,7 +144,7 @@ end
         @test QueryBuildError === PormG.QueryBuildError
         @test UnsafeMutationError === PormG.UnsafeMutationError
         @test InvalidValueError === PormG.InvalidValueError
-        @test PermissionError === PormG.PermissionError
+        @test WritesDisabledError === PormG.WritesDisabledError
         @test UnsupportedConnectionError === PormG.UnsupportedConnectionError
         @test FieldValidationError === PormG.FieldValidationError
         @test ModelDefinitionError === PormG.ModelDefinitionError
@@ -155,6 +167,53 @@ end
         fields = Dict("id" => Models.IDField(), "points" => Models.IntegerField()),
         field_names = ["id", "points"],
     )
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # #268 audit reclassifications: each gets ONE discriminating representative, because a
+    # supertype assertion (isa PormGError) passes for the pre-audit type too and proves nothing.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "audit reclassifications raise their promised types (#268)" begin
+        # Missing driver: every backend generic funnels to InvalidConfigurationError. This cannot
+        # be probed by plain dispatch in the suite: load_drivers.jl loads BOTH extensions, and the
+        # SQLite ext types some methods on the ABSTRACT PormGSQLite with fixed arity — which
+        # shadows the fallback for one-argument calls entirely (even via `invoke`). The extra
+        # positional argument below matches ONLY the varargs fallback, so this pins the fallback
+        # method's behavior deterministically with or without any driver loaded.
+        struct _DriverlessSQLite <: PormG.PormGSQLite end
+        err = try
+            PormG.backend_connect(_DriverlessSQLite(), :force_varargs_fallback)
+            nothing
+        catch e; e; end
+        @test err isa PormG.InvalidConfigurationError
+        @test occursin("using SQLite", PormG.error_message(err))
+
+        # Config entry exists but its pool was never built → typed, not a downstream MethodError.
+        PormG.config["docerr_nopool"] = PormG.Configuration.Settings(change_data = true)
+        nopool = Models.Model_Type(name = "np_probe",
+            fields = Dict("id" => Models.IDField()), field_names = ["id"])
+        nopool.connect_key = "docerr_nopool"
+        err = try; object(nopool).filter("id" => 1).list(show_query = :dict); nothing; catch e; e; end
+        @test err isa PormG.InvalidConfigurationError
+        @test occursin("no pool yet", PormG.error_message(err))
+
+        # SQLite too old for window functions → BackendCapabilityError (capability, not dispatch).
+        struct _OldSQLite_Taxo <: PormG.PormGSQLite end
+        PormG.backend_sqlite_version(::_OldSQLite_Taxo) = 3024000
+        err = try; PormG.Dialect._assert_sqlite_window_support(_OldSQLite_Taxo()); nothing; catch e; e; end
+        @test err isa PormG.BackendCapabilityError
+        @test occursin("3.25.0", PormG.error_message(err))
+
+        # Migration engine: no pending plan / unparseable introspected DDL → InvalidMigrationError.
+        mktempdir() do d
+            st = PormG.Configuration.Settings(change_data = true)
+            st.db_def_folder = d
+            err = try; PormG.Migrations._load_migration_plan(st); nothing; catch e; e; end
+            @test err isa PormG.InvalidMigrationError
+            @test occursin("No pending migrations", PormG.error_message(err))
+        end
+        err = try; PormG.Migrations.convertSQLToModel("CREATE TABLE noquotes (x INTEGER)"); nothing; catch e; e; end
+        @test err isa PormG.InvalidMigrationError
+    end
 
     @testset "representative misuse → specific subtype" begin
         # FilterError: a bad filter argument (Int is not a Pair/Q/Qor/operator).
@@ -228,7 +287,7 @@ end
         # with the error name prefixed. Pinned because the docs promise `error_message` never
         # returns *less* than `.msg` — a future showerror that dropped the message would break that
         # promise silently.
-        for e2 in (PormG.Configuration.MissingDatabaseConfigurationException("no connection.yml"),
+        for e2 in (PormG.Configuration.MissingConfigurationError("no connection.yml"),
                    PormG.Migrations.DestructiveMigrationError("refused", ["DROP TABLE \"drivers\""]))
             # `occursin` already implies the result is no shorter, so one assertion suffices.
             @test occursin(e2.msg, PormG.error_message(e2))

--- a/test/unit/test_execution_show.jl
+++ b/test/unit/test_execution_show.jl
@@ -1,5 +1,5 @@
 using Test
-using PormG: object, Q, PormGError, PermissionError
+using PormG: object, Q, PormGError, WritesDisabledError
 using PormG.Models: Model, CharField, IDField
 import PormG
 import DataFrames
@@ -157,7 +157,7 @@ end
       e
     end
 
-    @test err isa PermissionError    # #231: write-blocked is a typed PermissionError
+    @test err isa WritesDisabledError    # #231: write-blocked is a typed WritesDisabledError
     # #205: unified write-disabled message names the op and points at the `config:` block.
     let m = lowercase(sprint(showerror, err))
       @test occursin("error in delete:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
@@ -181,7 +181,7 @@ end
       e
     end
 
-    @test err isa PermissionError    # #231: write-blocked is a typed PermissionError
+    @test err isa WritesDisabledError    # #231: write-blocked is a typed WritesDisabledError
     let m = lowercase(sprint(showerror, err))
       @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
     end
@@ -193,7 +193,7 @@ end
       e
     end
 
-    @test inspect_err isa PermissionError    # #231: write-blocked is a typed PermissionError
+    @test inspect_err isa WritesDisabledError    # #231: write-blocked is a typed WritesDisabledError
     let m = lowercase(sprint(showerror, inspect_err))
       @test occursin("error in update:", m) && occursin("not allowed to write", m) && occursin("change_data", m)
     end
@@ -293,9 +293,9 @@ end
       e
     end
 
-    # Must raise a PermissionError with a message about not being allowed to
+    # Must raise a WritesDisabledError with a message about not being allowed to
     # write (sequence allocation is an insert-class operation).
-    @test err isa PermissionError
+    @test err isa WritesDisabledError
     @test occursin("not allowed", lowercase(sprint(showerror, err)))
 
     # The DataFrame must not have been mutated: no :id column should be present

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -703,7 +703,9 @@ end
         df_bad_scale = DataFrame(
             price = [123.456, 99.9999]
         )
-        @test_throws ErrorException bulk_insert(BoundaryModel.objects, df_bad_scale, show_query=:dict)
+        # #268 audit: bulk row validation now rethrows the taxonomy type instead of stringifying
+        # it into ErrorException — `catch InvalidValueError` behaves the same as for insert().
+        @test_throws InvalidValueError bulk_insert(BoundaryModel.objects, df_bad_scale, show_query=:dict)
         
         # Test 30: Bulk update with boundary values
         df_update_boundary = DataFrame(
@@ -1759,7 +1761,12 @@ end
             title = ["TITLE", "ANOTHER"],
             slug = ["slug1", "slug2"]
         )
-        @test_throws ErrorException bulk_insert(StringModel.objects, df_bad_strings, show_query=:dict)
+        # #268 audit: same contract as single-row insert — the taxonomy type survives bulk.
+        @test_throws InvalidValueError bulk_insert(StringModel.objects, df_bad_strings, show_query=:dict)
+        # …and bulk_update shares the rethrow pattern (bulk_copy is identical code, PG-only).
+        @test_throws InvalidValueError bulk_update(StringModel.objects,
+            DataFrame(id = [1], code = ["TOOLONG"]), columns = ["code"], match_on = ["id"],
+            show_query = :dict)
 
         # Test 15: Unicode strings (count as characters, not bytes)
         @test validate_field_data(StringModel, "code", "你好世", "insert") === true

--- a/test/unit/test_fluent_parity_208.jl
+++ b/test/unit/test_fluent_parity_208.jl
@@ -82,6 +82,10 @@ end
     _p208_error(() -> GocPg.objects.get_or_create("code"; show_query = :dict)))
   @test occursin("lookup field nope is not a field",
     _p208_error(() -> GocPg.objects.get_or_create("nope" => 1; show_query = :dict)))
+  # #268 audit: get_or_create's unknown-field check now matches update_or_create's type —
+  # UnknownFieldError, so `catch FieldAccessError` sees both. A PormGError assertion alone
+  # would also pass for the pre-audit QueryBuildError.
+  @test_throws PormG.UnknownFieldError GocPg.objects.get_or_create("nope" => 1; show_query = :dict)
   @test occursin("defaults field nope is not a field",
     _p208_error(() -> GocPg.objects.get_or_create("code" => "x"; defaults = ["nope" => 1], show_query = :dict)))
   @test occursin("appear in both lookup and defaults",

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -162,7 +162,9 @@ class UnsupportedFieldModel(models.Model):
     config_key, db_dir_existed = temp_import_config!()
 
     try
-        err = @test_throws ErrorException import_models_from_django(
+        # #268 audit: importer failures are typed; a wrapped PormG error rethrows as itself,
+        # anything foreign (here: the unsupported-field UndefVarError) wraps as InvalidMigrationError.
+        err = @test_throws PormG.InvalidMigrationError import_models_from_django(
             django_text;
             db = config_key,
             file = "unsupported_field_unit.jl",

--- a/test/unit/test_importers.jl
+++ b/test/unit/test_importers.jl
@@ -49,7 +49,7 @@ end
       db_def_folder = mktempdir(),
     )
     try
-      @test_throws PormG.UnsupportedConnectionError PormG.Migrations.import_models_from_sqlite(key)
+      @test_throws PormG.BackendCapabilityError PormG.Migrations.import_models_from_sqlite(key)
     finally
       delete!(PormG.config, key)
     end

--- a/test/unit/test_json_operators.jl
+++ b/test/unit/test_json_operators.jl
@@ -3,7 +3,7 @@ Unit coverage for the PostgreSQL-only JSONB containment/overlap operators (#27):
 `__@jcontains` (@>), `__@has_key` (?), `__@has_any_keys` (?|), `__@has_keys` (?&).
 
 These are PostgreSQL-only (SQLite has no equivalent): the SQLite renderer throws a friendly
-UnsupportedConnectionError, mirroring the `iunaccent_*` precedent. The RHS binds per operator — a jsonb
+BackendCapabilityError, mirroring the `iunaccent_*` precedent. The RHS binds per operator — a jsonb
 document (`::jsonb`) for @>, a text key for ?, a text[] key array for ?|/?&. LibPQ binds `\$N`
 placeholders, so a literal `?`/`?|`/`?&` in the SQL is the operator, not a bind marker.
 

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -50,7 +50,7 @@ using PormG
     #     Kernel-parented supertype made this check vacuous — it passed for every subtype ever,
     #     including the violation it exists to catch.
     #   • The walk is over `subtypes(PormGError)`, not `names(PormG)`. An export-list walk sees only
-    #     exported types, which silently omits `MissingDatabaseConfigurationException` and
+    #     exported types, which silently omits `MissingConfigurationError` and
     #     `DestructiveMigrationError` — the two that actually live mid-include-chain, i.e. precisely
     #     the ones this rule is about. Reparenting either to a bare `<: PormGError` must fail here.
     #

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -22,7 +22,7 @@ const EXPECTED_TOPLEVEL = Set([
     :PormGRow, :pk, :DoesNotExist, :MultipleObjectsReturned, :PoolTimeoutError, :PoolConnectError, :pool_stats,
     # Semantic error taxonomy (#231): PormGError root + query-builder subtypes
     :PormGError, :FieldAccessError, :UnknownFieldError, :LazyTraversalError, :FilterError,
-    :QueryBuildError, :UnsafeMutationError, :InvalidValueError, :PermissionError, :UnsupportedConnectionError,
+    :QueryBuildError, :UnsafeMutationError, :InvalidValueError, :WritesDisabledError, :UnsupportedConnectionError,
     # Taxonomy completion (#239): schema, configuration and migration errors. ConfigurationError
     # and MigrationError are abstract umbrellas (like FieldAccessError).
     :FieldValidationError, :ModelDefinitionError,
@@ -31,6 +31,9 @@ const EXPECTED_TOPLEVEL = Set([
     # Taxonomy edges (#261): PoolError is the connection-pool umbrella; error_message is the
     # uniform way to read a caught PormGError (the structured subtypes have no `.msg`).
     :PoolError, :error_message,
+    # #268 audit naming pass: renamed PermissionError→WritesDisabledError (in the taxonomy line
+    # above), plus the capability split, the PROTECT-delete type, and the definition-time umbrella.
+    :BackendCapabilityError, :ProtectedError, :DefinitionError,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API

--- a/test/unit/test_typed_exceptions.jl
+++ b/test/unit/test_typed_exceptions.jl
@@ -161,7 +161,7 @@ end
     fielderr    = PormG.Models._fielderr("bad kwarg")
 
     @test unsupported isa PormG.UnsupportedConnectionError
-    @test notallowed  isa PormG.PermissionError
+    @test notallowed  isa PormG.WritesDisabledError
     @test fielderr    isa PormG.FieldValidationError
 
     # …and each is still under the taxonomy root, so `catch PormGError` covers them.

--- a/test/unit/test_window_functions.jl
+++ b/test/unit/test_window_functions.jl
@@ -127,7 +127,9 @@ end
     "row_number" => RowNumber(over=WindowOver(order_by=["resultid"], frame="ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"))
   )
 
-  @test_throws PormGError q.list(show_query=:dict)
+  # #268 audit: frame= on SQLite is a capability limit; PormGError alone would also pass for
+  # the pre-split QueryBuildError.
+  @test_throws PormG.BackendCapabilityError q.list(show_query=:dict)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to the **2026-07-30 architectural audit** of the taxonomy #239 started — two independent adversarial reviews plus live probes. Their verdict: the *infrastructure* is complete and self-enforcing (Kernel placement, funnel convention, drift guards all sound), but the **contract** was not.

Of ~497 throw sites, ~480 already raised taxonomy types. The failures clustered exactly in the zones no guard policed.

## 1. Naming pass — free now, permanent after the registry

| Before | After | Why |
|---|---|---|
| `PermissionError` | **`WritesDisabledError`** (now `<: ConfigurationError`) | Read as OS/file permissions to some, database GRANTs to others; it means PormG's own `change_data: false` switch — whose remedy is a `connection.yml` edit |
| `MissingDatabaseConfigurationException` | **`MissingConfigurationError`** | The sole `*Exception` that survived #231's "clean break" |

## 2. `UnsupportedConnectionError` split three ways

One type covered three disjoint remedies, distinguishable only by message substring — the precise failure mode the taxonomy exists to remove:

| Situation | Now | Caller's remedy |
|---|---|---|
| JSONB/`iunaccent_*` on SQLite, `frame=` on SQLite, `bulk_copy` on SQLite, old SQLite | **`BackendCapabilityError`** (new, 17 sites) | change the query or the backend |
| Model not bound to a connection / pool never built | `InvalidConfigurationError` — its docstring **already claimed** this case | fix app initialization |
| Neither PG nor SQLite reached execution | `UnsupportedConnectionError` (funnel only) | file a PormG bug |

Also new: **`ProtectedError`** for a PROTECT/RESTRICT-blocked delete — previously the long-tail `QueryBuildError`, which made *"the data forbids this"* indistinguishable from *"your delete call is malformed"* (Django models these separately). And **`DefinitionError`**, an umbrella over `FieldValidationError` + `ModelDefinitionError`: one `include("models.jl")` raises either, and `UPGRADING.md`'s own #239 recipe named only one.

## 3. ~20 escape hatches closed

`catch PormGError` is the documented contract; these bypassed it:

- **Bulk row validation** rethrows PormG's own error instead of stringifying it into `ErrorException` — `catch InvalidValueError` now behaves identically for `insert()` and `bulk_insert()` of the same bad row.
- **Missing driver** — all 11 backend generics raise `InvalidConfigurationError` (message unchanged); this is the *first* thing a consumer hits with `using SQLite` forgotten.
- **Migration engine** ×5, **`before_connect` hook abort** → `PoolConnectError`, **`get_or_create`** → `UnknownFieldError` (matching `update_or_create`, which used a different type for the identical check 50 lines away), **`SET_NULL` on `null=false`** → `ModelDefinitionError`.
- A **fourth** not-bound path found by probe — config entry present, pool never built — escaped as a raw `MethodError`; now typed.

## 4. Guards

New testset polices `throw(ErrorException(`, bare `error(` and `Base.error(` across `src/` **and `ext/`** — ext/ previously had **zero** guard coverage of any kind. Eight deliberate internal-invariant keeps are positively pinned (`==`, not `<=`), so a stale allowlist entry fails as loudly as a new leak.

Every promised type now has a representative that **fails if the site is reverted** — including ones plain dispatch can't reach (missing-driver fallback, pool-never-built, the SQLite version gate, two migration sites, `bulk_update`'s rethrow). Review caught several asserting only `isa PormGError`, which passes for the pre-audit type and proves nothing.

⚠️ Recorded in the test for the next person: the SQLite extension types some methods on the **abstract** `PormGSQLite` at fixed arity, shadowing the missing-driver fallback for one-argument calls **even via `invoke`**. The probe passes an extra positional argument so only the varargs fallback matches.

## What this deliberately does NOT decide

**Runtime database failures** — constraint violations, rejected SQL, dropped connections — still propagate as raw driver exceptions. That boundary is filed as **#268** (`pre-publish`) with the probe evidence and both options shaped, and `api.md` now **states the current behavior honestly** instead of overclaiming. `with_advisory_lock`'s timeout stays `ErrorException` pending the same decision.

## Verification

| | |
|---|---|
| `Pkg.test()` | **4626 / 4626** |
| Docs build | exit 0 |
| SQLite integration | **1849 pass / 1 broken / 0 fail** |

**Not verified:** PostgreSQL (`db_2`) needs live credentials this environment lacks.

Two files fail **standalone-only** (`test_configuration_api`, `test_window_functions`) because they don't load drivers — stash-verified pre-existing on the unmodified tree, green in the suite.

Refs #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
