### PR TITLE
docs(#281): stop publishing internal mutator docstrings as public API

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -120,6 +120,23 @@ ways, and the choice is forced by whether the method takes keywords:
 So adding a keyword to a `ChainCaller`-backed method means **converting it to a closure**; leaving it
 as a `ChainCaller` makes the keyword throw. Coverage: `test/unit/test_fluent_parity_208.jl`.
 
+**A `ChainCaller`-backed helper carries no docstring.** `docs/src/api.md` builds `@autodocs` over the
+whole `QueryBuilder` module with **no `Private` key**, so Documenter's `Private = true` default
+publishes *any* docstring in the module as a public API heading — for a function no user can name.
+Three had drifted in (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280.
+Put the contract on the `object` docstring's `.method(...)` bullet and use a `#` comment on the
+helper. `test_docstring_coverage.jl` enforces it, scoped to the `ChainCaller(helper, q)` branches —
+widening it to every `sym === :name` branch is not possible, because the closure branches route to
+`first`/`last`/`get`/`deepcopy`, whose bindings resolve to `Base` and are documented there.
+
+**That guard covers the ChainCaller set only — it is not the whole leak.** 41 documented
+QueryBuilder-owned bindings are exported from neither `QueryBuilder` nor `PormG`, and `@autodocs`
+publishes every one (`_solve_field`, `get_filter_query`, `set_context!`, `quote_identifier`,
+`CTEDict`, …). Do not assume a docstring you add to an internal here stays private just because the
+guard is green. Closing the rest needs a deliberate call rather than a flag flip: those same 41 also
+include `delete`, `list`, `earliest`, `latest`, `cjoin`, `save` and `ObjectHandler`, which are
+genuinely user-facing, so `Private = false` would delete real documentation.
+
 New fluent method? `test/unit/test_docstring_coverage.jl` scans the `sym === :name` branches and
 requires each one documented in **both** the `object` docstring and `docs/src/api.md`.
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -16,7 +16,7 @@ flowchart TD
 
   subgraph API["Public API"]
     OBJ["object(model) → ObjectHandler<br/>wraps SQLObjectQuery (query state)<br/>querybuilder/types.jl"]
-    CHAIN["fluent methods: filter! / values!<br/>order_by! / annotate! / with! ...<br/>querybuilder/object_manager.jl"]
+    CHAIN["fluent methods: .filter() / .values()<br/>.order_by() / .limit() / .with() ...<br/>querybuilder/object_manager.jl"]
   end
 
   subgraph QB["QueryBuilder — src/querybuilder/"]

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -1812,25 +1812,33 @@ import .models as M
 result = run_in_transaction(pool) do
   driver_query = M.Driver |> object
   new_driver = driver_query.create(
+    "driverref" => "alice_lane",
+    "code" => "ALA",
     "forename" => "Alice",
     "surname" => "Lane",
+    "dob" => "1998-04-12",
     "nationality" => "British",
-    "driverref" => "alice_lane"
+    "url" => "https://example.com/alice_lane"
   )
 
   race_query = M.Race |> object
   race_query.create(
     "year" => 2025,
     "round" => 1,
+    "circuitid" => 1,
     "name" => "Gran Turismo",
-    "circuitid" => 1
+    "date" => "2025-03-16",
+    "url" => "https://example.com/gran_turismo"
   )
 
-  # Keep counting or aggregate inside the transaction if needed
-  driver_count = driver_query |> do_count
+  # Keep counting or aggregating inside the transaction if needed
+  driver_count = driver_query.count()
   return (new_driver[:driverid], driver_count)
 end
 ```
+
+Every column above is one the F1 models declare `null = false`; omitting any of them raises at
+`create()` before the statement is built.
 """
 function run_in_transaction(f::Function, pool::Union{PormGPostgres, PormGSQLite})
   # Reentrancy (#26): a nested run_in_transaction / atomic on the SAME pool becomes a

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -16,12 +16,13 @@ function _up_values(str::String)
   end
 end
 
-"""
-  up_values!(q::SQLObject, values)
-
-Set the query projection. Each `.values(...)` call **replaces** the previous one
-(last-call-wins, Django parity, #199) — unlike `.filter(...)`, which accumulates.
-"""
+# Backs `query.values(...)` through ChainCaller. Each call RESETS `q.values` — last-call-wins,
+# Django parity (#199) — unlike `up_filter!`, which accumulates.
+#
+# No docstring on purpose (#281): `docs/src/api.md` builds `@autodocs` over the whole QueryBuilder
+# module with no `Private` key, so Documenter's `Private = true` default publishes any docstring
+# here as a public API heading — for a function no user can name. The user-facing contract lives on
+# the `object` docstring's `.values(...)` bullet; `test_docstring_coverage.jl` enforces both halves.
 function up_values!(q::SQLObject, values)
   # every call of values, reset the values
   q.values = []
@@ -211,15 +212,12 @@ function up_get_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::
   return _get_or_create(q; target_fields = lookup_keys, show_query = show_query)
 end
 
-"""
-  up_filter!(q::SQLObject, filter)
-  Add filters to the SQLObject query.
-# Arguments
-- `q::SQLObject`: The SQL object to add filters to.
-- `filter`: A collection of filters to add. Each filter can be a `Pair`, `SQLTypeQ`, `SQLTypeQor`, `SQLTypeOper`, or `SQLTypeF`.
-# Returns
-- The modified SQLObject with the new filters added.
-"""
+# Backs `query.filter(...)` through ChainCaller. Each element of the packed tuple may be a `Pair` or
+# any `FilterType` — `SQLTypeQ`, `SQLTypeQor`, `SQLTypeOper`, `SQLTypeF`, `ExistsObject` (types.jl).
+# Calls ACCUMULATE (ANDed) — unlike `up_values!`/`order_by!`, which replace.
+#
+# No docstring on purpose (#281) — see the note on `up_values!` above. The accepted argument kinds
+# are documented on the `object` docstring's `.filter(...)` bullet.
 function up_filter!(q::SQLObject, filter)
   for v in filter
     if isa(v, FilterType)
@@ -300,13 +298,12 @@ function _query_select(array::Vector{SQLTypeField}, connection)
 end
 
 
-"""
-  order_by!(q::SQLObject, values)
-
-Set the query ordering. Each `.order_by(...)` call **replaces** the previous one
-(last-call-wins, matching Django's "each order_by() call clears previous ordering",
-#199) — unlike `.filter(...)`, which accumulates.
-"""
+# Backs `query.order_by(...)` through ChainCaller. Each call RESETS `q.order` — last-call-wins,
+# matching Django's "each order_by() call clears previous ordering" (#199) — unlike `up_filter!`,
+# which accumulates.
+#
+# No docstring on purpose (#281) — see the note on `up_values!` above. The user-facing contract
+# lives on the `object` docstring's `.order_by(...)` bullet.
 function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} where N)
   q.order = [] # every call of order_by, reset the order
   for v in values
@@ -342,6 +339,14 @@ struct ChainCaller{F,T}
   handler::T
 end
 
+# The fluent name the CALLER typed, recovered from the internal helper behind it: `up_filter!` →
+# "filter", `order_by!` → "order_by", `page!` → "page". Without this the kwarg error below could
+# only say "here", leaving the user to find which link of a long chain it meant (#281). The `up_`
+# alternative is what made #280 decline this — `nameof` alone yields `up_filter`, an internal
+# spelling that appears nowhere in the caller's code. Stripping both markers covers every current
+# helper, and the leading `_` branch keeps it correct if the internals are ever `_`-prefixed.
+_fluent_name(f) = replace(string(nameof(f)), r"^(up_|_)" => "", r"!$" => "")
+
 # When called (e.g., query.filter(...)), it executes and returns the handler itself.
 #
 # `kwargs...` is slurped only to REJECT it. Without it a keyword call dies on this functor with a
@@ -353,7 +358,7 @@ end
 # positional tuple, so a keyword has nowhere to go and must fail loudly rather than obscurely.
 function (c::ChainCaller)(args...; kwargs...)
   isempty(kwargs) || throw(QueryBuildError(
-    "Keyword arguments are not accepted here: $(join(keys(kwargs), ", ")). The chainable query methods take positional arguments only — e.g. page(20, 40), limit(20), order_by(\"-points\")."))
+    "Keyword arguments are not accepted by $(_fluent_name(c.func))() — got: $(join(keys(kwargs), ", ")). The chainable query methods take positional arguments only — e.g. page(20, 40), limit(20), order_by(\"-points\")."))
   c.func(c.handler.object, args)
   return c.handler
 end

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -1165,10 +1165,13 @@ the [API reference](api.md)) is where to look them up.
 
 Each mutates the handler and returns it, so calls can be chained or accumulated on a variable.
 
-- `.filter(pairs...)` — add `WHERE` conditions. Repeated calls **accumulate** (ANDed), unlike
-  `.values`/`.order_by`, which replace their previous call (#199)
-- `.values(fields...)` — choose/annotate the selected columns; `"*"` selects the main table
-- `.order_by(fields...)` — sort; prefix `-` for descending
+- `.filter(pairs...)` — add `WHERE` conditions. Each argument may be a `Pair`, a `Q`/`Qor`, an
+  operator expression, an `F` expression, or an `Exists(subquery)`. Repeated calls **accumulate**
+  (ANDed), unlike `.values`/`.order_by`, which replace their previous call (#199)
+- `.values(fields...)` — choose/annotate the selected columns; `"*"` selects the main table.
+  **Replaces** its previous call, last-call-wins (#199)
+- `.order_by(fields...)` — sort; prefix `-` for descending. **Replaces** its previous call, matching
+  Django's *each `order_by()` clears previous ordering* (#199)
 - `.limit(n)` / `.offset(n)` — pagination, one clause each
 - `.page(limit)` / `.page(limit, offset)` — pagination in one call; `.page(n)` sets the limit only
   and leaves any offset already on the handler in place. Those are the only two arities — anything

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -30,6 +30,22 @@ const DOCCOV_API_MD = joinpath(DOCCOV_REPO_ROOT, "docs", "src", "api.md")
 # #228). Normalize before matching or every assertion below becomes platform-dependent.
 _doccov_read(path) = replace(read(path, String), "\r\n" => "\n")
 
+# Isolate the body of `Base.getproperty(q::ObjectHandler, …)` — shared by the two scans below.
+# The file holds a SECOND getproperty (on `Models.Model_Type`, for `.objects`) whose branches are
+# not fluent query methods, so a whole-file scan would demand docs for `:objects` and fail wrongly.
+# The `"\nend\n"` stop works only because every nested `end` inside the chain is indented.
+# Returns "" when either anchor is missing, so the callers' floors turn a broken scan into a
+# failure instead of a vacuous pass.
+function _doccov_getproperty_body()
+    source = _doccov_read(DOCCOV_OBJECT_MANAGER)
+    start_idx = findfirst("function Base.getproperty(q::ObjectHandler", source)
+    start_idx === nothing && return ""
+    rest = source[first(start_idx):end]
+    stop_idx = findfirst("\nend\n", rest)
+    stop_idx === nothing && return ""
+    return rest[1:first(stop_idx)]
+end
+
 @testset "Docstring coverage (#212)" begin
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -95,17 +111,8 @@ _doccov_read(path) = replace(read(path, String), "\r\n" => "\n")
     # moment it is added, before anyone can execute it.
     # ─────────────────────────────────────────────────────────────────────────
     @testset "fluent methods are documented on `object` and in api.md" begin
-        source = _doccov_read(DOCCOV_OBJECT_MANAGER)
-
-        # Isolate Base.getproperty(q::ObjectHandler, …). The file holds a SECOND getproperty (on
-        # Models.Model_Type, for `.objects`) whose branches are not fluent query methods, so a
-        # whole-file scan would demand docs for `:objects` and fail wrongly.
-        start_idx = findfirst("function Base.getproperty(q::ObjectHandler", source)
-        @test start_idx !== nothing
-        rest = source[first(start_idx):end]
-        stop_idx = findfirst("\nend\n", rest)
-        @test stop_idx !== nothing
-        body = rest[1:first(stop_idx)]
+        body = _doccov_getproperty_body()
+        @test !isempty(body)
 
         fluent = unique([m.captures[1] for m in eachmatch(r"sym === :(\w+)", body)])
         # Sanity floor: the chain had 29 branches at the time of writing. A regex that silently
@@ -139,5 +146,71 @@ _doccov_read(path) = replace(read(path, String), "\r\n" => "\n")
     # ─────────────────────────────────────────────────────────────────────────
     @testset "ChainCaller carries no docstring" begin
         @test !Base.Docs.hasdoc(PormG.QueryBuilder, :ChainCaller)
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # …and neither do the helpers it dispatches to (#281)
+    # `api.md`'s `@autodocs` block sets no `Private` key, so Documenter's `Private = true` default
+    # publishes EVERY docstring in `PormG.QueryBuilder` as a public API heading. A docstring on
+    # `up_filter!` therefore ships a heading for a function no user can name — the same defect the
+    # ChainCaller guard above exists to prevent, one level down. Three had drifted in
+    # (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280.
+    #
+    # SCOPED TO `ChainCaller(helper, q)` BRANCHES ON PURPOSE — do not "fix" this by widening it to
+    # every `sym === :name` branch. That rule is not satisfiable: the closure branches route to
+    # `first`/`last`/`get`/`deepcopy`, whose bindings resolve to **Base**, so `hasdoc` is
+    # permanently true for them; and to `delete`/`earliest`/`latest`/`list`/`inspect_query`/
+    # `cjoin`/`With`, which are legitimately documented. The ChainCaller set is exactly the set
+    # with no user-facing binding to attach docs to.
+    #
+    # This is NOT the whole leak. 41 documented QueryBuilder-owned bindings are exported from
+    # neither `QueryBuilder` nor `PormG`, and `@autodocs` publishes every one of them
+    # (`_solve_field`, `get_filter_query`, `set_context!`, `quote_identifier`, `CTEDict`, …).
+    # Closing that needs a deliberate call, not a flag flip: the same 41 also contains `delete`,
+    # `list`, `earliest`, `latest`, `cjoin`, `save` and `ObjectHandler`, which are genuinely
+    # user-facing, so `Private = false` would drop real documentation. Tracked separately.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "ChainCaller-backed helpers carry no docstring (#281)" begin
+        body = _doccov_getproperty_body()
+        @test !isempty(body)
+
+        # `sym === :name` → any comment/blank lines → `return ChainCaller(helper, q)`.
+        # Comment-tolerant deliberately: `:select_for_update` already carries two comment lines
+        # between its `elseif` and its `return`, so a strict two-line pattern would silently stop
+        # matching the first time someone annotates a ChainCaller branch.
+        pattern = r"sym === :\w+\s*\n(?:[ \t]*#[^\n]*\n|[ \t]*\n)*[ \t]*return ChainCaller\((\w+!?), q\)"
+        matches = collect(eachmatch(pattern, body))
+        helpers = unique([m.captures[1] for m in matches])
+
+        # Guard the guard, two ways. The equality is self-calibrating — it proves the regex matched
+        # EVERY ChainCaller construction rather than a lucky subset, without hard-coding a count
+        # that a legitimate new method would have to bump. The floor catches both regexes failing
+        # together, which equality alone would report as a vacuous pass.
+        #
+        # Count over a COMMENT-STRIPPED copy, and keep the count regex shape-agnostic. Both halves
+        # are load-bearing, and the obvious simplifications each break one:
+        #   - stripping comments stops a mere mention of `ChainCaller(...)` — this file's own header
+        #     has one, and object_manager.jl is heavily commented — inflating the count into a bogus
+        #     "8 == 9" that reads like a missing branch.
+        #   - the count must NOT be anchored to `return ChainCaller(` the way `pattern` is. Sharing
+        #     a lexical shape makes both regexes blind to the same thing, so a construction written
+        #     any other way (`sym === :x; return ChainCaller(…)` on one line, or assigned to a local
+        #     first) passes silently — which is exactly the leak this guard exists to catch.
+        #   - compare `matches`, not `helpers`: two branches legitimately routing to one helper
+        #     (an alias) would otherwise fail as "7 == 8". `unique` matters only for the doc loop.
+        code = replace(body, r"^[ \t]*#[^\n]*$"m => "")
+        n_constructions = length(collect(eachmatch(r"ChainCaller\(", code)))
+        @test length(matches) == n_constructions
+        @test n_constructions >= 8
+
+        # `hasdoc` alone is NOT enough: it resolves the binding through to its defining module, so
+        # it returns true for anything named after a documented `Base` function. Require the
+        # docstring to be owned by QueryBuilder before calling it a leak.
+        documented = filter(helpers) do name
+            sym = Symbol(name)
+            Base.Docs.hasdoc(PormG.QueryBuilder, sym) &&
+                Base.Docs.Binding(PormG.QueryBuilder, sym).mod === PormG.QueryBuilder
+        end
+        @test documented == String[]
     end
 end

--- a/test/unit/test_fluent_parity_208.jl
+++ b/test/unit/test_fluent_parity_208.jl
@@ -269,8 +269,23 @@ end
   # `occursin("limit") && occursin("offset")` would have passed before and after the fix.
   # Keys follow call order, so this is deterministic.
   msg = _p208_error(() -> qk.page(limit = 20, offset = 40))
-  @test occursin("here: limit, offset", msg)
+  @test occursin("got: limit, offset", msg)
   @test occursin("positional", msg)
+
+  # …and it names the method the CALLER typed, recovered from the internal helper (#281). Before
+  # this the message could only say "here", leaving the user to find which link of a long chain it
+  # meant. Cover both prefix shapes: `.filter`/`.values` go through `up_*!` helpers, `.order_by`
+  # and `.page` do not — a strip that handled only one would pass on half the family.
+  @test occursin("page()", _p208_error(() -> qk.page(limit = 20)))
+  @test occursin("filter()", _p208_error(() -> qk.filter(code = "HAM")))
+  @test occursin("values()", _p208_error(() -> qk.values(fields = "code")))
+  @test occursin("order_by()", _p208_error(() -> qk.order_by(field = "points")))
+  # The internal spelling must NOT leak — that is the whole point (`up_filter`, `filter!`).
+  # Match the exact internal spellings, not a bare "!": punctuation added to the sentence later
+  # would fail that without anything being wrong.
+  fmsg = _p208_error(() -> qk.filter(code = "HAM"))
+  @test !occursin("up_", fmsg)
+  @test !occursin("filter!", fmsg)
 
   # Rejected before the mutator runs: nothing is half-applied.
   @test qk.object.limit == 0


### PR DESCRIPTION
Part 1 of #281 (does not close it — see *Scope* below).

## The bug

`docs/src/api.md` ends with an `@autodocs` block over nine modules with **no `Private` key**, so Documenter's `Private = true` default applies: every docstring in those modules becomes a heading on the public API reference. Three `ChainCaller`-backed mutators carried docstrings — `up_filter!`, `up_values!`, `order_by!` — and were therefore published as public API for functions no user can name. The internal `page` had the same problem until #280 deleted its docstring for exactly this reason.

Verified against a real build: the three headings are gone from `docs/build/api.html`, while `object`, `cjoin` and `inspect_query` remain.

## What's in here

- **The three docstrings are deleted**, each replaced with a `#` comment stating why, so they are not re-added.
- **Their user-facing content moves to the `object` docstring** — the one that declares itself *"the fluent-API reference"*. The `.filter` bullet now names every accepted argument shape **including `Exists(subquery)`**, which the deleted internal docstring had omitted; promoting an incomplete list into the authoritative reference would have been a regression.
- **A guard** in `test_docstring_coverage.jl`, scoped to the `ChainCaller(helper, q)` branches. Widening it to every `sym === :name` branch is *not satisfiable*: the closure branches route to `first`/`last`/`get`/`deepcopy`, whose bindings resolve to `Base` (so `hasdoc` is permanently true), and to `delete`/`earliest`/`latest`/`list`/`cjoin`/`With`, which are legitimately documented. The comment says so, to stop someone "fixing" the narrowness later.
- **The `ChainCaller` kwarg error names the method the user typed.** `.page(limit = 20)` now reports `page()` rather than a generic "here". #280 declined this because `nameof(c.func)` yields `up_filter` — stripping the `up_` prefix resolves all eight helpers, so it needs no rename.

## Two pre-existing doc defects fixed while here

- `docs/src/architecture.md` labelled the mutators `filter! / values! / order_by! / annotate! / with!` — three of those five **do not exist**. Now uses the user-facing fluent spellings, which cannot drift.
- The `run_in_transaction` docstring example called the un-exported `do_count` **and** omitted 3 of `Driver`'s 7 non-null fields and 2 of `Race`'s 6, so it could not have run against any schema. Only executing it revealed that. The example is now the version actually run against `db_sl/f1.sqlite`, inside a transaction that rolls back.

## Verification

- Unit **4829/4829**; Documenter build exit 0
- **The guard is mutation-tested in both directions** — a re-added docstring on a ChainCaller helper makes it fail; a comment merely *mentioning* `ChainCaller(...)` does not
- The doc example was executed against the live SQLite fixture and cross-checked (`count()` agreed with an independent recount; rollback left 0 rows)
- Two rounds of independent review; every finding fixed

## Scope — #281 stays open

This closes the leak for 8 helpers. **41** documented QueryBuilder-owned bindings are exported from neither `QueryBuilder` nor `PormG` and are all published today. That residue is **not** a flag flip away: the same 41 include `delete`, `list`, `earliest`, `latest`, `cjoin`, `save` and `ObjectHandler`, which are genuinely user-facing, so `Private = false` would delete real documentation. Tracked in #289 with four options.

#281's remaining box — `_`-prefixing the fluent internals — is also still open, and deliberately so: its stated payoff was the kwarg-error improvement, which shipped here without any rename, leaving that decision on consistency grounds alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
