### PR TITLE
docs(#295): document and publish the Models core API

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -43,10 +43,55 @@ public AutoField, BigIntegerField, BinaryField, BooleanField, CharField, DateFie
   IntegerField, JSONField, ManyToManyField, OneToOneField, PasswordField, PositiveIntegerField,
   PositiveSmallIntegerField, SlugField, TextField, TimeField, URLField, UUIDField
 
+# The module's ENTRY POINTS (#295), declared separately because they are a different category from
+# the field constructors above: a field is a column, these define and register the model itself.
+#
+# The trap worth naming, since it costs nothing to fall into: under #289's rule a docstring alone
+# publishes NOTHING. `Model` is the first call in essentially every example in `docs/src`, and
+# writing its docstring without this line would leave it invisible on the API reference exactly as
+# before. The two steps move together — and so does the frozen set in
+# `test/unit/test_docstring_coverage.jl`, which fails if this line and that literal disagree.
+#
+# `Model_Type` is deliberately NOT here. It is documented (users hold one as `M.Driver`) but never
+# named: it appears zero times in `docs/src`, and the vocabulary users are given for "a model" is
+# the abstract `PormGModel`. Publishing the concrete name would invite code to depend on it.
+public Model, UniqueConstraint, set_models
+
 
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Core Types
 #═══════════════════════════════════════════════════════════════════════════════
+"""
+    Model_Type <: PormGModel
+
+The concrete model object — what [`Model`](@ref) returns and what `M.Driver` is. It is the only
+concrete subtype of `PormGModel`, and it is reached by *holding* one, not by naming it: build models
+with `Model(...)` rather than calling this constructor.
+
+Construction fills `name`, `fields` and `field_names`; the remaining slots are populated later by
+[`set_models`](@ref) (directly or through `@import_models`), which is why a model used before
+registration has `connect_key === nothing` and no reverse relations.
+
+| Slot | Filled by | Holds |
+|---|---|---|
+| `name` | `Model(...)`, or `set_models` from the Julia binding | The table name — verbatim from the positional argument, or lowercased when derived from the binding |
+| `fields` | `Model(...)` | Declared field name → `PormGField`, including many-to-many fields |
+| `field_names` | `Model(...)` | The subset that owns a real column — many-to-many fields are excluded |
+| `related_objects` | `set_models` | Reverse accessors installed by foreign keys pointing *at* this model |
+| `_module` / `connect_key` | `set_models` | The defining module and the connection key it registered under |
+| `cache` | `set_models`, `Model(constraints = …)` | Derived metadata: many-to-many relations, declared unique constraints |
+
+`deepcopy` **shares** rather than clones (`deepcopy(model) === model`): a model is resolved schema
+state treated as an immutable shared reference, and recursion would otherwise descend into
+`_module::Module` and throw. The query builder relies on this — copying a query copies its state but
+keeps the same model.
+
+`verbose_name` is inert: no `Model` method accepts it, and nothing consumes it — it is only ever
+copied from one model to another. It does not reach the DDL and does not appear in generated model
+files.
+
+See also [`Model`](@ref), [`set_models`](@ref), [`UniqueConstraint`](@ref).
+"""
 @kwdef mutable struct Model_Type <: PormGModel
   name::AbstractString
   verbose_name::Union{String, Nothing} = nothing
@@ -193,6 +238,67 @@ function get_model_name(model::PormGModel, settings::PormGSettings, symbol::Bool
 end
 
 # TODO add related_name (like django validation) to check if the field is a ForeignKey and the related_name model is defined when models has more than one foreign key to the same model
+#
+# NOTE: keep this comment ABOVE the docstring. A comment between a docstring and the definition it
+# documents silently detaches it — `@doc` binds to the next expression, and the comment is not one,
+# so the string becomes a no-op and `?set_models` answers nothing. Nothing catches that: the package
+# still precompiles, and `checkdocs = :public` only verifies that docstrings which EXIST reach the
+# manual. It cost a debugging round in #295.
+"""
+    set_models(_module::Module, path::String) -> nothing
+
+Register every model defined in `_module` against the database configuration folder `path`, and
+resolve the relationships between them. This is the manual model-loading path; prefer
+`PormG.@import_models` (or `PormG.@models_module` for inline definitions), which call it for you and
+also handle precompilation and Revise reloads.
+
+Until a model is registered it is inert: it has no connection and no reverse relations. Building a
+query still appears to work — `M.Driver.objects.filter(...)` returns a handler — but rendering or
+executing it raises `InvalidConfigurationError`.
+
+Registration does four things:
+
+1. **Names the unnamed.** A model declared without a positional table name carries `name == ""`; it
+   is filled in here from the Julia binding, lowercased (`Race = Model(...)` → table `race`).
+2. **Binds the connection.** `path` is matched against the configured folders to find the connection
+   key. A folder that is not loaded yet is loaded implicitly — which also fixes the environment, so
+   call `PormG.Configuration.load(path; env = ...)` first when you need a specific one, and expect
+   `MissingConfigurationError` from that implicit load if `path` holds no `connection.yml`.
+3. **Resolves relationships.** Each `ForeignKey`/`OneToOneField` target is resolved (a target given
+   as a model-name `String` is replaced by the model object), `pk_field` defaults are applied, and
+   the reverse accessor is installed on the target. With two foreign keys to the same model, an
+   omitted `related_name` is auto-derived and logged. `ManyToManyField`s get their join-table
+   metadata built and cached.
+4. **Rejects contradictions.** `on_delete = SET_NULL` on a `null = false` field, or `SET_DEFAULT`
+   with no `default`, raises `ModelDefinitionError` here — at declaration, rather than later as a
+   mangled `UPDATE`. An unresolvable foreign-key target and a duplicate `related_name` raise the
+   same type.
+
+Calling it again is safe and is the supported way to pick up edits: reverse relations and
+many-to-many caches are cleared before being rebuilt, so a reload cannot accumulate duplicates.
+
+# Examples
+```julia
+module f1_models
+import PormG.Models
+
+Circuit = Models.Model(
+  circuitid = Models.IDField(),
+  name      = Models.CharField(max_length = 100),
+)
+
+Race = Models.Model(
+  raceid    = Models.IDField(),
+  year      = Models.IntegerField(),
+  circuitid = Models.ForeignKey(Circuit, pk_field = "circuitid", on_delete = "CASCADE"),
+)
+
+Models.set_models(@__MODULE__, "db")   # tables `circuit` / `race`; Circuit gains a `race` accessor
+end
+```
+
+See also [`Model`](@ref), `PormG.@import_models`, `PormG.@models_module`.
+"""
 function set_models(_module::Module, path::String)::Nothing
   @pormg_debug false
   models = get_all_models(_module)  
@@ -565,6 +671,55 @@ end
 # `name === nothing` ⇒ the planner derives `<table>_<cols>_uniq` (mirrors the M2M
 # auto-index naming convention). This is NOT a `PormGField` — it carries no column of
 # its own; it references existing fields by name.
+"""
+    UniqueConstraint(; fields, name = nothing)
+
+Require a combination of columns to be unique together — Django's `Meta.unique_together`, spelled as
+a named constraint object. Pass it to [`Model`](@ref) through `constraints =`; a single-column rule
+is the field option `unique = true` instead.
+
+`fields` names fields **on this model** — one name, or an iterable of them. Foreign keys are
+referenced by their field name and resolved to the physical column (honoring `db_column`), and the
+declared case is preserved, so name each field exactly as it was declared.
+
+`name` is the index name. Omitted, the migration planner derives `<table>_<cols>_uniq`, matching the
+automatic many-to-many index convention. Pass an explicit one when the derived name would exceed
+PostgreSQL's 63-byte identifier limit, which Postgres silently truncates — truncation can collide two
+constraints into one index.
+
+Invalid declarations raise `ModelDefinitionError` as early as they can be detected: no fields, a
+repeated field, or a blank `name` fails here in the constructor; a field that does not exist on the
+model, a `ManyToManyField` (it owns no column), or two constraints sharing a name fail when the
+model is built.
+
+!!! note "Materialized when the table is created"
+    Each constraint becomes a `CREATE UNIQUE INDEX` — identical on PostgreSQL and SQLite — emitted
+    when its table is **first created**. Adding or removing one on a table that already exists is
+    not yet detected by `makemigrations`; it needs composite-index introspection PormG does not have
+    (tracked as a follow-up). Declare composite uniqueness with the model, or add the index by hand.
+
+# Examples
+```julia
+Constructor_engine = Models.Model("constructor_engines",
+  id                  = Models.IDField(),
+  constructorid       = Models.ForeignKey(Constructor, pk_field = "constructorid", on_delete = "CASCADE"),
+  year                = Models.IntegerField(),
+  engine_manufacturer = Models.CharField(max_length = 50),
+  constraints = [
+    Models.UniqueConstraint(fields = ("constructorid", "year"), name = "uniq_constructor_year"),
+  ],
+)
+```
+
+which migrates to:
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_constructor_year"
+  ON "constructor_engines" ("constructorid", "year");
+```
+
+See also [`Model`](@ref).
+"""
 struct UniqueConstraint
   fields::Vector{String}
   name::Union{String, Nothing}
@@ -644,6 +799,90 @@ end
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Model Constructors
 #═══════════════════════════════════════════════════════════════════════════════
+"""
+    Model(; constraints = nothing, fields...)
+    Model(name; constraints = nothing, fields...)
+
+Define a model — one database table, described by its fields. Returns a `Model_Type`: the object the
+query builder starts from, as in `M.Driver.objects`.
+
+Every keyword other than `constraints` declares a field: `field_name = FieldType(...)`, where the
+field types are the constructors in this module ([`IDField`](@ref), [`CharField`](@ref),
+[`ForeignKey`](@ref), …). Declaring a keyword whose value is not a field raises
+`ModelDefinitionError` — see the note below, which is the usual reason that happens.
+
+The **table name** comes from the positional string when given, and otherwise from the Julia binding
+the model is assigned to, filled in when [`set_models`](@ref) (or `@import_models`) registers the
+module. Both forms are idiomatic and `Race = Model(...)` and `Race = Model("race", ...)` name the
+same table, because a binding-derived name is lowercased as it is filled in. Reach for the
+positional form when the binding name is not the table name you want.
+
+!!! warning "Give the positional name in lowercase"
+    A positional name is stored **verbatim**, and the two code paths that consume it disagree about
+    case: `makemigrations` lowercases it, while the query builder quotes it as declared. So
+    `Model("Driver_Profile", …)` migrates a table named `driver_profile`, and then every
+    `SELECT`/`INSERT`/`UPDATE` it builds addresses `"Driver_Profile"` — a table that does not exist
+    on a backend where a quoted identifier is case-sensitive, as it is on PostgreSQL.
+
+    Mapping a model to a fixed mixed-case table is
+    [issue #59](https://github.com/PingoLee/PormG.jl/issues/59); until it lands, declare table names
+    in lowercase.
+
+**Field names keep the case you declare** and are case-sensitive in queries, so a legacy `driverId`
+column is addressed as `driverId`. One leading underscore is stripped as the escape hatch for names
+that are Julia keywords or SQL reserved words (`_end = ...` declares the column `end`); a name
+containing `__` is rejected, since that is the lookup separator.
+
+A `ManyToManyField` is stored on the model but owns no column of its own, so it is absent from
+`field_names` and from the created table.
+
+`constraints` takes [`UniqueConstraint`](@ref) objects — one, or a collection — for uniqueness
+spanning more than one column. It is the **only** model-level option.
+
+!!! note "PormG has no Django `Meta` block"
+    There is no model-level `db_table`, `ordering`, or `verbose_name`. Each of those is a keyword
+    like any other, so it is read as a field declaration and raises:
+
+    ```julia
+    Models.Model("race", ordering = ["-year"], raceid = Models.IDField())
+    # ModelDefinitionError: All fields must be of type PormGField, exemple: …
+    ```
+
+    Instead: order at query time with `order_by()` — there is no per-model default sort; pin the
+    table name with the positional argument, subject to the lowercase warning above; and set
+    `verbose_name` per field, where it is accepted, rather than per model.
+
+# Examples
+```julia
+Circuit = Models.Model(                       # table `circuit`, inferred from the binding
+  circuitid = Models.IDField(),
+  name      = Models.CharField(max_length = 100),
+  country   = Models.CharField(max_length = 50),
+)
+
+Race = Models.Model(
+  raceid    = Models.IDField(),
+  year      = Models.IntegerField(),
+  round     = Models.IntegerField(),
+  circuitid = Models.ForeignKey(Circuit, pk_field = "circuitid", on_delete = "CASCADE"),
+  date      = Models.DateField(),
+  time      = Models.TimeField(null = true),
+  constraints = [                             # no two races share a (year, round)
+    Models.UniqueConstraint(fields = ("year", "round"), name = "race_year_round_uniq"),
+  ],
+)
+```
+
+See also [`set_models`](@ref), [`UniqueConstraint`](@ref), [`ForeignKey`](@ref).
+"""
+function Model(name::AbstractString; constraints = nothing, fields...)
+  # Peel `constraints` off BEFORE the `fields...` slurp — otherwise it would flow into the
+  # `NTuple{Pair{Symbol}}` method below and trip its `isa PormGField` check (#19). Generated
+  # model files (Model_to_str) reload through this kwargs form, so this is the round-trip seam.
+  model = Model(name, Tuple(pairs(fields)))
+  return _apply_unique_constraints!(model, constraints)
+end
+
 # Constructor a function that adds a field to the model the number of fields is not limited to the number of fields, the fields are added to the fields dictionary but the name of the field is the key
 function Model(name::AbstractString, fields::NTuple{N, <:Pair{Symbol}}) where N
   fields_dict::Dict{String, PormGField} = Dict{String, PormGField}()
@@ -658,13 +897,6 @@ function Model(name::AbstractString, fields::NTuple{N, <:Pair{Symbol}}) where N
   end
   # println(fields_dict)
   return Model_Type(name=name, fields=fields_dict, field_names=field_names)
-end
-function Model(name::AbstractString; constraints = nothing, fields...)
-  # Peel `constraints` off BEFORE the `fields...` slurp — otherwise it would flow into the
-  # `NTuple{Pair{Symbol}}` method below and trip its `isa PormGField` check (#19). Generated
-  # model files (Model_to_str) reload through this kwargs form, so this is the round-trip seam.
-  model = Model(name, Tuple(pairs(fields)))
-  return _apply_unique_constraints!(model, constraints)
 end
 function Model(name::AbstractString, dict::Dict{String, PormGField})
   field_names::Vector{String} = []

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -4,6 +4,11 @@ Documented error types are the public contract (#239) — CI-enforced half.
 Every user-facing *"this raises `X`"* claim in `docs/src` that can be triggered at query-build
 time is asserted here by running the documented failure and checking the type actually raised.
 
+A **docstring** claim counts as `docs/src` for this purpose (#295): since #289, `docs/src/api.md`
+renders every `public` docstring onto the API reference, so a sentence written in `src/` is
+published to exactly the same page and goes stale exactly the same way. Reference such a case by
+its source location, e.g. `"src/Models.jl — Model docstring: …"`.
+
 Why this exists: 26 such claims went stale and shipped in `0.3.0` because the only thing tying a
 doc sentence to a throw site was someone remembering. Its sibling
 `test/unit/test_docs_error_type_drift.jl` catches a page naming the *retired* `ArgumentError`;
@@ -21,7 +26,7 @@ Claims that genuinely need live data — the unprojected-FK read, `create()` val
 
 using Test
 using PormG
-using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, JSONField
+using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, JSONField, UniqueConstraint
 
 # Mock backends: dialect dispatch is by connection TYPE, so a bare subtype is enough to render
 # SQL and to fire the backend-capability guards. No DB, no pool.
@@ -145,6 +150,22 @@ const DOCERR_CASES = [
         QueryBuildError,
         () -> DOCERR_RESULT_PG.objects.page("20", "10"),
     ),
+    # ── Definition-time claims from the Models docstrings (#295) ──────────────
+    # These are not query-build failures, but they are published on the same api.md page and rot
+    # the same way. The first is the load-bearing one: the `Model` docstring tells users PormG has
+    # no Django `Meta` block, and the whole reason that sentence is safe to write is that a
+    # model-level option is indistinguishable from a field declaration. If a future PR ever peels
+    # a second name off the `fields...` slurp, this case stops throwing and says so.
+    (
+        "src/Models.jl — Model docstring: no Django `Meta` block, so `ordering =` reads as a field",
+        ModelDefinitionError,
+        () -> Model("docerr_meta_probe", ordering = ["-year"], raceid = IDField()),
+    ),
+    (
+        "src/Models.jl — UniqueConstraint docstring: no fields is rejected in the constructor",
+        ModelDefinitionError,
+        () -> UniqueConstraint(fields = ()),
+    ),
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -171,4 +192,26 @@ const DOCERR_CASES = [
             @test !(err isa ArgumentError)
         end
     end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Quoted error TEXT stays accurate (#295)
+# The table above pins types, not wording — deliberately, since messages are free to be reworded.
+# But a docstring that QUOTES a message is making a second, finer claim, and a reword would leave
+# the quote stale with every type assertion still green. `Model`'s "no Django `Meta` block" note
+# shows the message verbatim, because it is the string a user lands on and searches for. Pin the
+# part that is quoted, not the whole sentence, so the surrounding wording stays free to change.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Quoted error text in docstrings (#295)" begin
+    err = try
+        Model("docerr_text_probe", ordering = ["-year"], raceid = IDField())
+        nothing
+    catch e
+        e
+    end
+    # Same guard order as the harness above: a claim whose failure stopped happening is drift too,
+    # and without this `error_message(nothing)` would report a MethodError instead of the reason.
+    @test err !== nothing
+    @test err isa ModelDefinitionError
+    @test occursin("All fields must be of type PormGField", error_message(err))
 end

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -235,13 +235,17 @@ end
             PormG              => [:install_ai_skills, :setup],
             PormG.QueryBuilder => [:DataFrame, :ObjectHandler, :cjoin, :delete, :earliest, :first,
                                    :inspect_query, :last, :latest, :list, :save, :show_query],
+            # Models: the 27 field constructors #289 declared, plus the three entry points #295
+            # added (`Model`, `set_models`, `UniqueConstraint`) = 30. `Model_Type` is deliberately
+            # absent — it is documented but NOT public: users hold one as `M.Driver`, never name it.
             PormG.Models       => [:AutoField, :BigIntegerField, :BinaryField, :BooleanField,
                                    :CharField, :DateField, :DateTimeField, :DecimalField,
                                    :DurationField, :EmailField, :FileField, :FloatField,
                                    :ForeignKey, :IDField, :ImageField, :IntegerField, :JSONField,
-                                   :ManyToManyField, :OneToOneField, :PasswordField,
+                                   :ManyToManyField, :Model, :OneToOneField, :PasswordField,
                                    :PositiveIntegerField, :PositiveSmallIntegerField, :SlugField,
-                                   :TextField, :TimeField, :URLField, :UUIDField],
+                                   :TextField, :TimeField, :UniqueConstraint, :URLField, :UUIDField,
+                                   :set_models],
             PormG.Migrations   => [:MIGRATION_FORMAT_VERSION],
             PormG.Configuration => [:get_tx_connection, :is_loaded, :load_many, :ping, :status],
         )
@@ -259,6 +263,41 @@ end
                 # a worktree without it runs green while CI fails. Check it where it belongs.
                 undefined = filter(s -> !isdefined(mod, s), actual)
                 @test undefined == Symbol[]
+
+                # …and every one of them must actually ANSWER `?` (#295).
+                #
+                # `public` without a docstring is the mirror image of #289's bug: the name is
+                # advertised as API, `?` says "No documentation found", and the API reference shows
+                # a bare heading. NOTHING else catches it — `checkdocs = :public` only verifies that
+                # docstrings which EXIST are reachable from the manual, so a name with none at all
+                # is invisible to it.
+                #
+                # The failure mode is not hypothetical or limited to forgetting. A docstring
+                # separated from its definition by a COMMENT silently detaches (`@doc` binds to the
+                # next expression; a comment is not one), so the string is written, reviewed,
+                # committed — and documents nothing. That happened while writing `set_models` in
+                # #295 and was invisible until this assertion existed.
+                #
+                # `Base.Docs.hasdoc` is NOT the right predicate here — the same trap the fluent-method
+                # scan hits at :209-216. It resolves through to the defining module and then searches
+                # every loaded module, so it is true for any name that merely SHARES A SPELLING with a
+                # documented `Base` binding: `hasdoc(Models, :sort)`, `:first`, `:reduce` are all true
+                # and PormG documents none of them. Declaring `public sort` would satisfy it while
+                # documenting nothing.
+                #
+                # Nor is the stricter `Binding(mod,s).mod === mod` form from :215 usable: three names
+                # already in the frozen set are legitimately FOREIGN bindings — `QueryBuilder`'s
+                # `Base.first`/`Base.last` and `DataFrames.DataFrame`, whose docstrings PormG owns and
+                # stores in its OWN doc dict. That form would fail them wrongly.
+                #
+                # Membership in the module's own `Docs.meta` is exactly right for both: it is where
+                # `@doc` files a docstring written in this module, whichever module the binding
+                # belongs to, and it is empty for a name PormG never documented.
+                own = let d = Base.Docs.meta(mod; autoinit = false)
+                    d === nothing ? Set{Symbol}() : Set(b.var for b in keys(d))
+                end
+                undocumented = filter(s -> !(s in own), actual)
+                @test undocumented == Symbol[]
             end
         end
 


### PR DESCRIPTION
Closes #295.

## The gap

`Models.Model(...)` is the first call in essentially every example in the documentation, and `?Models.Model` returned nothing. Same for `set_models`, `UniqueConstraint` and `Model_Type`.

Post-#294 the rule is that a name reaches the API page **iff** its module marks it `public`, so a docstring alone publishes nothing. The docstrings, the `public` declarations, and the frozen set in `test/unit/test_docstring_coverage.jl` all move together here.

- **`Model`, `set_models`, `UniqueConstraint`** — documented **and** `public`, in a second `public` statement below #289's field-constructor list (they are a different category: a field is a column, these define and register the model).
- **`Model_Type`** — documented, deliberately **not** `public`. Users hold one as `M.Driver` and never name it; it appears zero times in `docs/src`, and the vocabulary they are given for "a model" is the abstract `PormGModel`. `?PormG.Models.Model_Type` now answers without inviting code to depend on the concrete name.

## The issue's kwarg list was wrong, and that is the finding

#295 asked for `Model`'s kwargs "`verbose_name`, `db_table`, `ordering`, constraints". Measured against the code, **only `constraints` exists**:

| Name | Reality |
|---|---|
| `constraints` | The only kwarg any `Model` method declares. Real: validated at construction, emits `CREATE UNIQUE INDEX` at table creation |
| `db_table` | Not a model kwarg — only a `ManyToManyField` one (renames the auto join table). Model-level is #59 |
| `verbose_name` | Not a model kwarg. `Model_Type` has the slot, but no constructor sets it and nothing consumes it |
| `ordering` | Does not exist anywhere as a model or field concept |

Each of the three absent names falls into the `fields...` slurp and raises `ModelDefinitionError`. The docstring documents that as a `!!! note "PormG has no Django Meta block"`, following #294's `BinaryField` precedent of saying what is true rather than what the prose claimed.

## Mixed-case table names are split-brained

Writing the table-name paragraph surfaced this. `Model("Driver_Profile", …)`:

```
DDL     : CREATE TABLE IF NOT EXISTS driver_profile ( … )   ← makemigrations lowercases
SELECT  : … FROM "Driver_Profile" as "Tb"                   ← query builder quotes verbatim
INSERT  : INSERT INTO "Driver_Profile" ( … )
UPDATE  : UPDATE "Driver_Profile" AS "Tb" SET …
DELETE  : DELETE FROM driver_profile WHERE "id" IN (SELECT … FROM "Driver_Profile" …)
```

Measured across five query shapes — after migrating, every query addresses a table that does not exist on PostgreSQL. My first draft of this paragraph said "noting it is lowercased", which would have walked users straight into it; it is now a warning pointing at #59. The one `deletion.jl` path that *does* lowercase was probed specifically and is not reachable from the fluent `.delete()` surface.

## A defect the work surfaced: comments silently detach docstrings

A comment between a docstring and the definition it documents detaches it — `@doc` binds to the next expression, and a comment is not one. `set_models` shipped that way mid-PR: the string was written, reviewed, and documented nothing.

Nothing catches it. The package precompiles fine, and `checkdocs = :public` only verifies that docstrings which **exist** reach the manual, so a name with none is invisible to it.

- All **321** docstring blocks in `src/` and `ext/` were swept — no other instance.
- `test_docstring_coverage.jl` now asserts every `public` name really carries a docstring. The predicate is membership in the module's own `Docs.meta`: `Base.Docs.hasdoc` is unusable (it returns true for `Models.sort`, `:first`, `:reduce` — PormG documents none), and the stricter `Binding(mod,s).mod === mod` form from the same file would wrongly fail QueryBuilder's `Base.first`/`Base.last`/`DataFrames.DataFrame`, whose docstrings PormG legitimately owns under foreign bindings.
- Mutation-tested both ways: inserting a comment before `Model`'s definition fails with `undocumented == [:Model]` while the frozen-set and `undefined` assertions stay green.

## Verification

DB-free throughout — no integration run.

- **77 assertions** running every `# Examples` block verbatim and asserting each factual claim (exact error types, not `PormGError`).
- Unit **4940/4940**, exit 0.
- Docs build exit 0, zero errors. `api.md` heading anchors vs baseline: **exactly +3**, **none removed**, and **no `Model_Type` heading** — the non-public decision confirmed in the rendered output rather than assumed.
- Two independent review rounds; every confirmed finding fixed. One declined: the wrapped SQL block in the `UniqueConstraint` example, since `docs/src/models.md:161-165` wraps the identical statement identically — the reviewer withdrew it.

## Deliberately not done

- **No `UPGRADING.md` entry and no `Project.toml` bump** — docstrings plus `public` are additive and force no consuming-app edit.
- **No `docs/src/api.md` edit** — `@autodocs` picks the new public names up automatically.
- **`docs/src/schema_conventions.md:164` is wrong and left alone.** It states "**Table names are lowercased** before quoting" (repeated at `:182` and `:189`), which is true only of the DDL, not the query path — the same false claim this PR corrects in the docstring. It is a page the docs call a frozen contract and it is outside this PR's scope, so the docstring's pointer to it was removed rather than the page amplified. Wants its own issue.
- **`Model_Type.verbose_name` is unreachable dead state** — no constructor sets it, nothing consumes it. Documented honestly here; wiring or removing it is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
