### PR TITLE
feat(#277): signal the SQLite advisory-lock no-op instead of staying silent

### DIFF
--- a/docs/src/advisory_lock.md
+++ b/docs/src/advisory_lock.md
@@ -59,13 +59,10 @@ The `timeout_ms` parameter ensures your application doesn't hang indefinitely.
 - **SQLite**: `with_advisory_lock` is a **no-op** — see the warning below.
 - **Async Safety**: `with_advisory_lock` uses `LibPQ.async_execute` and `fetch()` to ensure that the Julia task yields while waiting for the database, keeping the event loop unblocked.
 
-!!! warning "Advisory locks are a silent no-op on SQLite"
-    On a SQLite connection `with_advisory_lock(f, conn, key; kwargs...)` is defined as `f()` —
-    nothing more. The body runs **unprotected**, and:
-
-    - `wait`, `timeout_ms`, `strategy` and `interval_ms` are accepted and silently ignored.
-    - **No warning is logged.** Nothing in the output distinguishes a held lock from no lock.
-    - The contention path cannot fire, so code that reacts to `OperationalError` never sees one.
+!!! warning "Advisory locks are a no-op on SQLite"
+    On a SQLite connection the body of `with_advisory_lock` runs with **no mutual exclusion at
+    all**. `wait`, `timeout_ms`, `strategy` and `interval_ms` are accepted and ignored, and the
+    contention path cannot fire, so code that reacts to `OperationalError` never sees one there.
 
     SQLite's own writer serialization (`BEGIN IMMEDIATE`) is per-database-file and per-process; it
     is not a substitute for a named application lock, and it protects nothing for the non-SQL
@@ -73,6 +70,47 @@ The `timeout_ms` parameter ensures your application doesn't hang indefinitely.
     scheduled jobs. Treat SQLite as single-instance, exactly as
     [migrations do](migrations/index.md), and rely on advisory locks only where PostgreSQL is the
     production backend.
+
+### Choosing what SQLite does: `on_missing_lock`
+
+The no-op stays the default — it is what lets one codebase run PostgreSQL in production and SQLite
+in tests. But because what degrades here is a *guarantee* rather than a query, the SQLite path is
+not silent, and `on_missing_lock` lets you pick (#277):
+
+| `on_missing_lock` | On SQLite | Use it when |
+| :--- | :--- | :--- |
+| `:warn` (default) | Body runs; **warns once per key** | You want to be told, but not stopped |
+| `:ignore` | Body runs, silently | You have read this page and accepted the no-op |
+| `:error` | Raises [`BackendCapabilityError`](errors.md); the body does **not** run | The exclusion is genuinely required for correctness |
+
+The same call site works on both backends — that is the point of the keyword:
+
+```julia
+# Default: a real lock on PostgreSQL, a warning once per key on SQLite.
+PormG.with_advisory_lock(connection_key, "driver_update_$(driver_id)") do
+    # rebuild this driver's standings
+end
+
+# SQLite gives no protection here and that is acceptable — stay quiet.
+PormG.with_advisory_lock(connection_key, "circuit_cache_warm"; on_missing_lock = :ignore) do
+    # …
+end
+
+# This MUST be exclusive. Refuse to run on a backend that cannot promise it.
+PormG.with_advisory_lock(connection_key, "season_points_recalc"; on_missing_lock = :error) do
+    # never reached on SQLite — BackendCapabilityError is raised instead
+end
+```
+
+On PostgreSQL `on_missing_lock` is accepted and ignored: a real lock is always taken, so there is
+no missing-lock case to have a policy about. An unrecognised value raises `InvalidValueError` on
+**both** backends, so a typo cannot lie in wait until you happen to run on SQLite.
+
+The warning fires once per distinct lock key, tracked in-process and independently of the logger in
+use, so a scheduled job taking the same lock in a loop logs one line rather than one per iteration.
+Tracking is capped at 64 distinct keys — a fair ceiling for a genuinely per-entity key like
+`"driver_update_$(driver_id)"` — and the warning that reaches the cap says so rather than going
+quiet without telling you.
 
 ## API Reference
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -615,7 +615,9 @@ end
 - `:poll` (default) — Client-side polling with interval
 - `:block` — Server-side blocking via `pg_advisory_lock`
 
-SQLite: No-op (executes the block without locking).
+SQLite: no-op — the block executes without locking. It warns once per lock key;
+`on_missing_lock=:ignore` accepts that silently, `on_missing_lock=:error` raises
+`BackendCapabilityError` rather than running unprotected.
 
 See [Advisory Locks](advisory_lock.md) for the full reference.
 
@@ -711,7 +713,7 @@ field, and for the few with their own `showerror` it returns the richer renderin
 | `QueryBuildError` | Structural/API misuse while building a query (joins, CTEs, projection, ordering, window/bulk config). **The long-tail default** — it is the bucket for query-shape misuse that isn't one of the sharper categories, so `catch QueryBuildError` says little beyond "PormG rejected the query shape". Catch a sharper subtype when you need to branch on the cause. |
 | `UnsafeMutationError` | An `update()`/`delete()` was requested without a filter (or another unsafe shape). |
 | `ProtectedError` | A `delete()` was refused because rows reference the target through a `ForeignKey` with `on_delete = PROTECT`/`RESTRICT` — the data forbids it; delete or reassign the referencing rows first. |
-| `BackendCapabilityError` | The active backend cannot do this: PG-only lookups on SQLite (JSONB, `iunaccent_*`), explicit window `frame=` on SQLite, `bulk_copy` on SQLite, or a too-old SQLite library. Change the query or the backend. |
+| `BackendCapabilityError` | The active backend cannot do this: PG-only lookups on SQLite (JSONB, `iunaccent_*`), explicit window `frame=` on SQLite, `bulk_copy` on SQLite, `with_advisory_lock(...; on_missing_lock = :error)` on SQLite, or a too-old SQLite library. Change the query or the backend. |
 | `InvalidValueError` | A **value** failed coercion/type validation on insert/update, an identifier failed the safety check, or an interval/duration could not be parsed. |
 | `WritesDisabledError` | The connection is not permitted to insert/update/delete — `change_data: false` in `connection.yml`, which is why it lives under `ConfigurationError`. (Renamed from `PermissionError` in the pre-publish naming pass.) |
 | `UnsupportedConnectionError` | A connection object that is neither PostgreSQL nor SQLite reached an execution path — an internal PormG dispatch bug; please report it. (Capability limits are `BackendCapabilityError`; an unbound model is `InvalidConfigurationError`.) |

--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -93,7 +93,7 @@ end
 ### Key Technical Details
 - **Hashing:** Keys are hashed using MD5 to provide a 64-bit bigint identifier.
 - **Cleanup:** PostgreSQL releases the lock automatically if the session drops.
-- **SQLite Limitation:** SQLite does not support advisory locks; the helper is a **silent no-op** on that backend — the body runs unprotected, no warning is logged, and the wait/timeout keyword arguments are ignored. See [Advisory Locks](../advisory_lock.md).
+- **SQLite Limitation:** SQLite does not support advisory locks; the helper is a **no-op** on that backend — the body runs unprotected and the wait/timeout keyword arguments are ignored. It warns once per lock key; pass `on_missing_lock = :ignore` to accept the no-op silently, or `on_missing_lock = :error` to raise `BackendCapabilityError` instead of running unprotected. See [Advisory Locks](../advisory_lock.md).
 
 ---
 

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -34,7 +34,7 @@ Catch the umbrella when you want a category, the concrete type when you want a r
 | `row.driverid` on an unprojected FK | `LazyTraversalError` | PormG never lazily loads a relation — project it with `values(...)` |
 | any filter or `values` | `UnknownFieldError` | The field name does not exist on the model (lookups are case-sensitive) |
 | any filter | `FilterError` | The predicate itself is malformed |
-| PostgreSQL-only features on SQLite | `BackendCapabilityError` | e.g. `iunaccent_*`, JSONB containment, window `frame=` |
+| PostgreSQL-only features on SQLite | `BackendCapabilityError` | e.g. `iunaccent_*`, JSONB containment, window `frame=`, `with_advisory_lock(...; on_missing_lock = :error)` |
 | anything else about query shape | `QueryBuildError` | The long-tail default |
 
 ### Writing
@@ -58,6 +58,7 @@ Catch the umbrella when you want a category, the concrete type when you want a r
 | any query, pool saturated | `PoolTimeoutError` | Raise `pool_size`/`pool_timeout` — see [Advanced Configuration](configuration/advanced.md) |
 | any query, database unreachable | `PoolConnectError` | Carries the `cause` and a redacted connection string |
 | `with_advisory_lock(...; wait = false)` | `OperationalError` | Lock held elsewhere. **Never raised on SQLite** — see [Advisory Locks](advisory_lock.md) |
+| `with_advisory_lock(...; on_missing_lock = :error)` on SQLite | `BackendCapabilityError` | SQLite has no advisory locks; the body would run unprotected, so it is refused instead |
 
 ### Configuration and migrations
 

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -42,7 +42,7 @@ end
 ```
 
 - **PostgreSQL** uses `pg_advisory_lock` / `pg_try_advisory_lock`.
-- **SQLite** does not support advisory locks, so `with_advisory_lock` is a **no-op** — the block still runs, just without cross-process locking. This is deliberate, so the same code is correct in production and in SQLite tests.
+- **SQLite** does not support advisory locks, so `with_advisory_lock` is a **no-op** — the block still runs, just without cross-process locking. This is deliberate, so the same code is correct in production and in SQLite tests. It warns once per lock key; `on_missing_lock = :ignore` accepts that silently and `on_missing_lock = :error` raises `BackendCapabilityError` rather than running unprotected.
 
 Waiting strategies (`:poll` vs `:block`), timeouts, and async safety: **[Advisory Locks](advisory_lock.md)**.
 
@@ -95,7 +95,7 @@ PormG keeps the two backends aligned wherever it can and documents the differenc
 |------|-----------|--------|
 | **Bind placeholders** | `$1`, `$2`, … | `?` |
 | **Bulk load** | `bulk_copy()` (COPY) | `bulk_insert()` (no COPY) |
-| **Advisory locks** | real (`pg_advisory_lock`) | no-op |
+| **Advisory locks** | real (`pg_advisory_lock`) | no-op (warns once per key; `on_missing_lock=:error` raises) |
 | **PK allocation** | real sequences (`nextval`) | emulated via `sqlite_sequence` high-water mark |
 | **Drop a constraint (migrations)** | `ALTER TABLE … DROP CONSTRAINT` | full table rebuild (SQLite has no `DROP CONSTRAINT`) |
 | **`ON CONFLICT`** | supported | supported (SQLite ≥ 3.24) — same syntax |

--- a/src/AdvisoryLock.jl
+++ b/src/AdvisoryLock.jl
@@ -11,7 +11,7 @@ import PormG.ConnectionPool: acquire_connection, release_connection
 # database-error boundary (#268) or `with_advisory_lock` would be the last public entry point
 # still leaking raw `LibPQ.Errors.*`.
 import PormG.ConnectionPool: _as_database_error
-import PormG: PormGError, OperationalError
+import PormG: PormGError, OperationalError, BackendCapabilityError, InvalidValueError
 
 import PormG: @pormg_debug
 export with_advisory_lock
@@ -22,6 +22,11 @@ const TRY_SQL = "SELECT pg_try_advisory_lock($(ADVISORY_KEY_EXPR)) AS ok"
 # Workaround for pg_advisory_lock returning void: select true from the void function call
 const BLOCK_SQL = "SELECT true AS ok FROM (SELECT pg_advisory_lock($(ADVISORY_KEY_EXPR))) AS _"
 const UNLOCK_SQL = "SELECT pg_advisory_unlock($(ADVISORY_KEY_EXPR)) AS ok"
+
+# Ceiling on how many distinct lock keys the SQLite no-op warning tracks (#277). Declared up here,
+# ahead of the docstring below that interpolates it — a docstring is a plain string literal
+# evaluated in file order, so a const defined further down would be an UndefVarError at load.
+const SQLITE_LOCK_WARN_CAP = 64
 
 """
 Execute a lock/unlock query on a held connection and return boolean result.
@@ -46,7 +51,7 @@ function _exec_lock_query(pool::PormGPostgres, conn, sql::String, key::AbstractS
 end
 
 """
-    with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractString; wait::Bool=false, timeout_ms::Int=5_000, strategy::Symbol=:poll)
+    with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractString; wait::Bool=false, timeout_ms::Int=5_000, interval_ms::Int=100, strategy::Symbol=:poll, on_missing_lock::Symbol=:warn)
 
 Execute a function `f` while holding a PostgreSQL session-level advisory lock identified by `key`.
 
@@ -64,6 +69,31 @@ Advisory locks are an application-level locking mechanism provided by PostgreSQL
     - `:poll`: (Default) Periodically retries lock acquisition from the Julia client. Safe and recommended for most cases.
     - `:block`: Uses PostgreSQL's server-side blocking mechanism. Efficient but holds a connection and uses `statement_timeout`.
 - `interval_ms::Int=100`: Retry interval for the `:poll` strategy.
+- `on_missing_lock::Symbol=:warn`: What to do on a backend that cannot lock. Ignored on
+  PostgreSQL, which always takes a real lock — it exists for the SQLite path (see below).
+  An unrecognised value raises `InvalidValueError` on **both** backends, so a typo cannot lie in
+  wait until you run on SQLite.
+
+# SQLite
+
+SQLite has no advisory locks, so `with_advisory_lock` **runs the body with no mutual exclusion**.
+That is deliberate: it lets the same source run against PostgreSQL in production and SQLite in
+tests, exactly as [`select_for_update`](@ref) does. Unlike `select_for_update`, though, what
+degrades here is a *guarantee* rather than a query that still returns correct rows — so the SQLite
+path is not silent. `on_missing_lock` selects what happens (#277):
+
+| `on_missing_lock` | On SQLite |
+| :--- | :--- |
+| `:warn` (default) | Body runs; warns once per key |
+| `:ignore` | Body runs silently — you have accepted the no-op |
+| `:error` | Throws `BackendCapabilityError`; the body does **not** run |
+
+The other keywords (`wait`, `timeout_ms`, `strategy`, `interval_ms`) are accepted and ignored on
+SQLite, and the contention path cannot fire there, so `OperationalError` is never raised.
+
+The warning is emitted once per distinct key, tracked in-process, for up to
+`$(SQLITE_LOCK_WARN_CAP)` keys — the message says so when that cap is reached, rather than going
+quiet without saying.
 
 # Examples
 ```julia
@@ -75,11 +105,20 @@ PormG.with_advisory_lock(M.Constructor.objects.object.model.connect_key, "update
 end
 ```
 """
-function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractString; 
-                            wait::Bool = false, 
-                            timeout_ms::Int = 5_000, 
-                            interval_ms::Int = 100, 
-                            strategy::Symbol = :poll)
+function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractString;
+                            wait::Bool = false,
+                            timeout_ms::Int = 5_000,
+                            interval_ms::Int = 100,
+                            strategy::Symbol = :poll,
+                            # Accepted and ignored: PostgreSQL always takes a real lock, so there is
+                            # no "missing lock" case to have a policy about. It exists so the same
+                            # call site can carry `on_missing_lock` and still run on both backends —
+                            # on SQLite it is what turns the no-op into a warning or an error
+                            # (#277). Without it here, `on_missing_lock = :error` would be a
+                            # MethodError on the one backend that satisfies it. Still validated, so
+                            # a typo fails on PostgreSQL too rather than lying in wait for SQLite.
+                            on_missing_lock::Symbol = :warn)
+  _validate_on_missing_lock(on_missing_lock)
   conn = acquire_connection(pool)
   got_lock = false
   old_timeout = nothing
@@ -153,16 +192,25 @@ function with_advisory_lock(f::Function, pool::PormGPostgres, key::AbstractStrin
       end
     end
     
-    # Restore statement_timeout if we changed it
+    # Restore statement_timeout if we changed it.
+    #
+    # `Base.wait`, NOT a bare `wait` — the `wait::Bool` KEYWORD above shadows `Base.wait` inside
+    # this method, so `wait(...)` evaluated as `false(...)` and raised `MethodError: objects of
+    # type Bool are not callable`. The empty `catch` blocks below swallowed it, so this restore
+    # had never once completed: Julia evaluates the argument first, so the SET was dispatched
+    # asynchronously and then never awaited before `release_connection` returned the connection to
+    # the pool — which could hand back a connection still carrying the modified statement_timeout.
+    # The comment that used to sit here ("wait() is enough…") documented an intent that never ran.
+    # Found while working #277; the empty `catch`es stay, because restoring a timeout is genuinely
+    # best-effort, but a MethodError must no longer be one of the things they hide.
     if old_timeout !== nothing
       try
-        # wait() is enough for the async result when we don't need the output
-        wait(backend_execute_async(pool, conn, "SET statement_timeout = '$(old_timeout)'", nothing))
+        Base.wait(backend_execute_async(pool, conn, "SET statement_timeout = '$(old_timeout)'", nothing))
       catch
       end
     elseif strategy == :block
       try
-        wait(backend_execute_async(pool, conn, "SET statement_timeout TO DEFAULT", nothing))
+        Base.wait(backend_execute_async(pool, conn, "SET statement_timeout TO DEFAULT", nothing))
       catch
       end
     end
@@ -176,8 +224,81 @@ end
 with_advisory_lock(f::Function, settings::PormGSettings, key::AbstractString; kwargs...) =
   with_advisory_lock(f, settings.connections, key; kwargs...)
 
-# SQLite no-op (advisory locks not supported)
-with_advisory_lock(f::Function, conn::PormGSQLite, key::AbstractString; kwargs...) = f()
+# ==============================================================================
+# SQLite: no advisory locks exist, so the body runs UNPROTECTED (#277)
+# ==============================================================================
+#
+# Staying a no-op rather than throwing is what lets one source target PostgreSQL in production and
+# SQLite in tests, exactly as `select_for_update` does. But this degrades a mutual-exclusion
+# GUARANTEE, not a query that still returns correct rows, and the failure mode is a race visible
+# only under concurrency — the hardest class to notice in testing. So the caller chooses, by value:
+#
+#   :warn   (default) → run the body, warn once per key
+#   :ignore           → run the body silently; the caller has read the docs and accepted the no-op
+#   :error            → throw, rather than hand back a guarantee this backend cannot provide
+#
+# Dedup is an explicit Set rather than `@warn ... maxlog=1`. Two reasons, both found in review:
+#   1. `maxlog` is honoured only by loggers that implement it (SimpleLogger/ConsoleLogger/
+#      TestLogger). Under a custom application sink — common in Genie apps and LoggingExtras
+#      stacks — it degrades to warning on EVERY call, which is the log flood the dedup exists to
+#      prevent, for callers who never opted in.
+#   2. `_id=Symbol(..., key)` interns a Symbol per key, and Julia never frees Symbols. The docs
+#      teach `"driver_update_$(driver_id)"`, i.e. unbounded key cardinality, so that is a genuine
+#      slow leak (~4.5 MiB retained at 50k keys, measured).
+#
+# The Set is plain DATA in a module body, which is safe under cached precompilation — the #203 trap
+# is about side EFFECTS (atexit, hook registration), not container state. Same shape as
+# ConnectionPool's `leak_warned` monitor.
+const _SQLITE_LOCK_WARNED = Set{String}()
+const _SQLITE_LOCK_WARNED_LOCK = ReentrantLock()
+# The set is bounded by SQLITE_LOCK_WARN_CAP (declared at the top of this file) so a caller minting
+# a key per entity cannot grow it without limit. Reaching the cap is announced, not swallowed.
+
+# Test seam: the ledger is process-wide, so a suite asserting warn-once needs a way to re-arm.
+# Directly callable for the same reason `ConnectionPool._leak_check!` is.
+_reset_sqlite_lock_warnings!() = Base.@lock _SQLITE_LOCK_WARNED_LOCK empty!(_SQLITE_LOCK_WARNED)
+
+# :warn → warn now; :final → warn now AND say we are going quiet; :silent → already covered.
+function _claim_sqlite_lock_warning(key::AbstractString)::Symbol
+  Base.@lock _SQLITE_LOCK_WARNED_LOCK begin
+    key in _SQLITE_LOCK_WARNED && return :silent
+    length(_SQLITE_LOCK_WARNED) >= SQLITE_LOCK_WARN_CAP && return :silent
+    push!(_SQLITE_LOCK_WARNED, key)
+    return length(_SQLITE_LOCK_WARNED) == SQLITE_LOCK_WARN_CAP ? :final : :warn
+  end
+end
+
+function _validate_on_missing_lock(on_missing_lock::Symbol)
+  on_missing_lock in (:warn, :ignore, :error) && return nothing
+  throw(InvalidValueError(
+    "Invalid on_missing_lock: $(repr(on_missing_lock)). Expected :warn (default), :ignore or :error."))
+end
+
+# `kwargs...` still swallows wait/timeout_ms/strategy/interval_ms so the PostgreSQL call shape stays
+# portable — that tolerance is the whole point of the no-op.
+function with_advisory_lock(f::Function, conn::PormGSQLite, key::AbstractString;
+                            on_missing_lock::Symbol = :warn, kwargs...)
+  _validate_on_missing_lock(on_missing_lock)
+
+  if on_missing_lock === :error
+    throw(BackendCapabilityError(
+      "with_advisory_lock(on_missing_lock = :error) cannot be honoured on SQLite — it has no " *
+      "advisory locks, so the body for '$key' would run with no mutual exclusion. Use PostgreSQL, " *
+      "or pass on_missing_lock = :ignore to accept the no-op."))
+  end
+
+  if on_missing_lock === :warn
+    outcome = _claim_sqlite_lock_warning(key)
+    if outcome !== :silent
+      tail = outcome === :final ?
+        " Reached $(SQLITE_LOCK_WARN_CAP) distinct keys; further advisory-lock warnings are suppressed." : ""
+      @warn "Advisory locks are a no-op on SQLite: this body runs with NO mutual exclusion. Pass " *
+            "on_missing_lock=:ignore to accept that silently, or :error to refuse it." * tail key=key
+    end
+  end
+
+  return f()
+end
 
 # Wrapper to use by database name string
 function with_advisory_lock(f::Function, db::String, key::AbstractString; kwargs...)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -134,10 +134,12 @@ end
     BackendCapabilityError(msg) <: PormGError
 
 The active backend cannot do this — a PostgreSQL-only lookup on SQLite (JSONB containment,
-`iunaccent_*`), an explicit window `frame=` on SQLite, `bulk_copy` on SQLite, or a SQLite library
-older than a feature requires. The query is well-formed and the configuration is fine; the remedy
-is to change the query or the backend. Split out of `UnsupportedConnectionError` in the pre-publish
-naming pass — capability limits are a user-facing contract, not an internal error.
+`iunaccent_*`), an explicit window `frame=` on SQLite, `bulk_copy` on SQLite,
+`with_advisory_lock(...; on_missing_lock = :error)` on SQLite, or a SQLite library older than a
+feature requires. The query is well-formed and the configuration is fine; the remedy is to change
+the request or the backend — each message names the specific way out. Split out of
+`UnsupportedConnectionError` in the pre-publish naming pass — capability limits are a user-facing
+contract, not an internal error.
 """
 struct BackendCapabilityError <: PormGError
   msg::String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,7 @@ end
     @testset "Positive Integer Fields CHECK" include("unit/test_positive_small_integer_check.jl")
     @testset "alter_field Constraint DROPs (#283, #284)" include("unit/test_alter_field_constraint_drops.jl")
     @testset "Error Message ANSI (TTY-aware)" include("unit/test_error_message_ansi.jl")
+    @testset "SQLite Advisory-Lock Signalling (#277)" include("unit/test_advisory_lock_sqlite.jl")
     @testset "Migration Runner (checksum, guardrails)" include("unit/test_migrations_runner.jl")
     @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")
     @testset "FK Rename Rebuild Gate (#150)" include("unit/test_fk_rename_rebuild.jl")

--- a/test/unit/test_advisory_lock_sqlite.jl
+++ b/test/unit/test_advisory_lock_sqlite.jl
@@ -1,0 +1,266 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# with_advisory_lock on SQLite: the no-op now signals (#277)
+#
+# SQLite has no advisory locks, so the body runs with NO mutual exclusion. Staying
+# a no-op is deliberate — it is what lets one source target PostgreSQL in
+# production and SQLite in tests — but it degrades a *guarantee*, not a query that
+# still returns correct rows, and the failure mode is a race visible only under
+# concurrency. #277 made the path speak up without changing the default behavior.
+# `on_missing_lock` picks the policy by name:
+#
+#   :warn (default) → body runs, warns once per key
+#   :ignore         → body runs silently (the caller accepted the no-op)
+#   :error          → BackendCapabilityError; the body does NOT run
+#
+# Before #277 this method was `f()` and nothing else, and it had ZERO test
+# coverage anywhere: test/integration/test_advisorylock.jl returns before defining
+# any testset when the adapter is SQLite.
+#
+# Runs WITHOUT a live database — the SQLite method never touches a connection.
+# ─────────────────────────────────────────────────────────────────────────────
+
+using Test
+using PormG
+using Logging
+
+# Suffixed names on purpose: bare `MockSQLite` / `MockPostgres` already exist in
+# several unit files, and runtests.jl includes them all into ONE session, so a
+# duplicate silently redefines the struct for whichever file runs later.
+struct MockSQLiteLock277 <: PormG.PormGSQLite end
+
+const ADVLOCK_SRC = joinpath(normpath(joinpath(@__DIR__, "..", "..")), "src", "AdvisoryLock.jl")
+
+# Collect only the warnings a block emits, from a FRESH warn-ledger. The ledger is
+# process-wide (that is what makes "once per key" hold across a whole run), so
+# without the reset these testsets would suppress each other depending on order.
+function _advlock_warnings(f)
+  PormG.AdvisoryLock._reset_sqlite_lock_warnings!()
+  tl = Test.TestLogger()
+  Logging.with_logger(tl) do
+    f()
+  end
+  return filter(r -> r.level == Logging.Warn, tl.logs)
+end
+
+@testset "SQLite advisory-lock signalling (#277)" begin
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Default (:warn): the body still runs — the no-op is preserved — but it warns.
+  # The return value must pass through untouched; callers use this for real work.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset ":warn (default) runs the body, warns, passes the value through" begin
+    conn = MockSQLiteLock277()
+    result = Ref{Any}(nothing)
+
+    logs = _advlock_warnings() do
+      result[] = PormG.with_advisory_lock(() -> :body_ran, conn, "standings_rebuild_2024")
+    end
+
+    @test result[] == :body_ran
+    @test length(logs) == 1
+    @test occursin("mutual exclusion", logs[1].message)   # emphasis casing is not the contract
+    @test occursin("on_missing_lock", logs[1].message)    # the message must name the way out
+    @test logs[1].kwargs[:key] == "standings_rebuild_2024"
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The dedup IS the feature: a scheduled job taking the same lock in a loop must
+  # not fill the log. Three calls on one key produce exactly one warning.
+  #
+  # Deliberately NOT built on `@warn maxlog=1`: that is honoured only by loggers
+  # that implement it, so under a custom application sink it would degrade to
+  # warning on every call. The explicit ledger holds for any logger.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "same key warns exactly once, however many calls" begin
+    conn = MockSQLiteLock277()
+    calls = Ref(0)
+
+    logs = _advlock_warnings() do
+      for _ in 1:3
+        PormG.with_advisory_lock(() -> (calls[] += 1), conn, "nightly_result_import")
+      end
+    end
+
+    @test calls[] == 3          # every call still ran the body
+    @test length(logs) == 1     # …but only the first one warned
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Discrimination for the dedup: it is keyed per LOCK KEY, not once per session.
+  # A single global flag would collapse these to one and hide the second critical
+  # section entirely.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "distinct keys warn separately" begin
+    conn = MockSQLiteLock277()
+
+    logs = _advlock_warnings() do
+      PormG.with_advisory_lock(() -> nothing, conn, "driver_update_44")
+      PormG.with_advisory_lock(() -> nothing, conn, "driver_update_1")
+    end
+
+    @test length(logs) == 2
+    @test sort([l.kwargs[:key] for l in logs]) == ["driver_update_1", "driver_update_44"]
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The ledger is BOUNDED — `"driver_update_$(id)"` is the pattern the docs teach,
+  # so unbounded key cardinality is the expected case, not an edge case. Past the
+  # cap it must stop growing, and it must SAY it has gone quiet rather than
+  # silently swallowing the rest.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the warn ledger is capped, and announces the cap" begin
+    conn = MockSQLiteLock277()
+    cap = PormG.AdvisoryLock.SQLITE_LOCK_WARN_CAP
+
+    logs = _advlock_warnings() do
+      for i in 1:(cap + 25)   # comfortably past the ceiling
+        PormG.with_advisory_lock(() -> nothing, conn, "driver_update_$(i)")
+      end
+    end
+
+    @test length(logs) == cap                       # bounded, not one per key
+    @test occursin("suppressed", logs[end].message)  # and it said so
+    @test !occursin("suppressed", logs[1].message)   # only on the one that hit the cap
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Informed consent: `:ignore` means "I know, and I accept it" and must be
+  # completely silent — otherwise a SQLite test suite can never quiet this.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset ":ignore runs the body silently" begin
+    conn = MockSQLiteLock277()
+    result = Ref{Any}(nothing)
+
+    logs = _advlock_warnings() do
+      result[] = PormG.with_advisory_lock(() -> :quiet, conn, "cache_warm";
+                                          on_missing_lock = :ignore)
+    end
+
+    @test result[] == :quiet
+    @test isempty(logs)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The escape hatch. `:error` must FAIL rather than hand back a guarantee SQLite
+  # cannot provide — and critically, the body must not run. A `@test_throws` alone
+  # would pass even if the body had already executed, so the side-effect flag is
+  # the assertion that matters.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset ":error throws and does NOT run the body" begin
+    conn = MockSQLiteLock277()
+    ran = Ref(false)
+
+    err = try
+      PormG.with_advisory_lock(() -> (ran[] = true), conn, "payout_reconciliation";
+                               on_missing_lock = :error)
+      nothing
+    catch e
+      e
+    end
+
+    @test err isa PormG.BackendCapabilityError
+    @test ran[] == false
+    # Assert the cause, not merely the type: the message must name the remedy and
+    # the offending key, per the BackendCapabilityError house style.
+    msg = sprint(showerror, err)
+    @test occursin("on_missing_lock", msg)
+    @test occursin("payout_reconciliation", msg)
+    @test occursin("PostgreSQL", msg)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # A typo must fail loudly, and on BOTH backends — otherwise `:warm` for `:warn`
+  # passes every PostgreSQL test and only surfaces on SQLite. The SQLite side is
+  # checked here; the PostgreSQL method validates through the same helper, which
+  # is asserted directly since reaching its body needs a live connection.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "an unrecognised on_missing_lock raises InvalidValueError" begin
+    conn = MockSQLiteLock277()
+    ran = Ref(false)
+
+    err = try
+      PormG.with_advisory_lock(() -> (ran[] = true), conn, "k"; on_missing_lock = :warm)
+      nothing
+    catch e
+      e
+    end
+
+    @test err isa PormG.InvalidValueError
+    @test ran[] == false
+    @test occursin("warm", sprint(showerror, err))
+
+    # The shared validator the PostgreSQL method calls before acquiring anything.
+    @test PormG.AdvisoryLock._validate_on_missing_lock(:warn) === nothing
+    @test PormG.AdvisoryLock._validate_on_missing_lock(:ignore) === nothing
+    @test PormG.AdvisoryLock._validate_on_missing_lock(:error) === nothing
+    @test_throws PormG.InvalidValueError PormG.AdvisoryLock._validate_on_missing_lock(:nope)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Portability: the whole point of the keyword is that ONE call site can carry it
+  # and run on both backends. If the PostgreSQL method did not accept it,
+  # `on_missing_lock = :error` would be a MethodError on the very backend that
+  # satisfies it. Asserted on the signature because exercising the real
+  # PostgreSQL body needs a live connection.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the PostgreSQL method accepts on_missing_lock" begin
+    pg_methods = [m for m in methods(PormG.with_advisory_lock)
+                  if PormG.PormGPostgres in Base.unwrap_unionall(m.sig).parameters]
+    @test !isempty(pg_methods)
+    @test all(m -> :on_missing_lock in Base.kwarg_decl(m), pg_methods)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The SQLite path must keep swallowing the PostgreSQL keywords — that tolerance
+  # is what keeps a single source portable. Passing all four must not throw.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "PostgreSQL keywords are still accepted and ignored on SQLite" begin
+    conn = MockSQLiteLock277()
+    @test PormG.with_advisory_lock(() -> :ok, conn, "portable_key";
+                                   on_missing_lock = :ignore, wait = true, timeout_ms = 1,
+                                   strategy = :block, interval_ms = 5) == :ok
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Regression guard for the `Base.wait` shadowing bug fixed alongside #277.
+  #
+  # The `wait::Bool` keyword shadows `Base.wait` inside the PostgreSQL method, so
+  # a bare `wait(...)` evaluated as `false(...)` and raised MethodError, which the
+  # surrounding empty `catch` swallowed — the statement_timeout restore had never
+  # once completed, and the async SET was never awaited before the connection went
+  # back to the pool.
+  #
+  # A source scan because the only way to reach those lines is a live PostgreSQL
+  # connection with strategy=:block; a text assertion that genuinely fails on
+  # reintroduction beats a test that cannot run in CI. It scans the whole
+  # PostgreSQL METHOD BODY for any unqualified `wait(`, rather than matching one
+  # call shape — so hoisting the argument into a temporary (`h = ...; wait(h)`)
+  # is caught too. Same technique as test_docstring_coverage.jl. Line endings
+  # normalized: .jl is not pinned to LF in .gitattributes (#216, #228).
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the PostgreSQL method never calls the shadowed `wait`" begin
+    src = replace(read(ADVLOCK_SRC, String), "\r\n" => "\n")
+
+    start_idx = findfirst("function with_advisory_lock(f::Function, pool::PormGPostgres", src)
+    @test start_idx !== nothing
+    rest = src[first(start_idx):end]
+    stop_idx = findfirst("\nend\n", rest)
+    @test stop_idx !== nothing
+    body = rest[1:first(stop_idx)]
+
+    # Guard the guard: if the restore block were removed or renamed, the negative
+    # assertion below would pass vacuously.
+    @test occursin("SET statement_timeout TO DEFAULT", body)
+    @test occursin("Base.wait(", body)
+
+    # Strip comments before scanning — the comment ABOVE the fix quotes `wait(...)`
+    # while explaining the bug, and prose must not be able to fail a code guard.
+    # (Line-based, which is sound here: no string literal in this method contains
+    # a `#`.)
+    code = replace(body, r"(?m)#.*$" => "")
+    @test occursin("Base.wait(", code)   # the fix itself is code, not commentary
+
+    # Any `wait(` not preceded by a dot or word character is the shadowed kwarg.
+    @test !occursin(r"(?<![.\w])wait\s*\(", code)
+  end
+end


### PR DESCRIPTION
## What changed

`with_advisory_lock` on SQLite still runs the body — that no-op is what lets one source target
PostgreSQL in production and SQLite in tests, exactly as `select_for_update` does. But what
degrades here is a mutual-exclusion **guarantee** rather than a query that still returns correct
rows, and the failure mode is a race visible only under concurrency. So the caller now chooses, by
value:

| `on_missing_lock` | On SQLite |
| :--- | :--- |
| `:warn` (default) | Body runs; warns once per key |
| `:ignore` | Body runs silently — the no-op is accepted |
| `:error` | Throws `BackendCapabilityError`; the body does **not** run |

The PostgreSQL method accepts `on_missing_lock` and ignores it — it always takes a real lock, so
there is no "missing lock" case to have a policy about. It exists so one call site stays portable;
without it, `on_missing_lock = :error` would be a `MethodError` on the one backend that satisfies
it. It still **validates** the value, so a typo fails on PostgreSQL too rather than lying in wait
until you run on SQLite.

## Design decisions worth reviewing

**The dedup is an explicit bounded `Set`, not `@warn … maxlog=1 _id=`.** The `maxlog` approach was
the first implementation — it matched the house pattern at `Configuration.jl:587` and needed no
mutable state, sidestepping the `__init__`/#203 hazard. Review killed it on two counts:

1. `maxlog` is honoured only by loggers that implement it (`SimpleLogger`/`ConsoleLogger`/
   `TestLogger`). Under a custom application sink — common in Genie apps and `LoggingExtras` stacks
   — it degrades to warning on **every** call, which is exactly the log flood the dedup exists to
   prevent, for callers who never opted in.
2. `_id=Symbol(:pormg_…, key)` interns a `Symbol` per key, and Julia never frees `Symbol`s. The docs
   teach `"driver_update_$(driver_id)"`, i.e. unbounded key cardinality, so that is a genuine slow
   leak — ~4.5 MiB retained at 50k keys, measured. The `Configuration.jl` precedent keys on a config
   file path (cardinality ~1); generalising it here was the mistake.

The `Set` is plain **data** in a module body, which is safe under cached precompilation — the #203
trap is about side *effects* (`atexit`, hook registration), not container state. Same shape as
`ConnectionPool`'s `leak_warned`. It is capped at `SQLITE_LOCK_WARN_CAP = 64` keys, and the warning
that reaches the cap **says so** rather than going quiet without explanation.

**Naming.** This started as `require_lock::Union{Nothing,Bool}`. Review flagged the real trap: `false`
and unset were behaviourally identical (body runs) and differed only in logging, so the name implied
a boolean question the parameter did not actually answer. `on_missing_lock = :warn|:ignore|:error`
names the axis that varies.

## Latent bug fixed in passing

The `wait::Bool` keyword shadowed `Base.wait` inside `with_advisory_lock`, so both `statement_timeout`
restores evaluated as `false(...)` → `MethodError: objects of type Bool are not callable`, swallowed
by the empty `catch` blocks around them. **That restore had never once completed.** Julia evaluates
the argument first, so the `SET` was dispatched asynchronously and then never awaited before
`release_connection` returned the connection to the pool — which could hand back a connection still
carrying a modified `statement_timeout`. Now `Base.wait(...)`.

The empty `catch`es stay — restoring a timeout is genuinely best-effort — but a `MethodError` is no
longer one of the things they hide. The comment that used to sit there ("wait() is enough…")
documented an intent that never ran, and is replaced with one that explains the shadowing.

## Verification

| Check | Result |
| :--- | :--- |
| New test file alone | 35 / 35 |
| Full unit suite (post-rebase) | **4887 / 4887**, exit 0 |
| Docs build | exit 0, no unresolved references |
| SQLite integration (`db_sl`) | 1854 pass + 1 pre-existing `@test_broken` — run **pre-rebase**, see below |
| Mutation check | reverting `src/AdvisoryLock.jl` → 13 failed + 8 errored |
| Warning leak into `migrate()` | 0 occurrences |

The rendered docstring was checked in built HTML to confirm `$(SQLITE_LOCK_WARN_CAP)` interpolates
as "64" rather than shipping the literal.

## Deliberately not done

- **Integration was not re-run after the rebase**, on the maintainer's call. The pre-rebase run was
  green; this diff (`AdvisoryLock.jl`, the `BackendCapabilityError` docstring, docs) does not overlap
  the `on_delete`/deletion paths #291 changed. CI covers it.
- **No `UPGRADING.md` entry.** A new opt-in keyword argument forces no consuming-app source edit,
  which is the bar that file sets. The SQLite default does move from silent to warning — a
  behavioural change, but not one that breaks a call site.
- **No `Project.toml` bump** — release trains, per `/pormg-cut-release`.
- **#276 is untouched.** It is the thematically identical `pre-publish` issue ("SQLite silently
  doesn't enforce a guarantee") for foreign keys, but the situation differs materially: SQLite *can*
  enforce FKs via `PRAGMA foreign_keys`, whereas it has no advisory-lock primitive at all. The
  `on_missing_lock` shape here is offered as precedent, not applied there.

Closes #277
