### PR TITLE
docs(#289): publish only what each module marks as API

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -120,22 +120,31 @@ ways, and the choice is forced by whether the method takes keywords:
 So adding a keyword to a `ChainCaller`-backed method means **converting it to a closure**; leaving it
 as a `ChainCaller` makes the keyword throw. Coverage: `test/unit/test_fluent_parity_208.jl`.
 
-**A `ChainCaller`-backed helper carries no docstring.** `docs/src/api.md` builds `@autodocs` over the
-whole `QueryBuilder` module with **no `Private` key**, so Documenter's `Private = true` default
-publishes *any* docstring in the module as a public API heading — for a function no user can name.
-Three had drifted in (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280.
-Put the contract on the `object` docstring's `.method(...)` bullet and use a `#` comment on the
-helper. `test_docstring_coverage.jl` enforces it, scoped to the `ChainCaller(helper, q)` branches —
+**A `ChainCaller`-backed helper carries no docstring.** Not because it would be published — since
+#289 `api.md` sets `Private = false`, so an un-`public` name stays off the site either way — but
+because there is no **user-facing** binding to attach docs to — the fluent `.values(...)` a reader
+would `?` is synthesized by `getproperty` and has none, and nobody reaches `up_values!` by name — so
+the text would only ever be seen by someone already in the file. Three had drifted in (`up_filter!`, `up_values!`, `order_by!`) before
+#281; `page` had it until #280. Put the contract on the `object` docstring's `.method(...)` bullet
+and use a `#` comment on the helper. `test_docstring_coverage.jl` enforces it, scoped to the
+`ChainCaller(helper, q)` branches —
 widening it to every `sym === :name` branch is not possible, because the closure branches route to
 `first`/`last`/`get`/`deepcopy`, whose bindings resolve to `Base` and are documented there.
 
-**That guard covers the ChainCaller set only — it is not the whole leak.** 41 documented
-QueryBuilder-owned bindings are exported from neither `QueryBuilder` nor `PormG`, and `@autodocs`
-publishes every one (`_solve_field`, `get_filter_query`, `set_context!`, `quote_identifier`,
-`CTEDict`, …). Do not assume a docstring you add to an internal here stays private just because the
-guard is green. Closing the rest needs a deliberate call rather than a flag flip: those same 41 also
-include `delete`, `list`, `earliest`, `latest`, `cjoin`, `save` and `ObjectHandler`, which are
-genuinely user-facing, so `Private = false` would delete real documentation.
+**What reaches the published API page (#289).** `docs/src/api.md`'s `@autodocs` sets
+`Private = false`, so a docstring is published only if its name is `export`ed **or** declared
+`public` (Julia 1.11+). Adding a docstring to an internal is therefore safe — it stays in the source
+and off the site.
+
+The trap is which module Documenter asks. It calls `Base.ispublic(mod, name)` against the module the
+docstring was **written in**, never `PormG`'s re-export list, because `Docs.meta` is per-module and
+`import`/`export` do not copy entries. So a user-facing name defined here needs its `public`
+declaration **here** — `inspect_query` and `show_query` are exported from `PormG` and would still
+have vanished from the page without the declaration in `src/QueryBuilder.jl`.
+
+Making something user-facing? Declare it `public` next to the exports **and** add it to the frozen
+set in `test/unit/test_docstring_coverage.jl` ("the `public`-but-unexported surface"). That test
+exists because over-declaring silently republishes an internal and no docs build will tell you.
 
 New fluent method? `test/unit/test_docstring_coverage.jl` scans the `sym === :name` branches and
 requires each one documented in **both** the `object` docstring and `docs/src/api.md`.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,10 +97,10 @@ makedocs(
 
         assets = String[],
         # api.md is one comprehensive page: hand-written reference plus an @autodocs dump of every
-        # module. It renders to ~510 KiB as of #274 (measured, not estimated — the previous "~340
-        # KiB" note dated from before #212/#213/#274 added ~45 docstrings). Raised 600 → 900 KiB so
-        # the next batch of docstrings does not fail the build; re-measure `docs/build/api.html`
-        # and update this number whenever a PR adds a significant number of docstrings.
+        # module. It renders to ~438 KiB as of #289 (measured, not estimated — down from ~510 KiB
+        # because `Private = false` stopped publishing ~75 internal docstrings). Raised 600 → 900
+        # KiB so the next batch of docstrings does not fail the build; re-measure
+        # `docs/build/api.html` and update this number whenever a PR moves it materially.
         size_threshold = 900 * 1024,
         # Documenter warns at 100 KiB by default, which api.md passed long ago and will never go
         # back under — so that warning was pure noise. Move the warn limit to 700 KiB: below the
@@ -108,7 +108,11 @@ makedocs(
         # page is approaching the ceiling instead of on every single build.
         size_threshold_warn = 700 * 1024,
     ),
-    checkdocs = :exports,
+    # `:public`, not `:exports`, so this agrees with api.md's `@autodocs Private = false` (#289):
+    # both then use `Base.ispublic`, which covers `export`ed names AND ones declared `public`
+    # (Julia 1.11+). Under `:exports` a `public`-but-unexported name could have a docstring that
+    # never reaches the manual without anything complaining.
+    checkdocs = :public,
 )
 
 # Deploydocs: Sets up automatic upload to the gh-pages branch

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -899,7 +899,14 @@ The terminal `list()` methods return a documented, stable shape:
 
 ## Auto-Generated API Docs
 
-The following section contains auto-generated documentation from docstrings in the source code:
+The following section contains auto-generated documentation from docstrings in the source code.
+
+!!! note "What appears here"
+    `Private = false` means this section lists only names each module marks as API — `export`ed, or
+    declared `public` (Julia 1.11+). Internal helpers keep their docstrings in the source but stay
+    off this page (#289). Note Documenter tests `Base.ispublic` against the module a docstring was
+    *written in*, not `PormG`'s re-export list, so a user-facing name defined in a submodule needs a
+    `public` declaration **there** — see the note above `public` in `src/QueryBuilder.jl`.
 
 ```@autodocs
 Modules = [
@@ -913,5 +920,6 @@ Modules = [
     PormG.ConnectionPool,
     PormG.Utils,
 ]
-Order = [:module, :type, :function, :macro]
+Order = [:module, :constant, :type, :function, :macro]
+Private = false
 ```

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -724,7 +724,13 @@ Race_photo = Models.Model(
 
 **Purpose**: Binary data storage for files and encrypted content.
 
-**Database Type**: `BYTEA`
+**Database Type**: `TEXT` on both backends today — **not** `BYTEA`/`BLOB`.
+
+!!! warning "Incomplete"
+    `BinaryField` is not finished: it renders as `TEXT`, `default=` raises for every non-`nothing`
+    value, and `max_length` never reaches the DDL (it is checked on write, as a *character* count on
+    string values only). Use `TextField`/`CharField` with your own encoding until that is fixed.
+    See the `BinaryField` docstring in the [API reference](api.md).
 
 **Use Cases**: File storage, encrypted data, binary documents.
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -16,6 +16,11 @@ export env, Settings, connection, close_pool!, get_settings
 export with_tx_context, in_transaction_context, current_transaction_depth, register_connection, unregister_connection, set_connection_resolver
 export set_before_connect_hook, ensure_before_connect!
 
+# `public` (Julia 1.11+) — user-facing but not exported (#289). `docs/src/api.md` gives these their
+# own "Configuration API" section and `configuration/server.md` calls them qualified. Required for
+# them to survive `Private = false` in the api.md `@autodocs` block; see the note in QueryBuilder.jl.
+public is_loaded, load_many, ping, status, get_tx_connection
+
 const _REDACT_CONNECTION_STRING_RE = Regex("(?i)(password|user)=[^\\s]+")
 
 # Dynamic connection resolver hook

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -68,6 +68,13 @@ export get_migration_plan
 export init_migrations, status, dry_run
 export migrate_to, mark_applied, mark_failed, remove_migration_record, discard_pending_migration
 export MigrationStatus, DryRunResult
+
+# `public` (Julia 1.11+) — user-facing but not exported (#289). `docs/src/migrations/stability.md`
+# tells users to read `PormG.Migrations.MIGRATION_FORMAT_VERSION` to check plan compatibility.
+# Required for it to survive `Private = false`; see the note in QueryBuilder.jl. Note this is a
+# `const`, so `api.md`'s `@autodocs` `Order` must also include `:constant` or it is filtered out
+# of the page while `checkdocs` still demands it.
+public MIGRATION_FORMAT_VERSION
 export compute_checksum, is_destructive, total_statements, detect_destructive_actions
 export DestructiveMigrationError
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -24,6 +24,25 @@ using Decimals
 
 import PormG: @pormg_debug
 
+# ---
+# `public` (Julia 1.11+) — the field constructors are this module's user-facing API (#289).
+#
+# `Models` exports NOTHING (`names(Models) == [:Models]`) and that is deliberate: users write
+# `Models.CharField(...)` qualified, as every page of `docs/src/fields.md` shows. But un-exported is
+# not the same as private, and two things were reading it that way:
+#   - `docs/src/api.md`'s `@autodocs` uses `Private = false`, and Documenter decides via
+#     `Base.ispublic(mod, name)` against THIS module — so without these declarations every field
+#     constructor silently disappears from the API reference.
+#   - `names(Models)` and tooling reported the module as having no API at all.
+# `public` fixes both without changing what a bare `using` brings into scope.
+#
+# Everything else here (`add_field!`, `ensure_model_initialized`, `validate_default`,
+# `normalize_sqlite_datetime_string`, …) is genuinely internal and deliberately omitted.
+public AutoField, BigIntegerField, BinaryField, BooleanField, CharField, DateField, DateTimeField,
+  DecimalField, DurationField, EmailField, FileField, FloatField, ForeignKey, IDField, ImageField,
+  IntegerField, JSONField, ManyToManyField, OneToOneField, PasswordField, PositiveIntegerField,
+  PositiveSmallIntegerField, SlugField, TextField, TimeField, URLField, UUIDField
+
 
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Core Types

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -187,7 +187,10 @@ export pool_stats  # connection-pool health snapshot (#127)
 export with_tx_context, in_transaction_context  # Transaction context helpers
 # setup / install_ai_skills are deliberately NOT exported (#201): maximally generic names for
 # one-off lifecycle helpers — call them qualified (`PormG.setup()`, `PormG.install_ai_skills()`),
-# which is how every doc and README example already shows them.
+# which is how every doc and README example already shows them. They ARE public API though, and
+# `docs/src/api.md` says so — `public` (Julia 1.11+) records that without putting them in scope on
+# a bare `using PormG`, and keeps them on the API page under `Private = false` (#289).
+public setup, install_ai_skills
 export upgrade_guide  # version-scoped UPGRADING.md emitter (#216)
 
 include("Migrations.jl")

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -1,6 +1,10 @@
 module QueryBuilder
 
 import DataFrames, Tables, JSON, CSV, OrderedCollections
+# `DataFrame` by name, not just the module: `query |> DataFrame` has its docstring attached here, and
+# the `public DataFrame` below (#289) needs a BINDING to mark — `public` on a name this module cannot
+# resolve creates a public-but-undefined entry, which Aqua's `test_undefined_exports` rightly fails.
+import DataFrames: DataFrame
 using Dates, TimeZones, Decimals, UUIDs
 
 import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField
@@ -109,6 +113,26 @@ export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, Filt
   QueryBuildError, UnsafeMutationError, InvalidValueError, WritesDisabledError, UnsupportedConnectionError, BackendCapabilityError, ProtectedError
 # do_count and do_exists are now strictly used as functors (query.count(), query.exists())
 export bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
+
+# ---
+# `public` (Julia 1.11+) — user-facing but deliberately NOT exported (#289).
+#
+# These are real API: `docs/src/api.md` gives them tables and headings, and users reach them through
+# the fluent surface (`query.delete()`, `query.list()`, `q |> DataFrame`) rather than by importing a
+# name, which is why exporting them would only pollute a bare `using`. `public` says "this is API"
+# without changing what `using` dumps into scope.
+#
+# It is also load-bearing for the docs build: `docs/src/api.md`'s `@autodocs` sets `Private = false`,
+# and Documenter decides public/private with `Base.ispublic(mod, name)` against the module the
+# docstring was attached in — never PormG's export list. Anything user-facing here that is not
+# `public` silently vanishes from the API reference. `show_query`/`inspect_query` are the sharp case:
+# exported from `PormG`, but defined here, so only this declaration keeps them on the page.
+public cjoin, delete, list, save, earliest, latest, ObjectHandler, inspect_query, show_query
+
+# Foreign bindings whose docstrings live in this module's meta: the `.first()` / `.last()` terminals
+# and `query |> DataFrame`. `public` works on an imported name (it marks the binding in THIS module),
+# and does not touch `Base`/`DataFrames`.
+public first, last, DataFrame
 
 include("documentation/querybuilder.jl")
 

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -2239,6 +2239,26 @@ mutable struct sTimeField <: PormGField
   formatter::Function
 end
 
+"""
+    TimeField(; kwargs...)
+
+Time of day with no date component — SQL `TIME`.
+
+`default` accepts a `Time` or anything `Time(x)` parses (e.g. `"09:30:00"`); an invalid value raises
+`FieldValidationError` at model-definition time rather than on the first insert.
+
+# Examples
+```julia
+Team_store = Models.Model("team_store",
+  id           = Models.IDField(),
+  name         = Models.CharField(max_length = 100),
+  opening_time = Models.TimeField(),
+  closing_time = Models.TimeField(null = true),
+)
+```
+
+See also [`DateField`](@ref), [`DateTimeField`](@ref), [`DurationField`](@ref).
+"""
 function TimeField(; kwargs...)
   (; verbose_name, unique, blank, null, db_index, db_column, editable) =
     _common_kwargs("TimeField", kwargs)
@@ -2278,6 +2298,38 @@ mutable struct sBinaryField <: PormGField
   max_length::Union{Int, Nothing}
 end
 
+"""
+    BinaryField(; max_length = nothing, kwargs...)
+
+A column intended for binary payloads.
+
+!!! warning "Incomplete — verify before relying on it"
+    Measured against the current code, not the intent:
+
+    - It renders as **`TEXT` on both PostgreSQL and SQLite**, not `BYTEA`/`BLOB` — `_get_column_type`
+      (`Dialect.jl`) has no `sBinaryField` branch, so it reaches the `else` fallthrough.
+    - **`default=` cannot be used.** Every non-`nothing` value raises: a `String` (even valid
+      Base64) fails validation, and a `Vector{UInt8}` cannot be stored in the field's
+      `Union{String,Nothing}`.
+    - `max_length` never reaches the DDL — the column is unbounded `TEXT`. It *is* enforced on the
+      write path, but as a **character** count on `AbstractString` values (the check is
+      `hasfield`-gated, not type-gated); a `Vector{UInt8}` bypasses it entirely.
+
+    Prefer `TextField`/`CharField` with your own encoding until these are fixed. Documented here
+    rather than left silent because `docs/src/fields.md` advertises the `BYTEA` behavior.
+
+# Examples
+```julia
+Technical_document = Models.Model("technical_document",
+  id        = Models.IDField(),
+  name      = Models.CharField(max_length = 200),
+  file_data = Models.BinaryField(),          # renders TEXT today
+  mime_type = Models.CharField(max_length = 100),
+)
+```
+
+See also [`FileField`](@ref), [`TextField`](@ref), [`CharField`](@ref).
+"""
 function BinaryField(; kwargs...)
   (; verbose_name, unique, blank, null, db_index, db_column, editable) =
     _common_kwargs("BinaryField", kwargs; extra = (:max_length,))
@@ -2330,6 +2382,27 @@ mutable struct sDurationField <: PormGField
   formatter::Function
 end
 
+"""
+    DurationField(; kwargs...)
+
+An elapsed time span — `INTERVAL` on both PostgreSQL and SQLite.
+
+`default` is validated at model-definition time and re-raised as `FieldValidationError`, so a bad
+`default=` surfaces where the mistake is rather than on the insert path (where the same coercion
+raises `InvalidValueError`).
+
+# Examples
+```julia
+Pit_task = Models.Model("pit_task",
+  id                 = Models.IDField(),
+  name               = Models.CharField(max_length = 200),
+  estimated_duration = Models.DurationField(),
+  actual_duration    = Models.DurationField(null = true),
+)
+```
+
+See also [`TimeField`](@ref), [`DateTimeField`](@ref).
+"""
 function DurationField(; kwargs...)
   (; verbose_name, unique, blank, null, db_index, db_column, editable) =
     _common_kwargs("DurationField", kwargs)

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -798,10 +798,11 @@ end
 # drifting apart is exactly what #272 was. `test_fluent_parity_208.jl` now pins them equal; keep
 # that test passing rather than editing one side alone.
 #
-# No docstring on purpose — `docs/src/api.md` builds an `@autodocs` page over the whole QueryBuilder
-# module with `Private = true`, so a docstring here publishes `page` in the public API reference as
-# if the function form were supported surface. The `.page(...)` reference lives on the `object`
-# docstring and in `docs/src/api.md` (the split that test_docstring_coverage.jl enforces).
+# No docstring on purpose. Since #289 `api.md`'s `@autodocs` sets `Private = false`, so a docstring
+# here would no longer reach the site by itself — but adding one would still present the function
+# form as supported surface to anyone reading the source, and would invite a `public` declaration to
+# "fix" its absence from the page. The `.page(...)` reference lives on the `object` docstring and in
+# `docs/src/api.md` (the split that test_docstring_coverage.jl enforces).
 
 # Sets BOTH clauses (offset falls back to its 0 default). Unreachable from the chain: `ChainCaller`
 # forwards positional arguments only, so no keyword can arrive on the fluent path.

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -19,10 +19,12 @@ end
 # Backs `query.values(...)` through ChainCaller. Each call RESETS `q.values` — last-call-wins,
 # Django parity (#199) — unlike `up_filter!`, which accumulates.
 #
-# No docstring on purpose (#281): `docs/src/api.md` builds `@autodocs` over the whole QueryBuilder
-# module with no `Private` key, so Documenter's `Private = true` default publishes any docstring
-# here as a public API heading — for a function no user can name. The user-facing contract lives on
-# the `object` docstring's `.values(...)` bullet; `test_docstring_coverage.jl` enforces both halves.
+# No docstring on purpose (#281). Since #289 `api.md`'s `@autodocs` sets `Private = false`, so an
+# un-`public` name no longer reaches the site regardless — but the rule still stands here: there is
+# no USER-FACING binding to attach docs to — `.values(...)` is synthesized by `getproperty`, and
+# nobody reaches `up_values!` by name — so a docstring here would only ever be read by someone
+# already in this file. The user-facing contract lives on the `object` docstring's `.values(...)`
+# bullet; `test_docstring_coverage.jl` enforces both halves.
 function up_values!(q::SQLObject, values)
   # every call of values, reset the values
   q.values = []

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -4,7 +4,7 @@ Docstring coverage of the public surface (#212).
 Two invariants that nothing else enforces:
 
 1. **Every exported name answers `?`.** `?Name` is the first thing a Julia user tries. Documenter's
-   `checkdocs = :exports` does NOT catch a gap here — it flags docstrings that *exist* but are not
+   `checkdocs` (`:public` since #289) does NOT catch a gap here — it flags docstrings that *exist* but are not
    included in the manual, and a name with no docstring has no docs object for it to see. So an
    undocumented export ships silently, which is exactly what happened: the 2026-07-23 audit behind
    #212 missed `@pormg_debug`, and `PormGError` did not exist yet when it was written.
@@ -136,9 +136,10 @@ end
     # ─────────────────────────────────────────────────────────────────────────
     # `ChainCaller` stays undocumented — the `@doc "…" ChainCaller(up_filter!, q)` trap
     # That form does not document `.filter`: the docsystem does not evaluate the expression, it
-    # reads it as a signature and binds the text to `ChainCaller(::Any, ::Any)`. `@autodocs`
-    # (Private = true by default) then publishes it on the site under a `filter(args...)` heading
-    # that belongs to nothing. It looked like it worked for as long as nobody checked.
+    # reads it as a signature and binds the text to `ChainCaller(::Any, ::Any)`, which then shows up
+    # under a `filter(args...)` heading that belongs to nothing. It looked like it worked for as
+    # long as nobody checked. (`Private = false` since #289 keeps it off the site now, but the
+    # docstring would still be misattributed, and a stray `public` would put it back.)
     #
     # This forbids ANY docstring on ChainCaller, not just a misattributed one — deliberately. The
     # type is internal plumbing with nothing a user needs to read, and no-docstring is the only
@@ -150,11 +151,14 @@ end
 
     # ─────────────────────────────────────────────────────────────────────────
     # …and neither do the helpers it dispatches to (#281)
-    # `api.md`'s `@autodocs` block sets no `Private` key, so Documenter's `Private = true` default
-    # publishes EVERY docstring in `PormG.QueryBuilder` as a public API heading. A docstring on
-    # `up_filter!` therefore ships a heading for a function no user can name — the same defect the
-    # ChainCaller guard above exists to prevent, one level down. Three had drifted in
-    # (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280.
+    # Before #289, `api.md`'s `@autodocs` set no `Private` key, so Documenter's `Private = true`
+    # default published EVERY docstring in `PormG.QueryBuilder` as a public API heading — a docstring
+    # on `up_filter!` shipped a heading for a function no user can name. Three had drifted in
+    # (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280. `Private =
+    # false` now filters by `ispublic`, so this testset is no longer the thing keeping them off the
+    # site — it is the sharper rule that they should carry no docstring at all, since there is no
+    # USER-FACING binding to attach docs to (the helper is reachable by name, but only from inside
+    # the module; the fluent `.values(...)` a reader would `?` is synthesized and has none).
     #
     # SCOPED TO `ChainCaller(helper, q)` BRANCHES ON PURPOSE — do not "fix" this by widening it to
     # every `sym === :name` branch. That rule is not satisfiable: the closure branches route to
@@ -163,12 +167,11 @@ end
     # `cjoin`/`With`, which are legitimately documented. The ChainCaller set is exactly the set
     # with no user-facing binding to attach docs to.
     #
-    # This is NOT the whole leak. 41 documented QueryBuilder-owned bindings are exported from
-    # neither `QueryBuilder` nor `PormG`, and `@autodocs` publishes every one of them
-    # (`_solve_field`, `get_filter_query`, `set_context!`, `quote_identifier`, `CTEDict`, …).
-    # Closing that needs a deliberate call, not a flag flip: the same 41 also contains `delete`,
-    # `list`, `earliest`, `latest`, `cjoin`, `save` and `ObjectHandler`, which are genuinely
-    # user-facing, so `Private = false` would drop real documentation. Tracked separately.
+    # Closed module-wide by #289: `api.md`'s `@autodocs` now sets `Private = false`, so publication
+    # follows `Base.ispublic` and internals stay off the page whether or not they carry a docstring.
+    # The `PUBLIC_SURFACE` testset below is what keeps that honest. This testset survives as the
+    # sharper, name-level rule for the ChainCaller set: those helpers should carry no docstring at
+    # all, because there is no user-facing binding to attach them to.
     # ─────────────────────────────────────────────────────────────────────────
     @testset "ChainCaller-backed helpers carry no docstring (#281)" begin
         body = _doccov_getproperty_body()
@@ -212,5 +215,65 @@ end
                 Base.Docs.Binding(PormG.QueryBuilder, sym).mod === PormG.QueryBuilder
         end
         @test documented == String[]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # The `public` surface is frozen (#289)
+    # `docs/src/api.md` sets `@autodocs Private = false`, so what lands on the API reference is
+    # exactly what each module marks as API — `export`ed, or declared `public` (Julia 1.11+).
+    # Documenter tests `Base.ispublic` against the module a docstring was WRITTEN in, never
+    # `PormG`'s re-export list, which is why user-facing names defined in a submodule
+    # (`inspect_query`, `show_query`, every field constructor) need a `public` declaration there.
+    #
+    # The failure mode this guards is over-declaring: one stray `public` on an internal silently
+    # republishes it, and a docs build cannot tell you that is wrong. Freezing the set forces the
+    # question "is this really user-facing?" into review. Under-declaring is caught too — a
+    # user-facing name dropped from the page fails here rather than vanishing quietly.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "the `public`-but-unexported surface is exactly the declared set" begin
+        expected = Dict(
+            PormG              => [:install_ai_skills, :setup],
+            PormG.QueryBuilder => [:DataFrame, :ObjectHandler, :cjoin, :delete, :earliest, :first,
+                                   :inspect_query, :last, :latest, :list, :save, :show_query],
+            PormG.Models       => [:AutoField, :BigIntegerField, :BinaryField, :BooleanField,
+                                   :CharField, :DateField, :DateTimeField, :DecimalField,
+                                   :DurationField, :EmailField, :FileField, :FloatField,
+                                   :ForeignKey, :IDField, :ImageField, :IntegerField, :JSONField,
+                                   :ManyToManyField, :OneToOneField, :PasswordField,
+                                   :PositiveIntegerField, :PositiveSmallIntegerField, :SlugField,
+                                   :TextField, :TimeField, :URLField, :UUIDField],
+            PormG.Migrations   => [:MIGRATION_FORMAT_VERSION],
+            PormG.Configuration => [:get_tx_connection, :is_loaded, :load_many, :ping, :status],
+        )
+        for (mod, want) in expected
+            @testset "$(nameof(mod))" begin
+                actual = sort([s for s in names(mod)
+                               if s !== nameof(mod) && Base.ispublic(mod, s) && !Base.isexported(mod, s)])
+                @test actual == sort(want)
+
+                # `public X` on a name the module cannot resolve creates a public-but-UNDEFINED
+                # entry — `names()` lists it, `mod.X` throws UndefVarError, and the docs build says
+                # nothing. `public DataFrame` did exactly this until `import DataFrames: DataFrame`
+                # was added, because only the module was imported. Aqua's `test_undefined_exports`
+                # also catches it, but Aqua is an optional dep here (`HAS_AQUA` in runtests.jl), so
+                # a worktree without it runs green while CI fails. Check it where it belongs.
+                undefined = filter(s -> !isdefined(mod, s), actual)
+                @test undefined == Symbol[]
+            end
+        end
+
+        # Modules with no declarations must stay that way — otherwise a new one could be added to a
+        # module absent from `expected` and no assertion above would ever look at it.
+        for mod in (PormG.Kernel, PormG.Functions, PormG.ConnectionPool, PormG.Utils)
+            @test isempty([s for s in names(mod)
+                           if s !== nameof(mod) && Base.ispublic(mod, s) && !Base.isexported(mod, s)])
+        end
+
+        # A `_`-prefixed name is internal by convention here, without exception — 0 of 38 at #289.
+        # Declaring one `public` is always a mistake, whatever the module.
+        for mod in (PormG, PormG.Kernel, PormG.Functions, PormG.QueryBuilder, PormG.Models,
+                    PormG.Migrations, PormG.Configuration, PormG.ConnectionPool, PormG.Utils)
+            @test isempty([s for s in names(mod) if startswith(String(s), "_") && Base.ispublic(mod, s)])
+        end
     end
 end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -15,6 +15,11 @@ using Test
 using PormG
 
 # The frozen top-level surface of `using PormG` (must match docs/src/api.md exactly).
+#
+# NOTE (#289): `names(PormG)` reports exported names AND ones declared `public` (Julia 1.11+), so
+# this set is the *public* surface, not the *exported* one — the two now differ by exactly the two
+# `public` entries at the bottom. A bare `using PormG` still brings only the exported names into
+# scope; `public` records "this is API" for tooling, `?`, and Documenter's `Private = false`.
 const EXPECTED_TOPLEVEL = Set([
     # Query builder
     :object, :get, :Q, :Qor, :F, :Exists, :OuterRef, :Subquery, :Interval, :show_query, :inspect_query,
@@ -45,9 +50,15 @@ const EXPECTED_TOPLEVEL = Set([
     :run_in_transaction, :atomic, :with_savepoint, :with_tx_context, :in_transaction_context,
     # Locking
     :with_advisory_lock,
-    # Utilities & lifecycle (#201: setup / install_ai_skills are qualified-call-only, not exported)
+    # Utilities & lifecycle
     :upgrade_guide, :register_ignore_tables!,
     Symbol("@import_models"), Symbol("@models_module"), Symbol("@pormg_debug"),
+    # #201 kept `setup` / `install_ai_skills` OUT of `export` — they are maximally generic names
+    # for one-off helpers, and every example calls them qualified. That still holds: neither is
+    # exported, so a bare `using PormG` does not bind them. #289 additionally declares them
+    # `public`, which is what puts them in `names(PormG)` and therefore in this set — recording
+    # that they ARE API (as docs/src/api.md already stated) without widening `using`.
+    :setup, :install_ai_skills,
 ])
 
 # The SQL function library, namespaced under PormG.Functions (NOT exported by PormG).
@@ -70,6 +81,30 @@ const EXPECTED_FUNCTIONS = Set([
         @test setdiff(actual, EXPECTED_TOPLEVEL) == Set{Symbol}()   # nothing unexpected leaked in
         @test setdiff(EXPECTED_TOPLEVEL, actual) == Set{Symbol}()   # nothing documented went missing
         @test actual == EXPECTED_TOPLEVEL
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # `public` is not `export` (#289)
+    # The set above is `names(PormG)`, which since Julia 1.11 reports exported AND `public` names.
+    # That makes it a weaker statement than it looks: a name could enter it by being declared
+    # `public` while #201's "qualified-call-only" promise still holds. Pin the distinction, so a
+    # future `export setup` cannot slip in behind an unchanged EXPECTED_TOPLEVEL.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "public-but-not-exported lifecycle helpers stay out of `using`" begin
+        for n in (:setup, :install_ai_skills)
+            @test Base.ispublic(PormG, n)          # API, and Documenter's `Private = false` keeps it
+            @test !Base.isexported(PormG, n)       # …but #201 still says: call it qualified
+        end
+
+        # The load-bearing half: a bare `using PormG` must not bind them. `names(…; imported=false)`
+        # is what `using` consults, so check the binding directly in a throwaway module.
+        mod = Module(:PormGUsingProbe)
+        Core.eval(mod, :(using PormG))
+        for n in (:setup, :install_ai_skills)
+            @test !isdefined(mod, n)
+        end
+        # Control: something genuinely exported DOES arrive, so the probe itself is not vacuous.
+        @test isdefined(mod, :object)
     end
 
     # The SQL function constructors must NOT be exported at the top level (the whole point


### PR DESCRIPTION
Closes #289.

## The bug

`docs/src/api.md`'s `@autodocs` block set no `Public`/`Private` key, so Documenter's `Private = true` default published **every** docstring across nine modules as a public API heading — 126 bindings that are not API (`_execute_statements_pg`, `set_context!`, `quote_identifier`, `CTEDict`, …). Before the General-registry publish, that invites users to depend on internals, and withdrawing them afterwards reads as a breaking docs change.

**`Private = false` alone would have been destructive.** Documenter decides via `Base.ispublic` against the module a docstring was *written in* — never `PormG`'s re-export list, because `Docs.meta` is per-module and `import`/`export` don't copy entries. With zero `public` declarations in `src/`, the flip would have silently deleted **~45 user-facing docstrings**: every field constructor in `fields.md`, the `.first()`/`.last()`/`|> DataFrame` terminals, `inspect_query`, `show_query`, `setup`, `install_ai_skills`.

## What's in here

- **47 `public` declarations** (Julia 1.11+) in the module that *defines* each name — `Models` (27 field constructors; the module exports nothing at all, so `names(Models)` was `[:Models]`), `QueryBuilder` (12, including the foreign `Base.first`/`Base.last`/`DataFrames.DataFrame` whose docstrings live in its meta), `Configuration` (5), `PormG` (2), `Migrations` (1).
- **`Private = false`**, and `:constant` added to `Order` — a **pre-existing bug, and not latent**: `MIGRATION_FORMAT_VERSION` is documented, `migrations/stability.md` tells users to read it, and it was being filtered off the page. It appears for the first time in this PR.
- **`checkdocs = :exports` → `:public`**, so the completeness check and the publication filter share one predicate.
- **`import DataFrames: DataFrame`** — `public` on a name the module cannot resolve creates a public-but-*undefined* entry, which Aqua's `test_undefined_exports` rightly fails.
- **Docstrings for `TimeField`/`DurationField`/`BinaryField`**, which `fields.md` gives headings but which had none.
- **Guards**: the `public`-but-unexported set is frozen per module, every declared name must be `isdefined`, no `_`-prefixed name may be public, and a probe pins that `public` ≠ `export` (`using PormG` still does not bind `setup`/`install_ai_skills`).

## Verification

The load-bearing check is the rendered page, not the build passing: **281 heading anchors → 210**, with all 75 removals read individually (every one an internal) and **zero non-PormG anchors lost**. Foreign bindings render under their *defining* module, so a `PormG`-only grep misses `Base.first` — I got that wrong first time and rebuilt the true baseline.

Unit **4917/4917**; docs build clean. Two rounds of independent review; every finding fixed.

## `BinaryField` documents a broken feature, deliberately

Writing its docstring surfaced that the field does not work as `fields.md` claims. Measured, not read: it renders **`TEXT` on both backends** (no `sBinaryField` branch in `_get_column_type`), **every non-`nothing` `default=` raises**, and `max_length` never reaches the DDL — though it *is* enforced on write, as a character count on string values only. The docstring and `fields.md` now say so and point users at `TextField`/`CharField`. Fixing the field itself is out of scope and wants its own issue.

## Deliberately not done

- `FileField`, `PositiveIntegerField`, `PositiveSmallIntegerField` are declared `public` despite not appearing in `docs/src` — family symmetry; publishing 24 of 27 constructors would be stranger.
- `Configuration.load` is documented in `api.md` but stays non-public (it has no docstring, so nothing changes today).
- **`Models.Model` stays non-public** — worth tracking. It is the entry point in every example including the three new docstrings, and the day it gets a docstring it will silently not publish. `Model_Type`, `UniqueConstraint` and `set_models` are in the same position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
