### PR TITLE
docs(#213): typed error examples, an Error Handling guide, limitation admonitions

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,6 +66,7 @@ makedocs(
             "Q Objects" => "read/q_objects.md",
         ],
         "Guides" => [
+            "Error Handling" => "errors.md",
             "PostgreSQL Guide" => "postgres.md",
             "Async & Concurrency" => "async.md",
             "Advisory Locks" => "advisory_lock.md",

--- a/docs/src/advisory_lock.md
+++ b/docs/src/advisory_lock.md
@@ -43,7 +43,7 @@ end
 
 When a lock is already held by another session, you can choose how PormG should behave:
 
-1.  **Non-blocking (`wait=false`)**: Immediately throws an error if the lock cannot be acquired.
+1.  **Non-blocking (`wait=false`)**: Immediately raises [`OperationalError`](errors.md) if the lock cannot be acquired. The same type is raised when a `:poll` or `:block` acquisition exceeds `timeout_ms`.
 2.  **Client Polling (`strategy=:poll`)**: (Default) PormG will try to acquire the lock, wait for a few milliseconds, and try again until the `timeout_ms` is reached.
 3.  **Server Blocking (`strategy=:block`)**: PormG tells PostgreSQL to block the connection until the lock is granted. This is more efficient as it reduces network traffic, but it ties up a database connection from the pool.
 
@@ -56,8 +56,23 @@ The `timeout_ms` parameter ensures your application doesn't hang indefinitely.
 ## Implementation Details
 
 - **PostgreSQL**: Implementation uses `pg_try_advisory_lock` (non-blocking) or `pg_advisory_lock` (blocking).
-- **SQLite**: Since SQLite does not support advisory locks, `with_advisory_lock` is a **no-op** (it simply executes the function without any locking). This allows you to write database-agnostic code that behaves correctly on production PostgreSQL while still running on SQLite for simple tests.
+- **SQLite**: `with_advisory_lock` is a **no-op** — see the warning below.
 - **Async Safety**: `with_advisory_lock` uses `LibPQ.async_execute` and `fetch()` to ensure that the Julia task yields while waiting for the database, keeping the event loop unblocked.
+
+!!! warning "Advisory locks are a silent no-op on SQLite"
+    On a SQLite connection `with_advisory_lock(f, conn, key; kwargs...)` is defined as `f()` —
+    nothing more. The body runs **unprotected**, and:
+
+    - `wait`, `timeout_ms`, `strategy` and `interval_ms` are accepted and silently ignored.
+    - **No warning is logged.** Nothing in the output distinguishes a held lock from no lock.
+    - The contention path cannot fire, so code that reacts to `OperationalError` never sees one.
+
+    SQLite's own writer serialization (`BEGIN IMMEDIATE`) is per-database-file and per-process; it
+    is not a substitute for a named application lock, and it protects nothing for the non-SQL
+    critical sections this page recommends locks for — report generation, external API calls,
+    scheduled jobs. Treat SQLite as single-instance, exactly as
+    [migrations do](migrations/index.md), and rely on advisory locks only where PostgreSQL is the
+    production backend.
 
 ## API Reference
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -682,9 +682,10 @@ specific subtype for a specific reaction (#231, completed in #239):
 
 Use `error_message(e)`, **not** `e.msg`. Most subtypes carry a `msg::String`, but the ones built
 from structured fields — `DoesNotExist`, `MultipleObjectsReturned`, `PoolTimeoutError`,
-`PoolConnectError`, and the three `DatabaseError` subtypes (`IntegrityError`, `OperationalError`,
-`StatementError`) — do not, so `e.msg` throws on exactly the errors you are least likely to have
-tested against.
+`PoolConnectError`, the three `DatabaseError` subtypes (`IntegrityError`, `OperationalError`,
+`StatementError`), and `DestructiveMigrationError` (which renders its `statements` too) — do not
+render from `msg` alone, so reaching for that field breaks on exactly the errors you are least
+likely to have tested against. See [Error Handling](errors.md) for the per-type field list.
 
 ```julia
 try
@@ -733,10 +734,10 @@ field, and for the few with their own `showerror` it returns the richer renderin
 | :--- | :--- |
 | `ConfigurationError` *(abstract)* | Umbrella for configuration failures — covers `InvalidConfigurationError`, `MissingConfigurationError`, **and** `WritesDisabledError` (listed in the Querying table above, where users meet it). |
 | `InvalidConfigurationError` | Configuration is present but unusable — unsupported adapter, unknown connection key, malformed `extensions`, a model not bound to a connection (or bound to an entry whose pool was never built), a missing driver package, or an attempt to overwrite a static connection. |
-| `MissingConfigurationError` | No configuration folder / `connection.yml`, or the selected environment has no matching block. |
+| `MissingConfigurationError` | No configuration folder / `connection.yml`, or the selected environment has no matching block. **Not on the `using PormG` surface** — name it `PormG.Configuration.MissingConfigurationError`. |
 | `MigrationError` *(abstract)* | Umbrella for migration-engine failures — `catch` it to get both cases below. |
 | `InvalidMigrationError` | A duplicate index name in a plan, an invalid answer to an interactive `makemigrations` prompt, or an unimplemented `migrate_to(version)` path. |
-| `DestructiveMigrationError` | A destructive plan was applied non-interactively without `destructive=true`. |
+| `DestructiveMigrationError` | A destructive plan was applied non-interactively without `destructive=true`; carries the refused `statements`. **Not on the `using PormG` surface** — name it `PormG.Migrations.DestructiveMigrationError`. |
 | `PoolError` *(abstract)* | Umbrella for connection-pool failures — `catch` it to get both cases below. |
 | `PoolTimeoutError` / `PoolConnectError` | The pool is saturated / a physical connection could not be opened. Both carry structured fields (`adapter`, `pool_size`, `attempts`, …) rather than a `msg` — read them with `error_message`. |
 

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -93,7 +93,7 @@ end
 ### Key Technical Details
 - **Hashing:** Keys are hashed using MD5 to provide a 64-bit bigint identifier.
 - **Cleanup:** PostgreSQL releases the lock automatically if the session drops.
-- **SQLite Limitation:** SQLite does not support advisory locks; the helper will no-op with a warning on that backend.
+- **SQLite Limitation:** SQLite does not support advisory locks; the helper is a **silent no-op** on that backend — the body runs unprotected, no warning is logged, and the wait/timeout keyword arguments are ignored. See [Advisory Locks](../advisory_lock.md).
 
 ---
 
@@ -103,4 +103,10 @@ There is an important boot-time hazard when using `@import_models` in a server m
 
 `@import_models` eventually calls `Models.set_models(...)`. If the corresponding configuration path is not loaded yet, `set_models(...)` can trigger `Configuration.load(path)` implicitly. If that happens before the server has selected the intended environment, PormG may initialize that settings object using the default environment and retain it for the rest of the process.
 
-**Recommendation:** Always call `Configuration.load(path; env="...")` explicitly before `@import_models` in server-side code.
+!!! warning "Load the configuration before `@import_models`"
+    If `set_models(...)` triggers an implicit `Configuration.load(path)` before the server has
+    selected its environment, PormG initializes that settings object from the **default**
+    environment and keeps it for the rest of the process. Nothing errors — the application simply
+    runs against the wrong database until it restarts. Always call
+    `Configuration.load(path; env = "...")` explicitly **before** `@import_models` in server-side
+    code.

--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -74,6 +74,14 @@ dev:
 
 At the core of `connection.yml` is the `config` sub-dictionary. This section decides whether the application acts internally as a read-only client or a full administrative client:
 
+!!! warning "Both default to `false`, and a misplaced key is silent"
+    Omit the `config:` block and you get `change_data: false` **and** `change_db: false` — writes
+    raise `WritesDisabledError` and migrations are rejected. Both keys are only read from the
+    `config:` sub-dictionary of the environment you actually loaded; the same key at the top level,
+    or under a different environment, is **ignored without any error**. A config scaffolded by
+    `PormG.setup()` already sets `change_data: true`; one written by hand or registered through
+    `register_connection` does not.
+
 ### `change_data`
 - **`true`**: DML operations (Data Manipulation Language) are permitted. You can `save()`, `update()`, and `delete()` records through PormG models.
 - **`false`**: Makes the database connection read-only internally. Queries fetch data securely, but any invocation of model-mutating functions will fail safely at the ORM layer before generating SQL.

--- a/docs/src/configuration/dynamic.md
+++ b/docs/src/configuration/dynamic.md
@@ -6,6 +6,23 @@ For applications that connect to databases on the fly (e.g., per user or per sub
 
 Register a connection pool manually at any time using a connection string or adapter-specific parameters:
 
+!!! warning "Dynamically registered connections are read-only until you enable writes"
+    `register_connection` builds its `Settings` from the defaults, so `change_data` and
+    `change_db` are **`false`** — and there is no `connection.yml` `config:` block to set them in.
+    The first write raises `WritesDisabledError`. Enable it on the settings object directly:
+
+    ```julia
+    PormG.register_connection("tenant_01", "postgres://user:pass@host/db_01")
+    PormG.config["tenant_01"].change_data = true    # otherwise every write is refused
+    ```
+
+!!! note "Limitation: keys are namespaced against static configs"
+    Two guards, both `InvalidConfigurationError`: a key that names an existing **directory** is
+    rejected outright (folder paths are reserved for `load()`), and a key already bound to a
+    static configuration cannot be overwritten. Re-registering an existing *dynamic* key is
+    allowed — it closes the old pool first and logs a warning, so make sure nothing is still
+    borrowing a connection from it.
+
 ```julia
 # PostgreSQL
 PormG.register_connection("tenant_01", "postgres://user:pass@localhost/db_01")

--- a/docs/src/configuration/setup.md
+++ b/docs/src/configuration/setup.md
@@ -46,6 +46,14 @@ df = query |> DataFrame
 
 ---
 
+!!! warning "`load()` must come before `@import_models`"
+    The order in the snippet above is a requirement, not a style preference. `@import_models`
+    calls `set_models(...)`, which triggers an implicit `Configuration.load(path)` if no
+    configuration is loaded yet — and that implicit load picks the **default** environment and
+    keeps it for the rest of the process. Nothing errors; the application just runs against the
+    wrong database until it restarts. See
+    [The Boot-Time Hazard](advanced.md#The-Boot-Time-Hazard) for the full explanation.
+
 ## The Bootstrap Sequence
 
 For most applications, the bootstrap sequence is:

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -1,0 +1,135 @@
+# Error Handling
+
+Every failure PormG raises for a *domain* problem is a subtype of `PormGError`, so one `catch`
+clause covers the whole surface:
+
+```julia
+try
+    M.Result.objects.filter("driverid__surname" => "Senna").update("points" => 25)
+catch e
+    e isa PormGError || rethrow()
+    @error "PormG rejected the write" msg=error_message(e) type=typeof(e)
+end
+```
+
+`rethrow()` on anything that is not a `PormGError` matters: your own exceptions, and Julia-level
+misuse such as a missing keyword argument, still propagate as themselves. Only *driver* failures
+are wrapped into the taxonomy.
+
+This page is the **task-oriented** view — which operation raises what, and how to react. For the
+full type-by-type reference, including every umbrella and the fields each type carries, see
+[Error taxonomy](api.md#Error-taxonomy) in the API reference.
+
+## Which operation raises what
+
+Catch the umbrella when you want a category, the concrete type when you want a reaction.
+
+### Reading
+
+| Call | Raises | When |
+|---|---|---|
+| `get(...)` | `DoesNotExist` | No row matched |
+| `get(...)` | `MultipleObjectsReturned` | More than one row matched; carries `count` |
+| `earliest(...)` / `latest(...)` | `DoesNotExist` | Empty queryset — unlike `first()`/`last()`, which return `nothing` |
+| `row.driverid` on an unprojected FK | `LazyTraversalError` | PormG never lazily loads a relation — project it with `values(...)` |
+| any filter or `values` | `UnknownFieldError` | The field name does not exist on the model (lookups are case-sensitive) |
+| any filter | `FilterError` | The predicate itself is malformed |
+| PostgreSQL-only features on SQLite | `BackendCapabilityError` | e.g. `iunaccent_*`, JSONB containment, window `frame=` |
+| anything else about query shape | `QueryBuildError` | The long-tail default |
+
+### Writing
+
+| Call | Raises | When |
+|---|---|---|
+| `create` / `update` / `delete`, bulk, M2M mutators | `WritesDisabledError` | The connection has `change_data: false` — see [Creating Records](write/create.md) |
+| `update` / `delete` with no filter | `UnsafeMutationError` | Refused as unsafe; `delete` accepts `allow_delete_all = true` |
+| `delete` with `limit`/`offset`/`order_by`/`distinct`/aggregates | `UnsafeMutationError` | Those shapes make cascade counting unreliable — see [Deleting Records](write/delete.md) |
+| `delete` of a row referenced with `on_delete = PROTECT` | `ProtectedError` | The *data* forbids it; reassign or delete the referencing rows first |
+| `create` with a `null` value on a non-null field | `InvalidValueError` | Rejected by PormG **before** any statement is sent |
+| `create` / `bulk_insert` violating a constraint | `IntegrityError` | The **database** refused it — `UNIQUE`, `FOREIGN KEY`, `NOT NULL`, `CHECK` |
+
+### Transactions and connections
+
+| Call | Raises | When |
+|---|---|---|
+| `atomic(durable = true)` inside an open transaction | `TransactionError` | It must be the outermost transaction |
+| a model bound to another connection, inside a transaction | `TransactionError` | Open the transaction on that model's own connection |
+| any query, connection lost mid-flight | `OperationalError` | Transient. Retry the **whole transaction**, never the statement |
+| any query, pool saturated | `PoolTimeoutError` | Raise `pool_size`/`pool_timeout` — see [Advanced Configuration](configuration/advanced.md) |
+| any query, database unreachable | `PoolConnectError` | Carries the `cause` and a redacted connection string |
+| `with_advisory_lock(...; wait = false)` | `OperationalError` | Lock held elsewhere. **Never raised on SQLite** — see [Advisory Locks](advisory_lock.md) |
+
+### Configuration and migrations
+
+| Call | Raises | When |
+|---|---|---|
+| `Configuration.load(...)` | `PormG.Configuration.MissingConfigurationError` | No `connection.yml` found; try `PormG.setup(path)` |
+| `Configuration.load(...)` | `InvalidConfigurationError` | Unknown adapter, unsupported extension, bad `extensions` shape |
+| model definition | `FieldValidationError` / `ModelDefinitionError` | Bad field argument / bad model shape. Catch `DefinitionError` for both |
+| `makemigrations` / `migrate` | `InvalidMigrationError` | The migration or the schema it describes is not valid |
+| `migrate` on a destructive plan | `PormG.Migrations.DestructiveMigrationError` | Non-interactive run without `destructive = true`; carries `statements` |
+
+!!! note "Two types need a qualified name"
+    `DestructiveMigrationError` and `MissingConfigurationError` are **not** on the `using PormG`
+    surface — reach them as `PormG.Migrations.DestructiveMigrationError` and
+    `PormG.Configuration.MissingConfigurationError`. Catching their umbrellas (`MigrationError`,
+    `ConfigurationError`) works unqualified.
+
+## Reading a caught error
+
+Use `error_message(e)`, not `e.msg`. Most types carry a `msg` field, but eight do not — they carry
+structured fields instead, and `e.msg` on those is a `FieldError`:
+
+| Type | Fields instead of `msg` |
+|---|---|
+| `DoesNotExist` | `model_name`, `filters` |
+| `MultipleObjectsReturned` | `model_name`, `count`, `filters` |
+| `PoolTimeoutError` | `adapter`, `pool_size`, `max_size`, `attempts`, `elapsed_seconds` |
+| `PoolConnectError` | `adapter`, `cause`, `connection`, `attempts`, `elapsed_seconds` |
+| `IntegrityError`, `OperationalError`, `StatementError` | `adapter`, `cause` |
+| `DestructiveMigrationError` | `msg`, `statements` |
+
+`error_message` renders any of them to a plain `String`, so it is always safe:
+
+```julia
+catch e
+    e isa PormGError || rethrow()
+    @error "failed" msg=error_message(e)
+end
+```
+
+## Catching a whole category
+
+The abstract umbrellas exist so a handler can name a family without listing its members:
+
+```julia
+try
+    PormG.Configuration.load("db_2")
+    PormG.Migrations.migrate()
+catch e
+    if e isa ConfigurationError
+        @error "Fix connection.yml and retry" msg=error_message(e)
+    elseif e isa MigrationError
+        @error "The migration plan was rejected" msg=error_message(e)
+    else
+        rethrow()
+    end
+end
+```
+
+The umbrellas are `FieldAccessError`, `DefinitionError`, `ConfigurationError`, `MigrationError`,
+`PoolError` and `DatabaseError`, all under `PormGError`.
+
+`DatabaseError` is the boundary worth understanding: it means the statement **reached** the
+database and was refused there. A value PormG rejects before sending — a null on a non-null field,
+an unknown column — never gets that far and raises the query-side type instead.
+
+## Coming from an older PormG
+
+The taxonomy replaced the untyped errors and driver-native exceptions PormG used to raise, across
+several releases — so a `catch` block written against an older version may no longer match. The
+deliberate clean break is spelled out in [Error taxonomy](api.md#Error-taxonomy).
+
+If you are upgrading an app, `UPGRADING.md` carries the greps and the concrete `before → after`
+edits for each step — run `PormG.upgrade_guide(from = v"<your pinned version>")` to see only what
+applies to you, and read [Upgrading PormG](upgrading.md) for the workflow.

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -199,13 +199,16 @@ end
 try
     bulk_insert(M.Driver.objects, df)
 catch e
-    if contains(string(e), "duplicate key")
-        @warn "Some rows have duplicate values" exception=e
-    else
-        rethrow(e)
-    end
+    e isa IntegrityError || rethrow()
+    @warn "Some rows violate a constraint" msg=error_message(e) adapter=e.adapter
 end
+```
 
+`IntegrityError` is what the database itself refused — `UNIQUE`, `FOREIGN KEY`, `NOT NULL`,
+`CHECK`. Match on the **type**, never on the message: the wording differs between PostgreSQL and
+SQLite and is not part of any contract. See [Error Handling](../errors.md) for the full set.
+
+```julia
 # Pre-validate data before insertion
 using DataFrames
 

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -2,6 +2,26 @@
 
 PormG provides methods for inserting data into your database, from single rows to complex related objects. All create operations are **async-aware** and will automatically participate in a transaction context if one is active.
 
+!!! warning "Writes are disabled by default"
+    Every write path — `create`, `update`, `delete`, the bulk helpers, the ManyToMany mutators —
+    is gated on `change_data`, which defaults to **`false`**. Until you enable it, the first write
+    raises `WritesDisabledError` before any SQL is generated. Enable it under the `config:` block
+    of the **active environment** in `connection.yml`:
+
+    ```yaml
+    dev:
+      adapter: postgresql
+      # …
+      config:
+        change_data: true
+    ```
+
+    Two things bite here. A `change_data:` key placed anywhere else — at the top level, or outside
+    the environment you actually loaded — is **silently ignored**, not an error. And a config
+    created by `PormG.setup()` is already write-enabled, while one written by hand or registered
+    through `register_connection` is not. See
+    [Connection YML](../configuration/connection_yml.md).
+
 ## Single Record Creation
 
 Use the `.create()` method to insert individual records. It returns a [`PormGRow`](../read/index.md) — the same row object `get()`, `first()`, and `list()` return — containing the newly created record, including any database-generated fields (like auto-increment primary keys). Because it's a `PormGRow`, you can read fields by dot-access or key, and mutate it and call `.save()` to persist further changes.
@@ -22,6 +42,15 @@ VALUES ($1, $2)
 RETURNING *
 -- Parameters: ["test", 1]
 ```
+
+!!! note "SQLite does not use `RETURNING`"
+    The SQL above is the PostgreSQL form. On SQLite, PormG deliberately issues a plain `INSERT`
+    and then reads the row back with a follow-up `SELECT` on the **same** connection — SQLite's
+    `last_insert_rowid()` is per-connection session state, so the read-back has to share the
+    connection. `RETURNING` is avoided because it can hang inside `libsqlite3` for some table
+    shapes (observed with an `AUTOINCREMENT` primary key that migrations left in a non-first
+    column position). The returned `PormGRow` is identical either way; only the statement count
+    differs.
 
 ### Return Value
 
@@ -332,10 +361,11 @@ RETURNING *
 
 ### Foreign Key Constraints
 
-PormG enforces referential integrity. Attempting to create a record with a non-existent foreign key will raise an error:
+On PostgreSQL, creating a record whose foreign key points at a row that does not exist raises
+[`IntegrityError`](../errors.md) — the database refused the statement:
 
 ```julia
-# This will fail if circuit_id=9999 doesn't exist
+# This will fail if circuitid=9999 doesn't exist
 try
     race = M.Race.objects.create(
         "year" => 2025,
@@ -345,9 +375,26 @@ try
         "date" => Date(2025, 3, 23)
     )
 catch e
-    @error "Foreign key constraint violation" exception=e
+    e isa IntegrityError || rethrow()
+    @error "Foreign key constraint violation" msg=error_message(e) adapter=e.adapter
 end
 ```
+
+`IntegrityError` covers every constraint the database enforces — `FOREIGN KEY`, `UNIQUE`,
+`NOT NULL`, `CHECK`. It is a `DatabaseError`, so it means the statement *reached* the database and
+was rejected there; a value PormG rejects before sending raises `InvalidValueError` instead (see
+the null-field example above).
+
+!!! warning "SQLite does not enforce foreign keys"
+    SQLite ships with `PRAGMA foreign_keys` **off**, and PormG does not turn it on. The insert
+    above therefore **succeeds** on SQLite, storing a row that references a `circuitid` which does
+    not exist — no error, no warning. `UNIQUE` and `PRIMARY KEY` violations *are* enforced on both
+    backends and raise `IntegrityError` as described.
+
+    The practical consequence: referential integrity you rely on in production PostgreSQL is not
+    reproduced by a SQLite test run, so a dangling-FK bug can pass its tests. Declare the
+    relationship on the model either way — `on_delete` cascade handling is applied by the ORM and
+    works on both backends — but do not treat a green SQLite suite as proof the constraint holds.
 
 **Generated SQL (PostgreSQL):**
 ```sql

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -70,16 +70,40 @@ If the connection is configured with `change_data: false`, any call to `delete()
 # connection.yml: change_data: false
 query = M.Just_a_test_deletion.objects.filter("id" => 1)
 delete(query)
-# ERROR: Not allowed to delete ...
+# ERROR: WritesDisabledError: Error in delete: the connection db is not allowed to write.
+# Writes are disabled by default — set change_data: true under the `config:` block of the
+# active environment in connection.yml to enable creates, updates, and deletes.
 ```
 
 See [Connection YML](../configuration/connection_yml.md) for the `change_data` configuration option.
+
+### Query shapes `delete()` refuses
+
+!!! warning "`delete()` rejects `limit`, `offset`, `order_by`, `distinct` and aggregates"
+    The deletion collector walks the *complete* filtered set so that row counts, cascades and
+    constraint handling stay deterministic. Any query shape that collapses or truncates that set
+    is refused with `UnsafeMutationError` **before** SQL is generated:
+
+    ```julia
+    # ✗ all four raise UnsafeMutationError
+    M.Result.objects.filter("points" => 0).limit(10).delete()
+    M.Result.objects.filter("points" => 0).offset(5).delete()
+    M.Result.objects.filter("points" => 0).order_by("-points").delete()
+    M.Result.objects.filter("points" => 0).distinct().delete()
+
+    # ✓ bound the set with the filter instead
+    ids = M.Result.objects.filter("points" => 0).limit(10).values("resultid") |> DataFrame
+    M.Result.objects.filter("resultid__@in" => ids.resultid).delete()
+    ```
+
+    A query carrying `group_by`/aggregate annotations is refused for the same reason. There is no
+    "delete the first N rows" form — filter by primary key.
 
 ---
 
 ## Bulk Deletion
 
-By default, calling `delete()` on a query without filters will raise an error to prevent accidental data loss. You must explicitly set `allow_delete_all=true`.
+By default, calling `delete()` on a query without filters raises `UnsafeMutationError` to prevent accidental data loss. You must explicitly set `allow_delete_all=true`.
 
 ```julia
 # Delete all records (requires explicit permission)
@@ -128,5 +152,28 @@ WHERE "Tb"."name" = $1
 -- Note: Dependent rows in "result" are removed by DB FOREIGN KEY CASCADE or ORM cascade
 -- Parameters: ["Cancelled Grand Prix"]
 ```
+
+!!! warning "`PROTECT` and `RESTRICT` refuse the delete with `ProtectedError`"
+    A `ForeignKey` declared `on_delete = PROTECT` (or `RESTRICT`) makes the referenced row
+    undeletable while referencing rows exist. PormG checks this at the ORM layer and raises
+    [`ProtectedError`](../errors.md), naming the referencing model and field:
+
+    ```julia
+    try
+        M.Driver.objects.filter("driverid" => 1).delete()
+    catch e
+        e isa ProtectedError || rethrow()
+        @warn "Reassign or delete the referencing rows first" msg=error_message(e)
+    end
+    ```
+
+    Nothing about the call is malformed — the *data* forbids it, so the remedy is to delete or
+    reassign the dependents. The check is existence-driven: it only fires when referencing rows
+    are actually present.
+
+!!! note "Limitation: `SET_NULL` requires a nullable FK"
+    Declaring `on_delete = SET_NULL` on a field that is also `null = false` is a contradiction the
+    schema cannot satisfy. The delete raises `ModelDefinitionError` — declare the FK with
+    `null = true`, or choose a different `on_delete`.
 
 See [Models and Fields](../fields.md) for more details on configuring deletion behavior (CASCADE, PROTECT, SET_NULL, etc.).

--- a/docs/src/write/index.md
+++ b/docs/src/write/index.md
@@ -2,6 +2,13 @@
 
 This section covers all data manipulation operations in PormG, including creating, updating, and deleting records. PormG provides both single-record and bulk operations for efficient data management.
 
+!!! warning "Every write on this page is gated on `change_data`"
+    `change_data` defaults to **`false`**, so a connection cannot write until you enable it under
+    the `config:` block of the active environment in `connection.yml`. Until then the first
+    `create`, `update`, `delete`, bulk call or ManyToMany mutator raises `WritesDisabledError`
+    before any SQL is generated. See [Creating Records](create.md) for the exact YAML and the
+    two ways it commonly goes wrong.
+
 ## Async-First Philosophy
 
 PormG is designed as **Async-First**. All database operations must utilize non-blocking I/O where possible. Synchronous APIs (like `create()`, `update()`, `delete()`) are strictly wrappers around an asynchronous core. This ensures that even synchronous code yields to the Julia scheduler, preventing the blocking of the event loop—essential for integration with web frameworks like Genie.jl.

--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -346,31 +346,45 @@ try
       "constructorid" => 1,
       "points" => 25,
     )
-    
-    # Simulate a validation error
-    throw(ErrorException("Driver not found"))
+
+    # A constraint violation on the next write aborts the whole block
+    (M.Result.objects).create("raceid" => 999_999, "driverid" => 1, "constructorid" => 1)
   end
 catch e
-  @error "Transaction failed, rolling back" exception=e
+  e isa PormGError || rethrow()
+  @error "Transaction failed, rolled back" msg=error_message(e) type=typeof(e)
   # Perform cleanup (e.g., release temporary resources)
 end
 ```
+
+Two things worth separating here:
+
+- **PormG's own failures are typed.** The example above raises [`IntegrityError`](../errors.md)
+  (the FK does not exist); a filterless `update` would raise `UnsafeMutationError`, and a
+  connection with `change_data: false` raises `WritesDisabledError`. Catch `PormGError` to handle
+  any of them, or a specific subtype to react to one.
+- **Your own exceptions propagate as themselves.** Raising `ErrorException("Driver not found")`
+  inside the block still rolls the transaction back — PormG rolls back on *any* throw — but it
+  reaches your `catch` as an `ErrorException`, not wrapped. Only driver failures are wrapped into
+  the taxonomy.
+
 **Generated SQL (PostgreSQL):**
 ```sql
 BEGIN;
 
--- Insert attempted
+-- First insert succeeds
 INSERT INTO "result" ("raceid", "driverid", "constructorid", "points") 
 VALUES (\$1, \$2, \$3, \$4) 
 RETURNING *
 -- Parameters: [1, 1, 1, 25]
 
+-- Second insert violates the raceid foreign key -> IntegrityError
 -- Exception raised -> PormG intercepts and executes rollback
 ROLLBACK;
 ```
 
 ```julia
-# The record was never inserted because the transaction rolled back
+# Neither record was inserted because the transaction rolled back
 q = M.Result.objects
 q.filter("raceid" => 1)
 @test q.count() == 0
@@ -378,21 +392,25 @@ q.filter("raceid" => 1)
 
 ### Nested Exception Handling
 
-You can nest `try`/`catch` blocks and still maintain transaction semantics:
+!!! warning "Catching an exception inside the block cancels the rollback"
+    PormG rolls back when an exception **escapes** the `run_in_transaction` block — the rollback
+    lives in that function's `catch`. If an inner `try`/`catch` swallows the error, the block
+    returns normally and the transaction **commits**, including the writes that came before the
+    failure. To log an inner failure *and* still abort, `rethrow()` after logging, or use a
+    savepoint (see [Nested Transactions and Savepoints](#Nested-Transactions-and-Savepoints)) to
+    roll back just the inner step.
 
 ```julia
 PormG.run_in_transaction("db_2") do
   (M.Result.objects).create("raceid" => 1, "driverid" => 1, ...)
-  
+
   try
-    (M.Result.objects).create("raceid" => 999, "driverid" => 999, ...)
-    throw(ErrorException("Simulated error"))
+    (M.Result.objects).create("raceid" => 999_999, "driverid" => 1, ...)
   catch e
-    @warn "Inner block failed, outer transaction will roll back" exception=e
+    e isa PormGError || rethrow()
+    @warn "Inner write failed, aborting the transaction" msg=error_message(e)
+    rethrow()          # ← without this, the outer block COMMITS the first insert
   end
-  
-  # Even though we caught the error, it was already logged
-  # The outer transaction will still roll back when this block exits
 end
 ```
 
@@ -406,8 +424,34 @@ other exception: the transaction rolls back (or is already gone with the dead se
 pooled connection is renewed or discarded before returning to the pool, so the next borrower
 always gets a clean connection.
 
+The connection failure reaches your `catch` as an [`OperationalError`](../errors.md) — a
+`DatabaseError` for a condition that is transient rather than a defect in the statement. Retry the
+**whole transaction**, never the individual statement:
+
+```julia
+try
+    PormG.run_in_transaction("db_2") do
+        (M.Result.objects).filter("resultid" => 1).update("points" => 25)
+    end
+catch e
+    e isa OperationalError || rethrow()
+    @warn "Connection lost mid-transaction; the whole block must be retried" msg=error_message(e)
+end
+```
+
 Outside transactions, plain queries still recover transparently: the pooled connection is
 renewed and the statement retried once.
+
+### Misusing the transaction API
+
+[`TransactionError`](../errors.md) is raised *before* anything is sent, for two call patterns that
+cannot work:
+
+- `atomic(durable = true)` nested inside an already-open transaction — it must be outermost.
+- Touching a model bound to one connection while a transaction is open on another. Open the
+  transaction on that model's own connection instead: `run_in_transaction("<its connect_key>")`.
+
+It is deliberately **not** a `DatabaseError` — the database was never involved.
 
 If the work must survive connection loss, retry the **whole transaction** at the application
 level — the standard contract across ORMs:

--- a/docs/src/write/update.md
+++ b/docs/src/write/update.md
@@ -138,7 +138,11 @@ All updates pass through a centralized validation engine that enforces:
 
 ### Pagination Guard
 
-Standard SQL `UPDATE` does not support `LIMIT`, `OFFSET`, or `ORDER BY`. If any of these are set on the query handler when `.update()` is called, PormG throws an `UnsafeMutationError` immediately — before any SQL is generated — so the developer gets a clear error rather than silently mutating the wrong rows.
+!!! warning "`UPDATE` cannot carry `LIMIT`, `OFFSET` or `ORDER BY`"
+    Standard SQL `UPDATE` does not support them. If any is set on the query handler when
+    `.update()` is called, PormG raises `UnsafeMutationError` immediately — before any SQL is
+    generated — so you get a clear error rather than a silent mutation of the wrong rows. There is
+    no "update the first N rows" form; narrow the filter instead.
 
 ```julia
 # These all raise UnsafeMutationError before any SQL is sent

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -109,6 +109,37 @@ const DOCERR_CASES = [
         () -> DOCERR_RESULT_SL.objects.filter("payload__@has_key" => "wins").
             list(show_query = :dict),
     ),
+    # #213 — the delete guards. `write/delete.md` and `errors.md` both promise UnsafeMutationError
+    # for each of these query shapes; every one is refused before SQL is generated, so a mock
+    # connection is enough. The four are separate cases on purpose: they are four independent
+    # checks in `deletion.jl`, and collapsing them would let three regress unnoticed.
+    (
+        "write/delete.md — delete() rejects limit()",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.filter("points" => 0).limit(10).delete(show_query = :dict),
+    ),
+    (
+        "write/delete.md — delete() rejects offset()",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.filter("points" => 0).offset(5).delete(show_query = :dict),
+    ),
+    (
+        "write/delete.md — delete() rejects order_by()",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.filter("points" => 0).order_by("-points").
+            delete(show_query = :dict),
+    ),
+    (
+        "write/delete.md — delete() rejects distinct()",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.filter("points" => 0).distinct().
+            delete(show_query = :dict),
+    ),
+    (
+        "write/delete.md — a filterless delete() needs allow_delete_all = true",
+        UnsafeMutationError,
+        () -> DOCERR_RESULT_PG.objects.delete(show_query = :dict),
+    ),
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #213 (tasks 2–4; task 1 landed in #214).

## Two documented claims were false — both caught by running the examples, not by reading them

**1. `write/transaction.md` said a swallowed inner exception still rolls back. It commits.**

The page's "Nested Exception Handling" example ended with:

```julia
  # Even though we caught the error, it was already logged
  # The outer transaction will still roll back when this block exits
```

Rollback lives in `run_in_transaction`'s `catch` (`ConnectionPool.jl:1820`), so it only fires when the exception **escapes** the block. Swallow it and everything before the failure commits. Reproduced against `db_sl` — the row persisted. The example now `rethrow()`s, under a warning explaining why.

**2. `write/create.md` claimed a dangling foreign key raises `IntegrityError`. On SQLite the insert succeeds.**

PormG never issues `PRAGMA foreign_keys = ON`, and SQLite defaults it **off**. The documented example stores a row referencing a `circuitid` that does not exist — no error, no warning. Now stated as a backend divergence, and the `IntegrityError` claim is proven against a `PRIMARY KEY` violation, which both backends do enforce. Whether PormG should enable the pragma is a behavior question, filed separately.

## Task 2: the reference already existed — the examples were the defect

`api.md:659-805` is already a full exception reference (four `| Type | Raised when |` tables, four try/catch examples, the `error_message` rule, the not-`ArgumentError` warning). The #231 → #239 → #261 → #268 taxonomy work built it *after* the 2026-07-23 audit. Rebuilding it would duplicate ~147 lines, and two constraints forbid it outright:

- `api.md`'s `@autodocs` block already renders every exception docstring, so a ` ```@docs ` block for those types is a Documenter duplicate-docs error.
- `test_docs_error_type_drift.jl:102` asserts `allowed_hits == 4` **exactly**. A page restating the clean-break warning makes it 5 and fails the build. (The guard caught my first draft doing precisely this — the page was reworded rather than the guard raised.)

So `docs/src/errors.md` **links** instead of restating, and carries the one direction `api.md` lacks: an **operation → error index** — what `create`/`update`/`delete`, `get`, `migrate`, pool acquisition and advisory locks each raise.

What was actually wrong, and is now fixed — four examples teaching patterns the taxonomy exists to remove, none caught by any guard:

| Page | Was |
|---|---|
| `write/bulk.md` | `contains(string(e), "duplicate key")` — a message substring, across two backends whose wording differs |
| `write/create.md` | FK violation caught as bare `e`, type never named |
| `write/transaction.md` | The site's largest error-handling section — zero PormG types, `ErrorException` as the simulated failure |
| `advisory_lock.md` | "throws an error", type unnamed — it is `OperationalError` |

Also corrected: `configuration/advanced.md:96` promised advisory locks "no-op **with a warning**" on SQLite, contradicting `AdvisoryLock.jl:180` (a bare `= f()`) *and* `advisory_lock.md`'s own text. `api.md`'s structured-type list named 7 of 8 (omitted `DestructiveMigrationError`) and listed two qualified-name-only types unqualified.

## Tasks 3–4: admonitions, source-proven only

**96 → 111 admonitions; zero-admonition pages 11 → 3.**

The issue's census was stale (it said 111 total, 8 zero pages). It also missed `write/index.md` and `write/update.md`, both zero.

Highlights, each backed by the source that proves it:

- **`write/delete.md` documented one of five guards.** The `limit`/`offset`/`order_by`, `distinct` and `group_by` refusals (`deletion.jl:64-87`) were undocumented, as were `ProtectedError` for `PROTECT`/`RESTRICT` and the `ModelDefinitionError` raised when `SET_NULL` meets a `null = false` field. The page also printed a fabricated error message.
- **`write/create.md`** gained the `change_data` gate — including that a misplaced key is a *silent no-op*, and that `PormG.setup()` scaffolds it `true` while a hand-written config does not. Plus the SQLite-skips-`RETURNING` note that line 205 already cross-referenced but which did not exist.
- **`configuration/dynamic.md`** gained the trap that `register_connection` builds `Settings` from defaults, so a dynamic connection is read-only with **no `config:` block to fix it through** — the remedy is `PormG.config[key].change_data = true`.

**Left at zero deliberately:** `configuration/index.md`, `configuration/server.md`, `contributing.md`. Nothing on them is a limitation; filler would dilute the signal the other 111 carry.

## Guard

`test_docs_error_types.jl` grows **7 → 12 cases**. Each delete guard is pinned separately and DB-free against a mock, so three cannot regress behind one.

## Verification

| Check | Result |
|---|---|
| Unit suite | **4741 / 4741**, exit 0 |
| Docs build | exit 0 — CrossReferences and CheckDocument clean, new page in nav |
| Drift guard (`allowed_hits == 4`) | green, unchanged |
| Admonition census | 96 → 111; the 3 remaining zeros are the declared ones |
| Live run vs `db_sl` | **0 failures** — writes inside a rolled-back transaction, `Status` fixture at 139 before and after |

The live run pinned each type independently: `IntegrityError` from both `create()` and `bulk_insert` (and that the SQLite wording contains no "duplicate key", which is why message matching had to go), `InvalidValueError` raised *before* the statement is sent, `TransactionError` from `atomic(durable=true)` nested in an open transaction, `DoesNotExist`/`MultipleObjectsReturned`/`LazyTraversalError`, and the advisory-lock no-op running its body despite `wait=false, timeout_ms=1`.

## Follow-ups filed separately

Behavior questions this surfaced, deliberately kept out of a docs PR: whether SQLite should enforce foreign keys, whether a *locking* primitive should be a silent no-op, and the stale `delete` docstring (`show_query::Bool` vs the real `::Symbol`, published on the site via `@autodocs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
