### PR TITLE
docs(#212): docstring coverage for the exported surface + fluent reference

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,14 +26,20 @@ These methods modify the query builder and return the handler for further chaini
 
 | Method | Description | Example |
 | :--- | :--- | :--- |
-| `.filter(key => value, ...)` | Add WHERE conditions (AND). Multiple pairs are ANDed. | `.filter("nationality" => "British")` |
+| `.filter(key => value, ...)` | Add WHERE conditions (AND). Repeated calls **accumulate**, unlike `.values()`/`.order_by()` which replace. | `.filter("nationality" => "British")` |
 | `.values("field1", "field2", ...)` | Select specific columns. Use `"*"` for all main-table columns. | `.values("*", "driverid__surname")` |
 | `.order_by("field", "-field")` | Sort results. Prefix with `-` for descending. | `.order_by("-points", "surname")` |
 | `.limit(n)` | Limit the number of returned rows. | `.limit(10)` |
 | `.offset(n)` | Skip the first `n` rows. | `.offset(20)` |
+| `.page(limit, offset)` | Limit and offset in one call. | `.page(20, 40)` |
+| `.distinct()` | Add `DISTINCT` to the SELECT. | `.distinct()` |
 | `.db("key")` | Route the query to a different connection pool. | `.db("tenant_42")` |
 | `.on("path", key => value)` | Add predicates to the ON clause of an existing join path. | `.on("driverid", "nationality" => "British")` |
 | `.cjoin("field" => "Model", ...)` | Add a custom join at query time. | `.cjoin("driverid" => "Driver")` |
+| `.cjoin_on("Model"; alias, on, join_type)` | Anchor-less join: `on` is the **entire** ON clause. | `.cjoin_on("Driver"; alias = "d", on = [...])` |
+| `.with("name" => subquery; join_field, join_type)` | Define one CTE on the query; call again for a second. | `.with("fast" => sub)` |
+| `.select_for_update(; nowait, skip_locked, no_key)` | `SELECT … FOR UPDATE` row lock (PostgreSQL; must run inside a transaction). | `.select_for_update(nowait = true)` |
+| `.copy()` | Deep-copy the handler to branch a chain without disturbing the original. | `base.copy().filter("year" => 2020)` |
 
 See also: [`.cjoin()`](#cjoin) for custom join definitions and [`.with()`](#with-common-table-expressions) for CTEs.
 
@@ -67,6 +73,7 @@ These methods finalize the query and execute it against the database:
 | `.get_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Fetch-or-insert, never updates a match; returns `(row, created)`. See [Get or Create](write/create.md#get-or-create). |
 | `.update_or_create(lookup...; defaults)` | `(PormGRow, Bool)` | Row-level upsert: inserts on a fresh lookup or updates `defaults` on conflict; returns `(row, created)`. See [Update or Create](write/create.md#update-or-create). |
 | `.delete()` | — | Deletes all matching records. |
+| `.inspect()` | `Dict` | Full query metadata without executing — the `inspect_query` shape (see Query Inspection & Debugging below). |
 
 ### `PormGRow` Instance Methods
 
@@ -636,7 +643,7 @@ PormG's type hierarchy provides the foundation for the query builder and model s
 | `SQLTypeCTE` | Common Table Expression type. |
 | `PormGModel` | Base for model types. |
 | `PormGField` | Base for field type definitions. |
-| `PormGError` | Root of the semantic error taxonomy (`<: Exception`). Every PormG misuse — querying, model definition, configuration, migrations, the pool — raises a subtype (see [Error taxonomy](#error-taxonomy)); `catch PormGError` catches them all. |
+| `PormGError` | Root of the semantic error taxonomy (`<: Exception`). Every PormG misuse — querying, model definition, configuration, migrations, the pool — raises a subtype (see [Error taxonomy](#Error-taxonomy)); `catch PormGError` catches them all. |
 
 ---
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -151,6 +151,37 @@ function current_transaction_depth()::Int
   return _tx_context[].depth
 end
 
+"""
+    with_tx_context(f::Function, pool, conn)
+
+Run `f()` with `conn` installed as the ambient transaction connection, so every query inside the
+block reuses that one connection instead of checking a fresh one out of the pool.
+
+!!! warning "This does not start a transaction"
+    It only *binds the connection*. `BEGIN` and `COMMIT`/`ROLLBACK` are the caller's job —
+    [`run_in_transaction`](@ref) issues them around its own `with_tx_context` block. Call this
+    directly only when you already hold a connection with a transaction open on it; otherwise
+    [`in_transaction_context`](@ref) reports `true` while the database is still in autocommit and
+    nothing can be rolled back.
+
+Use [`run_in_transaction`](@ref) or [`atomic`](@ref) instead for ordinary work — they acquire the
+connection (in `:write` mode on SQLite), issue `BEGIN IMMEDIATE`/`BEGIN`, commit or roll back, and
+release it:
+
+```julia
+run_in_transaction("db_sl") do
+    in_transaction_context()                 # true — and really inside a transaction
+    PormG.current_transaction_depth()        # 1; a nested atomic() block reports 2
+    M.Status.objects.create("status" => "Heat shield fire")
+end
+```
+
+The context nests: `depth` increments by one per block (so [`current_transaction_depth`](@ref)
+drives savepoint naming), and a nested block **inherits** the outer block's SQLite
+reserved-primary-key reservations rather than starting a fresh table. Being a `ScopedValue` it is
+*dynamically* scoped — tasks spawned inside the block inherit it, and it unwinds automatically,
+including on a throw.
+"""
 function with_tx_context(f::Function, pool::Union{PormGPostgres, PormGSQLite}, conn)
   old_ctx = _tx_context[]
   new_ctx = TransactionContext()

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -71,10 +71,37 @@ abstract type PormGField <: PormGAbstractType end # define the type of the colum
 
 abstract type Migration <: PormGAbstractType end
 
-# Root of the semantic error taxonomy (#231). Subtypes <: Exception (NOT <: ArgumentError — a
-# clean break, so callers catch a type instead of string-matching a message). It lives in Kernel
-# precisely so every submodule can reach it and its concrete subtypes; see the module docstring
-# for why "defined later in PormG.jl" was not good enough. Extends the #197 typed-exception lineage.
+"""
+    PormGError <: Exception
+
+Root of PormG's semantic error taxonomy (#231). Every error PormG raises for a *domain* failure —
+an unknown field, an invalid value, a refused write, a pool timeout, a database rejection — is a
+subtype, so one `catch` clause covers the whole surface:
+
+```julia
+try
+    M.Driver.objects.get("driverref" => "nobody")
+catch e
+    e isa PormGError || rethrow()
+    @error "query failed" msg=error_message(e)
+end
+```
+
+Use [`error_message`](@ref) to read a caught error: the structured subtypes carry typed fields
+rather than a `.msg` string.
+
+Catch a narrower type when you want to act on one failure — `DoesNotExist`, `IntegrityError`,
+`PoolTimeoutError` — and the umbrellas (`FieldAccessError`, `PoolError`, `DatabaseError`,
+`ConfigurationError`, `MigrationError`, `DefinitionError`) to group a family.
+
+These are deliberately **not** `<: ArgumentError`: a clean break so callers match a type instead
+of string-matching a message. Plain Julia-level misuse (a missing kwarg, a missing path) still
+raises the stock Julia exception, because it is not a PormG domain error.
+
+The type lives in `PormG.Kernel` — layer 1 — so every submodule can name it and its subtypes
+regardless of include order (#239). The full list is in the
+[API reference](api.md#Error-taxonomy).
+"""
 abstract type PormGError <: Exception end
 
 #═══════════════════════════════════════════════════════════════════════════════

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -2,25 +2,24 @@ module PormG
 
 using PrecompileTools
 
-# Internal debug hook — no-op in production.
-#
-# HOW TO USE BREAKPOINTS (requires dev + Revise, because macros are compile-time):
-#
-#   Step 1 — switch to source in your project:
-#     ]dev PormG
-#
-#   Step 2 — load Revise + Infiltrator before PormG in your REPL/startup.jl:
-#     using Revise, Infiltrator
-#     using PormG   # Revise now tracks PormG source
-#
-#   Step 3 — redefine the macro (before editing any source file):
-#     PormG.eval(:(macro pormg_debug(ex); :(Infiltrator.@infiltrate($(esc(ex)))); end))
-#
-#   Step 4 — edit the target .jl file (e.g. change `@pormg_debug false` → `@pormg_debug true`).
-#     Revise re-parses the file and the macro now expands to a real breakpoint.
-#
-# NOTE: redefining the macro alone (without Revise re-parsing the call site) has no effect,
-# because macro expansion happens at parse time, not at runtime.
+"""
+    @pormg_debug
+    @pormg_debug condition
+
+Contributor-facing breakpoint hook, scattered through PormG's source. It expands to `nothing`, so
+it costs a package user exactly nothing at runtime.
+
+To make the call sites live while debugging PormG itself, `]dev PormG`, load `Revise` and
+`Infiltrator` before PormG, then redefine the macro to expand to a real breakpoint and edit the
+target file so Revise re-parses it — macros expand at parse time, so redefining the macro without
+touching the call site has no effect. The step-by-step recipe is in
+[Contributing & Debugging](contributing.md).
+
+```julia
+@pormg_debug false                  # inert; flip to `true` (or a real condition) to fire
+@pormg_debug model.name == "result" # fires only for that model, once wired up
+```
+"""
 macro pormg_debug()
   return nothing
 end

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -314,7 +314,33 @@ function query(q::SQLObjectHandler;
   end
   return resposta
 end
-# #43: build on a copy so inspecting a query never mutates the caller (see inspect_query).
+"""
+    show_query(q::SQLObjectHandler, mode::Symbol = :sql)
+
+Render a `SELECT` query without executing it. The default `:sql` mode returns just the SQL string,
+which makes it the quickest way to see what a chain builds.
+
+| `mode` | Returns |
+|--------|---------|
+| `:sql` | `String` — the generated SQL |
+| `:params` | `Vector` — the parameterized values, in bucket order |
+| `:dict` / `:inspection` | `Dict` — the full metadata shape of [`inspect_query`](@ref) |
+| `:none` | `nothing` — builds and discards, for benchmarking the builder |
+
+```julia
+query = M.Driver.objects.filter("nationality" => "British").values("forename", "surname")
+
+println(show_query(query))              # SELECT "Tb"."forename" … WHERE "Tb"."nationality" = \$1
+params = show_query(query, :params)     # ["British"]
+```
+
+Inspection builds on a `deepcopy`, so it never mutates the query you pass (#43) — the same chain
+can be inspected and then executed.
+
+For `INSERT`/`UPDATE`/`DELETE`, pass `show_query=` to the terminal method itself
+(`query.delete(show_query = :sql)`); this function always renders a `SELECT`. Use
+[`inspect_query`](@ref) when you want the metadata `Dict` with an explicit operation override.
+"""
 show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(deepcopy(q); show_query=mode)
 
 # ---

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -475,16 +475,8 @@ function Base.getproperty(m::Models.Model_Type, sym::Symbol)
   end
 end
 
-@doc """
-    filter(args...)
-
-Apply filters to the query. Chainable method that returns the query object.
-
-Usage: `query.filter("field" => value)`
-
-Repeated calls **accumulate**: each `.filter(...)` appends its conditions (ANDed) to
-those already on the handler — unlike `.values(...)`/`.order_by(...)`, which replace
-their previous call (Django parity, #199).
-
-See [Read documentation](read/index.md) for detailed filter syntax and examples.
-""" ChainCaller(up_filter!, q)
+# NOTE: do NOT try to document a fluent method here with `@doc "…" ChainCaller(up_filter!, q)`.
+# The docsystem does not evaluate that expression — it reads it as a method signature and binds the
+# text to `ChainCaller(::Any, ::Any)`, so the docstring documents the constructor, never `.filter`,
+# and `@autodocs` publishes it on the site under a heading that belongs to nothing (#212). There is
+# no binding behind `q.filter` to attach docs to; the fluent reference lives on `object`.

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -6,6 +6,43 @@
 @kwdef mutable struct ExistsObject <: SQLType
   query::SQLObjectHandler
 end
+"""
+    Exists(query::SQLObjectHandler) -> ExistsObject
+
+Wrap a subquery as a SQL `EXISTS` predicate. Renders as `EXISTS (SELECT 1 … LIMIT 1)`, so it
+answers "is there at least one match?" without counting or fetching the child rows.
+
+Correlate the subquery to the current outer row with [`OuterRef`](@ref); the result can be used
+two ways.
+
+**As a filter predicate** — pass it positionally to `filter`, alongside ordinary pairs or inside
+[`Qor`](@ref):
+
+```julia
+# Results whose driver set a lap under 90 s in that same race
+fast_laps = M.Lap_times.objects.filter(
+    "raceid"             => OuterRef("raceid"),
+    "driverid"           => OuterRef("driverid"),
+    "milliseconds__@lte" => 90_000,
+)
+
+n = M.Result.objects.filter(Exists(fast_laps)).count()
+```
+
+**As a projected boolean column** — pair it with an alias inside `values`:
+
+```julia
+standings = M.Driver_standings.objects.filter("driverid" => OuterRef("driverid"))
+
+query = M.Driver.objects
+query.values("surname", "has_standings" => Exists(standings))
+```
+
+SQLite returns `0`/`1` integers for a projected `Exists`; PostgreSQL returns booleans.
+
+See also [`Subquery`](@ref) for the scalar (single-value) form and
+[Subqueries and CTEs](read/subqueries_and_ctes.md).
+"""
 Exists(query::SQLObjectHandler) = ExistsObject(query=query)
 Base.deepcopy(x::ExistsObject) = ExistsObject(query=deepcopy(x.query))
 
@@ -16,6 +53,39 @@ Base.deepcopy(x::ExistsObject) = ExistsObject(query=deepcopy(x.query))
 @kwdef mutable struct SubqueryObject <: SQLType
   query::SQLObjectHandler
 end
+"""
+    Subquery(query::SQLObjectHandler) -> SubqueryObject
+
+Project a **scalar correlated subquery** as a column of the enclosing `SELECT` (#92) — one value
+per outer row, computed by its own sub-`SELECT`.
+
+The inner query must select exactly **one** column, and it correlates to the outer row through
+[`OuterRef`](@ref). Always project it with an alias — a bare `Subquery(...)` inside `values`
+raises.
+
+```julia
+# How many standings rows each driver has — one exact count per driver
+standings = M.Driver_standings.objects
+standings.filter("driverid" => OuterRef("driverid"))
+standings.values("t" => Count("driverstandingsid"))
+
+query = M.Driver.objects
+query.values("surname", "total_standings" => Subquery(standings))
+df = query |> DataFrame
+```
+
+This is the fan-out-safe way to aggregate across a to-many relation: two `Subquery` columns over
+two different relations stay exact, where a joined `values(Count(...), Count(...))` would
+row-multiply (the guard for that is #74).
+
+!!! warning "Outer `GROUP BY`"
+    Combining a correlated `Subquery` with an outer aggregate is only well-defined when the
+    correlated column is itself grouped. If it is not, PostgreSQL fails loudly while SQLite
+    silently evaluates the subquery against an arbitrary row of each group. See
+    [Subqueries and CTEs](read/subqueries_and_ctes.md).
+
+See also [`Exists`](@ref) for the boolean form and [`OuterRef`](@ref) for the correlation.
+"""
 Subquery(query::SQLObjectHandler) = SubqueryObject(query=query)
 Base.deepcopy(x::SubqueryObject) = SubqueryObject(query=deepcopy(x.query))
 # Defensive backstop: a SubqueryObject is always resolved to a string by get_select_query before any
@@ -404,31 +474,9 @@ Interval(s::AbstractString) = Interval(_parse_time_string_to_compoundperiod(s))
 # Duration operands accepted by F-expression +/- date arithmetic (#25).
 const _DurationOperand = Union{Dates.Period, Dates.CompoundPeriod, Interval}
 
-"""
-F object for direct database field references and operations (similar to Django F expressions).
-
-Allows you to reference database fields directly in operations without pulling data into Julia.
-
-# Examples
-```julia
-# Update a field with another field's value
-query = MyModel |> object
-query.filter("id" => 1)
-query.update("field1" => F("field2"))
-
-# Increment a field by a constant
-query.update("counter" => F("counter") + 1)
-
-# Update with arithmetic operations between fields
-query.update("total" => F("price") * F("quantity"))
-
-# Use in filters to compare fields
-query.filter(F("start_date") <= F("end_date"))
-
-# Use in annotations/values
-query.values("price", "discounted_price" => F("price") * 0.9)
-```
-"""
+# Carrier for an F reference and any arithmetic built on top of it. Users construct it through
+# `F(field_name)` (documented below) and the Base.:+/-/*// overloads further down; the struct
+# itself is internal.
 @kwdef mutable struct FExpression <: SQLTypeF
   field_name::Union{String,Integer,SQLTypeF,SQLTypeFunction}
   operation::OptionalString = nothing  # +, -, *, /, etc.
@@ -440,7 +488,37 @@ query.values("price", "discounted_price" => F("price") * 0.9)
   kwargs::Dict{String,Any} = Dict{String,Any}()
 end
 
-# Constructor for F expressions
+"""
+    F(field_name::String) -> FExpression
+
+Reference a **database column** rather than a Julia value (the Django `F()` equivalent). The
+comparison or arithmetic happens inside SQL, so no data is pulled into Julia and the update stays
+a single atomic statement.
+
+`F` expressions support `+`, `-`, `*` and `/` against constants, other `F`s and SQL functions.
+`+` and `-` additionally accept a `Dates` period or an [`Interval`](@ref), for date arithmetic
+(`*` and `/` do not).
+
+```julia
+# Field-to-field comparison — grid position worse than finishing position
+query = M.Result.objects.filter(F("grid") > F("positionorder"))
+
+# Arithmetic projection, computed by the database
+query = M.Result.objects
+query.values("resultid", "adjusted" => F("points") * 2)
+
+# Atomic update against the column's current value (no read-modify-write race)
+M.Result.objects.filter("resultid" => 1).update("points" => F("points") + 1)
+
+# Field-to-field update
+M.Result.objects.filter("resultid" => 1).update("position" => F("positionorder"))
+```
+
+Prefer a plain lookup when the predicate compares against a *scalar*: write
+`filter("points__@gt" => 20)`, not `filter(F("points") > 20)`.
+
+See also [Field Expressions](read/field_expressions.md).
+"""
 function F(field_name::String)
   return FExpression(
     field_name=field_name,
@@ -647,6 +725,38 @@ end
 @kwdef mutable struct OuterRefObject <: SQLTypeF
   field_name::String
 end
+
+"""
+    OuterRef(field_name::AbstractString) -> OuterRefObject
+
+Reference a column of the **enclosing** query from inside a subquery — the correlation that turns
+an independent child query into a per-outer-row one. Use it inside the query you hand to
+[`Exists`](@ref) or [`Subquery`](@ref).
+
+```julia
+# "did this driver set a lap under 90 s in this race?" — both columns come from the outer row
+fast_laps = M.Lap_times.objects.filter(
+    "raceid"             => OuterRef("raceid"),
+    "driverid"           => OuterRef("driverid"),
+    "milliseconds__@lte" => 90_000,
+)
+
+query = M.Result.objects.filter(Exists(fast_laps))
+```
+
+`OuterRef("pk")` resolves to the outer model's primary key, so a correlation does not have to
+name the column: `filter("driverid" => OuterRef("pk"))` against an outer `M.Driver` query.
+
+Two limits, both enforced with a `QueryBuildError`:
+
+- **One level only.** It binds to the immediately enclosing query, so a projected subquery nested
+  inside another projected subquery is rejected rather than silently correlated to the wrong level.
+- **Correlated context required.** Used outside an `Exists`/`Subquery` build there is no outer
+  query to bind to.
+
+Correlate on a base column of the outer model. A joined path (`OuterRef("constructorid__name")`)
+adds a join to the outer query and is outside the validated surface.
+"""
 function OuterRef(field_name::AbstractString)
   normalized = String(field_name)
   isempty(normalized) && throw(QueryBuildError("OuterRef requires a non-empty field name"))
@@ -851,9 +961,25 @@ function Base.xor(a::Integer, b::BitwiseExpression)
 end
 
 
-# ---
-# Define a struct ObjectHandler that wraps a SQLObjectQuery
-# ---
+"""
+    ObjectHandler <: SQLObjectHandler
+
+The query handler `Model.objects` returns — the object every fluent chain is built on.
+
+Its methods are synthesized by `getproperty` rather than being real fields, which means the Julia
+REPL cannot help you with them: `?query.filter` does not work (it errors, for any Julia value).
+**The complete fluent reference lives on [`object`](@ref)** — type `?object` — and on the
+[API reference](api.md).
+
+```julia
+query = M.Driver.objects          # an ObjectHandler
+query.filter("nationality" => "Brazilian")
+rows = query.values("forename", "surname").list()
+```
+
+Chainable methods mutate the handler and return it; terminal methods execute and return a result.
+Use `.copy()` when you need to branch a chain without disturbing the original.
+"""
 mutable struct ObjectHandler <: SQLObjectHandler
   object::SQLObject
 end
@@ -1007,60 +1133,88 @@ Tables.getcolumn(row::PormGRow, nm::Symbol) = getfield(row, :_data)[_normalize_r
 
 
 """
-Wraps a PormGModel into an ObjectHandler on which you can call:
-```
-- .filter(...) to add WHERE clauses
-- .values(...) to choose/annotate columns
-- .order_by(...) to sort
-- .distinct() to add DISTINCT clause
-- .create(...) for single-row DML
-- .update(...) for single-row DML
-- .limit(...), .offset(...), .page(...) for pagination
-- .count(), .exists() for quick checks without fetching data
-- .on(...) to specify joins with other models
-- .cjoin(...) for complex joins with custom conditions
-- .with(...) to define CTEs
-- plus bulk_insert, bulk_update, do_count, do_exists, list, etc.
-```
+    object(model::PormGModel) -> ObjectHandler
 
-# Arguments
-- `model::PormGModel`: The model to be wrapped and handled.
+Wrap a model in an [`ObjectHandler`](@ref) — the start of every query. `M.Driver.objects` is the
+idiomatic spelling; `object(M.Driver)` is the same thing as a function call.
 
-# Example
+**This docstring is the fluent-API reference.** The methods below are synthesized by
+`getproperty`, so they have no bindings of their own — `?query.filter` cannot work. `?object` (or
+the [API reference](api.md)) is where to look them up.
+
+# Chainable methods
+
+Each mutates the handler and returns it, so calls can be chained or accumulated on a variable.
+
+- `.filter(pairs...)` — add `WHERE` conditions. Repeated calls **accumulate** (ANDed), unlike
+  `.values`/`.order_by`, which replace their previous call (#199)
+- `.values(fields...)` — choose/annotate the selected columns; `"*"` selects the main table
+- `.order_by(fields...)` — sort; prefix `-` for descending
+- `.limit(n)` / `.offset(n)` / `.page(limit, offset)` — pagination
+- `.distinct()` — add `DISTINCT`
+- `.db("key")` — route the query to another connection pool
+- `.on(path, pairs...)` — add predicates to the `ON` clause of an existing join path
+- `.cjoin("field" => "Model"; filters, join_type)` — custom join at query time
+- `.cjoin_on(model; alias, on, join_type)` — anchor-less join where `on` is the entire `ON` clause
+- `.with("name" => subquery; join_field, join_type)` — define a CTE; call again for a second one
+- `.select_for_update(; nowait, skip_locked, no_key)` — `SELECT … FOR UPDATE` row lock
+- `.copy()` — deep copy, to branch a chain without disturbing the original
+
+# Terminal methods
+
+Each executes and returns a result. Every one below except `.inspect()` takes
+`show_query = :sql` / `:dict` / `:params` to render instead of executing; `.inspect()` is already
+an inspection call and takes `operation =` / `connection =` instead.
+
+- `.list()` → `Vector{PormGRow}`; `.list(:dict)` → `Vector{Dict}`; `.list(:json)` → JSON `String`
+- `query |> DataFrame` — preferred for analytical queries
+- `.get(pairs...)` — exactly one row, or `DoesNotExist` / `MultipleObjectsReturned`
+- `.first()` / `.last()` — one row or `nothing`, using the ordering already on the query
+  (`.last` inverts it, falling back to primary-key descending when none is set)
+- `.earliest(fields...)` / `.latest(fields...)` — **replace** the ordering with `fields`
+  (ascending / descending) and take one row; at least one field is required, and an empty
+  queryset raises `DoesNotExist` rather than returning `nothing`
+- `.count(column = nothing; distinct = false)` / `.exists()` — checks without fetching rows
+- `.aggregate(pairs...)` — whole-queryset aggregation with no `GROUP BY`; returns a `NamedTuple`
+- `.create(pairs...)` — insert one row, returned as a `PormGRow`
+- `.update(pairs...)` — update every matching row
+- `.get_or_create(lookup...; defaults)` / `.update_or_create(lookup...; defaults)` → `(row, created)`
+- `.delete()` — delete every matching row
+- `.inspect()` — the [`inspect_query`](@ref) metadata `Dict`
+
+# Examples
+
 ```julia
 using PormG, DataFrames
+using PormG.Functions: Count
 
-# assume models loaded as `M`
-query = M.User.objects
+# Accumulate on a variable — clearest for multi-step queries
+query = M.Result.objects
+query.filter("driverid__surname" => "Senna", "positionorder" => 1)
+query.values("raceid__year", "raceid__name", "constructorid__name")
 
-# 1) Filtering & selecting
-query.filter("is_active" => true)
-query.values("id", "username", "email")
-df = query |> DataFrame
-
-# 2) Counting
-active_users = query.count()
-
-# 3) Inserting a single row
-new = M.Status.objects.create("statusid" => 42, "status" => "Foo")
-# returns a PormGRow of the inserted row (dot-access + .save())
-
-# 4) Updating a single row
-M.Status.objects.filter("statusid" => 42).update("status" => "Bar")
-
-# 5) Ordering & aggregation
-query = M.Result.objects.filter("raceid__year" => 2020)
-query.values(
-  "driverid__forename", 
-  "constructorid__name", 
-  "laps" => Count("laps")
-).order_by("-laps")
-df2 = query |> DataFrame
-
-# 6) Existence check
-exists = M.User.objects.filter("id" => 1).exists()
-
+df    = query |> DataFrame
+wins  = query.count()
+any_  = query.exists()
 ```
+
+```julia
+# Inline chain — trailing dots; a leading dot on the next line is a ParseError
+podiums = M.Result.objects.
+    filter("raceid__year" => 2020, "positionorder__@lte" => 3).
+    values("driverid__surname", "n" => Count("resultid")).
+    order_by("-n").
+    limit(10).
+    list()
+```
+
+```julia
+# Single-row writes — let the IDField allocate the key, then read it off the returned row
+row = M.Status.objects.create("status" => "Heat shield fire")   # PormGRow
+M.Status.objects.filter("statusid" => row.statusid).update("status" => "Heat shield")
+```
+
+See also [`ObjectHandler`](@ref), [`show_query`](@ref), and [Reading Data](read/index.md).
 """
 function object(model::PormGModel)
   return ObjectHandler(object=SQLObjectQuery(model=model))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,7 @@ end
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")
     @testset "Public Export Surface (#35)" include("unit/test_public_exports.jl")
+    @testset "Docstring Coverage (#212)" include("unit/test_docstring_coverage.jl")
     @testset "Upgrade Guide Emitter (#216)" include("unit/test_upgrade_guide.jl")
     @testset "AI Skill Installer (#206)" include("unit/test_install_ai_skills.jl")
     # include("unit/test_migration_planner.jl")

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -1,0 +1,103 @@
+"""
+Docstring coverage of the public surface (#212).
+
+Two invariants that nothing else enforces:
+
+1. **Every exported name answers `?`.** `?Name` is the first thing a Julia user tries. Documenter's
+   `checkdocs = :exports` does NOT catch a gap here — it flags docstrings that *exist* but are not
+   included in the manual, and a name with no docstring has no docs object for it to see. So an
+   undocumented export ships silently, which is exactly what happened: the 2026-07-23 audit behind
+   #212 missed `@pormg_debug`, and `PormGError` did not exist yet when it was written.
+
+2. **The fluent surface stays documented as it grows.** `query.filter(...)` and friends are
+   synthesized by `getproperty`, so they have no bindings — `?query.filter` cannot work (it errors,
+   for any Julia value, not just PormG's). Their reference therefore lives in prose, in two places
+   that have no compiler link to the code: the `object` docstring and `docs/src/api.md`. Without
+   this guard they rot — `object`'s list had drifted 15 methods behind `getproperty` by #212.
+
+Runs WITHOUT a live database: it inspects module namespaces and scans source text.
+"""
+# julia --project=. test/unit/test_docstring_coverage.jl
+
+using Test
+using PormG
+
+const DOCCOV_REPO_ROOT = normpath(joinpath(@__DIR__, "..", ".."))
+const DOCCOV_OBJECT_MANAGER = joinpath(DOCCOV_REPO_ROOT, "src", "querybuilder", "object_manager.jl")
+const DOCCOV_API_MD = joinpath(DOCCOV_REPO_ROOT, "docs", "src", "api.md")
+
+# `.md`/`.jl` are not pinned to LF in `.gitattributes`, so a Windows checkout yields CRLF (#216,
+# #228). Normalize before matching or every assertion below becomes platform-dependent.
+_doccov_read(path) = replace(read(path, String), "\r\n" => "\n")
+
+@testset "Docstring coverage (#212)" begin
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Every exported name has a docstring
+    # `names(PormG)` is the curated public surface frozen by test_public_exports.jl (#35); this is
+    # the docs-side counterpart. Adding a public name means writing its docstring in the same PR.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "every exported name answers `?`" begin
+        exported = filter(n -> n !== :PormG, names(PormG))
+        # Guard the guard: if the export surface ever came back empty the loop below would pass
+        # vacuously and this file would silently stop testing anything.
+        @test length(exported) > 50
+
+        undocumented = filter(n -> !Base.Docs.hasdoc(PormG, n), exported)
+        # Name the offenders in the failure output so the fix is obvious.
+        @test undocumented == Symbol[]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Fluent-method drift: every getproperty branch is documented
+    # Source of truth is the `sym === :name` chain in Base.getproperty(::ObjectHandler). Scanning
+    # the text (rather than calling getproperty) keeps this DB-free and catches a method the
+    # moment it is added, before anyone can execute it.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "fluent methods are documented on `object` and in api.md" begin
+        source = _doccov_read(DOCCOV_OBJECT_MANAGER)
+
+        # Isolate Base.getproperty(q::ObjectHandler, …). The file holds a SECOND getproperty (on
+        # Models.Model_Type, for `.objects`) whose branches are not fluent query methods, so a
+        # whole-file scan would demand docs for `:objects` and fail wrongly.
+        start_idx = findfirst("function Base.getproperty(q::ObjectHandler", source)
+        @test start_idx !== nothing
+        rest = source[first(start_idx):end]
+        stop_idx = findfirst("\nend\n", rest)
+        @test stop_idx !== nothing
+        body = rest[1:first(stop_idx)]
+
+        fluent = unique([m.captures[1] for m in eachmatch(r"sym === :(\w+)", body)])
+        # Sanity floor: the chain had 29 branches at the time of writing. A regex that silently
+        # stopped matching would otherwise turn this testset into a no-op.
+        @test length(fluent) >= 25
+
+        object_doc = string(@doc PormG.QueryBuilder.object)
+        api_md = _doccov_read(DOCCOV_API_MD)
+
+        # Both surfaces are prose, so match on the `.method(` spelling a reader would search for.
+        # The trailing `(` is load-bearing: a bare `.$name` substring lets `.get_or_create` satisfy
+        # `.get` and `.update_or_create` satisfy `.update`, so deleting the `.get(...)` bullet would
+        # not fail this test. Every documented mention is a call form, so requiring it costs nothing.
+        missing_from_doc = filter(name -> !occursin(".$name(", object_doc), fluent)
+        missing_from_api = filter(name -> !occursin(".$name(", api_md), fluent)
+
+        @test missing_from_doc == String[]
+        @test missing_from_api == String[]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # `ChainCaller` stays undocumented — the `@doc "…" ChainCaller(up_filter!, q)` trap
+    # That form does not document `.filter`: the docsystem does not evaluate the expression, it
+    # reads it as a signature and binds the text to `ChainCaller(::Any, ::Any)`. `@autodocs`
+    # (Private = true by default) then publishes it on the site under a `filter(args...)` heading
+    # that belongs to nothing. It looked like it worked for as long as nobody checked.
+    #
+    # This forbids ANY docstring on ChainCaller, not just a misattributed one — deliberately. The
+    # type is internal plumbing with nothing a user needs to read, and no-docstring is the only
+    # state distinguishable from the trap by a test. Document the fluent surface on `object`.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "ChainCaller carries no docstring" begin
+        @test !Base.Docs.hasdoc(PormG.QueryBuilder, :ChainCaller)
+    end
+end


### PR DESCRIPTION
Closes #212.

## What

Every exported name now answers `?`. The verified gap was **8 of the 62 exported names** — measured with `Base.Docs.hasdoc` over `names(PormG)`, not by reading source:

```
F  Exists  Subquery  OuterRef  show_query  with_tx_context  PormGError  @pormg_debug
```

`PormGError` matters most: `api.md` tells users `catch PormGError` is the one name they have to remember, and `?PormGError` showed nothing.

`F`'s user-facing text was attached to the `FExpression` **struct** rather than the exported constructor, so `?F` was empty. It now lives on `F(field_name)`, recut with Formula 1 examples.

## The issue's Findings were stale — corrected in [a comment on #212](https://github.com/PingoLee/PormG.jl/issues/212#issuecomment-5148907208)

| Issue claim | Reality |
|---|---|
| `DoesNotExist` / `MultipleObjectsReturned` undocumented | Already documented by #231; and `src/querybuilder/exceptions.jl` was deleted by #262 |
| (not listed) | `PormGError` — it did not exist on 2026-07-23; #231 created it the next day |
| (not listed) | `@pormg_debug` — a genuine audit miss |
| "already breaking a strict docs build" | False. `checkdocs = :exports` flags docstrings that *exist* but are not included in the manual; a name with **no** docstring has no docs object for Documenter to see. CI was green throughout |

## REPL help for the fluent surface — settled by experiment

**`?query.filter` cannot be made to work.** On Julia 1.12 it raises `MethodError: Binding(::ObjectHandler, ::Symbol)` — reproduced with a plain two-field struct in a bare session, so it is generic REPL behavior for any value, not something PormG's `getproperty` causes. `?q` never prints the docstring of `q`'s type either (checked against `Float64`, which *is* documented).

Named bindings are the only surface we control, so the reference goes where a user can type it:

- **`object`'s docstring is now the canonical fluent reference.** It listed 14 methods and missed 15 (`.db .aggregate .get_or_create .update_or_create .first .last .earliest .latest .get .inspect .delete .copy .select_for_update .cjoin_on .list`), wrapped its list in a fence so it rendered as a code block, and used a generic `M.User` the house rules forbid.
- **`ObjectHandler`** gains a docstring pointing at it.
- **The `@doc """filter…""" ChainCaller(up_filter!, q)` attempt is removed.** The docsystem does not evaluate that expression — it reads it as a signature and binds the text to `ChainCaller(::Any,::Any)`, so it documented the *constructor*, and `@autodocs` (`Private = true` by default) published it on the site under a `filter(args...)` heading belonging to nothing. A comment now records why the form cannot work.
- **`api.md`'s hand-maintained tables** gain the 6 chainable + 1 terminal methods they were missing.

## Regression guard

`test/unit/test_docstring_coverage.jl` (registered next to the #35 export-surface freeze) pins three things: every exported name has a docstring; every `sym === :x` branch of `getproperty(::ObjectHandler)` appears in both the `object` docstring and `api.md`; and `ChainCaller` carries no docstring. The second is what stops the rot this PR found — `object`'s list had drifted 15 methods behind the code.

## Review

An independent review pass found **5 factual errors** in the first draft, all fixed and re-verified:

1. "All terminal methods accept `show_query`" — `.inspect()` does not (`inspect_query` takes only `connection`/`operation`), nor does `query |> DataFrame`.
2. `.with(pairs...)` implied multiple CTEs per call; only `With(::Handler, ::Pair)` exists.
3. `.cjoin(pairs...)` — takes one positional pair.
4. The `create` example used `"statusid" => 42`, which **collides with shipped fixture data** (`status.csv:43` is `42,"Heat shield fire"`) — it would raise `IntegrityError` and the follow-up `update` would rewrite a real row. Now lets the `IDField` allocate.
5. The `with_tx_context` example was **not a transaction** — it only binds the connection; `BEGIN`/`COMMIT` live in `_run_in_transaction_impl`. As written, `in_transaction_context()` reported `true` while the database was in autocommit. Replaced with a `!!! warning` stating the caller owns `BEGIN`/`COMMIT`, plus a correct `run_in_transaction` example.

Also corrected: `.earliest`/`.latest` *replace* the ordering and *require* a field (they are not `.first`/`.last` that raise); `F` duration operands apply to `+`/`-` only; the transaction context is dynamically scoped, not task-local; and the drift test now matches `.name(` rather than `.name`, which had let `.get_or_create` satisfy `.get`.

## Verification

| Check | Result |
|---|---|
| Exported names without docstrings | **0** (was 8) |
| Unit suite | **4721 / 4721**, exit 0 |
| Docs build (`checkdocs = :exports`) | exit 0 — CrossReferences and CheckDocument clean |
| `?` on all 9 names | render with signature lines |
| Examples vs live `db_sl` F1 data | **30 / 30** — SQL shape via `inspect_query`, then executed with values cross-checked independently |

The live run covers each new example: correlated `Exists` (5866 rows), `Subquery` totals matching a plain `GROUP BY` (34863), `F("grid") > F("positionorder")` matching a raw row scan (12809), all five `show_query` modes plus the #43 no-mutation contract, and the Senna chain returning **41** rows — his real career win count. The write example ran inside a deliberately rolled-back transaction; the `Status` table is unchanged.

## Out of scope

`PormG.Kernel`'s 67 undocumented exports (constants and abstract types, not on the `using PormG` surface), and the submodule-only exports of `Migrations`, `Functions`, `ConnectionPool` and `Configuration`. Separate issue if wanted.

No `UPGRADING.md` entry — additive docs, forces no consumer-app edit.

One drive-by outside #212: `api.md:646` linked `#error-taxonomy`, but Documenter does not lowercase slugs, so the anchor never resolved (real id is `Error-taxonomy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
