### PR TITLE
fix(#283, #284): repair the PostgreSQL constraint-DROP branches of alter_field

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,7 +67,14 @@ get_constraints_pk    get_constraints_unique get_constraints_check
 
 The last three are a special case: they are `PormG.Kernel` generics that `Kernel` already exports,
 so `Migrations` was re-exporting a name it did not own. **`PormG.get_constraints_check(...)` and
-friends keep working unchanged** — including extending them with your own method for a mock.
+friends keep resolving as qualified calls** — including extending them with your own method for a
+mock.
+
+> **Amended by #283:** one exception to "unchanged". `get_constraints_pk`'s second parameter was
+> narrowed from `Symbol` to `String`, so a qualified call passing a `Symbol` table name — or a mock
+> method typed `(::MyMock, ::Symbol, ::String)` — no longer dispatches. Pass a `String` instead. It
+> was unreachable through PormG itself (its only caller passed the wrong arity and always raised
+> `MethodError`), which is why it is recorded here rather than as its own entry.
 
 `names(PormG)` is unchanged (63), so nothing that only does `using PormG` is affected.
 

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -884,7 +884,7 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
     if new_field.unique
       push!(sql_statements, """ALTER TABLE "$table_name" ADD UNIQUE ("$field_name");""")
     else
-      contrains = get_constraints_unique(conn, table_name, field_name)
+      contrains = get_constraints_unique(conn, string(table_name), string(field_name))
       if contrains !== nothing
         push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(contrains)";""")
       end
@@ -906,7 +906,7 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
     if new_field.primary_key
       push!(sql_statements, """ALTER TABLE "$table_name" ADD PRIMARY KEY ("$field_name");""")
     else
-      contrains = get_constraints_pk(conn, table_name)
+      contrains = get_constraints_pk(conn, string(table_name), string(field_name))
       if contrains !== nothing
         push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(contrains)";""")
       end

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -522,19 +522,25 @@ function get_secondary_index_ddls(conn::PormGSQLite, table_name::Union{String,Sy
   return ddls
 end
 
-function get_constraints_pk(conn::PormGPostgres, table_name::Symbol, field_name::String )
+# `table_name::String` — NOT Symbol. This was the odd one out of the four `get_constraints_*`
+# helpers, and since `alter_field`'s model-based overload always resolves the table to
+# `model.name |> lowercase` (a String), a Symbol signature could never be dispatched to (#283).
+function get_constraints_pk(conn::PormGPostgres, table_name::String, field_name::String)
+  # Joins carry `table_schema` as well as `constraint_name`: constraint names are unique per
+  # SCHEMA, not per database, so joining on the name alone can splice rows from a same-named
+  # table in another schema and return a constraint that does not exist on the table the DDL
+  # targets. Same shape as get_constraints_check below, which is the exercised sibling. This
+  # query was unreachable until #283 (its only caller passed the wrong arity), so it had never
+  # run to expose the defect.
+  # Filters on `tc.table_name` rather than `ccu.table_name` — `tc` IS the constrained table.
   query = """
-  SELECT
-      tc.constraint_name, kcu.column_name,
-      ccu.table_name AS foreign_table_name,
-      ccu.column_name AS foreign_column_name
-  FROM 
-      information_schema.table_constraints AS tc 
-      JOIN information_schema.key_column_usage AS kcu
-        ON tc.constraint_name = kcu.constraint_name
-      JOIN information_schema.constraint_column_usage AS ccu
-        ON ccu.constraint_name = tc.constraint_name
-  WHERE tc.constraint_type = 'PRIMARY KEY' AND kcu.column_name = '$field_name' AND ccu.table_name = '$table_name';
+  SELECT tc.constraint_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+  WHERE tc.table_name = '$table_name'
+    AND tc.constraint_type = 'PRIMARY KEY'
+    AND kcu.column_name = '$field_name';
   """
   result = fetch(conn, query) |> DataFrame
   if nrow(result) == 0
@@ -543,12 +549,16 @@ function get_constraints_pk(conn::PormGPostgres, table_name::Symbol, field_name:
   return result[1, :constraint_name]
 end
 
-function get_constraints_unique(conn::PormGPostgres, table_name::String, field_name::String)::String
+# Returns `nothing` when no UNIQUE constraint matches — the annotation must admit it, or Julia
+# converts the `return nothing` below and raises instead of letting callers test it (#284).
+function get_constraints_unique(conn::PormGPostgres, table_name::String, field_name::String)::Union{String, Nothing}
+  # `AND tc.table_schema = ccu.table_schema` for the same reason as get_constraints_pk above:
+  # constraint names are unique per schema, so a name-only join can cross schemas (#283 review).
   query = """
   SELECT tc.constraint_name
   FROM information_schema.table_constraints tc
   JOIN information_schema.constraint_column_usage ccu
-  ON tc.constraint_name = ccu.constraint_name
+    ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
   WHERE tc.table_name = '$table_name' AND tc.constraint_type = 'UNIQUE' AND ccu.column_name = '$field_name';
   """
   result = fetch(conn, query) |> DataFrame
@@ -585,7 +595,8 @@ function get_constraints_check(conn::PormGPostgres, table_name::String, field_na
   return result[1, :constraint_name]
 end
 
-function get_sequence_name(conn::PormGPostgres, table_name::String, field_name::String)::String
+# Same empty-result contract as `get_constraints_unique` above (#284).
+function get_sequence_name(conn::PormGPostgres, table_name::String, field_name::String)::Union{String, Nothing}
   query = """
   SELECT pg_get_serial_sequence('$table_name', '$field_name');
   """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ end
     @testset "Schema Importers (key resolution)" include("unit/test_importers.jl")
     @testset "Discard Pending Migration" include("unit/test_discard_pending_migration.jl")
     @testset "Positive Integer Fields CHECK" include("unit/test_positive_small_integer_check.jl")
+    @testset "alter_field Constraint DROPs (#283, #284)" include("unit/test_alter_field_constraint_drops.jl")
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")

--- a/test/unit/test_alter_field_constraint_drops.jl
+++ b/test/unit/test_alter_field_constraint_drops.jl
@@ -1,0 +1,166 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# alter_field constraint-DROP branches: dispatch and empty-result contracts
+# (#283, #284)
+#
+# `alter_field(::PormGPostgres, table_name, field_name, …)` accepts
+# `Union{Symbol,String}` for both names, but the three `get_constraints_*`
+# introspection helpers it calls declared different concrete argument types, and
+# the primary-key branch called one of them with the wrong arity entirely. The
+# result was a `MethodError` on a code path that only fires when a migration
+# DROPS a primary key or a unique constraint — rare enough that no test reached it.
+#
+# Separately, two helpers annotated `::String` while returning `nothing` for
+# "no such constraint", so the empty-result branch raised a conversion error
+# instead of letting the caller's `!== nothing` guard do its job.
+#
+# Pure SQL-shape tests — no live DB. Follows the mock pattern established by
+# test_positive_small_integer_check.jl.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using Test
+using PormG
+using PormG.Models
+using DataFrames
+
+# Mock connection names carry a `283` suffix on purpose: several unit files already
+# define a bare `MockPostgres`, and because runtests.jl includes them all into one
+# session a duplicate name silently redefines the struct for whichever file runs later.
+struct MockPgPkNamed283 <: PormG.PormGPostgres end
+PormG.get_constraints_pk(::MockPgPkNamed283, table_name::String, field_name::String) = "circuits_pkey"
+
+struct MockPgPkNone283 <: PormG.PormGPostgres end
+PormG.get_constraints_pk(::MockPgPkNone283, table_name::String, field_name::String) = nothing
+
+struct MockPgUniqueNamed283 <: PormG.PormGPostgres end
+PormG.get_constraints_unique(::MockPgUniqueNamed283, table_name::String, field_name::String) = "circuits_alt_key"
+
+struct MockPgUniqueNone283 <: PormG.PormGPostgres end
+PormG.get_constraints_unique(::MockPgUniqueNone283, table_name::String, field_name::String) = nothing
+
+# For #284 we exercise the REAL introspection bodies, so the mock intercepts one layer
+# lower: `fetch` (which PormG extends from Base) returns an empty DataFrame, driving the
+# `nrow(result) == 0` branch without a database.
+struct MockPgEmptyResult283 <: PormG.PormGPostgres end
+Base.fetch(::MockPgEmptyResult283, sql::String; kwargs...) = DataFrame()
+
+@testset "alter_field constraint DROP branches (#283, #284)" begin
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # #283 — dropping a PRIMARY KEY.
+  # The branch fires when :primary_key is in colect_not_equal and the new field is
+  # NOT a primary key. Before the fix this raised MethodError: the call passed two
+  # arguments to a three-argument method, and the only method wanted a Symbol table
+  # name while alter_field's own model-based overload always supplies a String.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "drops the primary key by its introspected name" begin
+    new_field = Models.CharField(primary_key = false)
+    old_field = Models.CharField(primary_key = true)
+
+    sql = PormG.Dialect.alter_field(MockPgPkNamed283(), "circuits", "alt",
+                                    new_field, old_field, Symbol[:primary_key])
+
+    # Assert the WHOLE statement, not a fragment: the table name, the constraint name
+    # and the terminating semicolon are all knowable, so a regression in any of them
+    # should fail rather than slip past a substring match.
+    @test sql == "ALTER TABLE \"circuits\" DROP CONSTRAINT \"circuits_pkey\";"
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Discrimination: the other side of the `contrains !== nothing` guard. A table with
+  # no matching primary-key constraint must emit NOTHING, rather than a
+  # `DROP CONSTRAINT "nothing"`. The empty string is the exact contract.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "emits no DROP when no primary-key constraint exists" begin
+    new_field = Models.CharField(primary_key = false)
+    old_field = Models.CharField(primary_key = true)
+
+    sql = PormG.Dialect.alter_field(MockPgPkNone283(), "circuits", "alt",
+                                    new_field, old_field, Symbol[:primary_key])
+
+    @test sql == ""
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Control, not #283 coverage: this branch passed before the fix too. It guards the
+  # OTHER side of the `if new_field.primary_key` split — turning a column INTO a
+  # primary key must ADD one and never consult introspection at all.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "adds a primary key without touching introspection" begin
+    new_field = Models.CharField(primary_key = true)
+    old_field = Models.CharField(primary_key = false)
+
+    # MockPgPkNone283 would return `nothing`; if the ADD path wrongly called
+    # introspection we would still get no DROP, so assert the ADD is present.
+    sql = PormG.Dialect.alter_field(MockPgPkNone283(), "circuits", "alt",
+                                    new_field, old_field, Symbol[:primary_key])
+
+    @test occursin("ADD PRIMARY KEY (\"alt\")", sql)
+    @test !occursin("DROP CONSTRAINT", sql)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # #283 — the real production entry point.
+  # Every `Dialect.alter_field` call site in src/ (planner.jl:264, 367, 464, 544)
+  # goes through the `model::PormGModel` overload, which resolves the table as
+  # `model.name |> lowercase` before delegating here. This exercises that whole
+  # chain rather than the bare 3-arg form, so it pins the path migrations take.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "drops the primary key through the model overload" begin
+    model = Models.Model("circuits", alt = Models.CharField(primary_key = false))
+    new_field = Models.CharField(primary_key = false)
+    old_field = Models.CharField(primary_key = true)
+
+    sql = PormG.Dialect.alter_field(MockPgPkNamed283(), model, "alt",
+                                    new_field, old_field, Symbol[:primary_key])
+
+    @test occursin("ALTER TABLE \"circuits\" DROP CONSTRAINT \"circuits_pkey\";", sql)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # #283 — dropping a UNIQUE constraint: same branch shape, same coercion gap.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "drops a unique constraint by its introspected name" begin
+    new_field = Models.CharField(unique = false)
+    old_field = Models.CharField(unique = true)
+
+    sql = PormG.Dialect.alter_field(MockPgUniqueNamed283(), "circuits", "alt",
+                                    new_field, old_field, Symbol[:unique])
+
+    # Assert the WHOLE statement: a regression that emitted the right constraint name
+    # against the wrong table would still satisfy a fragment match.
+    @test sql == "ALTER TABLE \"circuits\" DROP CONSTRAINT \"circuits_alt_key\";"
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Discrimination for the unique branch: no constraint found means no statement at
+  # all. `alter_field` returns "" here, which is the exact knowable contract.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "emits no DROP when no unique constraint exists" begin
+    new_field = Models.CharField(unique = false)
+    old_field = Models.CharField(unique = true)
+
+    sql = PormG.Dialect.alter_field(MockPgUniqueNone283(), "circuits", "alt",
+                                    new_field, old_field, Symbol[:unique])
+
+    @test sql == ""
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # #284 — the empty-result contract of the introspection helpers themselves.
+  # These call the REAL bodies with `fetch` mocked to return zero rows. With the
+  # `::String` return annotation Julia converts the `return nothing`, so the call
+  # raised `MethodError: Cannot convert an object of type Nothing to ... String`
+  # instead of returning the `nothing` its own caller tests for.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "introspection helpers return nothing on an empty result" begin
+    conn = MockPgEmptyResult283()
+
+    @test PormG.Migrations.get_constraints_unique(conn, "circuits", "alt") === nothing
+    @test PormG.Migrations.get_sequence_name(conn, "circuits", "alt") === nothing
+
+    # The two siblings that were already correct — pinned so the contract stays uniform
+    # across the family rather than being fixed for two of four.
+    @test PormG.Migrations.get_constraints_pk(conn, "circuits", "alt") === nothing
+    @test PormG.Migrations.get_constraints_check(conn, "circuits", "alt") === nothing
+  end
+end


### PR DESCRIPTION
Closes #283. Closes #284.

Both bugs live in the PostgreSQL `alter_field` constraint-DROP branches, ~20 lines apart, in the same helper family — fixing one without the other would have left the adjacent branch broken.

## #283 — the drop-primary-key branch always raised `MethodError`

`src/Dialect.jl:909` called `get_constraints_pk(conn, table_name)` with two arguments against a three-argument method.

Fixing the arity alone was not enough. `get_constraints_pk` declared `table_name::Symbol` while its three siblings declared `String`, and `alter_field`'s model overload (`Dialect.jl:956`) always resolves the table to `model.name |> lowercase` — a String — so the `Symbol` signature was **undispatchable by construction**. Normalized it to `String` and coerced at both call sites, mirroring the already-correct `get_constraints_check` call 50 lines above at `Dialect.jl:836`.

`get_constraints_fk` and `get_constraints_index` deliberately keep `::Symbol`: their only callers (`planner.jl:99, 114, 381`) pass `model_name`, which the planner builds already-lowercased as a Symbol, so they dispatch correctly today. Checked rather than assumed.

## #284 — `::String` annotation on a function that returns `nothing`

`get_constraints_unique` and `get_sequence_name` were annotated `::String` but `return nothing` for "no such constraint". Julia applies the annotation as a `convert`, so the empty-result branch raised instead of returning the `nothing` the caller explicitly tests for at `Dialect.jl:888`.

Concretely: a migration dropping an already-absent unique constraint **crashed** rather than skipping the DROP. Both widened to `Union{String, Nothing}`, matching the two siblings that were already correct.

## Found in review: a cross-schema join defect

This one only started to matter once #283 made the query executable for the first time in the repo's history.

`get_constraints_pk` and `get_constraints_unique` joined `information_schema` on `constraint_name` **alone**. Constraint names are unique per *schema*, not per database — and `get_database_schema` pins the model set to `public` while these lookups scanned every schema the role can see. With the same table name in two schemas the join could surface another schema's constraint name, and with no `ORDER BY`, `result[1, :constraint_name]` picked arbitrarily. The emitted `DROP CONSTRAINT "<wrong name>"` would then abort the migration.

Both now join on `table_schema` too — the shape `get_constraints_check` already used and the one query in the family that gets exercised. `get_constraints_pk` additionally now filters `tc.table_name` rather than `ccu.table_name` (`tc` *is* the constrained table) and drops the vestigial `foreign_table_name` / `foreign_column_name` aliases left over from the FK query it was cloned from.

## Tests

DB-free, following the mock pattern in `test_positive_small_integer_check.jl`. #284 is covered by mocking `Base.fetch` to return an empty `DataFrame` and calling the **real** introspection bodies, so it pins actual behavior rather than a stub.

Verified as a genuine regression guard rather than green theater: rebuilt against the unfixed `src/`, the file reports **8 errors**, and the only pre-fix passes are the ADD-primary-key control and `get_constraints_check` (already correct). Assertions compare the whole `ALTER TABLE … DROP CONSTRAINT …;` statement and the exact `""` for the no-constraint branches, so a regression in the table name or a branch that silently stops emitting cannot slip past a substring match.

Mock type names carry a `283` suffix because a bare `MockPostgres` is already defined in four active unit files that runtests.jl includes into one shared session.

## `UPGRADING.md`

No new entry — this fixes paths that never worked. But #274's entry, in the same unreleased wave, promised these names "keep working unchanged, including extending them with your own method for a mock", and narrowing `get_constraints_pk` from `Symbol` to `String` breaks that for anyone with a `(::MyMock, ::Symbol, ::String)` method. That entry is amended in place with the exception rather than duplicating it as a new one.

## Verification

| Check | Result |
| :--- | :--- |
| Unit suite | 4815 / 4815, exit 0 |
| Integration (`db_sl`) | 1854 pass, 1 pre-existing `@test_broken`, exit 0 |
| `git diff --check` | clean |

**What is not verified:** the new `information_schema` predicates were not executed. Every changed method dispatches on `::PormGPostgres`, so neither suite reaches them — SQLite has no DROP CONSTRAINT path at all (it rebuilds the table). The corrected joins are reasoned from the sibling query that *is* exercised, not measured. A `db_2` run against real PostgreSQL is the outstanding check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
