### PR TITLE
fix(#287): reject contradictory on_delete declarations, remove the SET sentinel

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,84 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Contradictory `on_delete` declarations now raise, and the `SET` sentinel is gone (#287)
+
+- **Version**: Unreleased
+- **PormG ref**: #287; `src/constants.jl`, `src/Kernel.jl`, `src/Models.jl`, `src/QueryBuilder.jl`,
+  `src/models/fields.jl`, `src/querybuilder/deletion.jl`
+- **Recorded**: 2026-08-01
+- **Severity**: **breaking (raises where it previously warned or silently continued)** — narrow: it
+  affects only models whose `on_delete` declaration was already self-contradictory or used the
+  unimplemented `SET`. Part of the `0.3.x` pre-publish wave.
+
+### What changed
+
+Three `on_delete` states that used to be accepted, and then misbehaved later, are now rejected at the
+earliest point they can be detected.
+
+**1. `SET` is removed.** It was exported and accepted but no branch of the deletion collector
+implemented it, and the DDL renderer emitted the syntactically invalid `ON DELETE SET`. It could not
+be implemented coherently: Django's `SET(value)` carries a value or callable, and PormG's `on_delete`
+is a bare sentinel with nowhere to put one.
+
+Removing it also removes the `contains(on_delete, "SET")` fallback that produced it, which had been
+swallowing near-miss typos — `"SET-NULL"`, `"SETNULL"` and Django's `models.SET(fn)` all became `SET`
+silently. Those now raise `FieldValidationError` at field construction, with `models.SET(...)` getting
+a message that names it specifically.
+
+**2. `SET_NULL` on a `null=false` field** and **3. `SET_DEFAULT` with no `default`** now raise
+`ModelDefinitionError` from `set_models` at registration. Both checks already existed there as
+`@error` logs: they printed the problem and let the model through, so the contradiction resurfaced
+later as a database constraint violation, or — for `SET_DEFAULT` — as a silent `UPDATE … SET col =
+NULL`, i.e. `SET_DEFAULT` quietly behaving as `SET_NULL`. The deletion collector keeps its own copy of
+both guards for models that never pass through `set_models`.
+
+The throw is only reachable from `set_models`, and the migration planner deliberately does not call it
+(`src/migrations/planner.jl` loads models into a throwaway module), so `makemigrations` / `migrate` are
+unaffected.
+
+**Generated model files are affected, though.** Django's `on_delete=models.SET_DEFAULT, default=None`
+on a nullable FK used to import verbatim as `SET_DEFAULT` with no default — a shape that now fails at
+registration, so the generated file would not load and regenerating produced the identical broken file.
+The importer translates it to `SET_NULL` (which is what Django's combination denotes) and warns. If you
+import from a database rather than from Django, check any FK the introspector renders as
+`on_delete=SET_DEFAULT`: it does not carry the column default through, so you may need to add a
+`default=` by hand before the generated module will register.
+
+### How to find the calls to migrate
+
+```bash
+# 1. the removed sentinel, and any string that used to fall through to it.
+# Over-matches slightly: it also lists the still-valid "SET NULL" / "SET DEFAULT" spellings, so
+# read the hits rather than assuming every one needs an edit.
+rg -n 'on_delete\s*=\s*("?SET"?[,)\s]|"[^"]*SET\()' --glob '!*.md'
+
+# 2. SET_NULL fields that are not nullable
+rg -n -U 'ForeignKey\([^)]*SET_NULL[^)]*null\s*=\s*false' --glob '*.jl'
+
+# 3. SET_DEFAULT fields — check each one actually declares a default=
+rg -n 'on_delete\s*=\s*"?SET_DEFAULT' --glob '*.jl'
+```
+
+### Before → after
+
+```julia
+# before — all three were accepted and then misbehaved later
+parent = Models.ForeignKey(Team,   pk_field = "id",       on_delete = "SET",         null = true)
+driver = Models.ForeignKey(Driver, pk_field = "driverid", on_delete = "SET_NULL",    null = false)
+status = Models.ForeignKey(Status, pk_field = "statusid", on_delete = "SET_DEFAULT", null = true)
+
+# after — SET has no replacement, so pick the action you actually meant;
+#         SET_NULL needs a nullable column; SET_DEFAULT needs something to set
+parent = Models.ForeignKey(Team,   pk_field = "id",       on_delete = "SET_NULL",    null = true)
+driver = Models.ForeignKey(Driver, pk_field = "driverid", on_delete = "SET_NULL",    null = true)
+status = Models.ForeignKey(Status, pk_field = "statusid", on_delete = "SET_DEFAULT", null = true, default = 1)
+```
+
+If a model trips check 2 or 3 at `set_models`, the message names the model and field.
+
+---
+
 ## `PormG.Migrations` no longer exports its schema-introspection helpers (#274)
 
 - **Version**: Unreleased

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -830,9 +830,15 @@ Team_radio = Models.Model(
 - `CASCADE`: Delete this record when target is deleted
 - `RESTRICT`: Prevent deletion of target if this record exists
 - `SET_NULL`: Set field to NULL (requires `null=true`)
-- `SET_DEFAULT`: Set to default value
+- `SET_DEFAULT`: Set to the field's default value (requires `default=`)
 - `PROTECT`: Raise error to prevent deletion
 - `DO_NOTHING`: No action (may cause integrity errors)
+
+Omitting `on_delete` is also valid and is the default — PormG then emits no statement for the
+relation and the column renders `ON DELETE NO ACTION`, so the dependent row is **not** cascaded.
+
+The two "requires" above are enforced, not advisory: registering a model with `SET_NULL` on a
+`null=false` field, or `SET_DEFAULT` with no `default`, raises `ModelDefinitionError`.
 
 ### OneToOneField(to_model)
 

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -136,7 +136,8 @@ WHERE "Tb"."raceid" IN (
 
 ## Cascade Deletion
 
-If your models are configured with `on_delete="CASCADE"` (the default for `ForeignKey` fields), PormG or the database (depending on the adapter) will automatically remove related records to maintain integrity.
+A `ForeignKey` declared `on_delete="CASCADE"` makes PormG's deletion collector remove the related
+records too, in dependency order and inside the same transaction.
 
 ```julia
 # This will also delete related Result records if they reference this Race
@@ -145,11 +146,33 @@ query.filter("name" => "Cancelled Grand Prix")
 delete(query)
 ```
 
+!!! warning "`CASCADE` is **not** the default — an unset `on_delete` cascades nothing"
+    Omitting `on_delete` leaves it unset, which is a distinct state from `CASCADE`. PormG emits no
+    statement for that relation, and the column renders `ON DELETE NO ACTION` in DDL. What happens
+    when you delete the parent then depends entirely on the backend:
+
+    | Backend | Deleting a parent whose child FK has an unset `on_delete` |
+    |---|---|
+    | PostgreSQL | `NO ACTION` is enforced — the delete fails with a foreign-key violation |
+    | SQLite | the delete succeeds and **silently leaves the child orphaned** |
+
+    Declare the behaviour you want explicitly on every `ForeignKey`.
+
+!!! warning "SQLite does not enforce foreign keys at all"
+    SQLite defaults `PRAGMA foreign_keys` to **off** and PormG does not turn it on, so on SQLite no
+    FK constraint is enforced at runtime — the database will neither cascade a delete nor block one.
+    PormG's own deletion collector is the only thing that acts on `on_delete` there, which means an
+    `on_delete` PormG does not handle (unset, or `DO_NOTHING`) is a no-op rather than an error.
+
+    PostgreSQL enforces the constraint normally, so the same schema and the same `delete()` call can
+    succeed on SQLite and fail on PostgreSQL. Test destructive paths against the backend you deploy on.
+
 **Generated SQL (PostgreSQL):**
 ```sql
 DELETE FROM "race" AS "Tb" 
 WHERE "Tb"."name" = $1
--- Note: Dependent rows in "result" are removed by DB FOREIGN KEY CASCADE or ORM cascade
+-- Note: dependent rows in "result" are removed by PormG's deletion collector, which emits their
+-- DELETE separately in the same transaction (see the counts in the returned per-table Dict)
 -- Parameters: ["Cancelled Grand Prix"]
 ```
 
@@ -171,9 +194,17 @@ WHERE "Tb"."name" = $1
     reassign the dependents. The check is existence-driven: it only fires when referencing rows
     are actually present.
 
-!!! note "Limitation: `SET_NULL` requires a nullable FK"
-    Declaring `on_delete = SET_NULL` on a field that is also `null = false` is a contradiction the
-    schema cannot satisfy. The delete raises `ModelDefinitionError` — declare the FK with
-    `null = true`, or choose a different `on_delete`.
+!!! note "`SET_NULL` requires a nullable FK, `SET_DEFAULT` requires a default"
+    Both are contradictions the schema cannot satisfy, and both raise `ModelDefinitionError`:
+
+    - `on_delete = SET_NULL` on a field that is also `null = false` — declare the FK `null = true`,
+      or choose a different `on_delete`.
+    - `on_delete = SET_DEFAULT` on a field with no `default` — give the FK a `default =`, or choose
+      a different `on_delete`. Before this was enforced the delete emitted `SET <column> = NULL`,
+      so `SET_DEFAULT` silently behaved as `SET_NULL` and then violated the column's constraint.
+
+    The error is raised at model registration (`set_models` / `@import_models`), so a contradictory
+    schema fails as soon as the models load rather than at the first delete. `delete()` keeps its own
+    copy of both checks as a backstop for models built without going through registration.
 
 See [Models and Fields](../fields.md) for more details on configuring deletion behavior (CASCADE, PROTECT, SET_NULL, etc.).

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -285,7 +285,7 @@ export sqlite_type_map, postgres_type_map, sqlite_type_map_reverse, postgres_typ
        sqlite_date_format_map, sqlite_ignore_schema, postgres_ignore_table
 
 # on_delete handlers
-export CASCADE, RESTRICT, PROTECT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING
+export CASCADE, RESTRICT, PROTECT, SET_NULL, SET_DEFAULT, DO_NOTHING
 
 # `register_ignore_tables!` is exported by constants.jl itself (it is part of the documented
 # downstream-extension surface), so it needs no re-listing here.

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -17,7 +17,7 @@ import PormG: _emsg  # shared TTY-aware error-message strip helper (Kernel)
 #                          field constructors in src/models/fields.jl to check a `default=` kwarg.
 import PormG: ModelDefinitionError, InvalidValueError, FieldValidationError
 import PormG: PormGSettings, config, Configuration
-import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING, PROTECT
+import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, DO_NOTHING, PROTECT
 using Printf
 using Decimals
 
@@ -264,12 +264,16 @@ function set_models(_module::Module, path::String)::Nothing
           end
         end        
         
-        # check on_delete
+        # check on_delete — a schema that contradicts itself is rejected at registration (#287).
+        # These were `@error` logs until #287: they named the problem and then let the broken model
+        # through, so the contradiction resurfaced later as a mangled UPDATE or a database-level
+        # constraint violation. The delete collector keeps its own copies of both guards for models
+        # that never pass through `set_models`; this is the layer that catches them at declaration.
         if field.on_delete == SET_NULL && field.null == false
-          @error("The field $field_name in the model $(model.name) has on_delete SET_NULL and null false, this is not allowed")
+          throw(ModelDefinitionError("The field \e[4m\e[31m$(field_name)\e[0m in the model \e[4m\e[31m$(model.name)\e[0m declares on_delete SET_NULL but has null=false — the schema contradicts itself. Declare the field with null=true or use a different on_delete."))
         end
         if field.on_delete == SET_DEFAULT && field.default === nothing
-          @error("The field $field_name in the model $(model.name) has on_delete SET_DEFAULT and default nothing, this is not allowed")
+          throw(ModelDefinitionError("The field \e[4m\e[31m$(field_name)\e[0m in the model \e[4m\e[31m$(model.name)\e[0m declares on_delete SET_DEFAULT but has no default — the schema contradicts itself. Give the field a default= or use a different on_delete."))
         end
                  
       elseif is_many_to_many_field(field)

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -59,7 +59,7 @@ include("querybuilder/execution.jl")
 
 include("querybuilder/execution_bulk.jl")
 
-import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, PROTECT
+import PormG: CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, PROTECT
 
 include("querybuilder/deletion.jl")
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -279,5 +279,4 @@ function RESTRICT end
 function PROTECT end
 function SET_NULL end
 function SET_DEFAULT end
-function SET end
 function DO_NOTHING end

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -434,8 +434,9 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
           continue
         elseif field_type in ["ForeignKey", "OneToOneField"]
           # Add "_id" suffix for foreign keys
-          field_key = Symbol("$(field_name)_id")              
+          field_key = Symbol("$(field_name)_id")
           # println(related_model, " ", related_model |> typeof)
+          _normalize_django_set_default!(options, field_name)
           fields_dict[field_key] = getfield(Models, Symbol(field_type))(related_model; options...)
         elseif field_type == "ManyToManyField"
           fields_dict[Symbol(field_name)] = Models.ManyToManyField(related_model; options...)
@@ -511,6 +512,38 @@ function is_current_time_default(value::AbstractString)::Bool
   # Accept both `timezone.now` (callable reference) and `timezone.now()` (call).
   normalized = replace(strip(value), r"\(\s*\)$" => "")
   return normalized in CURRENT_TIME_CALLABLES
+end
+
+"""
+    _normalize_django_set_default!(options, field_name) -> options
+
+Rewrite Django's `on_delete=SET_DEFAULT, default=None` on a nullable FK to `SET_NULL` (#287).
+
+Django accepts that combination and it denotes exactly one thing: on parent delete, set the
+dependent FK to `None`, i.e. SQL `NULL`. PormG cannot express "SET_DEFAULT whose default is NULL" —
+since #287 that pair is a rejected self-contradiction — so the faithful translation is `SET_NULL`.
+
+Without this the importer emits a model file that raises `ModelDefinitionError` the moment it is
+loaded through `@import_models`, and regenerating produces the identical unloadable file. Only the
+nullable case is rewritten: `SET_DEFAULT` with no default on a **non**-nullable FK is genuinely
+contradictory in both ORMs and is left to fail loudly at registration.
+"""
+function _normalize_django_set_default!(options::Dict, field_name)
+  haskey(options, :on_delete) || return options
+  # A malformed on_delete (e.g. Django's `SET(callable)`) throws here; let the field constructor
+  # raise it in its usual place rather than from this helper.
+  mode = try
+    Models._get_on_delete_mode(options[:on_delete])
+  catch
+    return options
+  end
+  mode === Models.SET_DEFAULT || return options
+  get(options, :default, nothing) === nothing || return options
+  get(options, :null, false) === true || return options
+
+  @warn "Django field $(field_name): on_delete=SET_DEFAULT with default=None denotes SET NULL; importing it as on_delete=SET_NULL."
+  options[:on_delete] = "SET_NULL"
+  return options
 end
 
 function parse_value(value::AbstractString)

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -259,9 +259,14 @@ The `on_delete` parameter controls what happens when the referenced object is de
 - `RESTRICT`: Prevent deletion of referenced object if this object exists
 - `SET_NULL`: Set this field to NULL (requires `null=true`)
 - `SET_DEFAULT`: Set this field to its default value (requires `default` to be set)
-- `SET`: Set this field to a specific value
 - `PROTECT`: Raise an error to prevent deletion
 - `DO_NOTHING`: Take no action (may cause database integrity errors)
+
+Omitting `on_delete` is also valid and is the default: PormG then emits no statement for the relation
+and renders `ON DELETE NO ACTION`, leaving the reference to the database's own constraint.
+
+The two "requires" above are enforced, not advisory — `set_models` raises `ModelDefinitionError` for a
+`SET_NULL` field declared `null=false` or a `SET_DEFAULT` field with no `default` (#287).
 
 # Examples
 
@@ -382,9 +387,25 @@ function _get_on_delete_mode(on_delete::Nothing)
   return nothing
 end
 function _get_on_delete_mode(on_delete::AbstractString)
-  on_delete = uppercase(strip(on_delete))
+  raw = strip(on_delete)
+  on_delete = uppercase(raw)
   on_delete = replace(on_delete, r"\s+" => "_")
-  if contains(on_delete, "CASCADE")
+  # Django's callable sentinel, e.g. `models.SET(get_sentinel_user)` (#287). PormG's `on_delete`
+  # holds a bare sentinel with nowhere to carry a value, so the callable cannot be represented.
+  # Until #287 this fell through to a `contains(…, "SET")` branch that silently discarded the
+  # callable and produced a FK emitting the invalid `ON DELETE SET`.
+  #
+  # This is checked FIRST, before the substring branches: the callable's name is arbitrary text,
+  # so `models.SET(protect_sentinel)` matches `contains(…, "PROTECT")` and
+  # `models.SET(set_default_team)` matches `contains(…, "SET_DEFAULT")`. Ordering it last made the
+  # branch unreachable for exactly the plausible sentinel names and reinstated the silent
+  # mistranslation. Safe at the top: no legitimate input contains `(` — introspection emits
+  # CASCADE / SET NULL / NO ACTION / RESTRICT / SET DEFAULT, the Django importer emits `models.<NAME>`.
+  if occursin(r"\bSET_*\(", on_delete)
+    throw(_fielderr("The on_delete value \e[4m\e[31m$(raw)\e[0m is not supported: Django's SET(...) " *
+      "sentinel carries a value or callable, which PormG's on_delete cannot represent. Use " *
+      "SET_DEFAULT together with a `default=` on the field, or SET_NULL if the column is nullable."))
+  elseif contains(on_delete, "CASCADE")
     return CASCADE
   elseif contains(on_delete, "RESTRICT")
     return RESTRICT
@@ -394,19 +415,17 @@ function _get_on_delete_mode(on_delete::AbstractString)
     return SET_DEFAULT
   elseif contains(on_delete, "NO_ACTION") || contains(on_delete, "DO_NOTHING")
     return DO_NOTHING
-  elseif contains(on_delete, "SET")
-    return SET
   elseif contains(on_delete, "PROTECT")
     return PROTECT
   else
-    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
+    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, DO_NOTHING or PROTECT"))
   end
 end
 function _get_on_delete_mode(on_delete::Function)
   # check if the function is one of the valid functions
   check_function = on_delete |> string |> uppercase
-  if !(check_function in ["CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "SET", "DO_NOTHING", "PROTECT"])
-    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, SET, DO_NOTHING or PROTECT"))
+  if !(check_function in ["CASCADE", "RESTRICT", "SET_NULL", "SET_DEFAULT", "DO_NOTHING", "PROTECT"])
+    throw(_fielderr("The on_delete parameter must be CASCADE, RESTRICT, SET_NULL, SET_DEFAULT, DO_NOTHING or PROTECT"))
   end
   return on_delete
 end
@@ -551,9 +570,14 @@ The `on_delete` parameter controls what happens when the referenced object is de
 - `RESTRICT`: Prevent deletion of referenced object if this object exists
 - `SET_NULL`: Set this field to NULL (requires `null=true`)
 - `SET_DEFAULT`: Set this field to its default value (requires `default` to be set)
-- `SET`: Set this field to a specific value
 - `PROTECT`: Raise an error to prevent deletion
 - `DO_NOTHING`: Take no action (may cause database integrity errors)
+
+Omitting `on_delete` is also valid and is the default: PormG then emits no statement for the relation
+and renders `ON DELETE NO ACTION`, leaving the reference to the database's own constraint.
+
+The two "requires" above are enforced, not advisory — `set_models` raises `ModelDefinitionError` for a
+`SET_NULL` field declared `null=false` or a `SET_DEFAULT` field with no `default` (#287).
 
 # Examples
 

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -64,14 +64,18 @@ Dependent rows are then resolved per referencing field, by that field's `on_dele
   Declaring it on a `null = false` field is a contradiction the schema cannot satisfy, and raises
   [`ModelDefinitionError`](@ref).
 - `SET_DEFAULT`: issues `UPDATE ... SET <column> = <the field's default>` over the dependents.
+  Declaring it on a field with no `default` is the mirror-image contradiction, and raises
+  [`ModelDefinitionError`](@ref) too.
 - `DO_NOTHING`: PormG emits nothing for the relation and defers to the database's own constraint.
 
 Only `CASCADE` walks further down the graph; `SET_NULL` and `SET_DEFAULT` do not recurse.
 
-Any other state of `on_delete` — including an **unset** one, which is the default for `ForeignKey` —
-also produces no ORM statement for that relation, leaving the reference entirely to the database's own
-constraint. An unset `on_delete` renders `ON DELETE NO ACTION` in DDL, so a dependent row is *not*
-cascaded by PormG unless its field says so explicitly.
+Both contradictions are normally caught earlier, at `set_models` registration; the checks here are the
+backstop for models that never passed through it.
+
+An **unset** `on_delete` — the default for `ForeignKey` — produces no ORM statement for that relation,
+leaving the reference entirely to the database's own constraint. It renders `ON DELETE NO ACTION` in
+DDL, so a dependent row is *not* cascaded by PormG unless its field says so explicitly.
 
 The collected statements then execute in dependency order inside a single transaction (`BEGIN` on
 PostgreSQL, `BEGIN IMMEDIATE TRANSACTION` on SQLite), so any failure rolls the whole set back.
@@ -416,6 +420,13 @@ function handle_on_delete!(collector::DeletionCollector, field_name::Union{Strin
     collector.field_updates[(field_name |> string, nothing)][related_model] = prepare_related_query(keys, related_model, field_name)
 
   elseif field.on_delete == SET_DEFAULT
+    # check that there is a default to set — symmetric with the SET_NULL guard above (#287).
+    # Without it `field.default === nothing` flows into update_field, which renders a bare NULL,
+    # so SET_DEFAULT silently behaved as SET_NULL and then died on the column's NOT NULL constraint.
+    if field.default === nothing
+      throw(ModelDefinitionError("Error in delete: ON DELETE SET_DEFAULT is declared on \e[4m\e[31m$(field_name)\e[0m, but the field has no default — the schema contradicts itself. Give the FK a default= or use a different on_delete."))
+    end
+
     # Add field update to set field to default value
     default_value = field.default
     if !haskey(collector.field_updates, (field_name |> string, default_value))

--- a/test/integration/common_delete_setup.jl
+++ b/test/integration/common_delete_setup.jl
@@ -123,15 +123,17 @@ Set_null_guard_parent_scratch = Models.Model("set_null_guard_parent_scratch",
     name = Models.CharField()
 )
 
-# Intentionally invalid: SET_NULL on a non-null FK. set_models emits a
-# warning at registration time; the model exists only to exercise the
-# pre-mutation guard in the delete collector.
+# Declared VALID (null = true) so registration succeeds, then flipped to null = false below.
+# Since #287 `set_models` throws ModelDefinitionError on SET_NULL + null=false, so a model
+# declared contradictory here would fail at module load and take the whole Deletes suite with
+# it. Flipping after registration is also the more faithful fixture: the delete-collector guard
+# exists precisely for models that reach delete() in a state `set_models` never vetted.
 Set_null_guard_child_scratch = Models.Model("set_null_guard_child_scratch",
     id        = Models.IDField(),
     parent_id = Models.ForeignKey(Set_null_guard_parent_scratch,
                     pk_field     = "id",
                     on_delete    = "SET_NULL",
-                    null         = false,
+                    null         = true,
                     related_name = "nonnull_children"),
     label     = Models.CharField(null = true)
 )
@@ -140,5 +142,41 @@ end
 
 if !@isdefined(SetNullGuardM)
     Models.set_models(set_null_guard_scratch_models, joinpath(@__DIR__, PORMG_DB_FOLDER))
+    # Introduce the contradiction the delete collector must catch, after set_models (which would
+    # now reject it). Only the ORM-side view of the field changes; the table DDL is hand-written
+    # in test_deletes.jl's _reset_set_null_guard_scratch_schema! and already says NOT NULL.
+    set_null_guard_scratch_models.Set_null_guard_child_scratch.fields["parent_id"].null = false
     const SetNullGuardM = set_null_guard_scratch_models
+end
+
+module set_default_guard_scratch_models
+import PormG.Models
+
+Set_default_guard_parent_scratch = Models.Model("set_default_guard_parent_scratch",
+    id   = Models.IDField(),
+    name = Models.CharField()
+)
+
+# Mirror of the SET_NULL guard fixture above, for the SET_DEFAULT contradiction (#287).
+# Declared VALID (default = 1) so set_models accepts it, then the default is stripped below.
+# Before #287 the missing default flowed into update_field as a bare NULL, so SET_DEFAULT
+# silently behaved as SET_NULL; now the collector refuses before any SQL is sent.
+Set_default_guard_child_scratch = Models.Model("set_default_guard_child_scratch",
+    id        = Models.IDField(),
+    parent_id = Models.ForeignKey(Set_default_guard_parent_scratch,
+                    pk_field     = "id",
+                    on_delete    = "SET_DEFAULT",
+                    default      = 1,
+                    null         = true,
+                    related_name = "no_default_children"),
+    label     = Models.CharField(null = true)
+)
+
+end
+
+if !@isdefined(SetDefaultGuardM)
+    Models.set_models(set_default_guard_scratch_models, joinpath(@__DIR__, PORMG_DB_FOLDER))
+    # Strip the default after registration to create the contradiction the collector must catch.
+    set_default_guard_scratch_models.Set_default_guard_child_scratch.fields["parent_id"].default = nothing
+    const SetDefaultGuardM = set_default_guard_scratch_models
 end

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -204,6 +204,39 @@ function _reset_set_null_guard_scratch_schema!()
     return nothing
 end
 
+# ── Schema helpers: set_default_guard_scratch ─────────────────────────────────
+
+function _drop_set_default_guard_scratch_schema!()
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+    PormG.ConnectionPool.fetch(pool, "DROP TABLE IF EXISTS \"set_default_guard_child_scratch\";")
+    PormG.ConnectionPool.fetch(pool, "DROP TABLE IF EXISTS \"set_default_guard_parent_scratch\";")
+    return nothing
+end
+
+function _reset_set_default_guard_scratch_schema!()
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+    _drop_set_default_guard_scratch_schema!()
+
+    id_type = _scratch_id_type(pool)
+
+    PormG.ConnectionPool.fetch(pool, """
+    CREATE TABLE "set_default_guard_parent_scratch" (
+        "id" $id_type PRIMARY KEY,
+        "name" TEXT NOT NULL
+    );
+    """)
+
+    PormG.ConnectionPool.fetch(pool, """
+    CREATE TABLE "set_default_guard_child_scratch" (
+        "id" $id_type PRIMARY KEY,
+        "parent_id" INTEGER NOT NULL REFERENCES "set_default_guard_parent_scratch" ("id"),
+        "label" TEXT
+    );
+    """)
+
+    return nothing
+end
+
 # ── Fixture helpers ───────────────────────────────────────────────────────────
 
 """
@@ -624,6 +657,62 @@ end
             @test SetNullGuardM.Set_null_guard_child_scratch.objects.filter("id" => child_id).exists()
         finally
             _drop_set_null_guard_scratch_schema!()
+        end
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # SET_DEFAULT guard (#287): a FK declared SET_DEFAULT with no default is the
+    # mirror image of the SET_NULL contradiction. Before #287 the missing default
+    # flowed into update_field as a bare NULL — SET_DEFAULT silently acted as
+    # SET_NULL and then violated the column's NOT NULL constraint. The collector
+    # must now refuse before any SQL is sent.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "Delete with SET_DEFAULT: Missing default is Rejected" begin
+        parent_id = 940001
+        child_id  = 940101
+
+        _reset_set_default_guard_scratch_schema!()
+
+        try
+            SetDefaultGuardM.Set_default_guard_parent_scratch.objects.create(
+                "id"   => parent_id,
+                "name" => "set-default-guard-parent"
+            )
+            SetDefaultGuardM.Set_default_guard_child_scratch.objects.create(
+                "id"        => child_id,
+                "parent_id" => parent_id,
+                "label"     => "no-default-child"
+            )
+
+            delete_q = SetDefaultGuardM.Set_default_guard_parent_scratch.objects
+            delete_q.filter("id" => parent_id)
+
+            err = try
+                delete_q.delete()
+                nothing
+            catch e
+                e
+            end
+
+            # Typed, and the message must name the contradiction rather than the row.
+            # NB: the table is named set_default_guard_child_scratch, so `occursin("default")` or
+            # `occursin("parent_id")` would be satisfied by any database error that merely mentions
+            # the table. Match on wording only this guard produces.
+            @test err isa ModelDefinitionError
+            msg = _strip_ansi(lowercase(sprint(showerror, err)))
+            @test occursin("no default", msg)
+            @test occursin("default=", msg)
+
+            # The negative half — this is what proves it refused BEFORE writing. If the guard
+            # regressed to the old behaviour the child's FK would have been nulled (or the
+            # statement would have failed mid-transaction), so asserting both rows survive
+            # intact is what actually fails on a regression.
+            @test SetDefaultGuardM.Set_default_guard_parent_scratch.objects.filter("id" => parent_id).exists()
+            survivor = SetDefaultGuardM.Set_default_guard_child_scratch.objects.
+                filter("id" => child_id).values("id", "parent_id").list() |> first
+            @test survivor[:parent_id] == parent_id
+        finally
+            _drop_set_default_guard_scratch_schema!()
         end
     end
 

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1935,6 +1935,67 @@ end
     @test_throws PormG.ModelDefinitionError PormG.Models.set_models(bad_mod, "mock_sl_path")
 end
 
+@testset "set_models rejects contradictory on_delete declarations (#287)" begin
+    # Both checks existed in set_models as `@error` logs: they named the contradiction and then
+    # let the broken model through, so it resurfaced later as a mangled UPDATE (SET_DEFAULT with
+    # no default renders a bare NULL) or a database constraint violation. #287 made them throws.
+    # Nothing pinned either behaviour before this testset.
+    function _on_delete_mod(modname::Symbol, make_fk)
+        parent = PormG.Models.Model_Type(
+            name = "od_parent_$(modname)",
+            fields = Dict("id" => PormG.Models.IDField()),
+            field_names = ["id"]
+        )
+        child = PormG.Models.Model_Type(
+            name = "od_child_$(modname)",
+            fields = Dict("id" => PormG.Models.IDField(), "parent" => make_fk(parent)),
+            field_names = ["id", "parent"]
+        )
+        mod = Module(modname)
+        Core.eval(mod, :(const Parent = $parent))
+        Core.eval(mod, :(const Child = $child))
+        return mod
+    end
+
+    # `set_models` has several other ModelDefinitionError sites (duplicate related_name, strict FK
+    # target resolution), so a bare @test_throws would pass on a fixture typo for the wrong reason.
+    # Assert the cause, not just the type.
+    function _set_models_error(mod)
+        try
+            PormG.Models.set_models(mod, "mock_sl_path")
+            nothing
+        catch e
+            e
+        end
+    end
+
+    # SET_NULL on a field that cannot hold NULL.
+    sn_bad = _on_delete_mod(:od_set_null_bad, p -> PormG.Models.ForeignKey(p,
+        pk_field = "id", on_delete = "SET_NULL", null = false, related_name = "od_sn_bad"))
+    sn_err = _set_models_error(sn_bad)
+    @test sn_err isa PormG.ModelDefinitionError
+    @test occursin("SET_NULL", sprint(showerror, sn_err))
+    @test occursin("null=true", sprint(showerror, sn_err))
+
+    # SET_DEFAULT with nothing to set it to.
+    sd_bad = _on_delete_mod(:od_set_default_bad, p -> PormG.Models.ForeignKey(p,
+        pk_field = "id", on_delete = "SET_DEFAULT", null = true, related_name = "od_sd_bad"))
+    sd_err = _set_models_error(sd_bad)
+    @test sd_err isa PormG.ModelDefinitionError
+    @test occursin("SET_DEFAULT", sprint(showerror, sd_err))
+    @test occursin("default", sprint(showerror, sd_err))
+
+    # Discrimination: a guard that fires on everything proves nothing. The same two shapes with
+    # the contradiction resolved must still register cleanly.
+    sn_ok = _on_delete_mod(:od_set_null_ok, p -> PormG.Models.ForeignKey(p,
+        pk_field = "id", on_delete = "SET_NULL", null = true, related_name = "od_sn_ok"))
+    @test PormG.Models.set_models(sn_ok, "mock_sl_path") === nothing
+
+    sd_ok = _on_delete_mod(:od_set_default_ok, p -> PormG.Models.ForeignKey(p,
+        pk_field = "id", on_delete = "SET_DEFAULT", default = 1, null = true, related_name = "od_sd_ok"))
+    @test PormG.Models.set_models(sd_ok, "mock_sl_path") === nothing
+end
+
 # ── #64: db_column on M2M / CTE join keys (DB-free render asserts) ─────────────────────────
 @testset "M2M join honors db_column on renamed PKs (#64)" begin
     # Both participating models' PKs are renamed (driver code→driver_pk, sponsor code→sponsor_pk).

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -1475,6 +1475,46 @@ end
         @test string(sql_style_set_default.on_delete) == "SET_DEFAULT"
         @test string(sql_style_no_action.on_delete) == "DO_NOTHING"
 
+        # Test 5c (#287): the removed `SET` sentinel. `_get_on_delete_mode` used to end with a
+        # `contains(on_delete, "SET")` fallback, so anything vaguely SET-shaped that missed the
+        # exact SET_NULL / SET_DEFAULT substrings silently became a sentinel that no branch of
+        # handle_on_delete! implements and that renders the invalid `ON DELETE SET` in DDL.
+        # Those inputs must be rejected at construction now.
+        @test_throws PormG.FieldValidationError Models.ForeignKey("User", null=true, on_delete="SET")
+        # A near-miss typo: the hyphen is not whitespace, so it never normalized to SET_NULL and
+        # fell through to the old fallback. This is the case that made the fallback dangerous.
+        @test_throws PormG.FieldValidationError Models.ForeignKey("User", null=true, on_delete="SET-NULL")
+        @test_throws PormG.FieldValidationError Models.ForeignKey("User", null=true, on_delete="SETNULL")
+
+        # Django's callable sentinel gets its own message rather than the generic option list —
+        # it used to be swallowed by the same fallback, discarding the callable and producing a
+        # FK that emitted `ON DELETE SET`.
+        django_set_err = try
+            Models.ForeignKey("User", null=true, on_delete="models.SET(get_sentinel_user)")
+            nothing
+        catch e
+            e
+        end
+        @test django_set_err isa PormG.FieldValidationError
+        @test occursin("SET(...)", sprint(showerror, django_set_err))
+        @test occursin("SET_DEFAULT", sprint(showerror, django_set_err))
+
+        # The SET(...) check must run BEFORE the substring branches. The callable's name is
+        # arbitrary text, so a sentinel getter called `protect_sentinel` or `set_default_team`
+        # matches `contains(…, "PROTECT")` / `contains(…, "SET_DEFAULT")` first. With the check
+        # ordered last, every one of these silently returned a wrong action instead of raising —
+        # the exact mistranslation #287 removes. These names are all plausible in real Django code.
+        for callable_name in ("protect_sentinel", "set_default_team", "cascade_to_default",
+                              "restrict_fn", "do_nothing")
+            @test_throws PormG.FieldValidationError Models.ForeignKey(
+                "User", null=true, on_delete="models.SET($(callable_name))")
+        end
+
+        # Discrimination: the valid tokens must still be accepted, including the bare sentinel
+        # form, so the removal did not over-reach.
+        @test string(Models.ForeignKey("User", null=true, on_delete=Models.SET_NULL).on_delete) == "SET_NULL"
+        @test string(Models.ForeignKey("User", null=true, on_delete="set_null").on_delete) == "SET_NULL"
+
         # Test 6: ForeignKey field contains related_name when specified
         @test editor_field.related_name == "edited_posts"
 

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -329,11 +329,20 @@ class Bm2_map_aliq_am(models.Model):
         generated = read(generated_path, String)
         # The foreign key still imports, keeping its non-null options...
         @test occursin("plan_id = Models.ForeignKey(\"Bm2_map_ext_am\"", generated)
-        @test occursin("on_delete=SET_DEFAULT", generated)
         @test occursin("db_constraint=false", generated)
         # ...but None must never surface as a literal default value.
         @test !occursin("default=None", generated)
         @test !occursin("default=\"None\"", generated)
+
+        # #287: Django's `SET_DEFAULT, default=None` on a nullable FK denotes "set the FK to
+        # NULL", which is SET_NULL. It used to import verbatim as SET_DEFAULT-with-no-default —
+        # a combination PormG now rejects at set_models, so the generated file would not load at
+        # all, and regenerating produced the same broken file. The importer translates it.
+        # Registering the old output raised ModelDefinitionError, so the generated module could
+        # not be used at all; that rejection is pinned in test_alignment_sqlite.jl. Here we pin
+        # the other half: the importer no longer produces that shape.
+        @test occursin("on_delete=SET_NULL", generated)
+        @test !occursin("on_delete=SET_DEFAULT", generated)
     finally
         cleanup_import_test!(config_key, db_dir_existed)
     end

--- a/test/unit/test_schema_conventions.jl
+++ b/test/unit/test_schema_conventions.jl
@@ -52,6 +52,8 @@ _fk_ddl(; fk_kw...) = PormG.Dialect.create_table(MockSLConv(),
         @test occursin("ON DELETE RESTRICT",  _fk_ddl(on_delete = "RESTRICT"))
         @test occursin("ON DELETE RESTRICT",  _fk_ddl(on_delete = "PROTECT"))         # PROTECT → RESTRICT
         @test occursin("ON DELETE SET NULL",  _fk_ddl(on_delete = "SET_NULL", null = true))
+        # SET_DEFAULT was the one action missing from this frozen list (#287).
+        @test occursin("ON DELETE SET DEFAULT", _fk_ddl(on_delete = "SET_DEFAULT", default = 1))
         @test occursin("ON DELETE NO ACTION", _fk_ddl(on_delete = "DO_NOTHING"))      # DO_NOTHING → NO ACTION
         # And the backend-neutral renderer itself maps an unset on_delete to NO ACTION.
         @test PormG.Dialect._foreign_key_on_delete_sql(nothing) == "NO ACTION"


### PR DESCRIPTION
Closes #287.

Three `on_delete` states were accepted and then misbehaved later. All three now fail at the earliest
point they can be detected. Found while closing out #278, whose last task was deciding the fate of two
`# TODO : I dont check if this works` comments — these are the defects those TODOs were standing in
front of.

16 files, +458/−33. **Behavior change**, so it carries an `UPGRADING.md` entry under `## Unreleased`
and **no `Project.toml` bump** (release-train rule).

## 1. `SET` is removed

It was exported and accepted, but no branch of `handle_on_delete!` implemented it and
`Dialect._foreign_key_on_delete_sql` fell through to emit the syntactically invalid `ON DELETE SET` —
so a model using it failed to *migrate* on both backends. Nothing in the repo declared it: no test, no
fixture, no doc page, and it was already absent from every user-facing option list.

It cannot be implemented coherently — Django's `SET(value)` carries a value or callable and PormG's
`on_delete` is a bare sentinel with nowhere to put one, so it would be `SET_DEFAULT` with extra steps.

Removing it also removes the `contains(on_delete, "SET")` fallback that produced it, which had been
swallowing near-miss typos: `"SET-NULL"` (the hyphen is not whitespace, so it never normalized) and
`"SETNULL"` both became a sentinel that silently did nothing. Those now raise `FieldValidationError` at
field construction.

**The new `models.SET(...)` check runs first in the branch chain, not last.** The callable's name is
arbitrary text, so `models.SET(protect_sentinel)` matches `contains(…, "PROTECT")` and
`models.SET(set_default_team)` matches `contains(…, "SET_DEFAULT")`. Ordered last, the check was
unreachable for exactly the plausible sentinel names — reinstating the silent mistranslation it was
meant to remove. Five keyword-bearing callable names are pinned as a regression guard. Safe at the top:
no legitimate input contains `(` (introspection emits `CASCADE`/`SET NULL`/`NO ACTION`/`RESTRICT`/`SET
DEFAULT`, the importer emits `models.<NAME>`).

## 2. Contradictory declarations raise instead of logging

`SET_NULL` on a `null=false` field, and `SET_DEFAULT` with no `default`, now raise
`ModelDefinitionError` from `set_models`. Both checks **already existed there** (`Models.jl:267-273`) as
`@error` logs with no test coverage: they printed the problem and let the model through, so it
resurfaced later as a database constraint violation or — for `SET_DEFAULT` — as a silent
`UPDATE … SET col = NULL`, i.e. `SET_DEFAULT` quietly behaving as `SET_NULL`.

`set_models` is the right layer, not the `ForeignKey` constructor: `introspection.jl:131`/`:175` build
FKs straight from database metadata with no `default=`, so a constructor-level throw would crash the
introspector. The migration planner deliberately never calls `set_models`
(`planner.jl:849-851`), so `makemigrations`/`migrate` are unaffected. The delete collector keeps its own
copy of both guards for models that never pass through registration — the `SET_DEFAULT` one is new.

## 3. The Django importer no longer emits an unloadable file

`on_delete=models.SET_DEFAULT, default=None` on a nullable FK is valid Django and appears in the repo's
own fixture. It imported verbatim as `SET_DEFAULT` with no default — which change 2 now refuses to
register, so the generated module would not load *and regenerating produced the identical broken file*.
Django's combination denotes exactly one thing (set the FK to `None`), so the importer translates it to
`SET_NULL` and warns.

## 4. Docs

`docs/src/write/delete.md` claimed `on_delete="CASCADE"` was "the default for `ForeignKey` fields". It
is not — unset is, rendering `ON DELETE NO ACTION` (`fields.jl:332`, `Dialect.jl:697-699`, pinned by
`test_schema_conventions.jl:49`). The consequence is backend-divergent and now documented as such:

| Backend | Deleting a parent whose child FK has an unset `on_delete` |
|---|---|
| PostgreSQL | `NO ACTION` enforced — the delete fails with a foreign-key violation |
| SQLite | succeeds and **silently orphans the child** |

The SQLite half is because `_create_sqlite_connection` sets four pragmas but never
`PRAGMA foreign_keys`, and SQLite defaults it off. Measured, not inferred — `PRAGMA foreign_keys`
returns `0` on a live pool. Turning it on is deliberately **not** in this PR: it can start failing writes
against databases that already contain orphans, so it needs its own weighing.

## Tests

Both layers, per the "spans both layers" rule. New coverage:

- `test_alignment_sqlite.jl` — `set_models` throws for both contradictions, with **cause-checked
  messages** (that function has several other `ModelDefinitionError` sites), plus discrimination cases
  proving the same shapes still register cleanly once resolved.
- `test_field_validation_and_operations.jl` — `SET`, two typo forms, and five `models.SET(<name>)`
  callables all rejected; the valid sentinel and string forms still accepted.
- `test_deletes.jl` — integration testset for the delete-time `SET_DEFAULT` guard. Assertions match
  wording only this guard produces: the table is named `set_default_guard_child_scratch`, so
  `occursin("default")` would have passed on any error merely mentioning it.
- `test_schema_conventions.jl` — `SET_DEFAULT` was the one action missing from the frozen DDL mapping.

Both delete fixtures now declare valid models and introduce the contradiction **after** `set_models`,
since a contradictory declaration would otherwise fail at module load and take the whole Deletes suite
down. That is also the more faithful fixture: the collector guards exist precisely for models that reach
`delete()` in a state registration never vetted.

## Verification

| Gate | Baseline | This branch |
|---|---|---|
| Unit suite | 4804 / 4804 | **4852 / 4852** |
| db_sl integration | 1854 pass / 1 broken | **1859 pass / 1 broken** |
| `Delete Operations with FK Constraints` | 89 / 89 | **94 / 94** |
| `docs/make.jl` | exit 0 | **exit 0**, no cross-reference errors |

Rebased onto `e8cef5a` (#290) and the unit suite re-run after the rebase — the 4852 figure is from the
rebased tree. The single `@test_broken` is pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
