### PR TITLE
docs(#273): make the doc-example verification recipe runnable

### DIFF
--- a/.github/skills/pormg-public-api-development/SKILL.md
+++ b/.github/skills/pormg-public-api-development/SKILL.md
@@ -124,16 +124,20 @@ Use internal or function-style helpers only when the test is explicitly about in
 
 ### Verifying doc examples against the live database
 
-Every query example added or changed in `docs/`, `README.md`, or `src/*.md` should be confirmed **two ways** before commit: the **generated SQL shape** (no DB needed) and the **actual result** against the preloaded F1 data. `test/integration/db_sl/f1.sqlite` ships with the full dataset, so this needs no setup.
+Every query example added or changed in `docs/`, `README.md`, or `src/*.md` should be confirmed **two ways** before commit: the **generated SQL shape** (no DB needed) and the **actual result** against the preloaded F1 data in `test/integration/db_sl/f1.sqlite`. That fixture is gitignored *local* state rather than a checked-in file — the main checkout has it, and a fresh clone or worktree gets it from `scripts/worktree_setup.sh` (see `.worktreeinclude`).
 
-Run a scratch script placed under `test/integration/` (so `@import_models` resolves) or use absolute paths:
+Place the scratch script under `test/integration/` (so `@import_models` resolves) and run it with the **integration environment**, which carries the `LibPQ`/`SQLite` drivers as real dependencies:
 
 ```julia
+# One-time per checkout/worktree (test/integration/Manifest.toml is gitignored and not copied):
+#   julia --project=test/integration -e 'using Pkg; Pkg.instantiate()'
+# Then run the script with that environment:
+#   julia --project=test/integration test/integration/<scratch>.jl
 ENV["PORMG_ENV"] = "dev"            # never "test" — it breaks Generator scratch configs
-import Pkg; Pkg.activate(".")
-using PormG, DataFrames
-import PormG.QueryBuilder: Sum, Count, Max, Min, inspect_query
-cd("test/integration")
+using PormG, PormG.Functions, SQLite, DataFrames  # SQLite loads the weakdep extension (LibPQ for
+                                                  # db_2); without it the first query throws
+                                                  # "the SQLite backend requires SQLite"
+cd(@__DIR__)                                    # runnable from the repo root and from here
 PormG.Configuration.load("db_sl")               # local SQLite, F1 data preloaded
 PormG.@import_models "db_sl/models.jl" models
 import .models as M
@@ -150,6 +154,8 @@ raw = (M.Result.objects.filter("constructorid" => 131).values("points") |> DataF
 
 Rules and gotchas:
 
+- **Run it with `--project=test/integration`, never `Pkg.activate(".")`.** A `[weakdeps]` package (#34) cannot be `using`-ed by name from the package environment, and `Manifest.toml` is gitignored so a fresh checkout has no installed copy to fall back on — `Pkg.activate(".")` is the one choice guaranteed to fail with *"the SQLite backend requires SQLite"*. (The suite survives `--project=.` only because `common_setup.jl` redirects the environment and `test/load_drivers.jl` falls back to `Base.require` by UUID; a bare scratch script does neither.) Same rule as [`general.instructions.md`](../../instructions/general.instructions.md) → *Verification*.
+- **Shortcut:** a script already inside `test/integration/` can `include("common_setup.jl")` instead of writing the preamble — it redirects the environment, loads the drivers (via `test/load_drivers.jl`), `cd`s, and defines `M`, honouring `PORMG_DB` to pick db_sl or db_2. Heavier (also pulls in Test/CSV/Revise and the pool tuning), but it cannot drift from how the suite actually runs.
 - **Verify the value, not just execution.** For aggregates/computed columns, recompute the answer independently (raw row scan, plain `Sum`, etc.) and assert equality — a query that runs can still be wrong.
 - **Query a field by the exact case it was declared** — field lookups are case-sensitive (#57). The F1 models declare **lowercase** fields, so their paths are lowercase (`constructorid__name`); a camelCase path like `constructorId__name` throws *because the field is `constructorid`*, not because PormG folds case. (House style is lowercase snake_case; mixed-case is supported for legacy columns.)
 - **`@import_models` resolves its path relative to the script file's directory** — keep the script in `test/integration/` or pass an absolute path.

--- a/.github/skills/pormg-usage/SKILL.md
+++ b/.github/skills/pormg-usage/SKILL.md
@@ -32,7 +32,10 @@ Everything below covers setup, the read/query surface, and a summary of the writ
 ## 1. Project Setup
 
 ```julia
-using PormG
+using PormG, LibPQ   # Add the driver to your project (`Pkg.add("LibPQ")`, or `"SQLite"`) and load
+                     # it alongside PormG. Both are weak dependencies of PormG, so a bare
+                     # `using PormG` gives you the ORM but no backend, and the first query raises
+                     # "the PostgreSQL backend requires LibPQ".
 
 # First-time setup (interactive)
 PormG.setup()   # configures db/connection.yml and optionally installs AI skills
@@ -349,13 +352,13 @@ sql = query.list(show_query=:sql)
 
 # Full metadata (useful for mutations — update, delete, bulk ops)
 meta = query.update("nationality" => "GB", show_query=:dict)
-println(meta[:sql])
+println(meta[:sql_text])
 println(meta[:parameters])
 
 # Inspect SELECT queries without executing
 using PormG: inspect_query
 inspection = query |> inspect_query()
-println(inspection[:sql])
+println(inspection[:sql_text])
 println(inspection[:dialect])
 ```
 


### PR DESCRIPTION
Closes #273.

The public-API skill *mandates* verifying every changed doc example against the live database — and the recipe it handed you failed on its first query. Any agent following it as written lost a cycle rediscovering the same two lines.

## The problem

```julia
import Pkg; Pkg.activate(".")     # the one env that by design cannot carry the drivers
using PormG, DataFrames           # no driver → "the SQLite backend requires SQLite"
cd("test/integration")            # only works from the repo root
```

`Pkg.activate(".")` also contradicted `general.instructions.md` → *Verification*, which names `test/integration/Project.toml` as the environment that carries `LibPQ`/`SQLite`.

## `pormg-public-api-development/SKILL.md`

- Run under `--project=test/integration`, and document the one-time `Pkg.instantiate()` that env needs — its `Manifest.toml` is gitignored and **neither** `.worktreeinclude` nor `scripts/worktree_setup.sh` provisions it.
- `using PormG, PormG.Functions, SQLite, DataFrames`. The driver loads the weakdep extension; this also drops the reach into `PormG.QueryBuilder`, since the aggregate constructors live in `PormG.Functions` and `inspect_query` is already a top-level export.
- `cd(@__DIR__)` — the surrounding prose already said to place the script *in* `test/integration/`.
- Corrected the claim that `f1.sqlite` "ships with the full dataset, so this needs no setup". It is gitignored local state (`.gitignore:31`) provisioned by `scripts/worktree_setup.sh`.
- Two new gotchas: why the package env fails (a weakdep cannot be `using`-ed *by name*; the suite only survives `--project=.` because `common_setup.jl` redirects and `test/load_drivers.jl` falls back to `Base.require` by UUID), and the `include("common_setup.jl")` shortcut that cannot drift.

Section heading kept — `pormg-changed-code-review/SKILL.md:137` links to it by name.

## `pormg-usage/SKILL.md` — same defect, different shape

- §1 Project Setup was a bare `using PormG`, and **no part of that skill mentioned a driver at all**. Now installs and loads one, matching `docs/src/index.md`.
- `meta[:sql]` / `inspection[:sql]` → `[:sql_text]`. This is a real bug, not cosmetic: all 15 `show_query` call sites route through `_show_query_result`, which returns `:sql_text` and no `:sql`, so both lines raised `KeyError`.

## Verification

Fresh worktree, provisioned via `scripts/worktree_setup.sh` + the newly-documented integration instantiate (which precompiled `PormGSQLiteExt` and `PormGLibPQExt`, confirming it is both necessary and sufficient):

- Recipe runs end-to-end from the repo root **and** from inside `test/integration/` — `max_points=50.0, n=652`, `@assert` passes, SQL renders with the SQLite `?` placeholder.
- Confirmed live that `update(show_query=:dict)` and `inspect_query()` both return `:sql_text` with no `:sql`, and that the `:dict` render performed no write (driver 1 still `British`).

No `UPGRADING.md` entry — skills only, no behavior or API change.

## Follow-ups (not in this PR)

- `scripts/worktree_setup.sh:76` instantiates only `--project=.`, so the integration instantiate stays a manual step.
- `test/integration/db_sl/steps_to_migrations.jl:9-13` and `db_2/steps_to_migrations.jl:9-13` carry the identical `Pkg.activate(".")`-without-driver defect in tracked code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
