### PR TITLE
fix(#276): enforce foreign keys on SQLite

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,99 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## SQLite now enforces foreign keys (#276)
+
+- **Version**: Unreleased
+- **PormG ref**: #276; `ext/PormGSQLiteExt.jl`, `src/ConnectionPool.jl`, `src/migrations/runner.jl`,
+  `src/querybuilder/deletion.jl`, `docs/src/write/create.md`, `docs/src/write/delete.md`
+- **Recorded**: 2026-08-02
+- **Severity**: **breaking (runtime behavior, SQLite only)** — statements that silently succeeded now
+  raise. Part of the `0.3.x` pre-publish wave.
+
+### What changed
+
+SQLite ships with `PRAGMA foreign_keys` **off** and PormG never turned it on, so the `REFERENCES`
+clauses `makemigrations` emits were declared and never enforced. A dangling foreign key inserted
+cleanly on SQLite and raised `IntegrityError` on PostgreSQL.
+
+That is the wrong way round for a project that recommends SQLite for local/test and PostgreSQL for
+production: **a referential-integrity bug passed a green SQLite suite and only surfaced in
+production.** PormG now issues `PRAGMA foreign_keys = ON` on every SQLite connection, so both
+backends enforce the same contract.
+
+Two consequences for existing code:
+
+- Inserting or updating a row whose foreign key has no parent now raises `IntegrityError` on SQLite,
+  as it always has on PostgreSQL.
+- Deleting a parent that still has children raises, unless the relation says otherwise
+  (`on_delete = "CASCADE"`/`SET_NULL` behave as declared). Notably `DO_NOTHING` now defers to a
+  database that actually checks.
+
+**Enforcement is not retroactive.** Rows that are already dangling stay where they are; only new
+statements are constrained. So an existing database does not start failing on read — it fails the
+next time something writes a bad reference, which is the point.
+
+Migrations are unaffected: the SQLite table-rebuild suspends enforcement for the duration of the
+migration transaction (SQLite's own documented ALTER procedure), and the connection is renewed
+afterwards so enforcement is never left off.
+
+### How to find the calls to migrate
+
+```bash
+grep -rn "on_delete" --include=*.jl .
+grep -rn "bulk_insert\|bulk_update" --include=*.jl .
+```
+
+Look for anything that writes related rows **children-first**, or that relied on SQLite tolerating a
+reference to a row that does not exist — fixture loaders and data-repair scripts are the usual
+places. A load whose order is genuinely parent-last needs the escape hatch below.
+
+### Before → after
+
+```julia
+# before — succeeded on SQLite, raised on PostgreSQL
+M.Race.objects.create("year" => 2025, "circuitid" => 999_999, …)
+
+# after — raises IntegrityError on both. Either insert the parent first…
+M.Circuit.objects.create("circuitid" => 999_999, …)
+M.Race.objects.create("year" => 2025, "circuitid" => 999_999, …)
+```
+
+```julia
+# …or, if the order genuinely cannot be parent-first, wrap it in a transaction. Checks are deferred
+# to COMMIT on BOTH backends, so a transiently inconsistent block commits fine. Usually all you need.
+atomic(pool) do
+    bulk_insert(M.Result, results_df)   # children
+    bulk_insert(M.Race,   races_df)     # parents
+end
+```
+
+```julia
+# Only when a transaction is not enough — a load too big to hold in one, a repair that must leave a
+# violation standing — suspend enforcement outright. A PRAGMA foreign_key_check runs before COMMIT,
+# so the result is still verified. Pass check_on_exit = false when the violation is deliberate, or
+# when the database already contains orphans (the check is whole-database, not scoped to the block).
+without_foreign_keys(pool) do
+    …
+end
+```
+
+### Two timing details worth knowing
+
+**Inside a transaction, an FK error now surfaces at `COMMIT`, not at the statement.** PormG's
+PostgreSQL foreign keys have always been `DEFERRABLE INITIALLY DEFERRED`, and SQLite now matches
+(`PRAGMA defer_foreign_keys`). If you wrapped a single `create()` in its own `try`/`catch` expecting
+the `IntegrityError` there, it will now arrive when the surrounding transaction commits. Outside a
+transaction — an autocommit `create()` — nothing changes: the error still comes from the statement.
+
+**`on_delete = "PROTECT"` (`ON DELETE RESTRICT`) differs slightly.** PostgreSQL never defers
+`RESTRICT`, so it raises at the `DELETE`; SQLite defers it with everything else and raises at
+`COMMIT`. The error type is the same (`IntegrityError`) and PormG's own collector raises
+`ProtectedError` before any SQL in the usual path, so this only shows up if you reach the database
+directly.
+
+---
+
 ## Contradictory `on_delete` declarations now raise, and the `SET` sentinel is gone (#287)
 
 - **Version**: Unreleased

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -385,16 +385,24 @@ end
 was rejected there; a value PormG rejects before sending raises `InvalidValueError` instead (see
 the null-field example above).
 
-!!! warning "SQLite does not enforce foreign keys"
-    SQLite ships with `PRAGMA foreign_keys` **off**, and PormG does not turn it on. The insert
-    above therefore **succeeds** on SQLite, storing a row that references a `circuitid` which does
-    not exist — no error, no warning. `UNIQUE` and `PRIMARY KEY` violations *are* enforced on both
-    backends and raise `IntegrityError` as described.
+!!! note "Foreign keys are enforced on both backends"
+    The insert above raises `IntegrityError` on SQLite as well as PostgreSQL: PormG issues
+    `PRAGMA foreign_keys = ON` on every SQLite connection (#276). SQLite itself defaults the pragma
+    to **off**, which used to mean a dangling reference stored silently there while failing in
+    production PostgreSQL — a bug shape that passed its own test suite.
 
-    The practical consequence: referential integrity you rely on in production PostgreSQL is not
-    reproduced by a SQLite test run, so a dangling-FK bug can pass its tests. Declare the
-    relationship on the model either way — `on_delete` cascade handling is applied by the ORM and
-    works on both backends — but do not treat a green SQLite suite as proof the constraint holds.
+    Enforcement is **not retroactive**: rows already dangling in an existing database stay as they
+    are, and only new statements are checked.
+
+    **Inside a transaction the check happens at `COMMIT`, not at the statement**, on both backends
+    (PostgreSQL foreign keys are `DEFERRABLE INITIALLY DEFERRED`; SQLite matches with
+    `PRAGMA defer_foreign_keys`). So a block that writes children before their parents commits
+    normally — the inconsistency only has to be gone by the end. The example above is autocommit, so
+    it raises immediately.
+
+    For the rarer case where a violation must actually persist — a repair, or a load too large for
+    one transaction — [`without_foreign_keys`](@ref) suspends enforcement for a block on a single
+    pinned connection and verifies the result with `PRAGMA foreign_key_check` before committing.
 
 **Generated SQL (PostgreSQL):**
 ```sql

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -154,18 +154,20 @@ delete(query)
     | Backend | Deleting a parent whose child FK has an unset `on_delete` |
     |---|---|
     | PostgreSQL | `NO ACTION` is enforced — the delete fails with a foreign-key violation |
-    | SQLite | the delete succeeds and **silently leaves the child orphaned** |
+    | SQLite | `NO ACTION` is enforced — the delete fails the same way (#276) |
 
     Declare the behaviour you want explicitly on every `ForeignKey`.
 
-!!! warning "SQLite does not enforce foreign keys at all"
-    SQLite defaults `PRAGMA foreign_keys` to **off** and PormG does not turn it on, so on SQLite no
-    FK constraint is enforced at runtime — the database will neither cascade a delete nor block one.
-    PormG's own deletion collector is the only thing that acts on `on_delete` there, which means an
-    `on_delete` PormG does not handle (unset, or `DO_NOTHING`) is a no-op rather than an error.
+!!! note "Both backends enforce foreign keys"
+    PormG issues `PRAGMA foreign_keys = ON` on every SQLite connection (#276), so a delete the
+    database should refuse is refused on both. Before that, SQLite defaulted the pragma to **off**
+    and enforced nothing: an `on_delete` PormG's own collector did not handle (unset, or
+    `DO_NOTHING`) silently orphaned the child there while raising on PostgreSQL, so the same schema
+    and the same `delete()` could pass a SQLite test run and fail in production.
 
-    PostgreSQL enforces the constraint normally, so the same schema and the same `delete()` call can
-    succeed on SQLite and fail on PostgreSQL. Test destructive paths against the backend you deploy on.
+    PormG's deletion collector still applies `on_delete` itself — that is what makes `CASCADE` and
+    `SET_NULL` behave identically across backends — but the database is now a real backstop rather
+    than a formality.
 
 **Generated SQL (PostgreSQL):**
 ```sql

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -58,6 +58,17 @@ function _create_sqlite_connection(connection_string::String; read_only::Bool = 
   SQLite.execute(new_conn, "PRAGMA synchronous = NORMAL;")
   SQLite.execute(new_conn, "PRAGMA busy_timeout = 30000;")
   SQLite.execute(new_conn, "PRAGMA case_sensitive_like = ON;")
+  # #276: SQLite defaults `foreign_keys` OFF for backwards compatibility, so PormG's own REFERENCES
+  # clauses were declared and never enforced — a dangling FK inserted fine on SQLite and raised
+  # IntegrityError on PostgreSQL. That inverts what a test backend is for: the bug passes the SQLite
+  # suite and only surfaces in production.
+  #
+  # It is per-connection, so it belongs here rather than anywhere in core: this is the ONLY
+  # `SQLite.DB(` in the repo, and both `backend_connect` and `backend_renew_connection` route
+  # through it — which is also what lets a suspended connection be made safe again by renewing it
+  # (see `finalize_transaction_connection!(…; renew = true)`). Suspend it for a block with
+  # `without_foreign_keys`; migrations do so around the table rebuild.
+  SQLite.execute(new_conn, "PRAGMA foreign_keys = ON;")
   if read_only
     SQLite.execute(new_conn, "PRAGMA query_only = ON;")
   end

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -13,6 +13,10 @@ import PormG: PormGError, PoolError
 # Throw sites (#239): a bad acquire mode is a value error, an unresolvable pool is a config error,
 # and atomic(durable=true) nesting is transaction-API misuse (#268 — was QueryBuildError).
 import PormG: InvalidValueError, InvalidConfigurationError, TransactionError
+# #276: `without_foreign_keys` refuses to commit a block that left orphaned rows. Export alone is not
+# enough — a submodule needs the name on an explicit import list or it is an UndefVarError at the
+# throw site, which no unit test that avoids the path would catch.
+import PormG: UnsafeMutationError
 # The database-error boundary (#268). This module owns the wrap: every driver failure leaving the
 # pool passes `_as_database_error` and arrives as one of these instead of a raw
 # `SQLite.SQLiteException` / `LibPQ.Errors.*`.
@@ -24,6 +28,10 @@ import PormG: backend_connect, backend_renew_connection, backend_is_alive, backe
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
 export with_transaction, with_transaction_async, run_in_transaction, atomic, with_savepoint
+# #276. Exported HERE as well as from PormG: `src/PormG.jl` reaches this module via a bare
+# `using .ConnectionPool`, which imports only exported names — so a top-level `export` of a name this
+# module keeps to itself produces a public-but-undefined binding (Aqua's undefined_exports).
+export without_foreign_keys
 export acquire_connection, release_connection, finalize_transaction_connection!
 export PoolTimeoutError, PoolConnectError
 export pool_stats
@@ -1268,9 +1276,18 @@ Call this from a single terminal `finally`, exactly as `run_in_transaction` does
 never releases its connection to the pool before its ROLLBACK has run on it — the release-then-
 rollback use-after-release race of #139. Never throws: it runs while the transaction's original
 error is propagating.
+
+Pass `renew=true` when the lifecycle mutated per-connection **session state** that releasing cannot
+undo — today only SQLite's `PRAGMA foreign_keys = OFF`, which migrations and
+[`without_foreign_keys`](@ref) use to suspend enforcement (#276). Renewal re-runs the driver's
+connect path, which sets the pragma back ON by construction, and it is the *renewed* handle that
+returns to the slot; the suspended one is closed. Restoring the pragma with a statement instead
+would be unsound: `PRAGMA foreign_keys` is silently ignored while a transaction is open, so a failed
+COMMIT *and* failed ROLLBACK would leave enforcement off with the restore reporting success.
 """
-function finalize_transaction_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn; rollback_error = nothing)
-  if rollback_error !== nothing && !_is_benign_rollback_error(pool, rollback_error)
+function finalize_transaction_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn;
+                                          rollback_error = nothing, renew::Bool = false)
+  if renew || (rollback_error !== nothing && !_is_benign_rollback_error(pool, rollback_error))
     _renew_or_discard_connection!(pool, conn)
   else
     release_connection(pool, conn)
@@ -1278,8 +1295,8 @@ function finalize_transaction_connection!(pool::Union{PormGPostgres, PormGSQLite
   return nothing
 end
 # PormGSettings overload — delegates to the underlying pool, mirroring with_transaction(::PormGSettings).
-finalize_transaction_connection!(pool::PormGSettings, conn; rollback_error = nothing) =
-  finalize_transaction_connection!(pool.connections, conn; rollback_error = rollback_error)
+finalize_transaction_connection!(pool::PormGSettings, conn; rollback_error = nothing, renew::Bool = false) =
+  finalize_transaction_connection!(pool.connections, conn; rollback_error = rollback_error, renew = renew)
 
 # A statement that ends the current transaction (plain ROLLBACK) — deliberately NOT
 # "ROLLBACK TO SAVEPOINT", which keeps the outer transaction alive and must never
@@ -1792,6 +1809,162 @@ with_sqlite_write_lock(f::Function, pool::PormGSQLite) = Base.lock(f, pool.write
 with_sqlite_write_lock(f::Function, pool::PormGPostgres) = f()
 with_sqlite_write_lock(f::Function, settings::PormGSettings) = with_sqlite_write_lock(f, settings.connections)
 
+# Read `PRAGMA foreign_keys` back off a specific connection. Returns the *actual* session state, not
+# what was requested — the distinction matters because SQLite silently ignores `PRAGMA foreign_keys`
+# while a transaction is open (verified: setting OFF inside a BEGIN leaves the read-back at 1, with
+# no error). Anything that suspends enforcement must therefore confirm it took (#276).
+function sqlite_foreign_keys_enabled(pool::PormGSQLite, conn)::Bool
+  rows, _ = with_transaction(pool, "PRAGMA foreign_keys;", conn = conn)
+  # Fail CLOSED. A real SQLite always answers this with exactly one row, so an empty result means
+  # something unexpected answered — and the caller is a guard whose whole job is to refuse to
+  # continue unless suspension is *proven*. Reporting "not enabled" on no evidence would let the
+  # rebuild proceed with enforcement possibly live, which is the silent-cascade path.
+  isempty(rows) && return true
+  return first(rows).foreign_keys != 0
+end
+
+# Throws if enforcement is still on. Used by the migration runner and `without_foreign_keys` right
+# after issuing the suspension.
+function _assert_foreign_keys_suspended(pool::PormGSQLite, conn)
+  sqlite_foreign_keys_enabled(pool, conn) && throw(InvalidConfigurationError(
+    "PRAGMA foreign_keys is still ON on this connection after being asked to suspend it — the \
+     statement was almost certainly issued inside a transaction, where SQLite ignores it silently. \
+     Refusing to continue: a SQLite table rebuild would cascade-delete child rows and still commit (#276)."))
+  return nothing
+end
+
+"""
+    without_foreign_keys(f::Function, db; check_on_exit::Bool = true) -> result
+
+Run `f()` in a transaction with foreign-key enforcement **suspended**, on a single pinned connection.
+
+**Try a plain [`atomic`](@ref) first.** Inside a transaction PormG already defers foreign-key checks
+to `COMMIT` on both backends, so a block that is *transiently* inconsistent — writing children before
+their parents — commits without any special handling. Reach for this only when that is not enough:
+a load too large for one transaction, a repair that must leave a violation in place, or a test that
+plants one deliberately.
+
+`db` may be a pool, a `PormGSettings`, or a db-key `String`, like [`atomic`](@ref). Every query
+inside `f()` reuses the pinned connection, and a nested [`atomic`](@ref) becomes a `SAVEPOINT`.
+
+**This block must be the outermost transaction on its pool.** It cannot nest inside
+`run_in_transaction`/`atomic` and raises `TransactionError` if you try: suspension works by setting
+`PRAGMA foreign_keys = OFF`, which SQLite silently ignores while a transaction is open, so a nested
+call could not suspend anything.
+
+With `check_on_exit = true` (the default) a `PRAGMA foreign_key_check` runs before `COMMIT` and
+rolls the block back if it finds an orphaned row, raising `UnsafeMutationError` — so the escape hatch
+cannot quietly commit a corrupt database.
+
+Note the check is **whole-database, not scoped to what `f()` touched**: on a database that already
+contains orphans, it will abort a block that did nothing wrong. That is deliberate (it is the same
+`PRAGMA foreign_key_check` the migration rebuild gate uses, and narrowing it would mean guessing
+which rows the block touched), but it means a repair run against an already-inconsistent database
+wants `check_on_exit = false` — as does deliberately planting a violation.
+
+The connection is **renewed**, not returned as-is, so a suspended handle can never serve another
+caller (#276).
+
+# Example
+```julia
+# A load too large to hold in one transaction: commit each chunk, tolerating the inconsistency
+# between them, and let the exit check prove the finished result is sound.
+without_foreign_keys(pool) do
+    for chunk in Iterators.partition(eachrow(results_df), 50_000)
+        bulk_insert(M.Result, DataFrame(chunk))
+    end
+    bulk_insert(M.Race, races_df)
+end
+
+# For a merely transient inconsistency, a plain transaction is enough — and cheaper, since it does
+# not have to renew the connection afterwards:
+atomic(pool) do
+    bulk_insert(M.Result, results_df)   # children
+    bulk_insert(M.Race,   races_df)     # parents — checked at COMMIT, on both backends
+end
+```
+
+!!! note "Backend divergence"
+    SQLite genuinely suspends enforcement for the block. On PostgreSQL there is no equivalent — this
+    issues `SET CONSTRAINTS ALL DEFERRED`, which *defers* checks to `COMMIT` rather than skipping
+    them, so a violation still surfaces, just later. `check_on_exit` is SQLite-only.
+
+See also [`atomic`](@ref), [`run_in_transaction`](@ref).
+"""
+function without_foreign_keys(f::Function, pool::PormGSQLite; check_on_exit::Bool = true)
+  # Must be the OUTERMOST transaction on this pool. `run_in_transaction` degrades a nested call to a
+  # SAVEPOINT, but that is not available here: the whole point is `PRAGMA foreign_keys = OFF`, which
+  # SQLite ignores inside an open transaction — a nested block could not suspend anything. Worse, it
+  # would not fail fast: it re-enters the (reentrant) write lock, then acquires a SECOND connection
+  # whose `BEGIN IMMEDIATE` contends with the outer transaction's, and sits there until the busy
+  # timeout × retry budget expires (measured: ~11 minutes to `database is locked`, or a
+  # `PoolTimeoutError` on a split pool). Refuse immediately instead.
+  if in_transaction_context() && get_tx_pool() === pool
+    throw(TransactionError(
+      "without_foreign_keys must be the outermost transaction on this pool — it cannot nest inside \
+       run_in_transaction/atomic, because PRAGMA foreign_keys is silently ignored while a \
+       transaction is open. Move the block outside, or drop the surrounding transaction."))
+  end
+  # Lock BEFORE acquiring, matching run_in_transaction (write lock → writer slot). The reverse order
+  # deadlocks against it under split_read_write, where there is exactly one writer slot.
+  with_sqlite_write_lock(pool) do
+    conn = acquire_connection(pool; mode = :write)
+    local rollback_error = nothing
+    try
+      # Outside the transaction — see sqlite_foreign_keys_enabled for why the order is load-bearing.
+      with_transaction(pool, "PRAGMA foreign_keys = OFF;", conn = conn)
+      _assert_foreign_keys_suspended(pool, conn)
+      # A real transaction, not just the pragma: without one, a nested atomic/with_savepoint would
+      # issue SAVEPOINT with nothing enclosing it — savepoint semantics for a caller who asked for
+      # transaction semantics — and the block would not be atomic.
+      with_transaction(pool, "BEGIN IMMEDIATE TRANSACTION;", conn = conn)
+      try
+        result = with_tx_context(pool, conn) do
+          f()
+        end
+        if check_on_exit
+          violations, _ = with_transaction(pool, "PRAGMA foreign_key_check;", conn = conn)
+          # UnsafeMutationError, not IntegrityError: the database did not refuse anything — PormG
+          # detected the orphans itself and is refusing to commit them. IntegrityError is reserved
+          # for a driver exception it wraps as `.cause` (#268).
+          isempty(violations) || throw(UnsafeMutationError(
+            "without_foreign_keys left $(length(violations)) orphaned foreign-key row(s); rolling back. \
+             Pass check_on_exit = false if the violation is intentional."))
+        end
+        with_transaction(pool, "COMMIT;", conn = conn, release_conn = false)
+        return result
+      catch e
+        try
+          with_transaction(pool, "ROLLBACK;", conn = conn, release_conn = false)
+        catch rollback_err
+          rollback_error = rollback_err
+          @error "Failed to rollback without_foreign_keys block" exception=rollback_err
+        end
+        rethrow(e)
+      end
+    finally
+      # renew=true: this handle has enforcement OFF and must never go back to the pool as-is.
+      finalize_transaction_connection!(pool, conn; rollback_error = rollback_error, renew = true)
+    end
+  end
+end
+
+function without_foreign_keys(f::Function, pool::PormGPostgres; check_on_exit::Bool = true)
+  # PostgreSQL has no per-session "skip FK checks". PormG creates its foreign keys
+  # DEFERRABLE INITIALLY DEFERRED (Dialect.add_foreign_key), so deferring to COMMIT is the closest
+  # equivalent and is what the docstring promises. `check_on_exit` is meaningless here: COMMIT is
+  # itself the check.
+  run_in_transaction(pool) do
+    fetch(pool, "SET CONSTRAINTS ALL DEFERRED;")
+    f()
+  end
+end
+
+without_foreign_keys(f::Function, settings::PormGSettings; check_on_exit::Bool = true) =
+  without_foreign_keys(f, settings.connections; check_on_exit = check_on_exit)
+without_foreign_keys(f::Function, db::String; check_on_exit::Bool = true) =
+  without_foreign_keys(f, get_settings(db); check_on_exit = check_on_exit)
+
 """
     run_in_transaction(f::Function, pool::PormGPostgres) -> result
 
@@ -1903,6 +2076,19 @@ function _run_in_transaction_impl(f::Function, pool::Union{PormGPostgres, PormGS
         # Use BEGIN IMMEDIATE for SQLite to prevent deadlocks and ensure
         # write lock is acquired early for multi-threaded scenarios.
       task = sqlite_execute_async(pool, conn, "BEGIN IMMEDIATE TRANSACTION;", nothing)
+      _await_tx_statement(pool, task)
+      # The transaction is open from here on, so mark it BEFORE anything else can throw — otherwise
+      # a failure below skips the ROLLBACK in the catch and releases a connection with an open
+      # transaction back to the pool, which the acquire liveness probe cannot detect (#71).
+      tx_started = true
+      # #276: match PostgreSQL's timing, not just its strictness. `Dialect.add_foreign_key` creates
+      # every PG foreign key DEFERRABLE INITIALLY DEFERRED, so PG checks at COMMIT and a transaction
+      # may be transiently inconsistent — insert a child, then its parent, and it commits. SQLite's
+      # `foreign_keys` pragma checks per statement, so turning it on alone would make that same
+      # block raise on SQLite only: a NEW divergence, in the direction #276 exists to remove.
+      # `defer_foreign_keys` is per-transaction and resets itself at COMMIT and ROLLBACK, so it
+      # needs no renewal — unlike `foreign_keys`, which is why migrations suspend rather than defer.
+      task = sqlite_execute_async(pool, conn, "PRAGMA defer_foreign_keys = ON;", nothing)
       _await_tx_statement(pool, task)
     end
     tx_started = true

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -15,6 +15,10 @@ import OrderedCollections: OrderedDict
 import Random: randstring
 import SHA
 import PormG.ConnectionPool: fetch, with_transaction, with_sqlite_write_lock, finalize_transaction_connection!
+# #276: the SQLite lifecycle acquires its connection explicitly so it can suspend FK enforcement
+# before BEGIN, and asserts the suspension took. Both must be on this list — an export from
+# ConnectionPool alone is an UndefVarError here, and only the migration path would hit it.
+import PormG.ConnectionPool: acquire_connection, _assert_foreign_keys_suspended
 import PormG.Configuration
 import PormG.Configuration: get_settings
 using Logging

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -181,6 +181,7 @@ export PoolError, error_message, DefinitionError
 export DatabaseError, IntegrityError, OperationalError, StatementError, TransactionError
 export with_advisory_lock  # try_advisory_lock / release_advisory_lock removed (not implemented)
 export fetch_async, await_result, FetchTask, run_in_transaction, atomic, with_savepoint  # Async-first API
+export without_foreign_keys  # #276: suspend FK enforcement for a block (data repair, out-of-order loads)
 export PoolTimeoutError  # thrown by acquire_connection when the pool is saturated (#37)
 export PoolConnectError  # thrown by acquire_connection when a connection can't be opened (#72)
 export pool_stats  # connection-pool health snapshot (#127)

--- a/src/migrations/runner.jl
+++ b/src/migrations/runner.jl
@@ -946,47 +946,76 @@ function _execute_migration_lifecycle(connection::PormGSQLite, settings::PormGSe
   # `BEGIN IMMEDIATE`s would race and deadlock the single async worker. No-op on
   # PostgreSQL. See ConnectionPool.with_sqlite_write_lock.
   with_sqlite_write_lock(connection) do
-    # Begin transaction (IMMEDIATE for SQLite)
-    _, conn = with_transaction(connection, "BEGIN IMMEDIATE TRANSACTION;")
+    # #276: acquire EXPLICITLY rather than letting `with_transaction` acquire at BEGIN. SQLite
+    # ignores `PRAGMA foreign_keys` inside a transaction — silently, returning success — so
+    # enforcement has to be suspended on this exact handle BEFORE the BEGIN. Acquired inside the
+    # write lock to keep the lock→slot order `run_in_transaction` uses; the reverse order deadlocks
+    # against it under split_read_write, where there is exactly one writer slot.
+    conn = acquire_connection(connection; mode = :write)
     # Single terminal finally releases/renews the connection exactly once, so a failed COMMIT
     # never returns it to the pool before the cleanup ROLLBACK has run on it (#139).
     local rollback_error = nothing
 
     try
-      # Execute all SQL statements
-      _execute_statements_sqlite(connection, ordered_statements; conn=conn)
+      # #276: the SQLite table-rebuild drops the old table, and with enforcement on that implicit
+      # DELETE fires child ON DELETE actions — a CASCADE child's rows are deleted, the parent is
+      # renamed back, and the migration COMMITs. The per-table `PRAGMA foreign_key_check` gate
+      # cannot see it (after a cascade there are no orphans left, only missing children). This is
+      # step 1 of SQLite's own documented ALTER procedure. `foreign_key_check` still works while
+      # suspended, so the #82 gate keeps its full detection power.
+      with_transaction(connection, "PRAGMA foreign_keys = OFF;", conn=conn)
+      _assert_foreign_keys_suspended(connection, conn)
 
-      # Record in history table (within same transaction)
-      _record_migration(connection, version, name, checksum, all_sql, "applied", has_destructive; conn=conn)
+      # Begin transaction (IMMEDIATE for SQLite)
+      with_transaction(connection, "BEGIN IMMEDIATE TRANSACTION;", conn=conn)
 
-      # Commit — release_conn=false: the finally owns the single release.
-      with_transaction(connection, "COMMIT;", conn=conn, release_conn=false)
-      @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
-    catch e
-      # Roll back on the still-leased connection; capture a rollback failure so the finally
-      # renews/discards the dirty connection instead of releasing it (#71), then rethrow.
+      # Inner try scoped to "a transaction is actually open" (#276). Kept separate from the outer
+      # one on purpose: folding them together would make a failed PRAGMA or BEGIN run the ROLLBACK
+      # and write a spurious `failed` history row for a transaction that never started.
       try
-        with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=false)
-      catch rollback_err
-        rollback_error = rollback_err
-        @error "Failed to rollback transaction" exception=rollback_err
-      end
+        # Execute all SQL statements
+        _execute_statements_sqlite(connection, ordered_statements; conn=conn)
 
-      # Record failed status outside the (now rolled-back) transaction, reusing the transaction's
-      # own connection (conn=conn): it is still leased until the finally, and acquiring a fresh
-      # writer would deadlock on SQLite's single writer slot. Trade-off: if the ROLLBACK above also
-      # failed, `conn` is dirty and this INSERT fails too (logged and skipped, then the finally
-      # renews it) — so the `failed` row is not recorded in that rare double-failure.
-      try
-        _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive; conn=conn)
-      catch record_err
-        @error "Failed to record migration failure in history table" exception=record_err
-      end
+        # Record in history table (within same transaction)
+        _record_migration(connection, version, name, checksum, all_sql, "applied", has_destructive; conn=conn)
 
-      @error "Error applying migrations" exception=e
-      rethrow(e)
+        # Commit — release_conn=false: the finally owns the single release.
+        with_transaction(connection, "COMMIT;", conn=conn, release_conn=false)
+        @info(_emsg("\e[32mMigrations applied successfully. Version: $version\e[0m"))
+      catch e
+        # Roll back on the still-leased connection; capture a rollback failure so the finally
+        # renews/discards the dirty connection instead of releasing it (#71), then rethrow.
+        try
+          with_transaction(connection, "ROLLBACK;", conn=conn, release_conn=false)
+        catch rollback_err
+          rollback_error = rollback_err
+          @error "Failed to rollback transaction" exception=rollback_err
+        end
+
+        # Record failed status outside the (now rolled-back) transaction, reusing the transaction's
+        # own connection (conn=conn): it is still leased until the finally, and acquiring a fresh
+        # writer would deadlock on SQLite's single writer slot. Trade-off: if the ROLLBACK above also
+        # failed, `conn` is dirty and this INSERT fails too (logged and skipped, then the finally
+        # renews it) — so the `failed` row is not recorded in that rare double-failure.
+        try
+          _record_migration(connection, version, name, checksum, all_sql, "failed", has_destructive; conn=conn)
+        catch record_err
+          @error "Failed to record migration failure in history table" exception=record_err
+        end
+
+        @error "Error applying migrations" exception=e
+        rethrow(e)
+      end
     finally
-      finalize_transaction_connection!(connection, conn; rollback_error=rollback_error)
+      # renew=true (#276): this handle has FK enforcement OFF and must never go back to the pool as
+      # it stands. Renewal re-runs the connect path, which sets the pragma back ON by construction;
+      # the suspended handle is closed, so it cannot reach another borrower. A `PRAGMA foreign_keys
+      # = ON` here would be unsound — it is silently ignored if a transaction is still open.
+      #
+      # `rollback_error` is now redundant here (renew=true already short-circuits the helper's
+      # classification) — kept deliberately so this call still reads the same as its PG twin and the
+      # delete lifecycle, and stays correct if renew ever becomes conditional.
+      finalize_transaction_connection!(connection, conn; rollback_error=rollback_error, renew=true)
     end
   end
   

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -222,6 +222,17 @@ function delete(objct::SQLObjectHandler;
       # COMMIT never returns it to the pool before the cleanup ROLLBACK has run on it (#139).
       local rollback_error = nothing
       try
+        # #276: same deferral as run_in_transaction — PormG's PG foreign keys are DEFERRABLE
+        # INITIALLY DEFERRED, so the collector's intermediate states (a child DELETEd before its
+        # parent, a SET_NULL applied mid-sweep) are legal there. Defer on SQLite too, or enforcement
+        # would reject an ordering PostgreSQL accepts. Resets at COMMIT; no-op on PostgreSQL.
+        #
+        # INSIDE the try, not between it and the BEGIN: `with_transaction(…, conn=conn)` releases
+        # nothing on failure (conn_acquired = false), so a throw in that gap would skip the terminal
+        # finally entirely and strand this connection out of the pool holding an open
+        # BEGIN IMMEDIATE — i.e. the database write lock. The #139/#71 class.
+        connection isa PormGSQLite &&
+          with_transaction(settings, "PRAGMA defer_foreign_keys = ON;", conn=conn)
         with_tx_context(settings.connections, conn) do
           run_deletions(conn)
         end

--- a/test/integration/common_migration_setup.jl
+++ b/test/integration/common_migration_setup.jl
@@ -34,11 +34,23 @@ function _reset_sqlite!(pool::PormG.PormGSQLite)
     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;")
   df = DataFrame(rows)
   if nrow(df) > 0
-    PormG.ConnectionPool.fetch(pool, "PRAGMA foreign_keys = OFF;")
-    for tbl in df.name
-      PormG.ConnectionPool.fetch(pool, "DROP TABLE IF EXISTS \"$(tbl)\";")
+    # #276: dropping tables in `sqlite_master` order means dropping parents before children, which
+    # enforcement refuses (or, for a CASCADE child, silently empties). Suspend it for the block.
+    #
+    # This used to bracket the loop with two bare `fetch(pool, "PRAGMA …")` calls — which never
+    # worked: every `fetch` acquires its OWN pooled connection, `PRAGMA foreign_keys` is
+    # per-connection, and `_sqlite_is_read_query` even classifies PRAGMA as a *read*, so under
+    # split_read_write it routed to a reader while the DROPs went to the writer. The trailing
+    # `= ON` then stuck permanently on whichever slot ran it. Inert while enforcement was off
+    # everywhere; a live corruption of pool state the moment it is not. `without_foreign_keys`
+    # pins one connection for the whole block and renews it afterwards.
+    #
+    # check_on_exit = false: we are deleting every table, so a mid-teardown FK check is meaningless.
+    PormG.without_foreign_keys(pool; check_on_exit = false) do
+      for tbl in df.name
+        PormG.ConnectionPool.fetch(pool, "DROP TABLE IF EXISTS \"$(tbl)\";")
+      end
     end
-    PormG.ConnectionPool.fetch(pool, "PRAGMA foreign_keys = ON;")
   end
 end
 

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -455,8 +455,9 @@ end
     # ─────────────────────────────────────────────────────────────────────────
     # DO_NOTHING should not be preemptively handled by the collector.  The ORM
     # attempts the parent delete directly and defers the final outcome to the
-    # backend: PostgreSQL rejects the FK violation, while SQLite may allow the
-    # delete when PRAGMA foreign_keys is not set.
+    # backend — and since #276 both backends reject the FK violation, so there is
+    # no longer an adapter branch here. (SQLite used to permit it: PormG never set
+    # PRAGMA foreign_keys, so the delete succeeded and orphaned the child.)
     # ─────────────────────────────────────────────────────────────────────────
     @testset "Delete with DO_NOTHING: ORM Defers to Database" begin
         parent_id = 920001
@@ -484,8 +485,7 @@ end
             @test inspection[:operation] == :delete
             @test occursin("delete from do_nothing_parent_scratch", lowercase(inspection[:sql_text]))
 
-            # Live delete — outcome is adapter-dependent.
-            pool = PormG.config[PORMG_DB_FOLDER].connections
+            # Live delete — the database refuses it on both backends since #276.
             delete_q = DoNothingM.Do_nothing_parent_scratch.objects
             delete_q.filter("id" => parent_id)
 
@@ -495,16 +495,14 @@ end
                 e
             end
 
-            if pool isa PormG.PormGPostgres
-                # PostgreSQL enforces the FK at execute time and returns an error.
-                @test delete_result !== nothing
-                @test !(delete_result isa Tuple)
-                @test DoNothingM.Do_nothing_parent_scratch.objects.filter("id" => parent_id).exists()
-            else
-                # SQLite without PRAGMA foreign_keys permits the dangling row.
-                @test delete_result == (1, Dict("do_nothing_parent_scratch" => 1))
-                @test !DoNothingM.Do_nothing_parent_scratch.objects.filter("id" => parent_id).exists()
-            end
+            # #276: both backends now enforce the FK at execute time, so the branch is gone. SQLite
+            # used to permit the dangling row (`PRAGMA foreign_keys` defaults OFF and PormG never
+            # turned it on), which meant a DO_NOTHING delete quietly orphaned children on SQLite and
+            # failed on PostgreSQL — the divergence #276 removed. The ORM defers to the database
+            # either way; the difference was only whether the database bothered to check.
+            @test delete_result isa PormG.IntegrityError   # the constraint, not merely "something threw"
+            @test !(delete_result isa Tuple)               # pre-#276 SQLite returned (1, Dict(...))
+            @test DoNothingM.Do_nothing_parent_scratch.objects.filter("id" => parent_id).exists()
 
             # The child must still be present — the ORM did not touch it.
             @test DoNothingM.Do_nothing_child_scratch.objects.filter("id" => child_id).exists()

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -305,8 +305,11 @@ end
     manager.add(sponsor_a, sponsor_b, sponsor_c)
     expected = Set(["RollbackA", "RollbackB", "RollbackC"])
 
-    # Force remove to fail inside set's run_in_transaction (SQLite does not enforce
-    # FK at runtime unless PRAGMA foreign_keys=ON, so bogus IDs are not reliable).
+    # Force remove to fail inside set's run_in_transaction. Flipping `change_data`, not a bogus FK
+    # id: the trigger has to fire on both backends, and it needs to be independent of *why* a write
+    # is refused. (This used to say bogus IDs were unusable because SQLite did not enforce FKs —
+    # true until #276, which turned enforcement on. The workaround is still the right one; the
+    # reason is no longer.)
     orig_change_data = PormG.config[PORMG_DB_FOLDER].change_data
     try
         PormG.config[PORMG_DB_FOLDER].change_data = false

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1952,10 +1952,18 @@ if adapter_name == "SQLite"
       @test "added_on" in column_names(pool82, "indexchild82")
       @test user_idx(index_names(pool82, "indexchild82")) == idx_before   # add-field rebuild kept the index
 
-      # (f) the FK-check GATE fires: enforcement is off by default, so we can plant an orphan row, and the
-      #     next rebuild's PRAGMA foreign_key_check must abort the migration (rollback) rather than commit.
-      PormG.ConnectionPool.fetch(pool82,
-        """INSERT INTO "indexchild82" ("code", "parent_id", "payload", "added_on") VALUES ('orphan', 999, 'x', '2024-01-01')""")
+      # (f) the FK-check GATE fires: plant an orphan row, and the next rebuild's
+      #     PRAGMA foreign_key_check must abort the migration (rollback) rather than commit.
+      #
+      #     #276: enforcement is ON now, so the orphan goes in through the documented escape hatch.
+      #     check_on_exit = false because the orphan IS the fixture — the whole point is to hand the
+      #     rebuild a violation and prove the gate catches it. This still works because
+      #     `PRAGMA foreign_key_check` reports orphans regardless of whether enforcement is on, which
+      #     is also why suspending it during migrations costs the gate nothing.
+      PormG.without_foreign_keys(pool82; check_on_exit = false) do
+        PormG.ConnectionPool.fetch(pool82,
+          """INSERT INTO "indexchild82" ("code", "parent_id", "payload", "added_on") VALUES ('orphan', 999, 'x', '2024-01-01')""")
+      end
       write82("""
       IndexParent82 = Models.Model(
           id = Models.IDField(),
@@ -2074,3 +2082,94 @@ if adapter_name == "SQLite"
   end
 end
 
+
+# ── SQLite: a rebuild of a PARENT table must not cascade-delete its children (#276) ──
+#
+# Logic: PormG now enables `PRAGMA foreign_keys` on every SQLite connection. The table rebuild
+#        (CREATE new → INSERT…SELECT → DROP old → RENAME) drops the OLD table, and with enforcement
+#        on that DROP performs an implicit DELETE which fires child ON DELETE actions. For a CASCADE
+#        child that deletes its rows permanently; the parent is then renamed back, so the parent
+#        survives and the children do not — and the migration COMMITs successfully.
+# Why:   this is the one silent-data-loss path in #276, and the existing #82 gate cannot see it:
+#        `PRAGMA foreign_key_check` looks for ORPHANS, and after a cascade there are none — the
+#        children are simply gone. The migration lifecycle therefore suspends enforcement before
+#        BEGIN (SQLite's own documented step 1 of the ALTER procedure). Without that suspension this
+#        testset fails by finding zero child rows.
+#        Note #82 rebuilds the CHILD; this one rebuilds the PARENT, which is what fires the cascade.
+if adapter_name == "SQLite"
+  @testset "SQLite rebuild of a parent does not cascade-delete children (#276)" begin
+    db276 = "db_test_migration_276"
+    db276_path = joinpath(@__DIR__, db276)
+    write276(content::String) = open(joinpath(db276_path, "models.jl"), "w") do f
+      write(f, "module models\nimport PormG.Models\n", content, "\nend")
+    end
+
+    try
+      try; PormG.Configuration.close_pool!(db276_path); catch; end
+      try; ispath(db276_path) && rm(db276_path, recursive=true); catch; end
+      PormG.Generator.create_db_folder_and_yml(path=db276_path, adapter="SQLite")
+      yml = joinpath(db276_path, "connection.yml")
+      yml_content = replace(read(yml, String), "database: database.sqlite" => "database: migration_276.sqlite")
+      open(yml, "w") do f; write(f, yml_content); end
+      PormG.Configuration.load(db276_path)
+      pool276 = PormG.Configuration.get_settings(db276_path).connections
+
+      # Parent carries an unrelated field we will alter to force ITS rebuild; child cascades.
+      write276("""
+      Parent276 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField(),
+          note = Models.CharField(null=true)
+      )
+      Child276 = Models.Model(
+          id = Models.IDField(),
+          label = Models.CharField(),
+          parent_id = Models.ForeignKey(Parent276, pk_field="id", on_delete="CASCADE")
+      )
+      """)
+      makemigrations(db276_path, interactive=false)
+      migrate(db276_path, interactive=false, destructive=true)
+
+      PormG.ConnectionPool.fetch(pool276, """INSERT INTO "parent276" ("name", "note") VALUES ('p1', 'n')""")
+      PormG.ConnectionPool.fetch(pool276, """INSERT INTO "child276" ("label", "parent_id") VALUES ('c1', 1)""")
+      PormG.ConnectionPool.fetch(pool276, """INSERT INTO "child276" ("label", "parent_id") VALUES ('c2', 1)""")
+      child_count() = DataFrame(PormG.ConnectionPool.fetch(pool276, """SELECT COUNT(*) AS n FROM "child276" """))[1, :n]
+      @test child_count() == 2
+
+      # Enforcement really is on — this is the premise the whole testset rests on, so assert it
+      # rather than assume it (a dangling insert must be refused).
+      @test_throws PormG.IntegrityError PormG.ConnectionPool.fetch(pool276,
+        """INSERT INTO "child276" ("label", "parent_id") VALUES ('orphan', 999)""")
+
+      # Alter an unrelated field on the PARENT (note: null=true → NOT NULL) → rebuilds parent276.
+      write276("""
+      Parent276 = Models.Model(
+          id = Models.IDField(),
+          name = Models.CharField(),
+          note = Models.CharField(default="d")
+      )
+      Child276 = Models.Model(
+          id = Models.IDField(),
+          label = Models.CharField(),
+          parent_id = Models.ForeignKey(Parent276, pk_field="id", on_delete="CASCADE")
+      )
+      """)
+      makemigrations(db276_path, interactive=false)
+      migrate(db276_path, interactive=false, destructive=true)
+
+      # THE ASSERTION: the children survived the parent's rebuild.
+      @test child_count() == 2
+      parents = DataFrame(PormG.ConnectionPool.fetch(pool276, """SELECT COUNT(*) AS n FROM "parent276" """))
+      @test parents[1, :n] == 1
+
+      # And the migration did not leave an enforcement-disabled connection in the pool: a fresh
+      # dangling insert must still be refused after the migration ran.
+      @test_throws PormG.IntegrityError PormG.ConnectionPool.fetch(pool276,
+        """INSERT INTO "child276" ("label", "parent_id") VALUES ('orphan2', 999)""")
+    finally
+      try; PormG.Configuration.close_pool!(db276_path); catch; end
+      try; delete!(PormG.config, db276_path); catch; end
+      try; ispath(db276_path) && rm(db276_path, recursive=true); catch; end
+    end
+  end
+end

--- a/test/integration/test_transactions.jl
+++ b/test/integration/test_transactions.jl
@@ -619,3 +619,60 @@ settings = PormG.config[PORMG_DB_FOLDER]
   end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #276: a transaction may be transiently FK-inconsistent on BOTH backends
+#
+# PormG creates every PostgreSQL foreign key DEFERRABLE INITIALLY DEFERRED (Dialect.add_foreign_key),
+# so PG checks referential integrity at COMMIT, not per statement — writing a child before its
+# parent inside one transaction is legal there and always has been. #276 turned on SQLite's
+# `PRAGMA foreign_keys`, which checks per statement, so without a matching deferral that same block
+# would have started raising on SQLite ONLY: a new backend divergence created by the fix meant to
+# remove one. `run_in_transaction`/`delete()` therefore issue `PRAGMA defer_foreign_keys = ON`.
+#
+# This test exists because the mechanism is invisible when it breaks: SQLite silently IGNORES an
+# unrecognized pragma, so a typo, a rename, or deleting the line reverts the fix with no error and
+# every other test still green. Assert the behaviour, not the statement.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "FK checks are deferred to COMMIT inside a transaction (#276)" begin
+  parent_id = 940_001
+  child_id  = 940_002
+  orphan_id = 940_003
+
+  cleanup() = begin
+    for i in (child_id, orphan_id)
+      try; M.Just_a_nested_roll_back.objects.filter("id" => i).delete(); catch; end
+    end
+    try; M.Just_a_test_deletion.objects.filter("id" => parent_id).delete(); catch; end
+  end
+  cleanup()
+
+  try
+    # Child first, parent second — inconsistent between the two statements, consistent at COMMIT.
+    PormG.run_in_transaction(PORMG_DB_FOLDER) do
+      M.Just_a_nested_roll_back.objects.create(
+        "id" => child_id, "test" => parent_id, "description" => "deferred fk #276")
+      M.Just_a_test_deletion.objects.create("id" => parent_id, "name" => "deferred fk #276")
+    end
+
+    @test M.Just_a_nested_roll_back.objects.filter("id" => child_id).exists()
+    @test M.Just_a_test_deletion.objects.filter("id" => parent_id).exists()
+
+    # …and deferral is not a licence to commit a violation: a child whose parent never arrives must
+    # still fail, just at COMMIT rather than at the INSERT. Without this half the testset would pass
+    # even if enforcement were off entirely.
+    err = try
+      PormG.run_in_transaction(PORMG_DB_FOLDER) do
+        M.Just_a_nested_roll_back.objects.create(
+          "id" => orphan_id, "test" => 949_999, "description" => "orphan #276")
+      end
+      nothing
+    catch e
+      e
+    end
+    @test err isa PormG.IntegrityError
+    @test !M.Just_a_nested_roll_back.objects.filter("id" => orphan_id).exists()   # rolled back
+  finally
+    cleanup()
+  end
+end

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -977,9 +977,11 @@ end
         # back too. Before the fix this wrap was gated to PostgreSQL only, so on SQLite
         # each chunk auto-committed and chunk-K's failure left chunks 1…K-1 persisted.
         #
-        # Trigger choice: a UNIQUE index, not an FK. The runtime SQLite connection does
-        # not enable PRAGMA foreign_keys, so an FK violation is not a reliable mid-chunk
-        # failure there; a UNIQUE index is enforced by default. And unlike a pre-flight
+        # Trigger choice: a UNIQUE index, not an FK. UNIQUE has always been enforced on both
+        # backends, which is what makes it a reliable mid-chunk failure. (Before #276 an FK was
+        # additionally unusable here because SQLite did not enforce foreign keys at all; it does
+        # now, so an FK would also work — UNIQUE is kept because it needs no parent-row fixture.)
+        # And unlike a pre-flight
         # validation error (bad length / wrong type), a UNIQUE collision passes
         # validation (999 is a valid integer) and only fails once the chunk hits the DB —
         # which is exactly the transactional path under test. On PostgreSQL this passes

--- a/test/unit/test_commit_failure_release.jl
+++ b/test/unit/test_commit_failure_release.jl
@@ -106,11 +106,12 @@ mutable struct MockSQLitePool139 <: PormG.PormGSQLite
   executed::Vector{String}
   available_at_rollback::Union{Nothing, Bool}
   conn_at_rollback::Any
+  foreign_keys::Bool   # #276: mock session state, so the pragma read-back is honest
 end
 MockSQLitePool139(; fail_commit::Bool = false, rollback_error_msg::Union{Nothing, String} = nothing) =
   MockSQLitePool139(Any[FakeConn139(1)], [true], "mock://sqlite", 1, false, 1, 0,
                     ReentrantLock(), ReentrantLock(), fail_commit, rollback_error_msg, 1,
-                    String[], nothing, nothing)
+                    String[], nothing, nothing, true)
 
 PormG.backend_is_alive(::MockSQLitePool139, conn) = conn isa FakeConn139 && !conn.closed
 PormG.backend_connect(pool::MockSQLitePool139; read_only::Bool = false) = FakeConn139(pool.next_id += 1)
@@ -125,6 +126,15 @@ function PormG.backend_execute(pool::MockSQLitePool139, conn, sql::String, param
   pool.fail_commit && startswith(sql, "COMMIT") && error("mock: commit refused")
   if pool.rollback_error_msg !== nothing && startswith(sql, "ROLLBACK")
     error(pool.rollback_error_msg)
+  end
+  # #276: answer the pragma read-back honestly. The migration lifecycle suspends FK enforcement
+  # before BEGIN and then ASSERTS it took (`_assert_foreign_keys_suspended`). Returning the generic
+  # empty result for this query would make that guard pass without proving anything — with the
+  # fail-closed reading it now throws instead, and either way the assertion would be untested here.
+  # Track the mock's own state so the lifecycle's `= OFF` is what makes the guard pass.
+  if startswith(sql, "PRAGMA foreign_keys")
+    occursin("=", sql) && (pool.foreign_keys = occursin(r"=\s*ON"i, sql))
+    return occursin("=", sql) ? NamedTuple[] : [(foreign_keys = pool.foreign_keys ? 1 : 0,)]
   end
   return NamedTuple[]
 end
@@ -396,5 +406,12 @@ end
   @test any(s -> startswith(s, "COMMIT"),   pool.executed)
   @test any(s -> startswith(s, "ROLLBACK"), pool.executed)
   @test pool.available[1] === true
-  @test pool.connections[1] === old
+
+  # #276 changed this one line, and only on SQLite (the PG twin above still asserts `=== old`).
+  # The SQLite lifecycle suspends `PRAGMA foreign_keys` on its connection before BEGIN, so it now
+  # finalizes with `renew = true` unconditionally — a released-as-is handle would carry enforcement
+  # OFF back into the pool. The #139 guarantees this testset exists for are unaffected and still
+  # asserted above: the connection stays leased until ROLLBACK has run on it.
+  @test pool.connections[1] !== old       # renewed, not released as-is
+  @test old.closed === true               # …and the suspended handle is closed, so nothing can reuse it
 end

--- a/test/unit/test_public_exports.jl
+++ b/test/unit/test_public_exports.jl
@@ -50,6 +50,9 @@ const EXPECTED_TOPLEVEL = Set([
     :run_in_transaction, :atomic, :with_savepoint, :with_tx_context, :in_transaction_context,
     # Locking
     :with_advisory_lock,
+    # #276: SQLite now enforces foreign keys; this is the supported way to suspend that for a block
+    # (data repair, out-of-order bulk loads, planting a deliberate violation in a test).
+    :without_foreign_keys,
     # Utilities & lifecycle
     :upgrade_guide, :register_ignore_tables!,
     Symbol("@import_models"), Symbol("@models_module"), Symbol("@pormg_debug"),

--- a/test/unit/test_transaction_rollback_renewal.jl
+++ b/test/unit/test_transaction_rollback_renewal.jl
@@ -311,3 +311,34 @@ end
   @test pool.connections[1] isa FakeConn71            # pool untouched
   @test pool.available[1] === true
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #276: `renew = true` renews unconditionally, even on the clean path
+# The SQLite migration lifecycle and `without_foreign_keys` suspend `PRAGMA foreign_keys` on their
+# connection. That is per-connection session state a release cannot undo, and it CANNOT be undone by
+# a restoring statement either: `PRAGMA foreign_keys` is silently ignored while a transaction is
+# open, so a failed COMMIT + failed ROLLBACK would leave enforcement off with the restore reporting
+# success. Renewal is the structural fix — the suspended handle is closed, so nothing can reuse it.
+#
+# The distinction this pins: `renew = true` must renew even when `rollback_error === nothing`, which
+# is exactly the case the pre-#276 signature treated as "clean, safe to release".
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "finalize_transaction_connection!(…; renew = true) renews on the clean path (#276)" begin
+  pool = MockSQLitePool71()
+  old  = pool.connections[1]
+
+  CP.finalize_transaction_connection!(pool, old; rollback_error = nothing, renew = true)
+
+  @test pool.connections[1] !== old        # renewed, not released as-is
+  @test old.closed === true                # the suspended handle is gone for good
+  @test pool.available[1] === true          # and the slot is usable again
+
+  # Control: the default is unchanged — a clean lifecycle still releases the same handle, so this
+  # testset cannot pass merely because renewal became unconditional.
+  pool2 = MockSQLitePool71()
+  keep  = pool2.connections[1]
+  CP.finalize_transaction_connection!(pool2, keep; rollback_error = nothing)
+  @test pool2.connections[1] === keep
+  @test keep.closed === false
+  @test pool2.available[1] === true
+end


### PR DESCRIPTION
Closes #276 — **the last item on the `pre-publish` gate.**

## The bug

SQLite defaults `PRAGMA foreign_keys` **off** and PormG never turned it on, so the `REFERENCES` clauses `makemigrations` emits were declared and never enforced. A dangling foreign key inserted cleanly on SQLite and raised `IntegrityError` on PostgreSQL.

That is the wrong way round for a project that recommends SQLite for local/test and PostgreSQL for production: **the bug passed its own test suite and only surfaced in production.**

## Enabling the pragma is one line. The migration engine is the problem.

The SQLite table rebuild — the *only* way PormG alters a column there — drops the old table. With enforcement on, that `DROP TABLE` performs an implicit `DELETE` which fires child `ON DELETE` actions:

| Child `ON DELETE` | Result |
|---|---|
| `NO ACTION` / `RESTRICT` | every rebuild of a table with children hard-fails |
| **`CASCADE`** | **child rows permanently deleted**, parent renamed back, transaction **COMMITs** |

The existing `#82` `foreign_key_check` gate is blind to it: it looks for *orphans*, and after a cascade there are none — the children are simply gone. Reproduced end-to-end: **2 children before, 0 after**, gate returning 0 rows, clean commit.

So the lifecycle suspends enforcement before `BEGIN` — SQLite's own documented step 1 of the ALTER procedure, which PormG omitted. `PRAGMA foreign_key_check` still works while suspended, so the gate keeps full detection power.

The pragma is a **silent** no-op inside a transaction, so `_assert_foreign_keys_suspended` reads it back and refuses to continue if it did not take, and the connection is finalized with `renew = true` — a restoring statement would be equally silent if a transaction were still open.

## Keeping the backends aligned, not just strict

PormG's PostgreSQL foreign keys are `DEFERRABLE INITIALLY DEFERRED`, so PG checks at `COMMIT` and a transaction may be transiently inconsistent. Turning on SQLite's per-statement pragma alone would have made that same block raise on SQLite only — **a new divergence created by the fix meant to remove one.** `run_in_transaction` and `delete()` now issue `PRAGMA defer_foreign_keys = ON`, so both backends check at COMMIT.

## `without_foreign_keys`

New exported block API for what a transaction cannot cover: a load too large for one, a repair that must leave a violation standing, a test planting one deliberately. Pins one connection, runs `foreign_key_check` before COMMIT unless you opt out, renews afterwards. Refuses to nest rather than hanging on the write lock (measured: it used to take ~11 minutes to surface "database is locked").

It also fixes a **live bug**: `_reset_sqlite!` bracketed its `DROP TABLE` loop with pragmas issued through separate `fetch` calls — each taking its own pooled connection, and `PRAGMA` classifies as a *read* — so the `OFF` and the `ON` landed on different slots and the `ON` stuck permanently on one of them.

## Verification

- Unit **4924/4924**; SQLite integration **1869 pass / 1 broken (pre-existing) / 0 fail**; docs build clean
- **Every new guard is mutation-tested**: removing the migration suspension breaks the suite; typo'ing the deferral pragma — which SQLite ignores *silently* — turns the new transaction test red; reverting `renew = true` fails the `#139` assertion
- Two rounds of independent review, twelve findings, all fixed. Round 2 caught a connection leak I introduced *while fixing* a round-1 finding: the deferral statement sat outside the protected window at both sites, which would have stranded a connection holding an open `BEGIN IMMEDIATE`

## Behaviour changes (`UPGRADING.md` entry included, no `Project.toml` bump)

- A dangling insert/update raises `IntegrityError` on SQLite.
- A `DO_NOTHING` delete of a parent with children now defers to a database that actually checks.
- **Inside a transaction, FK errors surface at `COMMIT`, not at the statement** — this breaks a per-statement `try`/`catch`. Autocommit is unchanged.
- `PROTECT`/`RESTRICT` timing differs slightly: PostgreSQL never defers it, SQLite does. Same error type; documented.
- **Enforcement is not retroactive** — existing dangling rows stay put; only new statements are checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
