### PR TITLE
fix(#272): fluent page(20) works and page! joins the PormGError taxonomy

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -102,6 +102,27 @@ Error messages may colorize the offending token with ANSI for the REPL, but they
 
 Scope: `_emsg` is shared (`src/Kernel.jl`, `PormG` namespace, both string and `IO`-aware methods); `QueryBuilder`, `Models`, and `Migrations` all `import PormG: _emsg`. Any submodule that needs colored errors/logs should import `_emsg` from `PormG` rather than re-embedding raw ANSI. Regression coverage: `test/unit/test_error_message_ansi.jl`.
 
+### Fluent surface: `ChainCaller` vs closure
+
+`Base.getproperty(::ObjectHandler, sym)` in `object_manager.jl` builds each fluent method one of two
+ways, and the choice is forced by whether the method takes keywords:
+
+- **`ChainCaller(mutator!, q)`** — positional only. The functor packs the call's varargs into **one
+  tuple** and calls `mutator!(q.object, args)`, so the mutator's signature is
+  `f(::SQLObject, ::Tuple{…})` and **arity is dispatch**. Every accepted arity needs its own
+  `Tuple{…}` method *and* the family needs an `::Any` fallback throwing a taxonomy subtype —
+  otherwise a wrong shape escapes as a `MethodError` naming an internal `f!` and a tuple the caller
+  never wrote (#272). The functor rejects keywords with a `QueryBuildError` for the same reason.
+- **A closure** — e.g. `(args...; kwargs...) -> (f(q, args...; kwargs...); q)`, or `(; kwargs...)`
+  when there are no positional arguments — the only way to forward keywords (#26). `.with`,
+  `.cjoin`, `.cjoin_on`, `.on` and `.select_for_update` use this form.
+
+So adding a keyword to a `ChainCaller`-backed method means **converting it to a closure**; leaving it
+as a `ChainCaller` makes the keyword throw. Coverage: `test/unit/test_fluent_parity_208.jl`.
+
+New fluent method? `test/unit/test_docstring_coverage.jl` scans the `sym === :name` branches and
+requires each one documented in **both** the `object` docstring and `docs/src/api.md`.
+
 ### Query generation
 
 Focus on:

--- a/.github/skills/pormg-usage/SKILL.md
+++ b/.github/skills/pormg-usage/SKILL.md
@@ -138,6 +138,7 @@ df   = query |> DataFrame   # DataFrames.DataFrame
 | `.order_by("field", "-field")` | Sort. Prefix `-` for descending. |
 | `.limit(n)` | Limit rows returned. |
 | `.offset(n)` | Skip first `n` rows. |
+| `.page(limit)` / `.page(limit, offset)` | Limit, or limit and offset, in one call. `.page(n)` leaves any offset already set. Positional `Integer`s only — no keywords. |
 | `.db("key")` | Route to a different connection pool. |
 | `.on("path", key => value)` | Add ON-clause predicates to an existing join. |
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,7 +31,7 @@ These methods modify the query builder and return the handler for further chaini
 | `.order_by("field", "-field")` | Sort results. Prefix with `-` for descending. | `.order_by("-points", "surname")` |
 | `.limit(n)` | Limit the number of returned rows. | `.limit(10)` |
 | `.offset(n)` | Skip the first `n` rows. | `.offset(20)` |
-| `.page(limit, offset)` | Limit and offset in one call. | `.page(20, 40)` |
+| `.page(limit)` / `.page(limit, offset)` | Limit, or limit and offset in one call. The one-argument form leaves any `.offset()` already set untouched. | `.page(20, 40)` / `.page(20)` |
 | `.distinct()` | Add `DISTINCT` to the SELECT. | `.distinct()` |
 | `.db("key")` | Route the query to a different connection pool. | `.db("tenant_42")` |
 | `.on("path", key => value)` | Add predicates to the ON clause of an existing join path. | `.on("driverid", "nationality" => "British")` |

--- a/docs/src/read/index.md
+++ b/docs/src/read/index.md
@@ -195,7 +195,7 @@ These methods modify the query builder and return the handler for further chaini
 | `.order_by("field", "-field")` | Sort results. Prefix with `-` for descending. | **Replaces** previous call |
 | `.limit(n)` | Limit the number of returned rows. | Last value wins |
 | `.offset(n)` | Skip the first `n` rows. | Last value wins |
-| `.page(n)` | Convenience for pagination (requires `.limit()` to be set first). | Last value wins |
+| `.page(limit)` / `.page(limit, offset)` | Pagination in one call. `.page(n)` sets `LIMIT` only and leaves `.offset()` untouched; `.page(n, m)` sets both. Any other shape raises `QueryBuildError`. | Last value wins |
 | `.distinct()` | Add `SELECT DISTINCT` to the query. | Last value wins |
 | `.db("key")` | Route the query to a different connection pool. | Last value wins |
 | `.with("name" => subquery)` | Attach a Common Table Expression (CTE). | Adds another CTE |
@@ -232,6 +232,12 @@ page1 = M.Driver.objects.order_by("surname").limit(20).list()
 
 # Page 2: skip 20, take 20
 page2 = M.Driver.objects.order_by("surname").limit(20).offset(20).list()
+
+# Same thing in one call — .page(limit, offset)
+page2_alt = M.Driver.objects.order_by("surname").page(20, 20).list()
+
+# .page(n) is limit-only: it sets LIMIT and leaves any offset already on the handler alone
+top20 = M.Driver.objects.order_by("surname").page(20).list()
 ```
 
 ### Distinct Results

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -490,30 +490,32 @@ end
 
 
 # ---
-# Pagination functions
+# Pagination
 #
+# INTERNAL, and NOT the fluent implementation. `query.page(...)` routes through
+# `ChainCaller(page!, q)` (object_manager.jl), which dispatches on `SQLObject`; these methods take
+# an `SQLObjectHandler` and are never reached from the chain. `page` is un-exported (#202), has no
+# caller in this repo, and survives only because test_public_exports.jl pins it as
+# defined-but-unexported. The external API is the fluent `query.page(limit)` /
+# `query.page(limit, offset)` — nothing in `docs/` or `README.md` mentions the function form.
+#
+# It is a second, parallel implementation of the same semantics, and the two surfaces silently
+# drifting apart is exactly what #272 was. `test_fluent_parity_208.jl` now pins them equal; keep
+# that test passing rather than editing one side alone.
+#
+# No docstring on purpose — `docs/src/api.md` builds an `@autodocs` page over the whole QueryBuilder
+# module with `Private = true`, so a docstring here publishes `page` in the public API reference as
+# if the function form were supported surface. The `.page(...)` reference lives on the `object`
+# docstring and in `docs/src/api.md` (the split that test_docstring_coverage.jl enforces).
 
-
-"""
-Set pagination parameters for a SQL query object.
-
-# Arguments
-- `object::SQLObjectHandler`: The SQL object handler to modify
-- `limit::Integer`: Maximum number of records to return (default: 10)  
-- `offset::Integer`: Number of records to skip from the beginning (default: 0)
-
-# Examples
-query.page(20, 10) |> DataFrame
-query.page(20) |> DataFrame
-
-The function form `page(query, 20, 10)` is still supported, but the fluent
-`query.page(...)` style is the preferred public API.
-"""
+# Sets BOTH clauses (offset falls back to its 0 default). Unreachable from the chain: `ChainCaller`
+# forwards positional arguments only, so no keyword can arrive on the fluent path.
 function page(object::SQLObjectHandler; limit::Integer = 10, offset::Integer = 0)
   object.object.limit = limit
   object.object.offset = offset
   return object
 end
+# Limit-only: the offset already on the handler is left alone. `page!`'s 1-tuple method mirrors this.
 function page(object::SQLObjectHandler, limit::Integer)
   object.object.limit = limit
   return object
@@ -524,19 +526,34 @@ function page(object::SQLObjectHandler, limit::Integer, offset::Integer)
   return object
 end
 
+# ---
+# Fluent mutators behind `query.limit(...)`, `query.offset(...)` and `query.page(...)`.
+#
+# `ChainCaller` packs the call's varargs into ONE tuple and calls `f(q.object, args)`, so the
+# argument these receive is always a `Tuple` and the arity check IS the dispatch. Every shape that is
+# not an accepted arity therefore needs an `::Any` fallback throwing a `PormGError`: without one the
+# user gets a bare `MethodError` naming `page!` and a `Tuple{String, String}` — neither of which
+# appears anywhere in their code — and `catch PormGError` (#231/#239) does not cover it (#272).
 function limit!(object::SQLObject, limit::Tuple{Integer})
   object.limit = limit[1]
 end
 function limit!(object::SQLObject, limit)
-  throw(QueryBuildError("Error in page, limit must be an Integer"))
+  throw(QueryBuildError("Invalid limit() arguments: $(limit) (::$(typeof(limit))) — limit() takes exactly one Integer, e.g. limit(20)."))
 end
 function offset!(object::SQLObject, offset::Tuple{Integer})
   object.offset = offset[1]
 end
 function offset!(object::SQLObject, offset)
-  throw(QueryBuildError("Error in page, offset must be an Integer"))
+  throw(QueryBuildError("Invalid offset() arguments: $(offset) (::$(typeof(offset))) — offset() takes exactly one Integer, e.g. offset(40)."))
+end
+# page(n) is limit-only — the offset already on the handler survives, matching page(object, limit).
+function page!(object::SQLObject, v::Tuple{Integer})
+  object.limit = v[1]
 end
 function page!(object::SQLObject, v::Tuple{Integer, Integer})
   object.limit = v[1]
   object.offset = v[2]
+end
+function page!(object::SQLObject, v)
+  throw(QueryBuildError("Invalid page() arguments: $(v) (::$(typeof(v))) — page() takes one Integer (limit) or two Integers (limit, offset), e.g. page(20) or page(20, 40)."))
 end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -342,8 +342,18 @@ struct ChainCaller{F,T}
   handler::T
 end
 
-# When called (e.g., query.filter(...)), it executes and returns the handler itself
-function (c::ChainCaller)(args...)
+# When called (e.g., query.filter(...)), it executes and returns the handler itself.
+#
+# `kwargs...` is slurped only to REJECT it. Without it a keyword call dies on this functor with a
+# bare `MethodError` naming `ChainCaller{typeof(page!), ObjectHandler}` — outside the PormGError
+# taxonomy (#231/#239), and a spelling that appears nowhere in the caller's code (#272). Users reach
+# for it because the docs name the parameters (`.page(limit = 20)`) and because the sibling fluent
+# methods built from closures below — `.with`, `.cjoin`, `.cjoin_on`, `.on`, `.select_for_update` —
+# genuinely do take keywords. The mutators behind ChainCaller do not: their argument is the packed
+# positional tuple, so a keyword has nowhere to go and must fail loudly rather than obscurely.
+function (c::ChainCaller)(args...; kwargs...)
+  isempty(kwargs) || throw(QueryBuildError(
+    "Keyword arguments are not accepted here: $(join(keys(kwargs), ", ")). The chainable query methods take positional arguments only — e.g. page(20, 40), limit(20), order_by(\"-points\")."))
   c.func(c.handler.object, args)
   return c.handler
 end

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -1150,7 +1150,11 @@ Each mutates the handler and returns it, so calls can be chained or accumulated 
   `.values`/`.order_by`, which replace their previous call (#199)
 - `.values(fields...)` — choose/annotate the selected columns; `"*"` selects the main table
 - `.order_by(fields...)` — sort; prefix `-` for descending
-- `.limit(n)` / `.offset(n)` / `.page(limit, offset)` — pagination
+- `.limit(n)` / `.offset(n)` — pagination, one clause each
+- `.page(limit)` / `.page(limit, offset)` — pagination in one call; `.page(n)` sets the limit only
+  and leaves any offset already on the handler in place. Those are the only two arities — anything
+  else (no argument, three arguments, a non-`Integer`, a keyword) raises `QueryBuildError`, same as
+  `.limit(...)` / `.offset(...)` (#272)
 - `.distinct()` — add `DISTINCT`
 - `.db("key")` — route the query to another connection pool
 - `.on(path, pairs...)` — add predicates to the `ON` clause of an existing join path

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -593,6 +593,26 @@ end
     @test issorted(df.resultid)
   end
 
+  @testset "page functor with limit only (#272)" begin
+    # #272: `query.page(n)` — the single-argument form the docs had always advertised — raised a
+    # bare MethodError, because only page!(::SQLObject, ::Tuple{Integer, Integer}) existed. It sets
+    # LIMIT and must leave any OFFSET already on the handler alone.
+    query = M.Result.objects
+    query.filter("statusid__status" => "Finished")
+    query.values("resultid")
+    query.order_by("resultid")
+
+    first_four = query.copy().page(4) |> DataFrame
+    @test nrow(first_four) == 4
+    @test issorted(first_four.resultid)
+
+    # An offset set before the call survives it — page(n) is limit-only, not a pagination reset.
+    next_four = query.copy().offset(4).page(4) |> DataFrame
+    @test nrow(next_four) == 4
+    @test isempty(intersect(first_four.resultid, next_four.resultid))
+    @test minimum(next_four.resultid) > maximum(first_four.resultid)
+  end
+
   @testset "page functor with offset skips rows" begin
     query = M.Result.objects
     query.filter("statusid__status" => "Finished")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ end
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")
     @testset "update_or_create (#30)" include("unit/test_update_or_create.jl")
-    @testset "Fluent parity: get_or_create/last/aggregate (#208)" include("unit/test_fluent_parity_208.jl")
+    @testset "Fluent parity: get_or_create/last/aggregate/page (#208, #272)" include("unit/test_fluent_parity_208.jl")
     @testset "create() returns PormGRow (#166)" include("unit/test_create_returns_pormgrow.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -140,6 +140,11 @@ const DOCERR_CASES = [
         UnsafeMutationError,
         () -> DOCERR_RESULT_PG.objects.delete(show_query = :dict),
     ),
+    (
+        "read/index.md — `.page(...)` takes one or two Integers; anything else raises",
+        QueryBuildError,
+        () -> DOCERR_RESULT_PG.objects.page("20", "10"),
+    ),
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_fluent_parity_208.jl
+++ b/test/unit/test_fluent_parity_208.jl
@@ -5,13 +5,13 @@ using PormG.Functions: Sum, Count, Avg
 using PormG.QueryBuilder: SQLOrder, SQLField
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Fluent parity gaps (#208): get_or_create, last(), aggregate()
+# Fluent parity gaps (#208, #272): get_or_create, last(), aggregate(), page()
 #
 # DB-free: `show_query=:sql`/`:dict` render the full statement before any DB round-trip, so the
 # get_or_create ON CONFLICT DO NOTHING clause, the last() ORDER-BY inversion + pk fallback, the
-# aggregate() no-GROUP-BY projection, and every validation error are all assertable against bare
-# mock connections. Mirrors test_update_or_create.jl. (Row correctness lives in the integration
-# suite, which needs a live DB.)
+# aggregate() no-GROUP-BY projection, the page() LIMIT/OFFSET arities, and every validation error
+# are all assertable against bare mock connections. Mirrors test_update_or_create.jl. (Row
+# correctness lives in the integration suite, which needs a live DB.)
 # ─────────────────────────────────────────────────────────────────────────────
 
 struct MockPg208 <: PormG.PormGPostgres end
@@ -152,4 +152,132 @@ end
   qv.values("code")
   @test occursin("cannot combine with values() grouping",
     _p208_error(() -> qv.aggregate("total" => Sum("points"), show_query = :dict)))
+end
+
+@testset "page() fluent arities render LIMIT/OFFSET (#272)" begin
+  # The `page` docstring had always advertised `query.page(20)`, but only
+  # page!(::SQLObject, ::Tuple{Integer, Integer}) existed, so the single-argument form raised a bare
+  # MethodError. Asserted on the rendered statement, not just the handler field, because
+  # execution.jl only emits each clause when the field is non-zero.
+  q2 = GocPg.objects
+  q2.page(20, 10)
+  @test q2.object.limit == 20
+  @test q2.object.offset == 10
+  sql2 = q2.list(show_query = :sql)
+  @test occursin("LIMIT 20", sql2)
+  @test occursin("OFFSET 10", sql2)
+
+  # One-argument form: LIMIT only. offset stays 0, so NO OFFSET clause is emitted at all.
+  q1 = GocPg.objects
+  q1.page(20)
+  @test q1.object.limit == 20
+  @test q1.object.offset == 0
+  sql1 = q1.list(show_query = :sql)
+  @test occursin("LIMIT 20", sql1)
+  @test !occursin("OFFSET", sql1)
+
+  # page(n) is limit-only, NOT a pagination reset: an offset already on the handler survives it.
+  # This is the contract that separates it from page(limit, offset).
+  q3 = GocPg.objects
+  q3.offset(30)
+  q3.page(5)
+  @test q3.object.limit == 5
+  @test q3.object.offset == 30
+  @test occursin("OFFSET 30", q3.list(show_query = :sql))
+
+  # Chainable: the ChainCaller returns the handler, so page() composes like every other mutator.
+  q4 = GocPg.objects
+  @test q4.page(7).order_by("points") === q4
+  @test q4.object.limit == 7
+end
+
+@testset "fluent .page(...) and the internal page() stay in lockstep (#272)" begin
+  # ROOT CAUSE GUARD. `page` (SQLObjectHandler, functions.jl) and `page!` (SQLObject, behind the
+  # ChainCaller) are two parallel implementations of one contract, and #272 *was* them drifting:
+  # the free function grew a limit-only arity, the fluent one did not, and only the docstring
+  # noticed. Nothing but this test ties them together — assert equal end state from equal start,
+  # so touching one side alone fails here instead of shipping.
+  for (label, args) in (("limit only", (20,)), ("limit and offset", (20, 40)))
+    for preset_offset in (0, 30)   # 30 proves the limit-only arity preserves an existing offset
+      qf = GocPg.objects           # fluent: query.page(args...)
+      qi = GocPg.objects           # internal: page(handler, args...)
+      qf.offset(preset_offset)
+      qi.offset(preset_offset)
+
+      qf.page(args...)
+      PormG.QueryBuilder.page(qi, args...)
+
+      @test (qf.object.limit, qf.object.offset) == (qi.object.limit, qi.object.offset)
+      # Pin the absolute value too, so the pair agreeing on a WRONG answer still fails.
+      expected_offset = length(args) == 2 ? args[2] : preset_offset
+      @test (qf.object.limit, qf.object.offset) == (args[1], expected_offset)
+    end
+  end
+end
+
+@testset "page()/limit()/offset() reject non-Integer and wrong-arity arguments (#272)" begin
+  # #231/#239: every PormG domain failure is a PormGError. `page!` had no ::Any fallback, so
+  # query.page("20","10"), query.page() and query.page(1,2,3) all escaped as raw MethodErrors
+  # naming a `page!` and a Tuple that appear nowhere in the caller's code.
+  q = GocPg.objects
+
+  @test_throws PormG.QueryBuildError q.page("20", "10")
+  @test_throws PormG.QueryBuildError q.page()
+  @test_throws PormG.QueryBuildError q.page(1, 2, 3)
+  @test_throws PormG.QueryBuildError q.page(20, 10.5)
+  @test_throws PormG.PormGError      q.page("20")  # …and QueryBuildError <: the documented catch-all
+
+  # Message, not only type: a bare type assertion passes for ANY QueryBuildError, including one from
+  # an unrelated validator. Pin the tokens that identify THIS guard.
+  msg = _p208_error(() -> q.page("20", "10"))
+  @test occursin("page()", msg)
+  @test occursin("Tuple{String", msg)     # echoes what was actually passed
+  @test occursin("page(20)", msg)         # names the one-argument arity…
+  @test occursin("page(20, 40)", msg)     # …and the two-argument one
+
+  # Sibling mutators share the contract and had NO coverage at all before #272 — their messages used
+  # to say "Error in page" even though they are thrown by limit!/offset!.
+  @test occursin("limit()",  _p208_error(() -> q.limit("20")))
+  @test occursin("offset()", _p208_error(() -> q.offset("40")))
+  @test_throws PormG.QueryBuildError q.limit()
+  @test_throws PormG.QueryBuildError q.offset(1, 2)
+
+  # A rejected call must not half-apply — the handler is untouched by every throw above.
+  @test q.object.limit == 0
+  @test q.object.offset == 0
+end
+
+@testset "ChainCaller rejects keyword arguments as a PormGError (#272)" begin
+  # The docs name the parameters (`.page(limit = 20)`) and five sibling fluent methods (.with,
+  # .cjoin, .cjoin_on, .on, .select_for_update) are closures that DO take keywords — so a keyword
+  # call on a ChainCaller method is a natural user mistake. It used to die on the functor itself
+  # with a MethodError naming `ChainCaller{typeof(page!), ObjectHandler}`, outside the taxonomy and
+  # unrecognizable to the caller. Every ChainCaller-backed method shares the one functor, so this
+  # is asserted across the family, not just page.
+  qk = GocPg.objects
+  @test_throws PormG.QueryBuildError qk.page(limit = 20)
+  @test_throws PormG.QueryBuildError qk.page(20; offset = 10)
+  @test_throws PormG.QueryBuildError qk.limit(n = 20)
+  @test_throws PormG.QueryBuildError qk.offset(n = 20)
+  @test_throws PormG.QueryBuildError qk.order_by(field = "points")
+  @test_throws PormG.QueryBuildError qk.filter(code = "HAM")
+
+  # The message names the offending keyword(s) — without that it cannot tell the user which
+  # argument to move, and any unrelated QueryBuildError would satisfy a type-only assertion.
+  # Assert the INTERPOLATED segment, not the bare words: "limit" also appears in the static
+  # `e.g. … limit(20) …` tail, and the pre-fix MethodError text contained both names too, so
+  # `occursin("limit") && occursin("offset")` would have passed before and after the fix.
+  # Keys follow call order, so this is deterministic.
+  msg = _p208_error(() -> qk.page(limit = 20, offset = 40))
+  @test occursin("here: limit, offset", msg)
+  @test occursin("positional", msg)
+
+  # Rejected before the mutator runs: nothing is half-applied.
+  @test qk.object.limit == 0
+  @test qk.object.offset == 0
+  @test isempty(qk.object.filter)
+
+  # The positional path is untouched by the kwargs slurp.
+  @test qk.page(20, 40) === qk
+  @test (qk.object.limit, qk.object.offset) == (20, 40)
 end


### PR DESCRIPTION
Closes #272.

## The bug

`query.page(20)` was documented but raised a bare `MethodError`. `ChainCaller` packs a call's varargs into **one tuple**, so arity is dispatch, and the only `page!` method was `Tuple{Integer, Integer}`. `page!` also lacked the `::Any` fallback its neighbours `limit!`/`offset!` have, so `query.page("20","10")`, `query.page()` and `query.page(1,2,3)` all escaped the `PormGError` taxonomy (#231/#239) too.

## What's in here

- `page!(::SQLObject, ::Tuple{Integer})` — limit only, offset preserved, mirroring the internal `page(object, limit)`
- `page!(::SQLObject, v)` fallback throwing `QueryBuildError` that names both accepted arities and echoes the tuple type actually passed
- `limit!`/`offset!` messages corrected — they said *"Error in page"* while being thrown from `limit!`/`offset!`. Nothing asserted those strings; they now get their first-ever coverage
- **`ChainCaller` rejects keyword arguments** with a `QueryBuildError`. `.page(limit = 20)` died on the functor with a `MethodError` naming `ChainCaller{typeof(page!), ObjectHandler}` — same escape, and a likely user attempt given the docs name the parameters and five sibling fluent methods do take keywords. Fixed once for all eight `ChainCaller` methods
- **The internal `page` docstring is deleted.** `docs/src/api.md`'s `@autodocs` runs with Documenter's default `Private = true`, so it was publishing `page` on the public API page, advertising the function form as supported. `.page(...)` is the only external API; its reference now lives on the `object` docstring and in `api.md`
- `docs/src/read/index.md` claimed `.page(n)` *"requires `.limit()` to be set first"* — wrong on both counts. Corrected, plus two runnable examples
- A **parity testset** pinning the internal `page` and the fluent `.page` to identical end state. The two surfaces silently drifting apart *is* #272, and nothing previously tied them together

## Verification

- Unit: **4798/4798**
- SQLite integration (`PORMG_DB=db_sl`): **1854 pass, 1 broken (pre-existing), 0 fail**
- New doc examples confirmed two ways against `db_sl/f1.sqlite` — SQL shape via `inspect_query`, then executed and cross-checked that `.page(20, 20)` returns exactly the rows `.limit(20).offset(20)` does
- Two rounds of independent review; all findings fixed

No `UPGRADING.md` entry and no `Project.toml` bump: the arity is additive, and the `MethodError` → `QueryBuildError` change only affects calls that were already broken, so no consuming app needs an edit.

## Deliberately deferred

- **`Bool <: Integer`** — `.page(true)` renders `LIMIT true`. Identical and pre-existing for `.limit(true)` / `.offset(true)`; guarding only `page!` would be a worse inconsistency
- **Naming the method in the kwarg error** — `nameof(c.func)` yields `up_filter`/`up_db`/`up_values` for three of the eight, i.e. internal names appearing nowhere in the caller's code. Belongs with a follow-up that settles the mutator naming (that follow-up's more valuable half: `order_by!` carries a docstring and so *is* published on the API page today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
