### PR TITLE
feat(#268): wrap database failures in the taxonomy

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,91 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Database failures now raise `DatabaseError`, not the driver's exception type (#268)
+
+- **Version**: Unreleased
+- **PormG ref**: #268; `src/exceptions.jl`, `src/Backend.jl`, `src/ConnectionPool.jl`,
+  `src/AdvisoryLock.jl`, `src/Configuration.jl`, `ext/PormGLibPQExt.jl`, `ext/PormGSQLiteExt.jl`,
+  `docs/src/api.md`
+- **Recorded**: 2026-07-31
+- **Severity**: **breaking (error contract)** — closes the last hole in `catch PormGError`. Part of
+  the `0.3.x` pre-publish wave.
+
+### What changed
+
+Once a statement reached the database, failures used to propagate as the **driver's own exception
+type**. Handling a UNIQUE violation therefore meant `catch SQLite.SQLiteException` /
+`catch LibPQ.Errors.*` — a hard dependency on the driver package purely to *name* the type, which
+fights the `[weakdeps]` design that keeps LibPQ/SQLite optional. `docs/src/api.md` meanwhile
+promised "`catch PormGError` catches them all", which was simply false for this class.
+
+Those failures are now wrapped at the pool's own seams:
+
+| New type | Covers |
+|---|---|
+| `DatabaseError` *(abstract)* | umbrella for all three below |
+| `IntegrityError` | `UNIQUE` / `FOREIGN KEY` / `NOT NULL` / `CHECK` / exclusion violations |
+| `OperationalError` | connection dropped mid-query, deadlock, serialization failure, lock timeout (incl. `with_advisory_lock`) |
+| `StatementError` | invalid SQL, unknown table/column, rejected type, insufficient privilege — and the unclassified fallback |
+| `TransactionError` | transaction-**API** misuse; not a database error |
+
+The driver's exception is preserved on `.cause`, so nothing is lost. Classification is exact on
+PostgreSQL (LibPQ parameterizes its exception type on the SQLSTATE) and message-based on SQLite
+(`SQLiteException` carries only a message).
+
+**User code is untouched.** `run_in_transaction` / `atomic` / `with_savepoint` run your closure
+inside their `try`; an exception *you* raise still propagates as itself. Only driver failures wrap.
+
+### How to find the calls to migrate
+
+```bash
+grep -rn "SQLiteException\|LibPQ.Errors\|PQResultError" --include=*.jl .
+grep -rn "duplicate key\|UNIQUE constraint\|violates foreign key" --include=*.jl .
+```
+
+Also check any `catch` that matched a database failure by message substring — a type now exists.
+
+### Before → after
+
+```julia
+# before — needs `using SQLite` (or LibPQ) purely to name the type, and is backend-specific
+try
+    M.Driver.objects.create("driverref" => "senna", "code" => "SEN")
+catch e
+    if e isa SQLite.SQLiteException && occursin("UNIQUE constraint failed", e.msg)
+        return conflict()
+    end
+    rethrow()
+end
+
+# after — backend-agnostic, no driver dependency
+try
+    M.Driver.objects.create("driverref" => "senna", "code" => "SEN")
+catch e
+    e isa IntegrityError   && return conflict(error_message(e))
+    e isa OperationalError && return retry_later()
+    rethrow()
+end
+```
+
+Two further retypings in the same pass, both previously uncatchable via `PormGError`:
+
+```julia
+# before                                        # after
+catch e; e isa ErrorException && …              catch e; e isa OperationalError && …
+#   with_advisory_lock acquisition timeout
+
+catch e; e isa QueryBuildError && …             catch e; e isa TransactionError && …
+#   atomic(durable=true) nested in a transaction
+catch e; e isa InvalidConfigurationError && …   catch e; e isa TransactionError && …
+#   model bound to another connection during an open transaction
+```
+
+Read any of these with `error_message(e)`, **not** `e.msg` — like `PoolConnectError`, the three
+`DatabaseError` subtypes are built from structured fields and have no `msg`.
+
+---
+
 ## Error contract, final pass: renames, capability split, and closed escape hatches (audit / #268)
 
 - **Version**: Unreleased

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -657,15 +657,15 @@ Every PormG misuse raises a subtype of `PormGError` (`<: Exception`) so callers 
 **type** instead of matching on a message string. Catch `PormGError` for any PormG failure, or a
 specific subtype for a specific reaction (#231, completed in #239):
 
-`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `WritesDisabledError`, `UnsupportedConnectionError`, `BackendCapabilityError`, `ProtectedError`, `DefinitionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`, `PoolError`, `error_message`
+`PormGError`, `FieldAccessError`, `UnknownFieldError`, `LazyTraversalError`, `FilterError`, `QueryBuildError`, `UnsafeMutationError`, `InvalidValueError`, `WritesDisabledError`, `UnsupportedConnectionError`, `BackendCapabilityError`, `ProtectedError`, `DefinitionError`, `FieldValidationError`, `ModelDefinitionError`, `ConfigurationError`, `InvalidConfigurationError`, `MigrationError`, `InvalidMigrationError`, `PoolError`, `DatabaseError`, `IntegrityError`, `OperationalError`, `StatementError`, `TransactionError`, `error_message`
 
-!!! note "Database-level errors are not (yet) wrapped"
-    The taxonomy covers *misuse of PormG*. Once a statement reaches the database, failures —
-    a constraint violation, SQL the backend rejects, a connection dropped mid-query — currently
-    propagate as the **driver's own exception types** (`SQLite.SQLiteException`,
-    `LibPQ.Errors.*`), *not* as `PormGError`. Connect-time failures are the exception: they
-    arrive as `PoolConnectError`. Whether to wrap the rest is an open pre-publish decision —
-    see [#268](https://github.com/PingoLee/PormG.jl/issues/268).
+!!! note "Database failures are wrapped too"
+    The taxonomy has two halves. Most of it reports **misuse of PormG**, caught before anything is
+    sent. [`DatabaseError`](#database-errors) reports what the **database itself** refused once a
+    statement got there — a constraint violation, SQL the backend rejects, a connection dropped
+    mid-query — so `catch PormGError` really does cover both, and an app never has to name
+    `SQLite.SQLiteException` / `LibPQ.Errors.*` (which would mean depending on the driver package
+    just to spell the type). The driver's own exception stays reachable on `.cause` (#268).
 
 !!! warning "These are not `ArgumentError`s"
     The subtypes are deliberately **not** `<: ArgumentError`. A `catch ArgumentError` block around a
@@ -675,7 +675,8 @@ specific subtype for a specific reaction (#231, completed in #239):
 
 Use `error_message(e)`, **not** `e.msg`. Most subtypes carry a `msg::String`, but the ones built
 from structured fields — `DoesNotExist`, `MultipleObjectsReturned`, `PoolTimeoutError`,
-`PoolConnectError` — do not, so `e.msg` throws on exactly the errors you are least likely to have
+`PoolConnectError`, and the three `DatabaseError` subtypes (`IntegrityError`, `OperationalError`,
+`StatementError`) — do not, so `e.msg` throws on exactly the errors you are least likely to have
 tested against.
 
 ```julia
@@ -731,6 +732,43 @@ field, and for the few with their own `showerror` it returns the richer renderin
 | `DestructiveMigrationError` | A destructive plan was applied non-interactively without `destructive=true`. |
 | `PoolError` *(abstract)* | Umbrella for connection-pool failures — `catch` it to get both cases below. |
 | `PoolTimeoutError` / `PoolConnectError` | The pool is saturated / a physical connection could not be opened. Both carry structured fields (`adapter`, `pool_size`, `attempts`, …) rather than a `msg` — read them with `error_message`. |
+
+**Database errors**
+
+Everything above reports *misuse of PormG*, raised before a statement leaves the process. These
+report what the **database** refused once it got there. Each carries `adapter` (`"PostgreSQL"` /
+`"SQLite"`) and `cause` — the driver's own exception, kept so SQLSTATE-level detail stays reachable
+— instead of a `msg`, so read them with `error_message`.
+
+| Type | Raised when |
+| :--- | :--- |
+| `DatabaseError` *(abstract)* | Umbrella for every failure raised by the database itself. `catch DatabaseError` covers all three below without naming a driver package. |
+| `IntegrityError` | A constraint said no — `UNIQUE`, `FOREIGN KEY`, `NOT NULL`, `CHECK`, or an exclusion constraint. The one database failure applications routinely *handle* rather than propagate. |
+| `OperationalError` | Transient, and retrying may succeed — the connection dropped mid-query, a deadlock, a serialization failure, or a lock that could not be acquired (including a `with_advisory_lock` timeout). |
+| `StatementError` | The statement could not be executed — invalid SQL, unknown table/column, a rejected type, or insufficient privileges. Also the landing type for anything the backend could not classify, so the umbrella has no holes. |
+| `TransactionError` | Not a database error: the *transaction API* was used in a way that cannot work — `atomic(durable=true)` nested inside an open transaction, or touching a model bound to one connection while a transaction is open on another. Nothing was sent. |
+
+```julia
+try
+    M.Driver.objects.create("driverref" => "senna", "code" => "SEN")
+catch e
+    e isa IntegrityError   && return conflict(error_message(e))   # a constraint refused it
+    e isa OperationalError && return retry_later()                # transient — try again
+    rethrow()
+end
+```
+
+!!! note "Classification is exact on PostgreSQL, message-based on SQLite"
+    LibPQ parameterizes its exception type on the SQLSTATE, so on PostgreSQL the kind is read
+    straight off the error code. `SQLite.SQLiteException` carries only a message, so on SQLite the
+    kind comes from SQLite's own literal constraint strings (`"UNIQUE constraint failed"`, …) —
+    stable, but not a code. Treat `IntegrityError` as reliable on both; `.cause` is there when you
+    need more than PormG's three kinds.
+
+Connect-time failure is **not** a `DatabaseError` — it never reached a statement, and arrives as
+`PoolConnectError` under `PoolError`. A failed migration `ALTER TABLE` **is** one: `migrate()` lets
+the `StatementError` through rather than re-wrapping it as `MigrationError`, which would bury the
+constraint detail — so catch `DatabaseError` alongside `MigrationError` around `migrate()`.
 
 The abstract umbrellas exist so the buckets have **no holes**: `catch ConfigurationError` also
 catches a missing `connection.yml`, and `catch MigrationError` also catches a refused destructive

--- a/ext/PormGLibPQExt.jl
+++ b/ext/PormGLibPQExt.jl
@@ -70,6 +70,46 @@ function PormG.backend_is_permanent_connect_error(pool::PormGPostgres, e)
          (occursin("database ", msg) && occursin("does not exist", msg))
 end
 
+# ── Error classification (#268) ──────────────────────────────────────────────
+#
+# PostgreSQL is the precise half of the boundary: LibPQ parameterizes its exception type on the
+# SQLSTATE (`PQResultError{Class, Code}`), so the class is available without parsing a message.
+#
+# Two ordering rules, both load-bearing:
+#
+#   1. Ask `backend_is_connection_error` FIRST. A connection dropped mid-query arrives as
+#      `PQResultError{CUN, EUNOWN}` — libpq returned no SQLSTATE, so LibPQ synthesized the class
+#      "UN". Class-mapping that yields :statement, which would tell `fetch` the statement was bad
+#      and silently kill the reconnect-retry of #138.
+#   2. Dispatch on the LibPQ exception type, not on `PormGPostgres` alone. A method typed on the
+#      abstract pool marker would shadow core's default for every PG-flavored pool, including the
+#      behavioral mocks the unit suite builds — which throw plain `ErrorException`s and steer
+#      through their own `backend_is_connection_error` overrides. (PormG has been bitten by
+#      exactly this shadowing before; see test/unit/test_error_taxonomy.jl.)
+const _PG_OPERATIONAL_CLASSES = (
+  LibPQ.Errors.C08,   # connection_exception
+  LibPQ.Errors.C40,   # transaction_rollback — serialization_failure, deadlock_detected
+  LibPQ.Errors.C53,   # insufficient_resources — out of memory / disk / connections
+  LibPQ.Errors.C55,   # object_not_in_prerequisite_state — lock_not_available
+  LibPQ.Errors.C57,   # operator_intervention — query_canceled, admin_shutdown
+)
+
+function PormG.backend_classify_error(pool::PormGPostgres, e::LibPQ.Errors.LibPQException)
+  PormG.backend_is_connection_error(pool, e) && return :operational
+  # Connection-level failures are a SIBLING of PQResultError, not a subtype, so they carry no
+  # SQLSTATE to map. The realistic source is the COPY drain in `_drain_postgres_connection!` below,
+  # which raises this when `PQconsumeInput` fails mid-stream — the connection is gone, which is
+  # operational, not a bad statement.
+  e isa LibPQ.Errors.PQConnectionError && return :operational
+  e isa LibPQ.Errors.PQResultError || return :unknown
+  class = LibPQ.Errors.error_class(e)
+  class === LibPQ.Errors.C23 && return :integrity      # integrity_constraint_violation
+  class in _PG_OPERATIONAL_CLASSES && return :operational
+  # Everything else the server named — syntax (42), data (22), feature (0A), privilege — is the
+  # statement being refused. An unrecognized class lands here too, which is the safe default.
+  return :statement
+end
+
 PormG.backend_num_affected_rows(pool::PormGPostgres, result) = LibPQ.num_affected_rows(result)
 PormG.backend_num_rows(pool::PormGPostgres, result) = LibPQ.num_rows(result)
 

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -142,6 +142,38 @@ function PormG.backend_is_permanent_connect_error(pool::PormGSQLite, e)
   return occursin("unable to open database file", msg)
 end
 
+# ── Error classification (#268) ──────────────────────────────────────────────
+#
+# SQLite is the imprecise half of the boundary, and the asymmetry with PostgreSQL is deliberate —
+# do not "clean it up" into a shared helper.
+#
+# `SQLiteException` carries a single `msg::AbstractString` field and nothing else: `sqliteexception`
+# builds it from `sqlite3_errmsg` and discards the result code. `sqlite3_extended_errcode` does
+# exist in the C wrapper, but it is unusable from here — it reads live per-connection state, this
+# generic is handed `(pool, e)` with no connection, and by the time a caller classifies, the
+# transaction seams have already run `ROLLBACK` on that same handle and reset it.
+#
+# So this matches SQLite's own literal, self-generated constraint strings, which is what
+# ActiveRecord's SQLite3 adapter does for the same reason. They are stable across SQLite versions.
+#
+# Dispatch pins `SQLite.SQLiteException` rather than the abstract `PormGSQLite` marker alone, so
+# this never shadows core's default for the unit suite's mock pools (see `backend_classify_error`
+# in src/Backend.jl for why that matters).
+function PormG.backend_classify_error(pool::PormGSQLite, e::SQLite.SQLiteException)
+  PormG.backend_is_connection_error(pool, e) && return :operational
+  msg = lowercase(string(e.msg))
+  # SQLite spells every constraint failure "<KIND> constraint failed[: table.column]".
+  occursin("constraint failed", msg) && return :integrity
+  # Contention. `_sqlite_with_retry` above already burns 20 attempts on these, so reaching here
+  # means the lock never cleared — transient, and the caller may reasonably retry.
+  (occursin("database is locked", msg) || occursin("database table is locked", msg)) && return :operational
+  occursin("no such table", msg) && return :statement
+  occursin("no such column", msg) && return :statement
+  occursin("syntax error", msg) && return :statement
+  # Unrecognized: core maps :unknown onto StatementError, so the umbrella still has no hole.
+  return :unknown
+end
+
 # Window-function support probe used by src/Dialect.jl.
 PormG.backend_sqlite_version(pool::PormGSQLite) = Int(SQLite.C.sqlite3_libversion_number())
 

--- a/src/AdvisoryLock.jl
+++ b/src/AdvisoryLock.jl
@@ -6,6 +6,12 @@ import PormG
 import PormG: PormGSettings, PormGPostgres, PormGSQLite, backend_execute_async
 import PormG.Configuration: get_settings
 import PormG.ConnectionPool: acquire_connection, release_connection
+# This module is the only one outside ConnectionPool that talks to the driver directly, so no
+# `fetch`/`with_transaction` seam covers it — it has to funnel its own failures through the
+# database-error boundary (#268) or `with_advisory_lock` would be the last public entry point
+# still leaking raw `LibPQ.Errors.*`.
+import PormG.ConnectionPool: _as_database_error
+import PormG: PormGError, OperationalError
 
 import PormG: @pormg_debug
 export with_advisory_lock
@@ -29,7 +35,11 @@ function _exec_lock_query(pool::PormGPostgres, conn, sql::String, key::AbstractS
   # Base.fetch awaits the LibPQ AsyncResult and returns the driver result.
   # Qualified deliberately: this module imports no `fetch`, so a bare call would
   # resolve to Base only by absence — qualifying keeps it immune to import shadowing.
-  res = Base.fetch(async_res)
+  res = try
+    Base.fetch(async_res)
+  catch e
+    throw(_as_database_error(pool, e))
+  end
 
   rows = collect(res)
   return !isempty(rows) && rows[1][1] == true
@@ -95,7 +105,14 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
       try
         got_lock = _exec_lock_query(pool, conn, BLOCK_SQL, key)
       catch e
-        msg = lowercase(string(e))
+        # `sprint(showerror, e)`, not `string(e)` — and this was a latent bug, not just style.
+        # `_exec_lock_query` awaits an async handle, so a server-side cancellation used to arrive
+        # here as a `TaskFailedException`, whose `string()` does NOT include the inner driver
+        # message (the same fact `_is_benign_rollback_error`'s docstring records). The substring
+        # below therefore never matched and this branch had never once fired: the LibPQ
+        # `QueryCanceled` propagated instead of degrading to `got_lock = false`. The seam added
+        # above now unwraps, and `showerror` renders the cause (#268).
+        msg = lowercase(sprint(showerror, e))
         if occursin("canceling statement due to statement timeout", msg)
           @warn "Advisory lock timed out on server-side statement_timeout" key=key timeout_ms=timeout_ms
           got_lock = false
@@ -115,7 +132,12 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
     end
     
     if !got_lock
-      throw(ErrorException("Failed to acquire advisory lock for '$key'"))
+      # OperationalError, not ErrorException (#268): losing a race for a lock is a transient
+      # runtime condition — the caller may reasonably back off and retry — not misuse of PormG,
+      # and it must be reachable via `catch PormGError` like every other runtime failure. The
+      # `cause` is a plain String because no driver raised anything: the lock query succeeded and
+      # answered "no". `PoolConnectError` sets the precedent for a non-Exception cause.
+      throw(OperationalError("PostgreSQL", "Failed to acquire advisory lock for '$key'"))
     end
     
     # Execute user function while holding lock

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -52,3 +52,52 @@ for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
     $fn(pool::PormGSQLite, args...; kwargs...) = throw(InvalidConfigurationError(_SQLITE_DRIVER_HINT))
   end
 end
+
+"""
+    backend_classify_error(pool, e) -> Symbol
+
+Classify a failure raised by the database into one of the [`DatabaseError`](@ref) kinds:
+`:integrity`, `:operational`, `:statement`, or `:unknown`. `ConnectionPool._as_database_error` maps
+the symbol to a type; `:unknown` lands on `StatementError` so the umbrella never has a hole.
+
+Deliberately **not** part of the missing-driver loop above: those fallbacks `throw`, and a
+classifier that throws while an error is already propagating would replace the real failure with a
+setup hint. This one always returns.
+
+The default below is driver-agnostic — it can only recognize the case core already had a generic
+for. Extensions refine it, and they dispatch on the **driver exception type**, not just the pool
+marker:
+
+    PormG.backend_classify_error(pool::PormGSQLite, e::SQLite.SQLiteException) = …
+
+That is load-bearing. An extension method typed on the abstract marker alone shadows this default
+for *every* pool of that flavor, including the behavioral mock pools the unit suite builds — which
+throw plain `ErrorException`s and rely on their own `backend_is_connection_error` overrides. Pinning
+the exception type means an extension only claims errors it actually understands. (PormG has been
+bitten by exactly this shadowing before; see the note in `test/unit/test_error_taxonomy.jl`.)
+
+Precision differs by backend, on purpose:
+
+  * **PostgreSQL** — exact. LibPQ parameterizes its exception type on the SQLSTATE
+    (`PQResultError{Class, Code}`), so the extension reads the class directly. No string matching.
+  * **SQLite** — message-based. `SQLiteException` carries only `msg`. The extended result code
+    (`sqlite3_extended_errcode`) exists but is unusable here: it reads live per-connection state,
+    and the transaction seams issue `ROLLBACK` on that same connection before rethrowing, which
+    resets it. So the extension matches SQLite's own literal constraint strings — the same approach
+    ActiveRecord's SQLite3 adapter takes.
+"""
+function backend_classify_error end
+
+function backend_classify_error(pool::PormGBackend, e)
+  # `backend_is_connection_error` hits the throwing fallback above when no driver is loaded, and a
+  # pool mock may not define it at all. Never let classification throw: the caller is mid-`catch`,
+  # and the original failure is preserved on `.cause` regardless of how we label it.
+  try
+    return backend_is_connection_error(pool, e) ? :operational : :unknown
+  catch classify_failure
+    # Everything except a cancellation. Swallowing Ctrl-C here would make a hung query
+    # uninterruptible, which is worse than an unclassified error.
+    classify_failure isa InterruptException && rethrow()
+    return :unknown
+  end
+end

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -3,6 +3,7 @@ module Configuration
 import YAML, Logging
 import PormG: PormGSettings, PormGBackend, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
 import PormG: ConfigurationError, InvalidConfigurationError  # semantic error taxonomy (#239); defined in Kernel
+import PormG: TransactionError  # cross-connection transaction misuse (#268); the config is valid, the call pattern is not
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
 import PormG: Generator
 import PormG: @pormg_debug
@@ -184,7 +185,11 @@ function ensure_model_transaction_scope(model::PormGModel)
   end
   active_key = connection_key_for_pool(tx_pool)
   active_desc = active_key === nothing ? "unknown transaction" : active_key
-  throw(InvalidConfigurationError("Active transaction on connection $(active_desc) cannot include model $(model.name) bound to $(model.connect_key). Run run_in_transaction(\"$(model.connect_key)\") or move this operation outside the current transaction."))
+  # TransactionError, not InvalidConfigurationError (#268): the configuration is fine — both
+  # connections are correctly declared — and the caller's *call pattern* is what cannot work. Its
+  # sibling check, `ConnectionPool.atomic(durable=true)`, reported the same class as
+  # QueryBuildError until #268 gave both one honest home.
+  throw(TransactionError("Active transaction on connection $(active_desc) cannot include model $(model.name) bound to $(model.connect_key). Run run_in_transaction(\"$(model.connect_key)\") or move this operation outside the current transaction."))
 end
 
 function transaction_connection_for(settings::PormGSettings)

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -11,12 +11,16 @@ import PormG: @pormg_debug
 # modules included before this one can name it (#261). PormGError comes along for `catch` sites.
 import PormG: PormGError, PoolError
 # Throw sites (#239): a bad acquire mode is a value error, an unresolvable pool is a config error,
-# and misuse of atomic() nesting lands on the long-tail QueryBuildError bucket.
-import PormG: InvalidValueError, InvalidConfigurationError, QueryBuildError
+# and atomic(durable=true) nesting is transaction-API misuse (#268 — was QueryBuildError).
+import PormG: InvalidValueError, InvalidConfigurationError, TransactionError
+# The database-error boundary (#268). This module owns the wrap: every driver failure leaving the
+# pool passes `_as_database_error` and arrives as one of these instead of a raw
+# `SQLite.SQLiteException` / `LibPQ.Errors.*`.
+import PormG: DatabaseError, IntegrityError, OperationalError, StatementError
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
 import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
               backend_execute_async, backend_is_connection_error, backend_is_permanent_connect_error,
-              backend_copy_in!
+              backend_copy_in!, backend_classify_error
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, atomic, with_savepoint
@@ -137,6 +141,61 @@ function _unwrap_async_exception(exception)
     else
       return current
     end
+  end
+end
+
+"""
+    _driver_cause(e) -> Any
+
+The driver's own exception behind `e`, or `e` itself when it is not one of ours. Every site that
+*classifies* a failure must call this, because since #268 a driver error may already be wrapped in a
+[`DatabaseError`](@ref) by a lower seam — and the driver classifiers (`backend_is_connection_error`,
+`backend_is_permanent_connect_error`) match on the driver type and message, so handing them a
+wrapper silently answers `false`.
+
+That is not theoretical: LibPQ reports a connection dropped mid-query as `PQResultError{CUN,EUNOWN}`
+with an *empty* message, which `backend_is_connection_error` recognizes by exact type-and-string
+match. Wrapped, that branch never fires and `fetch`'s reconnect-retry (#138) dies silently.
+"""
+_driver_cause(e::DatabaseError) = e.cause
+_driver_cause(e) = e
+
+"""
+    _as_database_error(pool, e) -> Exception
+
+Funnel every failure leaving the pool through the taxonomy: unwrap the async envelope, pass PormG's
+own errors through untouched, and wrap anything else as a [`DatabaseError`](@ref) whose kind comes
+from [`backend_classify_error`](@ref) (#268).
+
+**Only ever apply this where the exception can only have come from the driver.** It must never see a
+caller's closure: `run_in_transaction`/`atomic`/`with_savepoint` run user code inside their `try`,
+and relabelling a user's `BoundsError` — or an `InterruptException` — as a `StatementError` would be
+worse than the raw-driver-error problem this solves. Those bodies wrap their own BEGIN/COMMIT/
+ROLLBACK statements individually instead (`_await_tx_statement`).
+"""
+function _as_database_error(pool, e)
+  root = _unwrap_async_exception(e)
+  root isa PormGError && return root
+  adapter = pool isa PormGPostgres ? "PostgreSQL" : "SQLite"
+  kind = backend_classify_error(pool, root)
+  kind === :integrity   && return IntegrityError(adapter, root)
+  kind === :operational && return OperationalError(adapter, root)
+  # `:statement` and anything unrecognized land here, so `catch DatabaseError` has no hole.
+  return StatementError(adapter, root)
+end
+
+"""
+    _await_tx_statement(pool, task)
+
+Await a bare BEGIN/COMMIT/ROLLBACK task and convert a driver failure into the taxonomy. These
+statements are issued directly through `backend_execute_async` / `sqlite_execute_async` rather than
+through `fetch`, so they are the one driver path a transaction body owns that no other seam covers.
+"""
+function _await_tx_statement(pool, task)
+  try
+    return Base.fetch(task)
+  catch e
+    throw(_as_database_error(pool, e))
   end
 end
 #
@@ -1123,9 +1182,17 @@ released normally. SQLite-only divergence: SQLite auto-rolls-back some failures,
 which `ROLLBACK` reports "no transaction is active"; PostgreSQL's `ROLLBACK` outside a
 transaction merely warns, it never throws. Unwraps before matching: async failures arrive
 as `TaskFailedException`, whose `string()` does not include the driver message.
+
+Stays a message match on purpose. "no transaction is active" is a SQLite-only condition and SQLite
+attaches no error code to it (`SQLiteException` carries only `msg`), so there is no kind for
+[`backend_classify_error`](@ref) to return — this is a *benign* signal, not an error class. It does
+have to see through a [`DatabaseError`](@ref) wrapper though: `finalize_transaction_connection!`
+is handed `rollback_error` values that already crossed a seam (`migrations/runner.jl`,
+`querybuilder/deletion.jl`), so `_driver_cause` is load-bearing here (#268).
 """
 _is_benign_rollback_error(pool::Union{PormGPostgres, PormGSQLite}, e) =
-  pool isa PormGSQLite && occursin("no transaction is active", string(_unwrap_async_exception(e)))
+  pool isa PormGSQLite &&
+  occursin("no transaction is active", string(_driver_cause(_unwrap_async_exception(e))))
 
 """
     finalize_transaction_connection!(pool, conn; rollback_error=nothing) -> Nothing
@@ -1295,8 +1362,11 @@ function await_result(ft::FetchTask)
     return result
   catch e
     ft.completed = true
-    root = _unwrap_async_exception(e)
-    root === e ? rethrow() : throw(root)
+    # `rethrow()` when nothing changed: PormG's own errors (DoesNotExist, QueryBuildError,
+    # PoolTimeoutError…) pass through `_as_database_error` untouched, and re-`throw`ing the same
+    # object would discard the backtrace saying where it came from.
+    err = _as_database_error(ft.pool, e)
+    err === e ? rethrow() : throw(err)
   finally
     # Only release connection if we're not in a transaction context
     # Transaction context manages its own connection lifecycle
@@ -1356,7 +1426,7 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
       return FetchTask(task, connection, conn, true)  # true = in_transaction
     catch e
       # Don't release - transaction context manages the connection
-      throw(e)
+      throw(_as_database_error(connection, e))
     end
   else
     # Normal path: acquire connection from pool
@@ -1378,7 +1448,7 @@ function fetch_async(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
     catch e
       # If EXEC fails immediately, release connection
       release_connection(connection, conn)
-      throw(e)
+      throw(_as_database_error(connection, e))
     end
   end
 end
@@ -1406,13 +1476,20 @@ function fetch(connection::Union{PormGPostgres, PormGSQLite}, sql::String;
   try
     return await_result(fetch_task)
   catch e
-    root = _unwrap_async_exception(e)
+    root = _as_database_error(connection, e)
     # Never retry inside a transaction context or on a caller-pinned conn (#138): the retry
     # re-runs the statement on a fresh autocommit session (a write that should die with the
     # transaction gets committed) and reconnect_db + await_result would swap and release the
     # transaction's pool slot mid-transaction. Propagate instead so run_in_transaction's
     # rollback/renewal path (#71) owns the cleanup on the original pinned connection.
-    if conn === nothing && !fetch_task.in_transaction && backend_is_connection_error(connection, root)
+    #
+    # `_driver_cause`, not `root`: await_result has already wrapped this, and the classifier
+    # matches on the driver's type/message. Deliberately NOT `root isa OperationalError` either —
+    # that kind also covers deadlock, lock timeout and serialization failure, and transparently
+    # re-running a statement on a fresh autocommit session after a deadlock is a data-corruption
+    # bug. Only a *dropped connection* is safe to retry, which is exactly what this asks (#268).
+    if conn === nothing && !fetch_task.in_transaction &&
+       backend_is_connection_error(connection, _driver_cause(root))
       @warn "Lost connection to database. Attempting to reconnect..."
       # Renew the dead handle in its slot, then retry through NORMAL pool acquisition —
       # never by pinning `conn=new_conn`: the failed task's finally already marked the slot
@@ -1442,15 +1519,25 @@ function fetch_copy(connection::PormGPostgres, sql::String, data_itr)
   # Check for transaction context
   tx_conn = get_tx_connection()
 
+  # COPY bypasses `fetch`/`await_result` entirely, so it needs its own catch to honor the
+  # database-error contract (#268) — before this it was the one write path that still leaked raw
+  # `LibPQ.Errors.*` to callers. The catch sits INSIDE the pool branch's try so the terminal
+  # `finally` still releases the lease.
   if tx_conn !== nothing
     # Reuse the transaction connection — COPY is part of the open transaction.
-    backend_copy_in!(connection, tx_conn, sql, data_itr)
+    try
+      backend_copy_in!(connection, tx_conn, sql, data_itr)
+    catch e
+      throw(_as_database_error(connection, e))
+    end
   else
     # Acquire a pool connection for the duration of the COPY stream. CopyIn owns the
     # connection until the stream is fully consumed, so we hold it until done.
     conn = acquire_connection(connection)
     try
       backend_copy_in!(connection, conn, sql, data_itr)
+    catch e
+      throw(_as_database_error(connection, e))
     finally
       release_connection(connection, conn)
     end
@@ -1487,7 +1574,7 @@ function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::St
     return task, conn
   catch e
     release_connection(pool, conn)
-    throw(e)
+    throw(_as_database_error(pool, e))
   end
 end
 
@@ -1528,7 +1615,7 @@ function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
       rollback_failed ? _renew_or_discard_connection!(pool, conn) : release_connection(pool, conn)
     end
     @error "Failed to execute SQL transaction, rolling back: $e"
-    throw(e)
+    throw(_as_database_error(pool, e))
   finally
     if release_conn
       rollback_failed ? _renew_or_discard_connection!(pool, conn) : release_connection(pool, conn)
@@ -1701,15 +1788,17 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
   tx_started = false
   local rollback_error = nothing
   try
-    # Begin transaction
+    # Begin transaction. `_await_tx_statement`, not a bare `Base.fetch`: these statements bypass
+    # `fetch`, so they are the only driver contact in this function that no seam covers. The
+    # function-wide `catch` below must NOT wrap — it also sees `f()`, the caller's own code (#268).
     if pool isa PormGPostgres
         task = backend_execute_async(pool, conn, "BEGIN;", nothing)
-        Base.fetch(task)
+        _await_tx_statement(pool, task)
     else
         # Use BEGIN IMMEDIATE for SQLite to prevent deadlocks and ensure
         # write lock is acquired early for multi-threaded scenarios.
       task = sqlite_execute_async(pool, conn, "BEGIN IMMEDIATE TRANSACTION;", nothing)
-      Base.fetch(task)
+      _await_tx_statement(pool, task)
     end
     tx_started = true
 
@@ -1721,10 +1810,10 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
     # Commit on success
     if pool isa PormGPostgres
         task = backend_execute_async(pool, conn, "COMMIT;", nothing)
-        Base.fetch(task)
+        _await_tx_statement(pool, task)
     else
       task = sqlite_execute_async(pool, conn, "COMMIT;", nothing)
-      Base.fetch(task)
+      _await_tx_statement(pool, task)
     end
 
     return result
@@ -1735,10 +1824,10 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
       try
         if pool isa PormGPostgres
             task = backend_execute_async(pool, conn, "ROLLBACK;", nothing)
-            Base.fetch(task)
+            _await_tx_statement(pool, task)
         else
           task = sqlite_execute_async(pool, conn, "ROLLBACK;", nothing)
-          Base.fetch(task)
+          _await_tx_statement(pool, task)
         end
       catch rb
         # Capture the rollback error so the finally can decide release-vs-renew (a benign
@@ -1802,7 +1891,11 @@ transaction is already active (mirrors Django's `atomic(durable=True)`).
 """
 function atomic(f::Function, pool::Union{PormGPostgres, PormGSQLite}; durable::Bool=false)
   if durable && in_transaction_context()
-    throw(QueryBuildError("atomic(durable=true) must be the outermost transaction, but a transaction is already active"))
+    # TransactionError, not QueryBuildError: nothing is wrong with the query shape — the
+    # transaction API was called in a way that cannot work. Its sibling check,
+    # `Configuration.ensure_model_transaction_scope`, reports the same class and used to say
+    # InvalidConfigurationError; #268 gave both one honest home.
+    throw(TransactionError("atomic(durable=true) must be the outermost transaction, but a transaction is already active"))
   end
   return run_in_transaction(f, pool)
 end

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -169,7 +169,11 @@ export PormGError,
        PoolError, error_message,
        # Pre-publish naming pass (#268-era audit): narrowed/added members (WritesDisabledError
        # replaces PermissionError on the taxonomy line above).
-       BackendCapabilityError, ProtectedError, DefinitionError
+       BackendCapabilityError, ProtectedError, DefinitionError,
+       # The database-error boundary (#268): everything above reports misuse of PormG; these report
+       # what the database itself refused, with the driver exception kept in `.cause`.
+       DatabaseError, IntegrityError, OperationalError, StatementError,
+       TransactionError
 
 # Shared state / generics
 export config, get_constraints_pk, get_constraints_unique, get_constraints_check

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -152,6 +152,12 @@ export FieldValidationError, ModelDefinitionError,
 # only concrete subtypes with neither a Kernel home nor an abstract one. `error_message` is the
 # uniform way to read a caught PormGError: the structured subtypes have no `.msg` field.
 export PoolError, error_message, DefinitionError
+# The database-error boundary (#268). Every export above reports *misuse of PormG*, raised before a
+# statement leaves the process; these report what the database itself refused once it got there, so
+# `catch PormGError` finally covers constraint violations, rejected SQL and dropped connections
+# without an app naming `SQLite.SQLiteException` / `LibPQ.Errors.*`. The driver exception stays
+# reachable on `.cause`. `TransactionError` is transaction-API misuse — not a database failure.
+export DatabaseError, IntegrityError, OperationalError, StatementError, TransactionError
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -31,6 +31,10 @@
 #
 # Also update `docs/src/api.md`'s taxonomy table and the frozen export list in
 # `test/unit/test_public_exports.jl`; both are asserted, so they fail loudly rather than drift.
+#
+# One trap the guards do NOT catch cleanly: a subtype built from structured fields (no `msg`) must
+# be added to the hand-written skip lists in `test_error_taxonomy.jl`'s `error_message` testset, or
+# it fails there as an opaque `MethodError` on `T("boom")` rather than as a readable assertion.
 
 # ── Query-builder errors (#231) ─────────────────────────────────────────────
 
@@ -203,6 +207,159 @@ and already reasons about pool failure, so it could not have named those types.
 """
 abstract type PoolError <: PormGError end
 
+# ── Database errors (#268) ──────────────────────────────────────────────────
+#
+# The boundary this taxonomy could not previously describe: everything above is *misuse of PormG*,
+# raised before a statement leaves the process. These four are the other half — the database
+# accepted a connection, ran something, and said no.
+#
+# Before #268 those failures propagated as the driver's own exception types, so an app that wanted
+# to handle a UNIQUE violation had to `catch SQLite.SQLiteException` / `LibPQ.Errors.*` — taking a
+# hard dependency on the driver package purely to *name* the type, which fights the weakdep design
+# that keeps LibPQ/SQLite optional. Every mature ORM wraps here (Django's PEP-249 tree,
+# SQLAlchemy's `DBAPIError.orig`, ActiveRecord's `translate_exception`, Diesel's
+# `DatabaseErrorKind`), always with the original reachable; PormG now does too, via `.cause`.
+#
+# Classification is per-adapter and lives in the extensions (`backend_classify_error`), because
+# telling a UNIQUE violation from a syntax error needs driver knowledge and core must never name a
+# driver type. The two backends are not equally precise, on purpose — see `backend_classify_error`
+# in `src/Backend.jl` and the two extension bodies.
+
+"""
+    DatabaseError <: PormGError  (abstract)
+
+Umbrella for failures raised *by the database itself*, once a statement has reached it — as opposed
+to the rest of the taxonomy, which reports misuse of PormG before anything is sent.
+`catch DatabaseError` covers every case below without naming a driver package.
+
+Subtypes: [`IntegrityError`](@ref) (a constraint said no), [`OperationalError`](@ref) (transient —
+the connection dropped, a deadlock, a lock timeout), and [`StatementError`](@ref) (the statement
+itself was rejected, plus anything the backend could not classify).
+
+All three are built from structured fields rather than a `msg::String`, so read them with
+[`error_message`](@ref). Each keeps the driver's own exception in `.cause`, so SQLSTATE-level
+detail stays available to callers that want it:
+
+```julia
+try
+    M.Driver.objects.create("code" => "SEN")
+catch e
+    e isa IntegrityError  && return conflict(error_message(e))
+    e isa OperationalError && return retry()
+    rethrow()
+end
+```
+
+Connect-time failure is *not* here: it never reached a statement, and has been
+`ConnectionPool.PoolConnectError` under [`PoolError`](@ref) since #261.
+"""
+abstract type DatabaseError <: PormGError end
+
+# Render a wrapped driver failure for human consumption.
+#
+# Driver exceptions are not required to be `Exception` subtypes (same defensive reasoning as
+# `PoolConnectError.cause`), so both shapes are handled.
+#
+# The `msg` branch exists because the two drivers are not equally well-behaved. LibPQ defines
+# `Base.showerror` for its exceptions, so `sprint(showerror, …)` renders "UniqueViolation: ERROR:
+# duplicate key …" — exactly what we want. SQLite.jl defines none, so Julia falls back to
+# `showerror(io, ::Exception) = show(io, ex)` and the cause renders as the struct literal
+# `SQLiteException("UNIQUE constraint failed: t.c")` — type name and quoting as noise inside our own
+# sentence. Comparing against `show` detects that fallback exactly (it is the same method), so a
+# driver that bothers to define `showerror` keeps its richer rendering and one that doesn't
+# contributes its bare message.
+function _cause_text(cause)
+  cause isa Exception || return string(cause)
+  rendered = sprint(showerror, cause)
+  if hasproperty(cause, :msg) && rendered == sprint(show, cause)
+    return string(getproperty(cause, :msg))
+  end
+  return rendered
+end
+
+"""
+    IntegrityError(adapter, cause) <: DatabaseError <: PormGError
+
+A constraint rejected the statement — `UNIQUE`, `FOREIGN KEY`, `NOT NULL`, `CHECK`, or an exclusion
+constraint. This is the one database failure applications routinely *handle* rather than propagate,
+which is why it is its own type.
+
+`adapter` is `"PostgreSQL"` or `"SQLite"`; `cause` is the driver's own exception. On PostgreSQL this
+is derived from SQLSTATE class `23`, so it is exact; on SQLite it comes from SQLite's own literal
+constraint messages.
+"""
+struct IntegrityError <: DatabaseError
+  adapter::String        # "PostgreSQL" | "SQLite"
+  cause                  # underlying driver exception (untyped: a driver may throw a non-Exception)
+end
+
+Base.showerror(io::IO, e::IntegrityError) = print(io,
+  "IntegrityError: ", e.adapter, " rejected the statement — a constraint was violated: ",
+  _cause_text(e.cause))
+
+"""
+    OperationalError(adapter, cause) <: DatabaseError <: PormGError
+
+The database could not complete the statement for a reason outside the statement itself, and
+retrying may succeed — the connection dropped mid-query, a deadlock was detected, a serialization
+failure occurred, or a lock could not be acquired in time.
+
+`catch OperationalError` is the retry signal. PormG raises it for `with_advisory_lock` acquisition
+timeouts too: contention is a runtime condition, not misuse.
+"""
+struct OperationalError <: DatabaseError
+  adapter::String
+  cause
+end
+
+Base.showerror(io::IO, e::OperationalError) = print(io,
+  "OperationalError: the ", e.adapter, " operation could not complete and may succeed on retry: ",
+  _cause_text(e.cause))
+
+"""
+    StatementError(adapter, cause) <: DatabaseError <: PormGError
+
+A statement failed to execute — invalid SQL, an unknown table or column, a type the backend would
+not accept, or insufficient privileges. Also the landing type for any failure on the database path
+that could not be classified, so `catch DatabaseError` never has a hole.
+
+Usually a bug to fix rather than a condition to handle. The driver's exception is in `.cause`; the
+SQL text is deliberately **not** stored, because it can embed user data (the `@error … sql=…` log
+sites already surface the statement where that is appropriate).
+
+The wording says *could not execute*, not *the database rejected this*, on purpose. Being the
+unclassified fallback means a PormG-internal fault on the statement path can land here too — the
+SQLite worker's malformed-payload invariant, for one — and claiming the server refused something it
+never saw would send a reader hunting for a SQL bug that does not exist.
+"""
+struct StatementError <: DatabaseError
+  adapter::String
+  cause
+end
+
+Base.showerror(io::IO, e::StatementError) = print(io,
+  "StatementError: the ", e.adapter, " statement could not be executed: ", _cause_text(e.cause))
+
+"""
+    TransactionError(msg) <: PormGError
+
+The transaction API was used in a way that cannot work — `atomic(durable=true)` nested inside an
+open transaction, or an operation on a model bound to one connection attempted while a transaction
+is open on another.
+
+Not a [`DatabaseError`](@ref): nothing was sent, and the database is not involved. Both cases are
+caught before any statement is issued. A deadlock or a rollback the *server* forces is an
+[`OperationalError`](@ref) instead.
+
+Introduced in #268 so the two checks stop reporting as unrelated types (`QueryBuildError` said
+"query shape" for what is a transaction-nesting mistake; `InvalidConfigurationError` said "your
+config is wrong" when the config was fine and the call pattern was not).
+"""
+struct TransactionError <: PormGError
+  msg::String
+  TransactionError(msg::AbstractString) = new(_emsg(msg))
+end
+
 # ── Schema, configuration and migration errors (#239) ───────────────────────
 
 """
@@ -316,7 +473,8 @@ end
 # One `showerror` covers every `msg`-carrying subtype. DoesNotExist / MultipleObjectsReturned
 # override with their field-built messages (a more specific method wins on dispatch); so do the
 # reparented types that carry their own structured fields (PoolTimeoutError, PoolConnectError,
-# MissingConfigurationError, DestructiveMigrationError), each next to its definition.
+# MissingConfigurationError, DestructiveMigrationError) and the three DatabaseError subtypes, each
+# next to its definition.
 Base.showerror(io::IO, e::PormGError) = print(io, e.msg)
 
 """
@@ -324,10 +482,11 @@ Base.showerror(io::IO, e::PormGError) = print(io, e.msg)
 
 The text of any PormG error, as a `String`.
 
-Use this instead of `e.msg`. Four subtypes are built from structured fields and have **no `msg`
+Use this instead of `e.msg`. Seven subtypes are built from structured fields and have **no `msg`
 field at all** — `DoesNotExist`, `MultipleObjectsReturned`, `ConnectionPool.PoolTimeoutError`,
-`ConnectionPool.PoolConnectError` — so `e.msg` throws a `FieldError` on exactly the errors a caller
-is least likely to have tested against (#261).
+`ConnectionPool.PoolConnectError`, and the three [`DatabaseError`](@ref) subtypes
+(`IntegrityError`, `OperationalError`, `StatementError`) — so `e.msg` throws a `FieldError` on
+exactly the errors a caller is least likely to have tested against (#261, #268).
 
 ```julia
 try

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -1219,7 +1219,16 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
         # With ON CONFLICT active a surviving duplicate-key error means a DIFFERENT constraint
         # than the clause target conflicted — the values came from the DataFrame, not a stale
         # sequence, so the resync-and-retry below would fail identically. Propagate instead.
-        if on_conflict_sql === nothing && occursin("duplicate key value violates unique constraint", e |> string)
+        #
+        # `sprint(showerror, e)`, not `string(e)` (#268): since the pool wraps driver failures,
+        # `e` is normally an `IntegrityError` here, and `string()` on a struct renders the struct
+        # literal rather than calling `showerror`. It happens to still contain the driver text
+        # because Julia's default `show` recurses into `.cause` — an accident that would evaporate
+        # the moment anyone gave the wrapper a `Base.show`, silently disabling the sequence resync.
+        # `showerror` is the contract for both wrapped and raw errors. Kept as a message match
+        # rather than `e isa IntegrityError`: the sequence-resync retry is specific to a PostgreSQL
+        # *duplicate-key* failure, not to constraint violations in general.
+        if on_conflict_sql === nothing && occursin("duplicate key value violates unique constraint", sprint(showerror, e))
           if !isempty(pk_field)
             # with_savepoint already rolled back and released the savepoint; the outer
             # transaction is still usable. Fix the sequence and retry without a savepoint.
@@ -1232,7 +1241,7 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
             @error "bulk_insert: duplicate key and no primary-key sequence to resync — the conflicting values came from the DataFrame" model=model.name exception=e
             rethrow()
           end
-        elseif occursin("violates foreign key constraint", e |> string)
+        elseif occursin("violates foreign key constraint", sprint(showerror, e))
           @error "bulk_insert: foreign key constraint violated — a referenced row is missing" model=model.name exception=e
           rethrow()
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")
     @testset "Typed Exceptions on Query Surface (#197)" include("unit/test_typed_exceptions.jl")
     @testset "Semantic Error Taxonomy (#231)" include("unit/test_error_taxonomy.jl")
+    @testset "Database-error Boundary (#268)" include("unit/test_database_error_boundary.jl")
     @testset "Error-contract Drift Guard (#239)" include("unit/test_docs_error_type_drift.jl")
     @testset "Documented Error Types (#239)" include("unit/test_docs_error_types.jl")
     @testset "Kernel Layering" include("unit/test_kernel_layering.jl")

--- a/test/unit/test_database_error_boundary.jl
+++ b/test/unit/test_database_error_boundary.jl
@@ -1,0 +1,250 @@
+# ============================================================
+# test/unit/test_database_error_boundary.jl
+#
+# The database-error boundary (#268).
+#
+# CONTRACT being tested:
+#   `docs/src/api.md` promises "`catch PormGError` catches them all". Before #268 that was false
+#   for runtime database failures: a UNIQUE violation, SQL the backend rejected, or a connection
+#   dropped mid-query reached the caller as a raw `SQLite.SQLiteException` / `LibPQ.Errors.*`, so an
+#   app had to depend on the driver package purely to NAME the type — fighting the weakdep design
+#   that keeps LibPQ/SQLite optional. The pool now wraps those at its own seams into
+#   `DatabaseError` subtypes, keeping the driver exception on `.cause`.
+#
+#   The half that is easy to get wrong is the NEGATIVE contract. `run_in_transaction`/`atomic`/
+#   `with_savepoint` run the CALLER'S closure inside their `try`. Wrapping there would relabel a
+#   user's `BoundsError` — or an `InterruptException` — as a `StatementError`, which is worse than
+#   the problem being solved. Those bodies wrap their BEGIN/COMMIT/ROLLBACK statements individually
+#   instead, and the tests below pin both directions.
+#
+# Runs against a REAL temp SQLite database, not a mock: classification reads driver message
+# fingerprints, so a mock that fabricates them would prove only that the mock matches itself.
+# The PostgreSQL half (exact SQLSTATE class mapping) is covered by the integration suite, which is
+# the only place a real `LibPQ.Errors.PQResultError` exists.
+# ============================================================
+
+using Test
+using PormG
+
+# Needs the real SQLite extension (runtests.jl loads it too; re-loading is idempotent).
+include(joinpath(@__DIR__, "..", "load_drivers.jl"))
+
+const CPB = PormG.ConnectionPool
+
+# ── Scratch database ────────────────────────────────────────────────────────
+# One table with a UNIQUE + NOT NULL column and a self-referencing FK, which is enough to raise
+# every integrity class SQLite distinguishes.
+const BOUNDARY_KEY = "pormg268_boundary"
+
+function _boundary_pool()
+  path = joinpath(mktempdir(), "boundary.sqlite")
+  pool = CPB.SQLiteConnectionPool(path)
+  # Registered in `config`, not just constructed: a NESTED `atomic` becomes a SAVEPOINT, and that
+  # path resolves settings from the pool via `connection_key_for_pool`, which scans `config`. An
+  # unregistered pool fails with "Cannot resolve connection settings for the active transaction
+  # pool" long before reaching the seam under test. Each call re-registers under the same key, and
+  # every testset uses the pool it just built, so the lookup always resolves to the live one.
+  PormG.config[BOUNDARY_KEY] = PormG.Configuration.Settings(
+      connections = pool, change_data = true)
+  CPB.fetch(pool, "PRAGMA foreign_keys = ON;")
+  CPB.fetch(pool, """
+    CREATE TABLE constructor (
+      id   INTEGER PRIMARY KEY,
+      code TEXT NOT NULL UNIQUE,
+      successor INTEGER REFERENCES constructor(id)
+    );""")
+  CPB.fetch(pool, "INSERT INTO constructor (id, code) VALUES (1, 'MCL');")
+  return pool
+end
+
+_raised(f) = try (f(); nothing) catch e; e end
+
+@testset "Database-error boundary (#268)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # The positive contract: the database said no, and it arrives as OUR type.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "database failures arrive as DatabaseError subtypes" begin
+    pool = _boundary_pool()
+
+    # Each case asserts the SPECIFIC kind, not just "some PormGError". A classifier that collapsed
+    # everything into StatementError would still satisfy `isa PormGError`, and the whole point of
+    # IntegrityError is that an app can branch on it.
+    unique_err = _raised(() -> CPB.fetch(pool, "INSERT INTO constructor (id, code) VALUES (2, 'MCL');"))
+    @test unique_err isa PormG.IntegrityError
+
+    notnull_err = _raised(() -> CPB.fetch(pool, "INSERT INTO constructor (id, code) VALUES (3, NULL);"))
+    @test notnull_err isa PormG.IntegrityError
+
+    fk_err = _raised(() -> CPB.fetch(pool, "INSERT INTO constructor (id, code, successor) VALUES (4, 'FER', 999);"))
+    @test fk_err isa PormG.IntegrityError
+
+    missing_table = _raised(() -> CPB.fetch(pool, "SELECT * FROM no_such_table;"))
+    @test missing_table isa PormG.StatementError
+
+    syntax = _raised(() -> CPB.fetch(pool, "SELEC 1;"))
+    @test syntax isa PormG.StatementError
+
+    # The umbrella must have no holes, and the root claim in api.md must hold.
+    for e in (unique_err, notnull_err, fk_err, missing_table, syntax)
+      @test e isa PormG.DatabaseError
+      @test e isa PormGError
+    end
+
+    # Discrimination: StatementError and IntegrityError must not be the same bucket, or branching
+    # on IntegrityError is meaningless. (A classifier returning :integrity unconditionally would
+    # pass every assertion above.)
+    @test !(missing_table isa PormG.IntegrityError)
+    @test !(unique_err isa PormG.StatementError)
+  end
+
+  @testset "the driver exception survives on .cause" begin
+    pool = _boundary_pool()
+    err = _raised(() -> CPB.fetch(pool, "INSERT INTO constructor (id, code) VALUES (2, 'MCL');"))
+
+    @test err isa PormG.IntegrityError
+    @test err.adapter == "SQLite"
+    # The exact driver type — this is what an app reaches for when it needs detail PormG's kinds
+    # don't carry, and it is the promise `.cause` makes.
+    @test err.cause isa SQLite.SQLiteException
+    # …and the driver's own text must reach the caller through the documented accessor. A wrapper
+    # that dropped the message would pass every `isa` assertion above.
+    @test occursin("UNIQUE constraint failed", PormG.error_message(err))
+    # `.msg` deliberately does not exist on the structured subtypes.
+    @test :msg ∉ fieldnames(PormG.IntegrityError)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # The NEGATIVE contract. This is the one that would have shipped a bug.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "user code inside a transaction is never relabelled" begin
+    pool = _boundary_pool()
+
+    # Every one of these is raised by the CALLER's closure, not the driver. If `_as_database_error`
+    # were applied to `_run_in_transaction_impl`'s function-wide catch (the obvious-looking place),
+    # each would come back as a StatementError and every assertion here would fail.
+    for (label, thunk) in (
+          ("ErrorException", () -> error("validation failed")),
+          ("BoundsError",    () -> [1, 2, 3][99]),
+          ("KeyError",       () -> throw(KeyError(:nope))),
+          ("custom type",    () -> throw(DimensionMismatch("bad shape"))),
+        )
+      err = _raised(() -> CPB.atomic(pool) do; thunk(); end)
+      @test err !== nothing
+      @test !(err isa PormG.DatabaseError)
+      @test !(err isa PormGError)
+    end
+
+    # The identity of the user's exception must be preserved exactly, not merely its abstract class.
+    sentinel = DimensionMismatch("f1 grid is 20 cars, got 22")
+    err = _raised(() -> CPB.atomic(pool) do; throw(sentinel); end)
+    @test err === sentinel
+
+    # Same rule for savepoints (nested atomic → SAVEPOINT), which has its own catch.
+    err = _raised(() -> CPB.atomic(pool) do
+      CPB.atomic(pool) do; throw(sentinel); end
+    end)
+    @test err === sentinel
+  end
+
+  @testset "a real database failure inside a transaction still wraps" begin
+    # The mirror of the test above: suppressing the wrap for user code must NOT suppress it for the
+    # driver. Without this pair, "never relabel" could be satisfied by never wrapping at all.
+    pool = _boundary_pool()
+    err = _raised(() -> CPB.atomic(pool) do
+      CPB.fetch(pool, "INSERT INTO constructor (id, code) VALUES (2, 'MCL');")
+    end)
+    @test err isa PormG.IntegrityError
+    @test occursin("UNIQUE constraint failed", PormG.error_message(err))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Passthrough: PormG's own errors must not be re-wrapped or re-labelled.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "PormG's own errors pass through the seam untouched" begin
+    pool = _boundary_pool()
+
+    # A QueryBuildError raised above the pool must not come back as a StatementError just because
+    # it crossed a seam. `_as_database_error` returns PormGError values unchanged.
+    original = PormG.QueryBuildError("not a database problem")
+    @test CPB._as_database_error(pool, original) === original
+
+    # …including when it arrives wrapped in the async envelope.
+    task = @async throw(original)
+    envelope = _raised(() -> Base.fetch(task))
+    @test envelope isa TaskFailedException
+    @test CPB._as_database_error(pool, envelope) === original
+  end
+
+  @testset "_driver_cause reaches the driver exception through the wrapper" begin
+    # This accessor is what keeps `fetch`'s #138 reconnect-retry alive: the driver classifiers match
+    # on the driver's type and message, so handing them the wrapper answers `false` and the retry
+    # silently dies. Pin both directions.
+    raw = ErrorException("server closed the connection")
+    wrapped = PormG.OperationalError("PostgreSQL", raw)
+    @test CPB._driver_cause(wrapped) === raw
+    @test CPB._driver_cause(raw) === raw            # non-wrapper passes through unchanged
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Classification, exercised directly.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "backend_classify_error never throws and always returns a kind" begin
+    pool = _boundary_pool()
+
+    @test PormG.backend_classify_error(pool, SQLite.SQLiteException("UNIQUE constraint failed: t.c")) === :integrity
+    @test PormG.backend_classify_error(pool, SQLite.SQLiteException("FOREIGN KEY constraint failed")) === :integrity
+    @test PormG.backend_classify_error(pool, SQLite.SQLiteException("NOT NULL constraint failed: t.c")) === :integrity
+    @test PormG.backend_classify_error(pool, SQLite.SQLiteException("no such table: nope")) === :statement
+    @test PormG.backend_classify_error(pool, SQLite.SQLiteException("database is locked")) === :operational
+
+    # A non-driver exception must fall to the core default rather than the SQLite method — that is
+    # what keeps the behavioral pool mocks (which throw plain ErrorExceptions) working.
+    @test PormG.backend_classify_error(pool, ErrorException("something else")) === :unknown
+
+    # An unclassifiable failure must still land somewhere, so `catch DatabaseError` has no hole.
+    @test CPB._as_database_error(pool, ErrorException("something else")) isa PormG.StatementError
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Transaction-API misuse is NOT a database error.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "transaction-API misuse raises TransactionError (#268)" begin
+    pool = _boundary_pool()
+
+    err = _raised(() -> CPB.atomic(pool) do
+      CPB.atomic(pool; durable = true) do; nothing; end
+    end)
+    @test err isa PormG.TransactionError
+    @test occursin("outermost transaction", PormG.error_message(err))
+    # Nothing was sent to the database, so this must not be filed under DatabaseError…
+    @test !(err isa PormG.DatabaseError)
+    # …nor under the buckets it used to borrow, which is the whole reason the type exists.
+    @test !(err isa PormG.QueryBuildError)
+    @test !(err isa PormG.ConfigurationError)
+
+    # `durable=true` outside a transaction is legal and must still run.
+    @test CPB.atomic(pool; durable = true) do; 42; end == 42
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Rendering.
+  # ─────────────────────────────────────────────────────────────────────────
+  @testset "showerror names the adapter and renders the cause" begin
+    e = PormG.IntegrityError("SQLite", SQLite.SQLiteException("UNIQUE constraint failed: constructor.code"))
+    msg = PormG.error_message(e)
+    @test occursin("IntegrityError", msg)
+    @test occursin("SQLite", msg)
+    @test occursin("UNIQUE constraint failed: constructor.code", msg)
+    # SQLite.jl defines no `showerror`, so `_cause_text` falls back to the cause's `msg` rather
+    # than Julia's default struct rendering — otherwise the sentence reads
+    # `… violated: SQLiteException("UNIQUE constraint failed: …")`, with the type name and quoting
+    # as noise inside our own message.
+    @test !occursin("SQLiteException(", msg)
+
+    # A non-Exception cause is supported on purpose (advisory-lock contention passes a String, and
+    # PoolConnectError set that precedent) — it must not throw when rendered.
+    lock_err = PormG.OperationalError("PostgreSQL", "Failed to acquire advisory lock for 'grid'")
+    @test occursin("Failed to acquire advisory lock", PormG.error_message(lock_err))
+  end
+end

--- a/test/unit/test_docs_error_type_drift.jl
+++ b/test/unit/test_docs_error_type_drift.jl
@@ -119,7 +119,9 @@ const DRIFT_EXT_DIR = joinpath(DRIFT_REPO_ROOT, "ext")
 # Internal invariant violations ("should not happen; please report") — not PormG misuse, so they
 # stay ErrorException by design rather than polluting the taxonomy with an InternalError type.
 const ALLOWED_UNTYPED_ERROREXCEPTION = Dict(
-    "src/AdvisoryLock.jl"    => 1,  # lock-acquisition timeout — parked with the #268 boundary decision
+    # AdvisoryLock's entry is GONE, not zeroed: #268 settled the boundary decision it was parked
+    # with, and lock-acquisition timeout is now an OperationalError (contention is a transient
+    # runtime condition, not misuse). This dict is asserted with `==`, so a stale key fails too.
     "src/ConnectionPool.jl"  => 1,  # SQLite async worker returned a malformed payload (internal)
 )
 const ALLOWED_UNTYPED_BARE_ERROR = Dict(

--- a/test/unit/test_error_taxonomy.jl
+++ b/test/unit/test_error_taxonomy.jl
@@ -35,6 +35,20 @@ const TAXONOMY_TYPES = (
     PormG.PoolTimeoutError, PormG.PoolConnectError,
     PormG.Configuration.MissingConfigurationError,
     PormG.Migrations.DestructiveMigrationError,
+    # #268 — the database-error boundary: what the database itself refused, once a statement got
+    # there. Plus transaction-API misuse, which is neither a query-shape nor a config problem.
+    PormG.IntegrityError, PormG.OperationalError, PormG.StatementError,
+    PormG.TransactionError,
+)
+
+# The subtypes built from structured fields instead of a `msg::String`. Declared ONCE: this list
+# used to be hand-copied into three testsets below, and a type missing from any copy failed as an
+# opaque `MethodError` on `T("boom")` rather than as a readable assertion.
+const STRUCTURED_TYPES = (
+    PormG.DoesNotExist, PormG.MultipleObjectsReturned,
+    PormG.PoolTimeoutError, PormG.PoolConnectError,
+    PormG.Migrations.DestructiveMigrationError,
+    PormG.IntegrityError, PormG.OperationalError, PormG.StatementError,
 )
 
 # The abstract mid-nodes. Each groups its concrete leaves so `catch <node>` has no holes.
@@ -45,6 +59,9 @@ const TAXONOMY_ABSTRACT = (
     PormG.PoolError,
     # #268 audit: definition-time umbrella — one include("models.jl") can raise either member.
     PormG.DefinitionError,
+    # #268: the database-error umbrella. `catch DatabaseError` is the one name an app needs for
+    # "the database said no", without naming SQLite.jl / LibPQ to reach the driver's own type.
+    PormG.DatabaseError,
 )
 
 # Walk the real type tree. `names(PormG)` only sees EXPORTED names, which silently omits
@@ -154,6 +171,12 @@ end
         @test InvalidMigrationError === PormG.InvalidMigrationError
         @test PoolError === PormG.PoolError
         @test error_message === PormG.error_message
+        # #268 — the database-error boundary.
+        @test DatabaseError === PormG.DatabaseError
+        @test IntegrityError === PormG.IntegrityError
+        @test OperationalError === PormG.OperationalError
+        @test StatementError === PormG.StatementError
+        @test TransactionError === PormG.TransactionError
 
         # QueryBuilder must see the SAME objects it imported, not redefinitions.
         @test QB.QueryBuildError === PormG.QueryBuildError
@@ -244,12 +267,18 @@ end
             PormG.PoolConnectError("SQLite", "disk I/O error", "f1.sqlite", 2, 0.5),
             # carries the blocked statements alongside its message
             PormG.Migrations.DestructiveMigrationError("boom", ["DROP TABLE \"drivers\""]),
+            # #268 — (adapter, cause); the cause is the driver's own exception
+            PormG.IntegrityError("SQLite", ErrorException("UNIQUE constraint failed: drivers.code")),
+            PormG.OperationalError("PostgreSQL", ErrorException("server closed the connection")),
+            PormG.StatementError("PostgreSQL", ErrorException("syntax error at end of input")),
         ]
+        # Guard the samples list itself: every structured type must be represented above, or the
+        # `error_message` coverage below silently skips it.
+        @test Set(typeof.(samples)) == Set(STRUCTURED_TYPES)
+
         for T in TAXONOMY_TYPES
             # the msg-carrying majority share one constructor shape
-            T in (PormG.DoesNotExist, PormG.MultipleObjectsReturned,
-                  PormG.PoolTimeoutError, PormG.PoolConnectError,
-                  PormG.Migrations.DestructiveMigrationError) && continue
+            T in STRUCTURED_TYPES && continue
             push!(samples, T("boom"))
         end
 
@@ -263,9 +292,7 @@ end
         # name. Assert the actual text reaches the caller for every sample built from a known
         # message — that is the contract, and it is knowable.
         for T in TAXONOMY_TYPES
-            T in (PormG.DoesNotExist, PormG.MultipleObjectsReturned,
-                  PormG.PoolTimeoutError, PormG.PoolConnectError,
-                  PormG.Migrations.DestructiveMigrationError) && continue
+            T in STRUCTURED_TYPES && continue
             @test occursin("boom", PormG.error_message(T("boom")))
         end
 
@@ -273,8 +300,8 @@ end
         # exists. Assert on the FIELD SET rather than `@test_throws Exception …msg`: the latter also
         # matches a MethodError from a changed constructor arity, so it could pass while the thing
         # it documents had moved.
-        for T in (PormG.PoolTimeoutError, PormG.PoolConnectError,
-                  PormG.DoesNotExist, PormG.MultipleObjectsReturned)
+        for T in STRUCTURED_TYPES
+            T === PormG.Migrations.DestructiveMigrationError && continue  # carries msg AND statements
             @test :msg ∉ fieldnames(T)
         end
 

--- a/test/unit/test_fetch_retry_transaction.jl
+++ b/test/unit/test_fetch_retry_transaction.jl
@@ -32,6 +32,24 @@ using PormG
 
 const CP = PormG.ConnectionPool
 
+# #268: the pool wraps driver failures in the taxonomy, so the mock's "connection lost" reaches the
+# caller as an `OperationalError` carrying the original on `.cause` — not as the bare
+# `ErrorException` these tests used to assert. Check all three facts rather than just the type:
+#
+#   * the KIND is what the retry gate reads, so a misclassification (`:statement`) would silently
+#     disable the #138 reconnect path while a type-only assertion still passed;
+#   * `.cause` must be the driver's own exception, or apps lose SQLSTATE-level detail;
+#   * the text must still reach the caller, so a wrapper that swallowed the message fails here.
+#
+# It also pins that classification reaches a MOCK pool at all: these mocks define
+# `backend_is_connection_error` on their concrete type, and the core default classifier is what
+# consults it. An extension method typed on the abstract marker would shadow that and break this.
+function assert_wrapped_conn_loss_138(err)
+  @test err isa PormG.OperationalError
+  @test err.cause isa MockConnLost138
+  @test occursin("mock: connection lost", PormG.error_message(err))
+end
+
 # ── Fake driver handle: tracks whether the pool cleanup closed it ──
 # (structs live at file top level — Julia forbids type definitions inside @testset blocks)
 mutable struct FakeConn138
@@ -40,6 +58,16 @@ mutable struct FakeConn138
 end
 FakeConn138(id::Int) = FakeConn138(id, false)
 Base.close(c::FakeConn138) = (c.closed = true; nothing)
+
+# ── Driver-shaped "connection lost" sentinel ──
+# Deliberately its own TYPE rather than `error("mock: connection lost")`, because the real
+# classifiers recognize a mid-query drop by type: LibPQ matches
+# `e isa LibPQ.Errors.UnknownError && string(e) == "…UnknownError(\"\")"`. A substring-matching
+# mock cannot detect a `_driver_cause` regression at fetch's retry gate — Julia's default `show`
+# recursively prints `.cause`, so `occursin(…, string(wrapper))` keeps answering `true` even when
+# the classifier is handed the WRAPPER instead of the driver exception (#268).
+struct MockConnLost138 <: Exception end
+Base.showerror(io::IO, ::MockConnLost138) = print(io, "mock: connection lost")
 
 # ── PG-shaped mock: PostgresConnectionPool's exact fields + failure knobs ──
 mutable struct MockPGPool138 <: PormG.PormGPostgres
@@ -72,7 +100,7 @@ function PormG.backend_execute_async(pool::MockPGPool138, conn, sql::String, par
     end
     if pool.fail_prefix !== nothing && pool.fail_times > 0 && startswith(sql, pool.fail_prefix)
       pool.fail_times -= 1
-      error("mock: connection lost")
+      throw(MockConnLost138())
     end
     NamedTuple[]
   end
@@ -83,7 +111,7 @@ function PormG.backend_renew_connection(pool::MockPGPool138, conn; kwargs...)
 end
 # Classify only the injected failure as a lost connection, so the retry branch is
 # reachable under the mock (the real drivers match their own message fingerprints).
-PormG.backend_is_connection_error(::MockPGPool138, e) = occursin("mock: connection lost", string(e))
+PormG.backend_is_connection_error(::MockPGPool138, e) = e isa MockConnLost138
 
 # ── SQLite-shaped mock: SQLiteConnectionPool's exact fields + the same knobs.
 #    Statements funnel through the REAL global async worker → backend_execute, proving the
@@ -126,11 +154,11 @@ function PormG.backend_execute(pool::MockSQLitePool138, conn, sql::String, param
   end
   if pool.fail_prefix !== nothing && pool.fail_times > 0 && startswith(sql, pool.fail_prefix)
     pool.fail_times -= 1
-    error("mock: connection lost")
+    throw(MockConnLost138())
   end
   return NamedTuple[]
 end
-PormG.backend_is_connection_error(::MockSQLitePool138, e) = occursin("mock: connection lost", string(e))
+PormG.backend_is_connection_error(::MockSQLitePool138, e) = e isa MockConnLost138
 
 # Run a transaction whose body issues one INSERT through the retry-capable fetch() wrapper —
 # the exact path ORM writes take inside run_in_transaction — and return the caught error.
@@ -161,7 +189,7 @@ end
     run_tx_with_failing_fetch_138(pool)
   end
 
-  @test err isa ErrorException && occursin("mock: connection lost", err.msg)  # root error wins
+  assert_wrapped_conn_loss_138(err)                                          # root error wins
   @test count(sql -> startswith(sql, "INSERT"), pool.executed) == 1           # never re-run
   @test pool.renewals == 1                            # renewed by the #71 path, not the retry
   @test pool.connections[1] !== old                   # slot renewed (identity changed)
@@ -187,7 +215,7 @@ end
     run_tx_with_failing_fetch_138(pool)
   end
 
-  @test err isa ErrorException && occursin("mock: connection lost", err.msg)
+  assert_wrapped_conn_loss_138(err)
   @test count(sql -> startswith(sql, "INSERT"), pool.executed) == 1
   @test pool.renewals == 0                            # nothing to heal
   @test pool.connections[1] === old                   # same handle stays in the slot
@@ -235,7 +263,7 @@ end
     end
   end
 
-  @test err isa ErrorException && occursin("mock: connection lost", err.msg)
+  assert_wrapped_conn_loss_138(err)
   @test count(sql -> startswith(sql, "SELECT"), pool.executed) == 1
   @test pool.renewals == 0
 end
@@ -254,7 +282,7 @@ end
     run_tx_with_failing_fetch_138(pool)
   end
 
-  @test err isa ErrorException && occursin("mock: connection lost", err.msg)
+  assert_wrapped_conn_loss_138(err)
   @test count(sql -> startswith(sql, "INSERT"), pool.executed) == 1
   @test pool.renewals == 1
   @test pool.connections[1] !== old

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -34,6 +34,9 @@ const EXPECTED_TOPLEVEL = Set([
     # #268 audit naming pass: renamed PermissionError→WritesDisabledError (in the taxonomy line
     # above), plus the capability split, the PROTECT-delete type, and the definition-time umbrella.
     :BackendCapabilityError, :ProtectedError, :DefinitionError,
+    # #268 the database-error boundary: what the database itself refused, once a statement reached
+    # it. `TransactionError` is transaction-API misuse — nothing was sent.
+    :DatabaseError, :IntegrityError, :OperationalError, :StatementError, :TransactionError,
     # Bulk operations
     :bulk_insert, :bulk_update, :bulk_copy, :allocate_primary_keys,
     # Async API


### PR DESCRIPTION
Closes #268 — **the last issue in the `pre-publish` gate.**

## The problem

`docs/src/api.md` promised *"`catch PormGError` catches them all"*. For runtime database failures that was false, verified by live probe: a UNIQUE violation, SQL the backend rejects, or a connection dropped mid-query reached the caller as a raw `SQLite.SQLiteException` / `LibPQ.Errors.*`. Handling a constraint violation therefore meant depending on the driver package purely to **name** the type — fighting the `[weakdeps]` design that keeps LibPQ/SQLite optional.

Every mature ORM wraps here (Django's PEP-249 tree, SQLAlchemy's `DBAPIError.orig`, ActiveRecord's `translate_exception`, Diesel's `DatabaseErrorKind`), always with the original reachable. PormG now does too, via `.cause`.

## New types

| Type | Covers |
|---|---|
| `DatabaseError` *(abstract)* | umbrella — `catch DatabaseError` needs no driver package |
| `IntegrityError` | `UNIQUE` / `FOREIGN KEY` / `NOT NULL` / `CHECK` / exclusion |
| `OperationalError` | connection dropped, deadlock, serialization failure, lock timeout |
| `StatementError` | rejected statement + the unclassified fallback (no holes) |
| `TransactionError` | transaction-**API** misuse — not a database error |

## Architecture

Core owns the wrap; `ext/` owns the classification. The seam already existed — `backend_is_connection_error` is a driver-implemented classifier core calls without importing LibPQ — so this adds one generic beside it:

```
Kernel          DatabaseError umbrella + 3 concrete types          (nouns)
Backend.jl      backend_classify_error(pool, e)::Symbol + default  (verb)
ext/            the two driver bodies — the only place a driver type is named
ConnectionPool  _as_database_error — unwrap -> passthrough -> classify -> wrap
```

A MySQL backend (#60) gets classification by implementing one method.

**Precision is asymmetric on purpose.** LibPQ parameterizes its exception type on the SQLSTATE (`PQResultError{Class, Code}`), so PostgreSQL is exact — zero string matching. `SQLiteException` carries only a message and discards the result code (`sqlite3_extended_errcode` needs the live handle, which the transaction seams reset via `ROLLBACK` before rethrowing), so SQLite matches SQLite's own literal constraint strings — the approach ActiveRecord's SQLite3 adapter takes. Both are documented in code and in `api.md`.

## The bug this nearly shipped

`run_in_transaction` / `atomic` / `with_savepoint` run the **caller's closure** inside their `try`. Wrapping at those catches — the obvious-looking place, and what #268 originally proposed — would relabel a user's `BoundsError`, `KeyError` or **`InterruptException`** as a `StatementError`. Those bodies now wrap their own BEGIN/COMMIT/ROLLBACK individually (`_await_tx_statement`), and both directions are pinned by tests.

Two more ordering rules, each load-bearing:

- **`_driver_cause` before any classification.** LibPQ reports a mid-query drop as `PQResultError{CUN,EUNOWN}` with an *empty* message, matched by exact type — handing the classifier a wrapper answers `false` and silently kills `fetch`'s reconnect-retry (#138). Deliberately **not** `root isa OperationalError`: that kind also covers deadlock, and transparently re-running a statement on a fresh autocommit session after a deadlock corrupts data.
- **ext methods dispatch on the driver exception type**, not the pool marker alone, so they never shadow core's default for the suite's mock pools.

## Parked family members get final homes

| Site | Before | After |
|---|---|---|
| `with_advisory_lock` timeout | `ErrorException` | `OperationalError` |
| `atomic(durable=true)` nested | `QueryBuildError` | `TransactionError` |
| cross-connection tx misuse | `InvalidConfigurationError` | `TransactionError` |

## Latent bugs fixed on the way

- **AdvisoryLock's statement-timeout matcher had never fired.** It matched `string(e)` on a `TaskFailedException`, whose `string()` does not include the inner driver message, so the `:block` strategy propagated LibPQ's `QueryCanceled` instead of degrading to `got_lock = false`.
- **`fetch_copy` (bulk_copy) had no catch at all** — the last write path leaking raw driver errors. It has one now, inside the `try` so the lease still releases.

## Verification

| | result |
|---|---|
| Unit | **4724 / 4724** (baseline 4626) |
| SQLite integration | **1849 pass / 1 broken / 0 fail** — baseline match |
| **PostgreSQL `db_2` integration** | **1883 / 1883** |
| Docs build | exit 0 |

The PG run matters specifically: #268 was filed saying that side *"cannot be integration-verified in the dev environment — mock-level unit tests only."* That was wrong.

**Six mutations run against the new guards, all caught.** One exposed green-theater in the existing retry tests: dropping `_driver_cause` at `fetch`'s retry gate **passed**, because the mock matched by substring and Julia's default `show` recurses into `.cause`, while the real drivers match by type. The mock now raises a dedicated type and that mutation fails 5 assertions.

## Note for review

Migration DDL failures surface as `StatementError` rather than being re-wrapped as `MigrationError` — re-wrapping would bury the SQLSTATE this change exists to preserve. It means `catch MigrationError` around `migrate()` has a hole it didn't have before; documented in `api.md`. No test asserted the old behavior, so it is a free choice — say the word if you'd rather it went the other way.

`UPGRADING.md` entry included (`- **Version**: Unreleased`, no `Project.toml` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)