### PR TITLE
docs(#274): docstring coverage for the submodule surfaces

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,68 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## `PormG.Migrations` no longer exports its schema-introspection helpers (#274)
+
+- **Version**: Unreleased
+- **PormG ref**: #274; `src/Migrations.jl`
+- **Recorded**: 2026-08-01
+- **Severity**: **breaking (export surface)** — narrow: it affects only code that does
+  `using PormG.Migrations` *and* calls one of nine names unqualified. Part of the `0.3.x`
+  pre-publish wave.
+
+### What changed
+
+Nine names were exported by `PormG.Migrations` that are schema-introspection and module-scanning
+plumbing, not API. None appears anywhere in the documentation, every call site outside
+`src/migrations/` was already qualified, and `get_sequence_name` had no caller anywhere in the repo.
+Exporting them made them read as public, and put them on the docstring-coverage guard for a surface
+nobody consumes.
+
+They are **still there and still work** — they are just no longer exported, so reach them qualified:
+
+```
+get_database_schema   get_all_models        get_all_dicts
+get_constraints_fk    get_constraints_index get_sequence_name
+get_constraints_pk    get_constraints_unique get_constraints_check
+```
+
+The last three are a special case: they are `PormG.Kernel` generics that `Kernel` already exports,
+so `Migrations` was re-exporting a name it did not own. **`PormG.get_constraints_check(...)` and
+friends keep working unchanged** — including extending them with your own method for a mock.
+
+`names(PormG)` is unchanged (63), so nothing that only does `using PormG` is affected.
+
+### How to find the calls to migrate
+
+```bash
+# Only files that pull the module in wholesale can be affected:
+rg -l 'using PormG\.Migrations|using PormG: Migrations' --type julia
+# …then, within those, look for the nine bare names:
+rg -n '\b(get_database_schema|get_all_models|get_all_dicts|get_constraints_fk|get_constraints_index|get_sequence_name|get_constraints_pk|get_constraints_unique|get_constraints_check)\s*\(' --type julia
+```
+
+An already-qualified call (`Migrations.get_migration_plan(...)`, `PormG.get_constraints_check(...)`)
+needs no change.
+
+### Before → after
+
+```julia
+# before — relied on the export
+using PormG.Migrations
+schema = get_database_schema(conn)
+models = get_all_models(my_models_module)
+
+# after — qualify
+using PormG.Migrations
+schema = PormG.Migrations.get_database_schema(conn)
+models = PormG.Migrations.get_all_models(my_models_module)
+```
+
+Note `get_all_models` also collides with a *different* `Models.get_all_models`; qualifying removes
+the ambiguity as a side effect.
+
+---
+
 ## Database failures now raise `DatabaseError`, not the driver's exception type (#268)
 
 - **Version**: Unreleased

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -96,7 +96,17 @@ makedocs(
         collapselevel = 1,
 
         assets = String[],
-        size_threshold = 600 * 1024, # api.md is one comprehensive auto-generated page (~340 KiB); headroom for growth
+        # api.md is one comprehensive page: hand-written reference plus an @autodocs dump of every
+        # module. It renders to ~510 KiB as of #274 (measured, not estimated — the previous "~340
+        # KiB" note dated from before #212/#213/#274 added ~45 docstrings). Raised 600 → 900 KiB so
+        # the next batch of docstrings does not fail the build; re-measure `docs/build/api.html`
+        # and update this number whenever a PR adds a significant number of docstrings.
+        size_threshold = 900 * 1024,
+        # Documenter warns at 100 KiB by default, which api.md passed long ago and will never go
+        # back under — so that warning was pure noise. Move the warn limit to 700 KiB: below the
+        # 900 KiB hard limit, but above today's 510 KiB, so it fires as an early signal that the
+        # page is approaching the ceiling instead of on every single build.
+        size_threshold_warn = 700 * 1024,
     ),
     checkdocs = :exports,
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -812,13 +812,16 @@ end
 `fetch_async`, `await_result`, `FetchTask` — see [Async & Concurrency](async.md)
 
 ### Transactions
-`run_in_transaction`, `atomic`, `with_savepoint`, `with_tx_context`, `in_transaction_context`
+`run_in_transaction`, `atomic`, `with_savepoint`, `with_tx_context`, `in_transaction_context` —
+plus `PormG.ConnectionPool.with_transaction` for hand-rolled lifecycles
 
 ### Locking
 `with_advisory_lock`
 
 ### Connection pool
-`pool_stats`, `PoolTimeoutError`, `PoolConnectError`
+`pool_stats`, `PoolTimeoutError`, `PoolConnectError` — manual checkout via
+`PormG.ConnectionPool.acquire_connection` / `release_connection` (pair them in a `finally`;
+on SQLite a write needs `mode = :write`)
 
 ### Utilities & lifecycle
 `upgrade_guide`, `register_ignore_tables!`, `@import_models`, `@models_module`, `@pormg_debug`
@@ -854,6 +857,20 @@ M.Result.objects.values(              # …or qualify without importing
 `bulk_*`, `Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Subquery`, `Interval` stay at the top level —
 they are query primitives, not part of the function library.
 
+The library in full — the same index `?PormG.Functions` prints in the REPL:
+
+**Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min` — see [Filters and Aggregates](read/filters_and_aggregates.md)
+
+**Conditional** — `Case`, `When` — see [Functions and Dates](read/functions_and_dates.md)
+
+**Window** — `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue` — see [Window Functions](read/window_functions.md)
+
+**String** — `Concat`, `Lower`, `Upper`, `Length`, `Replace`, `Trim`, `LTrim`, `RTrim`
+
+**Math** — `Abs`, `Round`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`
+
+**Type / value** — `Cast`, `Extract`, `ToChar`, `Value`, `Coalesce`, `Greatest`, `Least`, `NullIf`
+
 ### Functional CTE constructor: `PormG.QueryBuilder.With`
 
 The `With` (CTE) constructor lives in the `PormG.QueryBuilder` submodule and is **not** part
@@ -864,13 +881,6 @@ when you want the functional style. Import it explicitly:
 ```julia
 using PormG.QueryBuilder: With        # or qualify: PormG.QueryBuilder.With(...)
 ```
-
-**Aggregate** — `Sum`, `Avg`, `Count`, `Max`, `Min`
-**Conditional** — `Case`, `When`
-**Window** — `WindowOver`, `WindowSpec`, `Rank`, `DenseRank`, `RowNumber`, `Lag`, `Lead`, `FirstValue`, `LastValue`, `NthValue`
-**String** — `Concat`, `Lower`, `Upper`, `Length`, `Replace`, `Trim`, `LTrim`, `RTrim`
-**Math** — `Abs`, `Round`, `Floor`, `Ceil`, `Sqrt`, `Exp`, `Ln`, `Power`, `Mod`
-**Type / value** — `Cast`, `Extract`, `ToChar`, `Value`, `Coalesce`, `Greatest`, `Least`, `NullIf`
 
 ### Result-shape contract for `list()`
 

--- a/docs/src/write/transaction.md
+++ b/docs/src/write/transaction.md
@@ -596,6 +596,44 @@ If you need finer control (e.g., manual `SAVEPOINT` or multi-statement blocks), 
 - **`with_transaction(settings, sql, conn=nothing, release_conn=false)`**: Execute raw SQL inside a transaction context.
 - **`get_tx_connection()`**: Check if a transaction context is active and return the connection.
 - **`finalize_transaction_connection!(settings, conn; rollback_error=nothing)`**: Return `conn` to the pool exactly once from a terminal `finally`. Pass `rollback_error=nothing` when the COMMIT succeeded or the cleanup ROLLBACK ran cleanly; pass the caught error when the cleanup ROLLBACK itself threw, and a non-benign one causes the connection to be renewed or discarded instead of released.
+- **`acquire_connection(pool; timeout_seconds=nothing)`** / **`release_connection(pool, conn)`**: Lease a connection and give it back. Every acquire must be paired with a release, from a `finally`. `with_transaction` does this for you when you pass `conn=nothing`. Neither is exported — call them qualified, as below.
+
+!!! warning "SQLite: acquire writes with `mode = :write`"
+    SQLite allows only one writer, so a PormG SQLite pool splits its slots into readers plus a
+    single **writer slot**. The SQLite method of `acquire_connection` therefore takes an extra
+    `mode` keyword — `:read`, `:write`, or `:any` (the default). Acquire with `:read` or `:any`
+    and you can be handed a read-only connection on which a write fails.
+
+    ```julia
+    import PormG.ConnectionPool: acquire_connection, release_connection
+
+    settings = PormG.Configuration.get_settings("db_sl")
+    pool = settings.connections
+
+    conn = acquire_connection(pool; mode = :write)   # SQLite: required before writing
+    try
+        # … use conn …
+    finally
+        release_connection(pool, conn)               # exactly once, from a finally
+    end
+    ```
+
+    **`mode` is SQLite-only — it is not a keyword the PostgreSQL method accepts**, so passing it
+    to a PostgreSQL pool is a `MethodError`, not a no-op. Backend-portable code must branch on
+    the pool type, which is what PormG's own internals do:
+
+    ```julia
+    conn = pool isa PormG.PormGSQLite ? acquire_connection(pool; mode = :write) :
+                                        acquire_connection(pool)
+    ```
+
+    This applies **only** to manual checkout — `run_in_transaction`, `atomic` and
+    `with_transaction(conn = nothing)` already request the writer slot on your behalf.
+
+    If you are driving a `BEGIN`/`COMMIT`/`ROLLBACK` lifecycle rather than a single statement,
+    do **not** end it with `release_connection`: a failed cleanup `ROLLBACK` can leave the
+    connection holding an open transaction. Terminate with `finalize_transaction_connection!`
+    instead, exactly as the example below does.
 
 ### Example: Manual Savepoint
 

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -705,6 +705,44 @@ end
 # `config` entry) aborts with a `FieldError` the first time it reaches a leaked test mock (#147).
 close_pool!(::Union{PormGPostgres, PormGSQLite}) = nothing
 
+"""
+    acquire_connection(pool::PormGPostgres; timeout_seconds=nothing, max_retries=300)
+    acquire_connection(pool::PormGSQLite; timeout_seconds=nothing, max_retries=300, mode=:any)
+
+Lease a connection from the pool. **You own it until you give it back** — every
+`acquire_connection` must be paired with a [`release_connection`](@ref), and the release
+belongs in a `finally` so an exception cannot leak the slot:
+
+```julia
+conn = acquire_connection(pool)
+try
+    # … use conn …
+finally
+    release_connection(pool, conn)
+end
+```
+
+Most code should not call this at all — `run_in_transaction` and the fluent terminals do the
+pairing for you. Reach for it only when hand-rolling a connection lifecycle.
+
+# Keyword arguments
+- `timeout_seconds`: how long to wait for a free connection. Defaults to the pool's
+  `pool_timeout` from `connection.yml` (30 s if unset, #126); passing it explicitly wins.
+- `max_retries`: a safety bound on scan/materialize iterations, not a poll count — waiting is
+  event-driven (#124), so this is normally 1.
+- `mode` (**SQLite only**): `:read`, `:write`, or `:any`. When the pool has read/write
+  splitting enabled, only the writer slot may write, so **a connection you intend to write on
+  must be acquired with `mode = :write`**; `:read` or `:any` can hand you a read-only handle
+  and the write will fail. Any other symbol raises `InvalidValueError`.
+
+The pool grows lazily up to `pool_size × 10`. Exhausting that budget within the timeout raises
+`PoolTimeoutError`; a permanent connect failure (bad credentials, missing database, unopenable
+SQLite file) fails fast with `PoolConnectError`, whose connection string is redacted. Both are
+catchable and exported.
+
+See also [`release_connection`](@ref), `pool_stats`, and the
+[Advanced Configuration](@ref) guide for pool tuning and leak detection.
+"""
 function acquire_connection(pool::PormGPostgres; timeout_seconds::Union{Nothing, Real} = nothing, max_retries::Int = 300)
   start_time = time()
   # Default acquire timeout comes from the pool (connection.yml `pool_timeout`, #126); an explicit
@@ -1003,6 +1041,29 @@ function acquire_connection(pool::PormGSQLite; timeout_seconds::Union{Nothing, R
   end
 end
 
+"""
+    release_connection(pool, conn) -> Bool
+
+Return a connection leased by [`acquire_connection`](@ref) to its pool. The other half of the
+pairing contract — call it from a `finally`.
+
+Returns `true` when the slot was found and freed, `false` (with a warning) when it was not,
+which means the connection had already been replaced after a failure. The slot is matched by
+object **identity**, so you must release the same handle you were given: after a renewal, pass
+the renewed connection, not the original.
+
+On release the pool either hands the slot straight to a caller waiting for one (#124) or marks
+it available; an overflow connection past its `max_lifetime` is closed and retired instead of
+reused (#125).
+
+!!! warning "Not for a transaction that may have failed"
+    A connection whose `ROLLBACK` itself threw can still hold an open transaction, and this
+    function would hand it back to the pool as-is. Terminate a manual `BEGIN`/`COMMIT`/
+    `ROLLBACK` lifecycle with [`finalize_transaction_connection!`](@ref), which renews or
+    discards it in that case (#71).
+
+See also [`acquire_connection`](@ref).
+"""
 function release_connection(pool::PormGPostgres, conn)
   retired = nothing
   released = Base.lock(pool.lock) do
@@ -1578,6 +1639,42 @@ function with_transaction_async(pool::Union{PormGPostgres, PormGSQLite}, sql::St
   end
 end
 
+"""
+    with_transaction(pool, sql::String; conn=nothing, release_conn=false, params=nothing) -> (result, conn)
+
+Run one statement on a transaction-carrying connection. The building block behind manual
+`BEGIN` / `COMMIT` / `ROLLBACK` sequences.
+
+!!! tip "Prefer `run_in_transaction`"
+    It acquires, commits, rolls back and releases correctly on every path. Reach for
+    `with_transaction` only when you genuinely need to drive the lifecycle statement by
+    statement.
+
+Returns a **tuple** `(result, conn)`, not just the result — `conn` is the connection the
+statement ran on, which you pass back in as `conn` for the next statement of the same
+transaction.
+
+# Keyword arguments
+- `conn`: an existing connection to reuse. When `nothing`, one is acquired — on SQLite with
+  `mode = :write`, since a transaction writes.
+- `release_conn`: return the connection to the pool when this call finishes. Leave it `false`
+  while the transaction is still open; you receive `conn` back in the return tuple.
+- `params`: bound query parameters. Never interpolate values into `sql`.
+
+On error the connection is never orphaned: it is released if this call acquired it, and a
+transaction-ending `ROLLBACK` that itself failed causes a renew-or-discard instead, so a
+connection with an open or aborted transaction cannot go back into the pool (#71). The
+underlying driver exception is rethrown as a `DatabaseError` subtype.
+
+!!! warning "`release_conn=true` on a COMMIT/ROLLBACK is a use-after-release race"
+    It releases the connection **even when the statement fails**, which can hand it back to
+    the pool before your cleanup `ROLLBACK` runs on it (#139). Do the cleanup on the still-
+    leased connection and return it exactly once from a single `finally` via
+    [`finalize_transaction_connection!`](@ref).
+
+See also [`acquire_connection`](@ref), `with_transaction_async`, and the
+[Transactions and `run_in_transaction`](@ref) guide.
+"""
 function with_transaction(pool::Union{PormGPostgres, PormGSQLite}, sql::String;
   conn = nothing,
   release_conn::Bool = false,

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -38,16 +38,54 @@ module Kernel
 
 abstract type PormGAbstractType end
 abstract type PormGSettings <: PormGAbstractType end
-# Backend/dialect markers: the dispatch key for SQL rendering and driver selection. NOT <: PormGSettings —
-# PormGSettings is the Settings/config type, and a pool carries none of its fields (#186). Concrete pools are
-# PostgresConnectionPool <: PormGPostgres and SQLiteConnectionPool <: PormGSQLite.
+"""
+    PormGBackend <: PormGAbstractType
+
+The backend/dialect marker — the dispatch key for SQL rendering and driver selection.
+
+Its two subtypes, `PormGPostgres` and `PormGSQLite`, are what every dialect method dispatches
+on, so a function that renders SQL differently per backend is written as a pair of methods on
+them rather than as a runtime branch. The values you actually hold are the concrete connection
+pools: `PostgresConnectionPool <: PormGPostgres` and `SQLiteConnectionPool <: PormGSQLite`.
+
+Deliberately **not** `<: PormGSettings`: that is the configuration/`Settings` type, and a pool
+carries none of its fields (#186).
+
+Adding a backend means defining `PormG.backend_*` methods in a package extension — see
+[Extending PormG](@ref).
+"""
 abstract type PormGBackend <: PormGAbstractType end
 abstract type PormGPostgres <: PormGBackend end
 abstract type PormGSQLite <: PormGBackend end
 abstract type AbstractPormGParam <: PormGAbstractType end  # Base type for all parameterized queries
 abstract type PormGPostgresParam <: AbstractPormGParam end  # PostgreSQL numbered params ($1, $2...)
 abstract type PormGSQLiteParam <: AbstractPormGParam end    # SQLite positional params with contextual buckets
+"""
+    SQLObject <: PormGAbstractType
+
+Base type for the query state itself — the accumulated filters, projections, joins and
+ordering that a query is built from.
+
+The concrete type you hold is `SQLObjectQuery`. You rarely name `SQLObject` in application
+code; it appears when a helper accepts "the underlying query object", e.g. the `mq.object`
+handed to a subquery or CTE constructor.
+
+See also [`SQLObjectHandler`](@ref), [Architecture & Request Flow](@ref).
+"""
 abstract type SQLObject <: PormGAbstractType end
+
+"""
+    SQLObjectHandler <: SQLObject
+
+Base type for the chainable wrapper around a query — the thing `Model.objects` returns and
+`.filter(...)`, `.values(...)`, `.list()` hang off.
+
+The concrete type is `ObjectHandler`; its fluent methods are synthesized by `getproperty`, so
+they have no bindings of their own and `?query.filter` cannot work — the full method reference
+lives on `object` instead (`?object`).
+
+See also [`SQLObject`](@ref) (the state it wraps).
+"""
 abstract type SQLObjectHandler <: SQLObject end
 abstract type SQLTableAlias <: SQLObject end # Manage the name from table alias
 abstract type SQLInstruction <: PormGAbstractType end # instruction to build a query
@@ -64,9 +102,34 @@ abstract type SQLTypeOrder <: SQLTypeField end # Order to be used in the query
 abstract type SQLTypeCTE <: SQLType end # Common Table Expression (WITH clause)
 
 
+"""
+    PormGModel <: PormGAbstractType
+
+Base type for model definitions — one table, its fields, and its relations.
+
+Instances are produced by `Models.Model("table_name", field = FieldType(...), ...)` and
+collected by `@import_models` / `set_models`. Dispatch on it when you are writing code that
+takes "any model", such as a framework extension that registers its own tables.
+
+See also [`PormGField`](@ref), [Defining Models in PormG](@ref), [Extending PormG](@ref).
+"""
 abstract type PormGModel <: PormGAbstractType end
-# A field is a COMPONENT of a model, not a kind of model — a sibling, not a subtype, so it does not
-# satisfy ::PormGModel signatures (which all read model-only attributes) (#186).
+
+"""
+    PormGField <: PormGAbstractType
+
+Base type for field definitions — `CharField`, `IntegerField`, `ForeignKey`, and the rest.
+
+A field is a **component** of a model, not a kind of model: `PormGField` is a *sibling* of
+[`PormGModel`](@ref), not a subtype, so it deliberately does not satisfy `::PormGModel`
+signatures, which all read model-only attributes (#186).
+
+Fields own their validation — a value is checked here, before any SQL is generated — and
+carry the formatter that coerces a Julia value on its way *into* the database (inserts, bulk
+writes, bound filter parameters). Values read back are not decoded through the field type.
+
+See also [PormG Field Types Reference](@ref).
+"""
 abstract type PormGField <: PormGAbstractType end # define the type of the column from the model
 
 abstract type Migration <: PormGAbstractType end

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -49,9 +49,20 @@ include("migrations/runner.jl")
 export makemigrations, migrate
 export import_models_from_postgres, import_models_from_sqlite, import_models_from_django
 export django_to_string
-export convertSQLToModel, convert_schema_to_models, get_database_schema
-export get_migration_plan, get_all_models, get_all_dicts
-export get_constraints_fk, get_constraints_index, get_constraints_pk, get_constraints_unique, get_constraints_check, get_sequence_name
+export convertSQLToModel, convert_schema_to_models
+export get_migration_plan
+
+# NOT exported, on purpose (#274) — schema-introspection and module-scanning plumbing whose only
+# callers live inside src/migrations/. They were exported by accident, which made them read as
+# public API and put them on the docstring-coverage guard for a surface nobody consumes. Reach
+# them qualified (`PormG.Migrations.get_database_schema(...)`) if you are extending PormG itself:
+#
+#   get_database_schema, get_all_models, get_all_dicts,
+#   get_constraints_fk, get_constraints_index, get_sequence_name
+#
+# get_constraints_pk / get_constraints_unique / get_constraints_check are NOT re-exported here
+# either — they are Kernel generics (Kernel.jl) that Kernel already exports, so `PormG.get_*`
+# keeps resolving; re-exporting them from Migrations only duplicated the name.
 
 # Exports — new migration lifecycle APIs (Phases 1–7)
 export init_migrations, status, dry_run

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -111,19 +111,41 @@ import .QueryBuilder: object, get, PormGRow, pk, Q, Qor, F, Exists, OuterRef, Su
 """
     PormG.Functions
 
-The SQL function library — aggregate (`Sum`, `Avg`, `Count`, `Max`, `Min`), conditional
-(`Case`, `When`), window (`WindowOver`, `Rank`, `Lag`, …), string (`Lower`, `Replace`,
-`Trim`, …) and math (`Round`, `Floor`, `Power`, …) constructors.
+The SQL function library, and the index of it. Because these names are **not** exported into
+`Main` by `using PormG`, `?Sum` answers nothing until you import them — so this docstring is
+the entry point: it lists every constructor and where each family is documented.
 
-These are **not** exported into `Main` by `using PormG`: the names are generic enough to
-collide with `Base` and user code (`Sum`, `Count`, `Max`, `Replace`, `Round`, `Length`…).
-Opt in explicitly:
+**Aggregate** — [`Sum`](@ref), [`Avg`](@ref), [`Count`](@ref), [`Max`](@ref), [`Min`](@ref)
+— see [Filters and Aggregates](@ref)
+
+**Conditional** — [`Case`](@ref), [`When`](@ref) — see [Functions and Dates](@ref)
+
+**Window** — [`WindowOver`](@ref), [`WindowSpec`](@ref), [`Rank`](@ref), [`DenseRank`](@ref),
+[`RowNumber`](@ref), [`Lag`](@ref), [`Lead`](@ref), [`FirstValue`](@ref), [`LastValue`](@ref),
+[`NthValue`](@ref) — see [Window Functions](@ref)
+
+**String** — [`Concat`](@ref), [`Lower`](@ref), [`Upper`](@ref), [`Length`](@ref),
+[`Replace`](@ref), [`Trim`](@ref), [`LTrim`](@ref), [`RTrim`](@ref)
+
+**Math** — [`Abs`](@ref), [`Round`](@ref), [`Floor`](@ref), [`Ceil`](@ref), [`Sqrt`](@ref),
+[`Exp`](@ref), [`Ln`](@ref), [`Power`](@ref), [`Mod`](@ref)
+
+**Type / value** — [`Cast`](@ref), [`Extract`](@ref), [`ToChar`](@ref), [`Value`](@ref),
+[`Coalesce`](@ref), [`Greatest`](@ref), [`Least`](@ref), [`NullIf`](@ref)
+
+They live here rather than at the top level because the names are generic enough to collide
+with `Base` and user code (`Sum`, `Count`, `Max`, `Replace`, `Round`, `Length`…), so the
+library has exactly one home and you opt in explicitly:
 
 ```julia
 using PormG, PormG.Functions          # brings Sum, Count, … into scope
+using PormG.Functions: Sum, Count     # …or just the ones you use
 # or qualify without importing:
 M.Result.objects.values("n" => PormG.Functions.Count("resultid"))
 ```
+
+`Q`, `Qor`, `F`, `Exists`, `OuterRef`, `Subquery` and `Interval` are **not** part of this
+library — they are query primitives and stay on the top-level `using PormG` surface.
 """
 module Functions
   import ..QueryBuilder: Sum, Avg, Count, Max, Min, Case, When, Cast, Concat, Extract,

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -197,17 +197,17 @@ end
 # ---
 
 """
-  django_to_string(path::String)
+    django_to_string(path::String) -> Union{String, Nothing}
 
-Reads the content of a Django model file and returns it as a string.
+Read a Django `models.py` and return its text, ready for [`import_models_from_django`](@ref).
 
-# Description
-This function reads the content of a Django model file and returns it as a string. The file path is provided as an argument.
+Single quotes are normalized to double quotes so the Django parser sees one string delimiter.
+A missing file logs a warning and returns `nothing` rather than throwing.
 
-# Example
+```julia
 django_to_string("/home/user/models.py") |> import_models_from_django
-""" 
-
+```
+"""
 function django_to_string(path::String)
   # check if db/models/automatic_models.jl exists
   if !isfile(path)

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -588,7 +588,27 @@ end
 # Public API (makemigrations)
 # ---
 
-# Compare model definitions to the current database schema
+"""
+    get_migration_plan(models, current_schema, conn, settings; interactive = true)
+
+Diff the model definitions against the live database schema and return the DDL that would
+reconcile them, as an `OrderedDict{Symbol, OrderedDict{String, String}}` — model name ⇒
+ordered (human description ⇒ SQL statement). It only *computes* the plan; nothing is written
+or executed. [`makemigrations`](@ref) is the entry point that drives it.
+
+!!! warning "The two schema arguments read backwards"
+    `models` is the **old** schema, reverse-engineered from the database. `current_schema` is
+    the **new** state defined in your `models.jl`. The names predate the current terminology
+    and are kept to avoid churning the planner's unit tests.
+
+An empty `models` means an empty database, so every model becomes a `CREATE TABLE`.
+
+With `interactive = true` (the default) a model with no matching table prompts whether it is
+new or a rename of a table that disappeared, so a rename keeps its data. `interactive = false`
+answers "new table" and "not a rename" for everything — a non-interactive run therefore
+**never renames**, it drops and creates. Choosing a nonexistent option at the prompt raises
+`InvalidMigrationError`.
+"""
 function get_migration_plan(models::Vector{PormGModel}, current_schema::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, conn, settings::PormGSettings; interactive::Bool = true)
 # models is olds models
 
@@ -698,7 +718,31 @@ end
 return migration_plan
 end
 
-# Main function to simulate makemigrations
+"""
+    makemigrations(db::String; interactive = true)
+    makemigrations(connection, settings::PormGSettings; path = "db/models.jl", interactive = true)
+
+Compare your `models.jl` against the live database and **write** the pending migration plan.
+The first form is the one to call: `db` is a connection key from your configuration, e.g.
+`makemigrations("db")`.
+
+It does **not** touch the schema. The generated DDL lands in
+`<db_def_folder>/migrations/pending_migrations.jl` for review; apply it with
+`PormG.Migrations.migrate(db)`.
+
+# Keyword arguments
+- `path`: the models file. Defaults to `<db>/<settings.model_file>` in the `String` form.
+- `interactive`: when `true`, a model with no matching table prompts whether it is a new
+  table or a rename of one that disappeared — a rename preserves the data. `false` answers
+  "new table" for everything and so **never renames**; use it in CI, not on real data.
+
+Returns `nothing`. Logs and returns early — writing no plan — when the connection has
+`change_db: false`. An up-to-date schema logs that no migrations are pending. A missing models
+file raises `MissingConfigurationError`.
+
+See also [`migrate`](@ref), [`get_migration_plan`](@ref), and the
+[Database Migrations in PormG](@ref) guide.
+"""
 function makemigrations(connection::PormGPostgres, settings::PormGSettings; path::String = "db/models.jl", interactive::Bool = true)
 if !settings.change_db
   @warn("Schema changes are disabled (`change_db: false`). Set `change_db: true` in your db/connection.yml under the active environment to allow migrations.")

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -50,7 +50,23 @@ Computes the sum of all values in the column.
 """
 function Sum(x; distinct::Bool = false)
   return FObject(function_name = "SUM", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
-end  
+end
+
+"""
+    Avg(x; distinct::Bool = false)
+
+Aggregate `AVG(x)` — the mean of `x` across the group.
+
+`x` is a field path (`"points"`, `"driverid__surname"`), an `F` expression, or a nested
+function object. With `distinct = true` it renders `AVG(DISTINCT x)`.
+
+Like [`Count`](@ref) and [`Sum`](@ref) — and unlike [`Max`](@ref)/[`Min`](@ref) — `AVG` is
+covered by the to-many fan-out guard (#74): a join that multiplies rows would silently
+inflate the mean, so PormG raises instead. Passing `distinct = true` is an explicit opt-in
+and is exempt.
+
+See also [Filters and Aggregates](@ref).
+"""
 function Avg(x; distinct::Bool = false)
   return FObject(function_name = "AVG", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
 end
@@ -75,9 +91,36 @@ df = query |> DataFrame
 function Count(x; distinct::Bool = false)
   return FObject(function_name = "COUNT", column = x, aggregate = true, kwargs = Dict{String, Any}("distinct" => distinct))
 end
+"""
+    Max(x)
+
+Aggregate `MAX(x)` — the largest value of `x` in the group.
+
+There is **no** `distinct` keyword: `MAX(DISTINCT x)` and `MAX(x)` are the same value.
+
+`MAX`/`MIN` are deliberately exempt from the to-many fan-out guard (#74) that
+[`Count`](@ref), [`Sum`](@ref) and [`Avg`](@ref) trip: duplicating rows across a to-many
+join cannot change an extremum, so the query is safe where a sum would be wrong.
+
+The value comes back in whatever form the backend returns for that column — an aggregate is
+not decoded through the model field's type, so a `MAX` over a `DateField` is the driver's
+representation (a `String` on SQLite), not a `Date`. Convert it yourself if you need one.
+
+See also [`Min`](@ref), [Filters and Aggregates](@ref).
+"""
 function Max(x)
   return FObject(function_name = "MAX", column = x, aggregate = true)
 end
+
+"""
+    Min(x)
+
+Aggregate `MIN(x)` — the smallest value of `x` in the group. The mirror of [`Max`](@ref) in
+every respect: no `distinct` keyword, exempt from the fan-out guard (#74), and the result
+is the backend's own representation rather than the model field's type.
+
+See also [Filters and Aggregates](@ref).
+"""
 function Min(x)
   return FObject(function_name = "MIN", column = x, aggregate = true)
 end
@@ -106,6 +149,45 @@ function _window_order_vector(value)::Vector{WindowOrderPart}
   return parts
 end
 
+"""
+    WindowOver(partition_by, order_by = []; frame = nothing) -> WindowSpec
+    WindowOver(; partition_by = [], order_by = [], frame = nothing) -> WindowSpec
+
+Build the `OVER (...)` clause shared by every window function — this is the constructor you
+want; [`WindowSpec`](@ref) is the value it returns.
+
+# Arguments
+- `partition_by`: restart the window per group. A field path, an `F` expression, or a
+  vector/tuple of them. `Symbol`s are accepted and converted.
+- `order_by`: ordering inside each window. Strings use the repo-wide `"-field"` convention
+  for `DESC`; `SQLOrder` objects also work.
+- `frame`: a raw frame clause such as `"ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"`.
+
+Both list arguments accept a bare scalar, so `partition_by = "raceid"` and
+`partition_by = ["raceid"]` are equivalent. An entry of any other type raises
+`QueryBuildError`.
+
+!!! warning "`frame` is PostgreSQL-only"
+    Passing `frame` on a SQLite connection raises `BackendCapabilityError`. Everything else
+    here works on both backends (SQLite ≥ 3.25.0).
+
+```julia
+using PormG.Functions: WindowOver, Rank
+
+# Rank drivers within each race — the ranking restarts per race.
+query = M.Driver_standings.objects
+query.filter("raceid__@in" => [305, 306], "points__@gt" => 0)
+query.values(
+    "raceid", "driverid__surname", "points",
+    "race_rank" => Rank(over=WindowOver(
+        partition_by=["raceid"],   # restart the ranking for each race
+        order_by=["-points"]       # highest points = rank 1
+    ))
+)
+```
+
+See also [Window Functions](@ref).
+"""
 function WindowOver(partition_by, order_by=WindowOrderPart[]; frame::OptionalString=nothing)
   return WindowSpec(
     partition_by=_window_part_vector(partition_by, "partition_by"),
@@ -117,13 +199,71 @@ function WindowOver(; partition_by=WindowPartitionPart[], order_by=WindowOrderPa
   return WindowOver(partition_by, order_by; frame=frame)
 end
 
+"""
+    Rank(; over::WindowSpec = WindowOver())
+    Rank(over::WindowSpec)
+
+Window `RANK()` — position within the window, **leaving gaps after ties**: two rows tied for
+1st are both `1` and the next row is `3`.
+
+Takes no column; the ordering comes entirely from `over`. Omitting `over` ranks the whole
+result set as one unordered window, which is rarely what you want — pass a
+[`WindowOver`](@ref) with `order_by`. The positional form `Rank(spec)` is shorthand for
+`Rank(over=spec)`.
+
+See also [`DenseRank`](@ref) (no gaps), [`RowNumber`](@ref) (always unique),
+[Window Functions](@ref).
+"""
 Rank(; over::WindowSpec=WindowOver()) = WindowFunction(function_name="RANK", column=nothing, over=over)
 Rank(over::WindowSpec) = Rank(over=over)
+
+"""
+    DenseRank(; over::WindowSpec = WindowOver())
+    DenseRank(over::WindowSpec)
+
+Window `DENSE_RANK()` — like [`Rank`](@ref), but **without gaps after ties**: two rows tied
+for 1st are both `1` and the next row is `2`, not `3`.
+
+Use it when you want "how many distinct values outrank this one", and [`Rank`](@ref) when
+you want a true finishing position.
+
+See also [`RowNumber`](@ref), [Window Functions](@ref).
+"""
 DenseRank(; over::WindowSpec=WindowOver()) = WindowFunction(function_name="DENSE_RANK", column=nothing, over=over)
 DenseRank(over::WindowSpec) = DenseRank(over=over)
+
+"""
+    RowNumber(; over::WindowSpec = WindowOver())
+    RowNumber(over::WindowSpec)
+
+Window `ROW_NUMBER()` — a unique sequential number per row within the window, starting at 1.
+
+Unlike [`Rank`](@ref) and [`DenseRank`](@ref) it never repeats a value, which means tied rows
+get an **arbitrary** order between them. If the numbering has to be reproducible, add a
+tiebreaker column to the `order_by` of the [`WindowOver`](@ref).
+
+See also [Window Functions](@ref).
+"""
 RowNumber(; over::WindowSpec=WindowOver()) = WindowFunction(function_name="ROW_NUMBER", column=nothing, over=over)
 RowNumber(over::WindowSpec) = RowNumber(over=over)
 
+"""
+    Lag(x; offset::Integer = 1, default = nothing, over::WindowSpec = WindowOver())
+
+Window `LAG(x, offset)` — the value of `x` from `offset` rows **earlier** in the window.
+
+# Arguments
+- `x`: the column to read. Required — passing `nothing` raises `QueryBuildError`.
+- `offset`: how many rows back. Must be non-negative; negatives raise `QueryBuildError`
+  (use [`Lead`](@ref) to look forward).
+- `default`: value returned at the window edge where no previous row exists. Omit it and
+  those rows come back `missing`/`NULL`.
+- `over`: the [`WindowOver`](@ref) spec. `order_by` is what makes "earlier" meaningful.
+
+`offset` and `default` are bound as query parameters, not interpolated.
+
+See also [`Lead`](@ref), [Window Functions](@ref).
+"""
 function Lag(x::WindowColumnPart; offset::Integer=1, default=nothing, over::WindowSpec=WindowOver())
   offset < 0 && throw(QueryBuildError("Lag offset must be a non-negative integer"))
   kwargs = Dict{String,Any}("offset" => offset)
@@ -131,6 +271,16 @@ function Lag(x::WindowColumnPart; offset::Integer=1, default=nothing, over::Wind
   return WindowFunction(function_name="LAG", column=x, over=over, kwargs=kwargs)
 end
 
+"""
+    Lead(x; offset::Integer = 1, default = nothing, over::WindowSpec = WindowOver())
+
+Window `LEAD(x, offset)` — the value of `x` from `offset` rows **later** in the window. The
+forward-looking mirror of [`Lag`](@ref); the arguments, the parameter binding, the
+`QueryBuildError` on a negative `offset`, and the `default`-at-the-edge behavior are
+identical.
+
+See also [Window Functions](@ref).
+"""
 function Lead(x::WindowColumnPart; offset::Integer=1, default=nothing, over::WindowSpec=WindowOver())
   offset < 0 && throw(QueryBuildError("Lead offset must be a non-negative integer"))
   kwargs = Dict{String,Any}("offset" => offset)
@@ -138,8 +288,68 @@ function Lead(x::WindowColumnPart; offset::Integer=1, default=nothing, over::Win
   return WindowFunction(function_name="LEAD", column=x, over=over, kwargs=kwargs)
 end
 
+"""
+    FirstValue(x; over::WindowSpec = WindowOver())
+
+Window `FIRST_VALUE(x)` — the value of `x` in the first row of the window frame.
+
+Safe under the default frame (`RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`), because
+the frame always starts at the partition's first row. [`LastValue`](@ref) is **not** — see
+its docstring.
+
+See also [`NthValue`](@ref), [Window Functions](@ref).
+"""
 FirstValue(x::WindowColumnPart; over::WindowSpec=WindowOver()) = WindowFunction(function_name="FIRST_VALUE", column=x, over=over)
+
+"""
+    LastValue(x; over::WindowSpec = WindowOver())
+
+Window `LAST_VALUE(x)` — the value of `x` in the last row of the window frame.
+
+!!! warning "The default frame makes this return the current row"
+    SQL's default frame is `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`, so with an
+    `order_by` and no explicit `frame` the "last visible row" *is* the current row —
+    `LastValue` silently returns each row's own value instead of the partition's last. This
+    is correct SQL, not a PormG bug, and it is the single most common window-function trap.
+
+    Pass an explicit frame to see the whole partition:
+
+    ```julia
+    WindowOver(
+        partition_by = ["constructorid"],
+        order_by     = ["positionorder"],
+        frame = "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING"  # PostgreSQL only
+    )
+    ```
+
+    `frame` is PostgreSQL-only (`BackendCapabilityError` on SQLite). On SQLite, drop the
+    `order_by` so the whole partition is one frame, or compute the value another way.
+
+See also [`FirstValue`](@ref), [Window Functions](@ref).
+"""
 LastValue(x::WindowColumnPart; over::WindowSpec=WindowOver()) = WindowFunction(function_name="LAST_VALUE", column=x, over=over)
+
+"""
+    NthValue(x, n::Integer; over::WindowSpec = WindowOver())
+
+Window `NTH_VALUE(x, n)` — the value of `x` in the `n`-th row of the window frame, counting
+from 1. `n <= 0` raises `QueryBuildError`.
+
+`n` is **positional, not a keyword**, and is rendered as a literal integer in the SQL rather
+than a bound parameter — SQL requires a constant there.
+
+The same frame caveat as [`LastValue`](@ref) applies whenever `n` reaches past the current
+row: under the default frame those rows come back `NULL`.
+
+```julia
+using PormG.Functions: NthValue, WindowOver
+
+"runner_up" => NthValue("driverid__surname", 2,
+    over=WindowOver(partition_by=["raceid"], order_by=["positionorder"]))
+```
+
+See also [`FirstValue`](@ref), [Window Functions](@ref).
+"""
 function NthValue(x::WindowColumnPart, n::Integer; over::WindowSpec=WindowOver())
   n <= 0 && throw(QueryBuildError("NthValue n must be a positive integer"))
   return WindowFunction(function_name="NTH_VALUE", column=x, over=over, kwargs=Dict{String,Any}("n" => n))
@@ -203,6 +413,34 @@ function _make_when(column, then, otherwise)
   return FObject(function_name = "CASE", column = fobj, kwargs = Dict{String, Any}("else" => otherwise, "output_field" => nothing))
 end
 
+"""
+    When(condition; then = 0, otherwise = missing)
+
+One `WHEN condition THEN value` branch of a SQL `CASE`.
+
+`condition` accepts four forms:
+
+- a lookup pair — `When("points__@gt" => 10, then = 1)`
+- a tuple of pairs, ANDed together — `When(("points__@gt" => 10, "grid" => 1), then = 1)`
+- a `Q(...)` / `Qor(...)` object, for OR and nested boolean logic
+- an operator or function object, e.g. an `F` comparison
+
+`then` defaults to `0`. Both `then` and the `CASE` `ELSE` value are bound as query
+parameters.
+
+!!! tip "`otherwise` makes `When` standalone"
+    Passing `otherwise` wraps the branch in a complete `CASE … ELSE … END`, so a two-way
+    conditional needs no [`Case`](@ref) at all:
+
+    ```julia
+    # Points scored, or 0 for a non-points finish — one call, no Case needed.
+    "scored" => When("points__@gt" => 0, then = 1, otherwise = 0)
+    ```
+
+    Inside `Case([...])`, leave `otherwise` unset — `Case` owns the `ELSE` branch.
+
+See also [`Case`](@ref), [Functions and Dates](@ref).
+"""
 function When(x::NTuple{N, <:Pair}; then::Any = 0, otherwise::Any = missing) where N
   return When(Q(x), then = then, otherwise = otherwise)
 end
@@ -215,11 +453,41 @@ end
 function When(x::Union{SQLTypeOper, SQLTypeFunction}; then::Any = 0, otherwise::Any = missing)
   return _make_when(x, then, otherwise)
 end
+"""
+    Case(conditions; default = "NULL", output_field = nothing)
+
+A SQL `CASE … END` expression: evaluate each [`When`](@ref) branch in order and return the
+first match.
+
+# Arguments
+- `conditions`: a `Vector` of `When` branches, or a single bare `When`.
+- `default`: the `ELSE` branch. Defaults to the **string** `"NULL"`, which is emitted as the
+  SQL literal `NULL` — it is not a bound parameter, so pass a Julia value (`0`, `""`) when
+  you want a real default.
+- `output_field`: the result type. Accepts a `PormGField` instance (e.g. `CharField()`, whose
+  `.type` is used) or a raw SQL type string. Renders as a `::type` cast on PostgreSQL and a
+  `CAST(...)` on SQLite.
+
+Usable anywhere a column expression is — in `values()`, nested inside [`Sum`](@ref), as a
+filter right-hand side, and in `.update()`.
+
+```julia
+using PormG.Functions: Case, When
+using PormG.Models: CharField          # field types are not part of PormG.Functions
+
+"podium" => Case([
+    When("positionorder" => 1, then = "win"),
+    When("positionorder__@lte" => 3, then = "podium"),
+], default = "none", output_field = CharField())
+```
+
+See also [`When`](@ref), [Functions and Dates](@ref).
+"""
 function Case(conditions::Vector{N} where N <: SQLTypeFunction; default::Any = "NULL", output_field::Union{N, String, Nothing} where N <: PormGField = nothing)
   if isa(output_field, PormGField)
     output_field = output_field.type
-  end  
-  return FObject(function_name = "CASE", column = conditions, kwargs = Dict{String, Any}("else" => default, "output_field" => output_field)) 
+  end
+  return FObject(function_name = "CASE", column = conditions, kwargs = Dict{String, Any}("else" => default, "output_field" => output_field))
 end
 function Case(conditions::SQLTypeFunction; default::Any = "NULL", output_field::Union{N, String, Nothing} where N <: PormGField = nothing)
   if isa(output_field, PormGField)
@@ -227,6 +495,33 @@ function Case(conditions::SQLTypeFunction; default::Any = "NULL", output_field::
   end  
   return FObject(function_name = "CASE", column = conditions, kwargs = Dict{String, Any}("else" => default, "output_field" => output_field)) 
 end
+"""
+    ToChar(x, format::String; formatter = nothing)
+
+Format a date/time column as text — PostgreSQL `to_char(x, format)`, SQLite `strftime`.
+
+# Arguments
+- `x`: a field path, `F` expression, function object, or a vector of field paths.
+- `format`: a PostgreSQL `to_char` pattern, e.g. `"YYYY-MM"`, `"YYYY-MM-DD"`, `"YYYY"`.
+- `formatter`: an optional Julia-side hook applied to the returned values. Accepts a
+  `Function`, or a `PormGField` whose `.formatter` is used.
+
+!!! warning "SQLite supports only the mapped formats"
+    On SQLite the pattern is translated through PormG's `strftime` map rather than passed
+    through, so only the patterns in that map work. The common date buckets (`"YYYY"`,
+    `"YYYY-MM"`, `"YYYY-MM-DD"`) are portable; exotic `to_char` patterns are PostgreSQL-only.
+
+```julia
+using PormG.Functions: ToChar, Count
+
+# Races per month
+query.values("month" => ToChar("date", "YYYY-MM"), "n" => Count("raceid"))
+```
+
+Named `ToChar` since `0.3.0` (previously `To_char`, with a `formater` keyword).
+
+See also [Functions and Dates](@ref).
+"""
 function ToChar(x::Union{String, SQLTypeField, SQLTypeFunction, SQLTypeF, Vector{String}}, format::String; formatter::Union{Nothing, Function, PormGField} = nothing)
   isa(formatter, PormGField) && (formatter = formatter.formatter)
   return FObject(function_name = "EXTRACT_DATE", column = x, formatter = formatter, kwargs = Dict{String, Any}("format" => format))

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -787,6 +787,25 @@ function Base.deepcopy(f::FObject)
   )
 end
 
+"""
+    WindowSpec <: SQLType
+
+The `OVER (...)` clause of a window function, in structured form.
+
+# Fields
+- `partition_by::Vector` — the grouping the window restarts on. Empty means one window over
+  the whole result set.
+- `order_by::Vector` — the ordering inside each window, stored **as given**: a `"-points"`
+  entry stays `"-points"`, and the `-` prefix is resolved to `DESC` at build time.
+- `frame::Union{String,Nothing}` — an explicit frame clause, or `nothing` for the SQL default
+  (`RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`). PostgreSQL only.
+
+Build one with [`WindowOver`](@ref), which validates and coerces its arguments; the `@kwdef`
+constructor is exported for the rare case where you want to assemble or mutate a spec
+directly. The same spec can be reused across several window functions in one query.
+
+See also [Window Functions](@ref).
+"""
 @kwdef mutable struct WindowSpec <: SQLType
   partition_by::Vector{WindowPartitionPart} = WindowPartitionPart[]
   order_by::Vector{WindowOrderPart} = WindowOrderPart[]

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -49,6 +49,46 @@ _doccov_read(path) = replace(read(path, String), "\r\n" => "\n")
     end
 
     # ─────────────────────────────────────────────────────────────────────────
+    # The same invariant for the submodule surfaces (#274)
+    # `using PormG` does not bring these names into scope, so the loop above never saw them —
+    # yet the docs tell users to reach the function library by `using PormG.Functions`, which
+    # makes it just as public as the top level. #274 closed the gap: Functions 16 missing,
+    # Migrations 12, ConnectionPool 3.
+    #
+    # `PormG.Kernel` is deliberately NOT in this list. Its ~95 exports are almost entirely
+    # constants and type maps (`APP_PATH`, `*_type_map`, `reserved_words`, `CASCADE`, …) that no
+    # user types at the REPL; docstrings on them would be noise in the `@autodocs` dump for no
+    # gain. Only the extension-facing types (`PormGModel`, `PormGField`, `SQLObject`,
+    # `SQLObjectHandler`, `PormGBackend`) are documented, which is partial by design and so
+    # cannot be enforced by an all-or-nothing check.
+    #
+    # `Models`, `QueryBuilder`, `Configuration` and `Utils` are also in `docs/make.jl`'s
+    # `modules` list and the api.md `@autodocs` block but are NOT guarded here — #274 scoped
+    # itself to the three surfaces the docs actively tell users to import. Adding them is a
+    # follow-up, and each needs its own gap measured first.
+    #
+    # Note the one thing this cannot catch: a name can always be made to pass by DELETING its
+    # export rather than documenting it. That is a legitimate fix (it is what #274 did for nine
+    # Migrations internals) but it is a public-surface decision, so the floors below exist to
+    # make a wholesale export cull fail loudly rather than silently satisfy the check.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "submodule exports answer `?`" begin
+        # (module, floor) — the floor is the vacuous-pass guard. `names(M)` on a module whose
+        # export list vanished returns just `[:M]`, which would filter to an empty
+        # `undocumented` and pass while testing nothing. Floors sit just under the real counts
+        # at the time of writing (42 / 24 / 16) so a genuine addition does not trip them.
+        for (mod, floor) in ((PormG.Functions, 40), (PormG.Migrations, 20), (PormG.ConnectionPool, 14))
+            @testset "$(nameof(mod))" begin
+                exported = filter(n -> n !== nameof(mod), names(mod))
+                @test length(exported) >= floor
+
+                undocumented = sort(filter(n -> !Base.Docs.hasdoc(mod, n), exported))
+                @test undocumented == Symbol[]
+            end
+        end
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
     # Fluent-method drift: every getproperty branch is documented
     # Source of truth is the `sym === :name` chain in Base.getproperty(::ObjectHandler). Scanning
     # the text (rather than calling getproperty) keeps this DB-free and catches a method the


### PR DESCRIPTION
Closes #274.

Follow-up to #212, which closed the gap on the top-level surface. This does the submodules.

## Coverage

| Module | Before | After |
| :--- | ---: | ---: |
| `PormG.Functions` | 16 missing / 42 | **0 / 42** |
| `PormG.Migrations` | 12 missing / 33 | **0 / 24** |
| `PormG.ConnectionPool` | 3 missing / 16 | **0 / 16** |
| `PormG.Kernel` | 66 missing / 95 | 5 extension-facing types documented, rest declined |

`checkdocs = :exports` cannot catch any of this — a name with no docstring has no docs object for Documenter to flag — so the guard stays a test. `test/unit/test_docstring_coverage.jl` grows a module loop with vacuous-pass floors (42/24/16 actual against 40/20/14).

`Kernel` is deliberately excluded from the guard: its ~95 exports are almost entirely constants and type maps (`APP_PATH`, `*_type_map`, `reserved_words`, `CASCADE`, …) that nobody types at the REPL, and docstrings on them would be noise in the `@autodocs` dump. Only `PormGModel`, `PormGField`, `SQLObject`, `SQLObjectHandler`, `PormGBackend` are documented — partial by design, so an all-or-nothing check cannot enforce it.

## Beyond the checklist

Three additions that make this useful rather than merely complete:

**`?PormG.Functions` is now a real index.** After a plain `using PormG`, `?Max` answers nothing — #35 keeps the library namespaced on purpose. A docstring alone therefore only helps someone who already knows the name exists. The module docstring now lists all 42 constructors by category with links to their guides, and `docs/src/api.md`'s category block (which had drifted away from its own heading, landing under the `With`/CTE section) is moved back and given the same links.

**Docstrings do not duplicate the guides.** They carry the signature, arguments, and the one non-obvious gotcha, then `@ref` the guide page. `window_functions.md` already documents 10 of the 16 names; a second copy of that prose is precisely how `object`'s method list fell 15 entries behind before #212.

**SQLite's `mode = :write` is documented at all.** It routes every SQLite write and appeared nowhere in `docs/src/`. It is now in `transaction.md`'s manual-checkout section, where someone hand-rolling a lifecycle would actually look.

## Breaking: `PormG.Migrations` un-exports nine internals

Per the issue's "worth deciding whether they should be exported at all": `get_database_schema`, `get_all_models`, `get_all_dicts`, `get_constraints_fk`, `get_constraints_index`, `get_sequence_name`, plus the redundant re-exports of `get_constraints_pk` / `_unique` / `_check` (Kernel generics that Kernel already exports).

Narrow by construction — every call site outside `src/migrations/` was already qualified, none appears in the docs, and `get_sequence_name` had no caller anywhere. `names(PormG)` is unchanged at **63**, and `PormG.get_constraints_check` still resolves via Kernel's export, so the mock method in `test/unit/test_positive_small_integer_check.jl` and the call in `test/integration/common_migration_setup.jl` need no edit. `UPGRADING.md` entry included under `## Unreleased`, no `Project.toml` bump.

## Incidental fixes

- **`django_to_string` already had a docstring** — a blank line and trailing space after the closing `"""` detached it from the definition. That is why it measured as missing; fixed by removing the separator rather than writing a second one.
- **`make.jl`'s "~340 KiB" comment was stale.** Measured: `api.html` renders at 510.7 KiB. `size_threshold` raised 600 → 900 KiB, and `size_threshold_warn` moved 100 → 700 KiB so it signals approach to the ceiling instead of firing on every build.

## Review

An independent review found 10 issues, all fixed. Two were HIGH, and both were **docstring claims of mine that were false** — caught by executing them, not by reading them:

- I claimed `Max`/`Min` results inherit the model field's formatter. They do not: `Max` over a `DateField` returns `"2024-12-08"::String`. The formatter is write-side only (inserts, bulk, bound filter params). The same error had propagated into the `PormGField` docstring.
- I claimed PostgreSQL "ignores" `mode = :write`. It does not — the PG method's kwargs are `[:timeout_seconds, :max_retries]`, so passing `mode` is a `MethodError`. The prose now shows the pool-type branch, and both snippets are verified to run.

Also fixed: a `transaction.md` example that contradicted this PR's own `release_connection` warning, a wrong `WindowSpec.order_by` claim (`"-points"` is stored as given, resolved at build time), an unrunnable unqualified `CharField()`, a run-on markdown block, and two inaccurate comments.

## Verification

| Check | Result |
| :--- | :--- |
| Unit suite | 4747 / 4747, exit 0 |
| Integration (`db_sl`) | 1849 pass, 1 pre-existing `@test_broken`, exit 0 |
| Docstring claims vs live F1 data | 38 / 38 |
| Docs build | exit 0, all `@ref`s resolve |
| `git diff --check` | clean |

Both suites were re-run after the review fixes. Every claim was executed against the preloaded F1 fixture — including the `LastValue` default-frame trap, `Rank`/`DenseRank` tie behavior, `NthValue`'s literal `n`, `frame=` raising `BackendCapabilityError` on SQLite, `When(otherwise=…)` self-wrapping, `ToChar` on SQLite, and the #74 fan-out asymmetry (`Avg` raises `QueryBuildError`; `Max`/`Min` and `distinct=true` are exempt).

## Out of scope — filed separately

Two pre-existing bugs surfaced while auditing the introspection surface. Both are code, not docs, and are untouched here:

- #283 — `Dialect.alter_field` calls `get_constraints_pk` with 2 args when only a 3-arg method exists; the PG drop-primary-key branch raises `MethodError`.
- #284 — `get_constraints_unique` / `get_sequence_name` declare `::String` but `return nothing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
