### PR TITLE
refactor(#281): one naming rule for the helpers behind the fluent chain

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -120,12 +120,57 @@ ways, and the choice is forced by whether the method takes keywords:
 So adding a keyword to a `ChainCaller`-backed method means **converting it to a closure**; leaving it
 as a `ChainCaller` makes the keyword throw. Coverage: `test/unit/test_fluent_parity_208.jl`.
 
+**Naming the helpers behind the chain (#281).** The rule:
+
+> Of the helpers **PormG itself owns**, one is `_`-prefixed unless the name is API in its own
+> right — i.e. unless `Base.ispublic(QueryBuilder, name)`.
+
+The 29 branches route to 29 targets: **16** `_`-prefixed (`_filter!`, `_db!`, `_values!`,
+`_order_by!`, `_limit!`, `_offset!`, `_page!`, `_distinct!`, `_select_for_update!`, `_create!`,
+`_update!`, `_update_or_create!`, `_get_or_create!`, `_count`, `_aggregate`, `_exists` — matching the
+`_` marker the rest of `src/` already uses for an internal, `_query_select`, `_validate_identifier`,
+…), **7** bare and public (`list`, `delete`, `earliest`, `latest`, `inspect_query`, `With`, `cjoin`),
+**2** bare exceptions (below), and **4** Base-owned and out of scope (`first`, `last`, `get`,
+`deepcopy`).
+
+**The ownership clause is load-bearing, not a hedge** — read it as *"a name PormG can rename"*. The
+chain routes to `first`, `last`, `get` and `deepcopy`, whose bindings resolve to `Base`; an unscoped
+rule would demand renaming `Base.deepcopy`. And it is *not* "Base's names are exempt": `first`/`last`
+pass `ispublic` only because `src/QueryBuilder.jl:135` declares `public first, last` and `get`
+because `:105` exports it, while `deepcopy` and `copy` are equally Base's and are `ispublic == false`.
+Ownership sets the scope; `ispublic` decides what is in it. It is rooted at **PormG**, not
+QueryBuilder, so a helper defined in a sibling module and imported here stays covered — it is
+renameable, and just as able to leak through `_fluent_name`.
+
+**Two names do not fit, and that is stated rather than hidden.** `on` and `cjoin_on` are PormG's and
+`ispublic == false`, so the rule says prefix them. They stay bare because they are
+the `SQLObjectHandler` overloads of the `ctes.jl` join family whose siblings `cjoin` and `With` *are*
+public; splitting one family's spelling trades this inconsistency for a worse one. The rule's own
+second clause points at the real fix — declare them `public`, since both are documented in
+`docs/src/api.md` and `docs/src/read/custom_joins.md` — which is a #289 docs-surface decision, not a
+rename. If you pick that up, the frozen `public` set in `test_docstring_coverage.jl` moves with it,
+and so does the two-name exception list in its `getproperty helpers follow the #281 naming rule`
+testset — **delete the name from that list, do not widen it.**
+
+The rule is enforced, not just documented: that testset extracts every QueryBuilder-owned function
+named in the `getproperty` body and asserts the only non-`_`, non-public ones are those two.
+
+The rule is about the **name**, not about call sites. `_count`/`_exists` (`deletion.jl`) and
+`_values!`/`_filter!` (`execution.jl`) are all called from elsewhere inside `src/querybuilder/`;
+internal reuse does not make a helper API, being declared API does.
+
+This is diagnostic, not cosmetic: these names are what a user sees when a chain misfires (#272 surfaced
+as `no method matching page!(::SQLObjectQuery, ::Tuple{Int64})`), and the prefix is the signal that the
+spelling is one they could not have typed. `_fluent_name` in `object_manager.jl` is the exact inverse
+of this rule — it strips `^_` and `!$` to recover the method the caller wrote — so **adding a helper
+that does not follow the rule silently degrades the kwarg-rejection message.**
+
 **A `ChainCaller`-backed helper carries no docstring.** Not because it would be published — since
 #289 `api.md` sets `Private = false`, so an un-`public` name stays off the site either way — but
 because there is no **user-facing** binding to attach docs to — the fluent `.values(...)` a reader
-would `?` is synthesized by `getproperty` and has none, and nobody reaches `up_values!` by name — so
-the text would only ever be seen by someone already in the file. Three had drifted in (`up_filter!`, `up_values!`, `order_by!`) before
-#281; `page` had it until #280. Put the contract on the `object` docstring's `.method(...)` bullet
+would `?` is synthesized by `getproperty` and has none, and nobody reaches `_values!` by name — so
+the text would only ever be seen by someone already in the file. Three had drifted in — under their
+pre-#281 spellings `up_filter!`, `up_values!` and `order_by!`; `page` had it until #280. Put the contract on the `object` docstring's `.method(...)` bullet
 and use a `#` comment on the helper. `test_docstring_coverage.jl` enforces it, scoped to the
 `ChainCaller(helper, q)` branches —
 widening it to every `sym === :name` branch is not possible, because the closure branches route to
@@ -160,7 +205,7 @@ Focus on:
 - `execution.jl`
 - `deletion.jl`
 
-Gotcha — `do_count` (`execution.jl`): it clears `.values`/`.order` before rendering, so `count()` cannot reuse a `.values()` select. `COUNT(DISTINCT *)` is **invalid SQL on both PostgreSQL and SQLite**, so the count forms diverge:
+Gotcha — `_count` (`execution.jl`): it clears `.values`/`.order` before rendering, so `count()` cannot reuse a `.values()` select. `COUNT(DISTINCT *)` is **invalid SQL on both PostgreSQL and SQLite**, so the count forms diverge:
 
 - `count()` → `COUNT(*)`.
 - query-level distinct (`.distinct().count()` / `count(distinct=true)`) → wrap `SELECT DISTINCT *` in an **outer `COUNT(*)` subquery** (so `count() == length(distinct list())`).

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -111,7 +111,8 @@ export PormGRow, pk, DoesNotExist, MultipleObjectsReturned
 # Semantic error taxonomy (#231): every query-builder misuse throws a PormGError subtype.
 export PormGError, FieldAccessError, UnknownFieldError, LazyTraversalError, FilterError,
   QueryBuildError, UnsafeMutationError, InvalidValueError, WritesDisabledError, UnsupportedConnectionError, BackendCapabilityError, ProtectedError
-# do_count and do_exists are now strictly used as functors (query.count(), query.exists())
+# _count and _exists are un-exported (#202); the public form is the fluent query.count() /
+# query.exists(). They still have internal callers — deletion.jl uses both.
 export bulk_insert, bulk_update, bulk_copy, allocate_primary_keys
 
 # ---

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -157,7 +157,7 @@ if ccall(:jl_generating_output, Cint, ()) == 1
       Base.precompile(Tuple{getfield(QB, Symbol("#9#10")), QB.SQLTypeQ})          # 0.09 s
     Base.precompile(Tuple{typeof(QB._get_filter_query), QB.QorObject, QB.InstructionObject})  # 0.11 s
     Base.precompile(Tuple{typeof(QB.deepcopy), QB.QObject})                       # 0.08 s
-    Base.precompile(Tuple{QB.ChainCaller{typeof(QB.order_by!), QB.ObjectHandler}, String, Vararg{String}})  # 0.04 s
+    Base.precompile(Tuple{QB.ChainCaller{typeof(QB._order_by!), QB.ObjectHandler}, String, Vararg{String}})  # 0.04 s
     Base.precompile(Tuple{typeof(QB.F), String})                                  # 0.01 s
     Base.precompile(Tuple{typeof(*), QB.FExpression, Float64})                    # 0.02 s
     Base.precompile(Tuple{typeof(QB._get_join_filters), QB.SQLObjectQuery, String})       # 0.005 s

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -154,7 +154,7 @@ function delete(objct::SQLObjectHandler;
   end
   
   # If no objects to delete, return early (unless we're just inspecting the query)
-  if show_query === :execute && objct |> !do_exists
+  if show_query === :execute && objct |> !_exists
     return 0, Dict{String, Integer}()
   end
 
@@ -380,7 +380,7 @@ function find_related_objects!(collector::DeletionCollector, model::PormGModel, 
     # PROTECT/RESTRICT do not raise false positives. Mock/unit-test connections keep
     # the previous behavior and assume related rows exist because no database is available.
     should_check_existence = collector.show_query === :execute || should_check_related_existence(collector)
-    should_check_existence && (_query |> !do_exists) && continue
+    should_check_existence && (_query |> !_exists) && continue
      
     # @info _query |> query
 
@@ -514,7 +514,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     objct = keys[1][:objct]
     isempty(objct.object.filter) || throw(QueryBuildError("Delete on keyless model $(model.name) with filters is not supported; define a primary key or delete all rows explicitly"))
 
-    deleted_counter[model.name] = show_query === :execute ? (objct |> do_count) : 0
+    deleted_counter[model.name] = show_query === :execute ? (objct |> _count) : 0
     sql = "DELETE FROM $(model.name |> lowercase)"
 
     if show_query !== :execute
@@ -537,7 +537,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
   end
   sql::String = ""
   if size(keys, 1) == 1
-    deleted_counter[model.name] = show_query === :execute ? (keys[1][:objct] |> do_count) : 0
+    deleted_counter[model.name] = show_query === :execute ? (keys[1][:objct] |> _count) : 0
     sql = "DELETE FROM $(model.name |> lowercase) WHERE $(join(_where, " OR "))"
   else
     # Multi-path merge: all entries for the same model share the same resolved key field.
@@ -553,7 +553,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
       push!(or_object, "$(pk_field)__@in" => key[:objct])
     end
     _query.filter(or_object)
-    deleted_counter[model.name] = show_query === :execute ? (_query |> do_count) : 0
+    deleted_counter[model.name] = show_query === :execute ? (_query |> _count) : 0
     _query.values(pk_field) # Ensure the query is built
     @pormg_debug false
     sql = "DELETE FROM $(model.name |> lowercase) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -347,7 +347,7 @@ show_query(q::SQLObjectHandler, mode::Symbol = :sql) = query(deepcopy(q); show_q
 # Count or check if exists
 #
 
-function do_count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} = nothing, distinct::Bool = false,
+function _count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} = nothing, distinct::Bool = false,
                   table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
   # Column form: COUNT([DISTINCT] column). Reuse the Count() aggregate so column
   # resolution, joins and dialect rendering are shared with values(Count(...)); we
@@ -359,7 +359,7 @@ function do_count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} =
     cq.object.distinct = false      # DISTINCT belongs to COUNT(col), not the row set
     cq.object.limit = 0
     cq.object.offset = 0
-    up_values!(cq.object, Any["__pormg_count" => Count(String(column); distinct = distinct)])
+    _values!(cq.object, Any["__pormg_count" => Count(String(column); distinct = distinct)])
     show_query !== :execute && return query(cq; table_alias = table_alias, show_query = show_query)
     rows = list(cq, Val(:dict))
     return isempty(rows) ? 0 : Base.first(values(Base.first(rows)))
@@ -429,9 +429,9 @@ end
 
 # Whole-queryset aggregation (#208). Django's aggregate(): compute one or more aggregate scalars
 # over the ENTIRE queryset (no GROUP BY) and return them as a single-row NamedTuple keyed by alias.
-# Built on the same column-form path as do_count() — inject the aggregate projections via values(),
+# Built on the same column-form path as _count() — inject the aggregate projections via values(),
 # read the single row back — but generalized to multiple aggregates and a dot-accessible result.
-function do_aggregate(oq::SQLObjectHandler; pairs, show_query::Symbol = :execute)
+function _aggregate(oq::SQLObjectHandler; pairs, show_query::Symbol = :execute)
   isempty(pairs) &&
     throw(QueryBuildError("aggregate() requires at least one \"alias\" => AggregateFunction(...) pair, e.g. aggregate(\"total\" => Sum(\"points\"))."))
   # aggregate() is whole-queryset only. If the caller already projected grouping columns via
@@ -457,8 +457,8 @@ function do_aggregate(oq::SQLObjectHandler; pairs, show_query::Symbol = :execute
   cq.object.distinct = false
   # Inject the aggregate projections through the shared values() path (column resolution, joins and
   # dialect rendering stay identical to values(Sum(...))). With ONLY aggregates projected, no
-  # non-aggregate column is present, so the builder emits no GROUP BY (same as do_count).
-  up_values!(cq.object, collect(Any, pairs))
+  # non-aggregate column is present, so the builder emits no GROUP BY (same as _count).
+  _values!(cq.object, collect(Any, pairs))
 
   if show_query !== :execute
     return query(cq; show_query=show_query)
@@ -470,7 +470,7 @@ function do_aggregate(oq::SQLObjectHandler; pairs, show_query::Symbol = :execute
   return NamedTuple{Tuple(aliases)}(Tuple(get(row, a, nothing) for a in aliases))
 end
 
-function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
+function _exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias} = nothing, show_query::Symbol = :execute)
   try
     # Resolve settings
     settings, connection, conn_key = get_settings(oq)
@@ -521,7 +521,12 @@ function do_exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAli
     # Silently returning false would mask connection failures, SQL errors, and
     # permission errors as "does not exist", which is incorrect and dangerous.
     # The only legitimate false return is from `length(result) > 0` above.
-    @error "Error in do_exists for model $(oq.object.model.name): $e"
+    # Names the fluent method the caller typed, not the `_exists` helper behind it — the same
+    # reason the helpers are `_`-prefixed at all (#281): an internal spelling in a log line sends
+    # the reader looking for something that appears nowhere in their code. Structured form per
+    # AGENTS.md; `(e, catch_backtrace())` rather than a bare `e` because only the tuple form logs a
+    # backtrace, matching the sibling catch in object_manager.jl.
+    @error "Error in exists()" model=oq.object.model.name exception=(e, catch_backtrace())
     rethrow(e)
   end
 end
@@ -694,7 +699,7 @@ end
 # Dialect.on_conflict_clause), and returns `(PormGRow, created::Bool)`.
 #
 # `target_fields` (the lookup keys) and `set_fields` (defaults + auto_now) are LOGICAL field names,
-# resolved to quoted physical columns here (like bulk_insert). Caller (up_update_or_create!) has
+# resolved to quoted physical columns here (like bulk_insert). Caller (_update_or_create!) has
 # already merged lookup+defaults into real_obj.insert and validated the fields.
 #
 # created detection per backend:
@@ -1581,7 +1586,7 @@ function query_list(objct::SQLObjectHandler; show_query::Symbol = :execute)
   # "model" into q.object.ctes; doing that on `objct` would give .list()/.first()
   # a hidden write side effect and make .copy() aliasing corrupt re-execution.
   # deepcopy(SQLObjectQuery) now clones CTE state independently (see _copy_ctes),
-  # so the copy is fully isolated. Mirrors do_count/do_exists/get, which already copy.
+  # so the copy is fully isolated. Mirrors _count/_exists/get, which already copy.
   q = deepcopy(objct)
   sql = query(q, connection=connection, show_query=show_query)
   if show_query !== :execute
@@ -1897,7 +1902,7 @@ function get(objct::SQLObjectHandler, filters...; show_query::Symbol = :execute)
   # #199: copy-first — inline filters and the limit(2) probe apply to the copy only,
   # so they never leak into the caller's handler.
   q = deepcopy(objct)
-  !isempty(filters) && up_filter!(q.object, filters)
+  !isempty(filters) && _filter!(q.object, filters)
   q = q.limit(2)
 
   if show_query !== :execute

--- a/src/querybuilder/functions.jl
+++ b/src/querybuilder/functions.jl
@@ -788,7 +788,7 @@ end
 # Pagination
 #
 # INTERNAL, and NOT the fluent implementation. `query.page(...)` routes through
-# `ChainCaller(page!, q)` (object_manager.jl), which dispatches on `SQLObject`; these methods take
+# `ChainCaller(_page!, q)` (object_manager.jl), which dispatches on `SQLObject`; these methods take
 # an `SQLObjectHandler` and are never reached from the chain. `page` is un-exported (#202), has no
 # caller in this repo, and survives only because test_public_exports.jl pins it as
 # defined-but-unexported. The external API is the fluent `query.page(limit)` /
@@ -811,7 +811,7 @@ function page(object::SQLObjectHandler; limit::Integer = 10, offset::Integer = 0
   object.object.offset = offset
   return object
 end
-# Limit-only: the offset already on the handler is left alone. `page!`'s 1-tuple method mirrors this.
+# Limit-only: the offset already on the handler is left alone. `_page!`'s 1-tuple method mirrors this.
 function page(object::SQLObjectHandler, limit::Integer)
   object.object.limit = limit
   return object
@@ -828,28 +828,28 @@ end
 # `ChainCaller` packs the call's varargs into ONE tuple and calls `f(q.object, args)`, so the
 # argument these receive is always a `Tuple` and the arity check IS the dispatch. Every shape that is
 # not an accepted arity therefore needs an `::Any` fallback throwing a `PormGError`: without one the
-# user gets a bare `MethodError` naming `page!` and a `Tuple{String, String}` — neither of which
+# user gets a bare `MethodError` naming `_page!` and a `Tuple{String, String}` — neither of which
 # appears anywhere in their code — and `catch PormGError` (#231/#239) does not cover it (#272).
-function limit!(object::SQLObject, limit::Tuple{Integer})
+function _limit!(object::SQLObject, limit::Tuple{Integer})
   object.limit = limit[1]
 end
-function limit!(object::SQLObject, limit)
+function _limit!(object::SQLObject, limit)
   throw(QueryBuildError("Invalid limit() arguments: $(limit) (::$(typeof(limit))) — limit() takes exactly one Integer, e.g. limit(20)."))
 end
-function offset!(object::SQLObject, offset::Tuple{Integer})
+function _offset!(object::SQLObject, offset::Tuple{Integer})
   object.offset = offset[1]
 end
-function offset!(object::SQLObject, offset)
+function _offset!(object::SQLObject, offset)
   throw(QueryBuildError("Invalid offset() arguments: $(offset) (::$(typeof(offset))) — offset() takes exactly one Integer, e.g. offset(40)."))
 end
 # page(n) is limit-only — the offset already on the handler survives, matching page(object, limit).
-function page!(object::SQLObject, v::Tuple{Integer})
+function _page!(object::SQLObject, v::Tuple{Integer})
   object.limit = v[1]
 end
-function page!(object::SQLObject, v::Tuple{Integer, Integer})
+function _page!(object::SQLObject, v::Tuple{Integer, Integer})
   object.limit = v[1]
   object.offset = v[2]
 end
-function page!(object::SQLObject, v)
+function _page!(object::SQLObject, v)
   throw(QueryBuildError("Invalid page() arguments: $(v) (::$(typeof(v))) — page() takes one Integer (limit) or two Integers (limit, offset), e.g. page(20) or page(20, 40)."))
 end

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -4,7 +4,7 @@
 #
 
 # Why Vector{String}
-function _up_values(str::String)
+function _values_field(str::String)
   check = String.(split(str, "__@"))
   if size(check, 1) == 1
     return SQLField(str, str)
@@ -17,15 +17,15 @@ function _up_values(str::String)
 end
 
 # Backs `query.values(...)` through ChainCaller. Each call RESETS `q.values` — last-call-wins,
-# Django parity (#199) — unlike `up_filter!`, which accumulates.
+# Django parity (#199) — unlike `_filter!`, which accumulates.
 #
 # No docstring on purpose (#281). Since #289 `api.md`'s `@autodocs` sets `Private = false`, so an
 # un-`public` name no longer reaches the site regardless — but the rule still stands here: there is
 # no USER-FACING binding to attach docs to — `.values(...)` is synthesized by `getproperty`, and
-# nobody reaches `up_values!` by name — so a docstring here would only ever be read by someone
+# nobody reaches `_values!` by name — so a docstring here would only ever be read by someone
 # already in this file. The user-facing contract lives on the `object` docstring's `.values(...)`
 # bullet; `test_docstring_coverage.jl` enforces both halves.
-function up_values!(q::SQLObject, values)
+function _values!(q::SQLObject, values)
   # every call of values, reset the values
   q.values = []
   for v in values
@@ -59,7 +59,7 @@ function up_values!(q::SQLObject, values)
         v.second.custom_as = v.first
         push!(q.values, v.second)
       elseif isa(v.second, String)
-        z = _up_values(v.second)
+        z = _values_field(v.second)
         z.custom_as = v.first
         push!(q.values, z)
       else
@@ -68,7 +68,7 @@ function up_values!(q::SQLObject, values)
         throw(QueryBuildError("Invalid values pair \"$(v.first)\" => ::$(typeof(v.second)): the right side must be a field name, a function (Count, Sum, …), Value(x), Subquery(inner), or Exists(inner)."))
       end
     elseif isa(v, String)
-      push!(q.values, _up_values(v))
+      push!(q.values, _values_field(v))
     else
       throw(QueryBuildError("Invalid argument: $(v) (::$(typeof(v)))); use a string field name, a function (Count, Sum, Day, …), or an aliased pair \"alias\" => expr (e.g. \"total\" => Subquery(inner))."))
     end
@@ -77,7 +77,7 @@ function up_values!(q::SQLObject, values)
   return q
 end
 
-function up_create!(q::SQLObject, values; kwargs...)
+function _create!(q::SQLObject, values; kwargs...)
   # OrderedDict so the rendered INSERT column list follows call order deterministically (#97)
   q.insert = OrderedCollections.OrderedDict{String,Any}()
   for (k, v) in values
@@ -87,7 +87,7 @@ function up_create!(q::SQLObject, values; kwargs...)
   return insert(q; kwargs...)
 end
 
-function up_update!(q::SQLObject, values; kwargs...)
+function _update!(q::SQLObject, values; kwargs...)
   # check if kwargs is not empty and check if kwargs just contains show_query
   show_query = :execute
   if !isempty(kwargs)
@@ -125,7 +125,7 @@ end
 # ON CONFLICT target and their values the INSERT match values; `defaults` are the columns SET on a
 # conflict (via EXCLUDED) and are merged into the INSERT. Returns `(PormGRow, created::Bool)`.
 # All validation fires here, before any DB work, so `show_query=:dict` surfaces it.
-function up_update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
+function _update_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
   model = q.model
   lookup_pairs  = _normalize_uoc_pairs(lookup, "lookup")
   default_pairs = _normalize_uoc_pairs(defaults, "defaults")
@@ -179,7 +179,7 @@ end
 # the create path uses `ON CONFLICT (lookup) DO NOTHING` as its concurrency guard, so the lookup
 # fields must be a unique constraint for it to be race-safe (re-raised as an actionable error
 # otherwise). All validation fires here, before any DB work, so `show_query=:dict` surfaces it.
-function up_get_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
+function _get_or_create!(q::SQLObject, lookup; defaults = Pair[], show_query::Symbol = :execute)
   model = q.model
   lookup_pairs  = _normalize_uoc_pairs(lookup, "lookup"; op = "get_or_create")
   default_pairs = _normalize_uoc_pairs(defaults, "defaults"; op = "get_or_create")
@@ -216,11 +216,11 @@ end
 
 # Backs `query.filter(...)` through ChainCaller. Each element of the packed tuple may be a `Pair` or
 # any `FilterType` — `SQLTypeQ`, `SQLTypeQor`, `SQLTypeOper`, `SQLTypeF`, `ExistsObject` (types.jl).
-# Calls ACCUMULATE (ANDed) — unlike `up_values!`/`order_by!`, which replace.
+# Calls ACCUMULATE (ANDed) — unlike `_values!`/`_order_by!`, which replace.
 #
-# No docstring on purpose (#281) — see the note on `up_values!` above. The accepted argument kinds
+# No docstring on purpose (#281) — see the note on `_values!` above. The accepted argument kinds
 # are documented on the `object` docstring's `.filter(...)` bullet.
-function up_filter!(q::SQLObject, filter)
+function _filter!(q::SQLObject, filter)
   for v in filter
     if isa(v, FilterType)
       push!(q.filter, v) # TODO I need process the Qor and Q with _check_filter
@@ -235,7 +235,7 @@ function up_filter!(q::SQLObject, filter)
   return q
 end
 
-function up_db!(q::SQLObject, keys)
+function _db!(q::SQLObject, keys)
   if isempty(keys) || length(keys) > 1 || !isa(keys[1], String)
     throw(QueryBuildError("db() expects exactly one String argument (the database key). Received: $(keys)"))
   end
@@ -243,13 +243,13 @@ function up_db!(q::SQLObject, keys)
   return q
 end
 
-function distinct!(q::SQLObject, value::Bool) #::Union{Bool, Nothing}) 
+function _distinct!(q::SQLObject, value::Bool) #::Union{Bool, Nothing}) 
   q.distinct = value
   return q
 end
-distinct!(q::SQLObject, value::Tuple{}) = distinct!(q, true) # if no value is passed, distinct is true
-distinct!(q::SQLObject, value::Tuple{Bool}) = distinct!(q, value[1]) # if a value is passed, distinct is the value
-function distinct!(q::SQLObject, value)
+_distinct!(q::SQLObject, value::Tuple{}) = _distinct!(q, true) # if no value is passed, distinct is true
+_distinct!(q::SQLObject, value::Tuple{Bool}) = _distinct!(q, value[1]) # if a value is passed, distinct is the value
+function _distinct!(q::SQLObject, value)
   throw(QueryBuildError("Invalid distinct() argument: $(value) (::$(typeof(value))) — use a Bool (true or false)."))
 end
 
@@ -257,7 +257,7 @@ end
 # on PostgreSQL; a silent no-op on SQLite. `nowait` and `skip_locked` are mutually exclusive
 # (Django parity). Always builds a fresh ForUpdateClause (set-once semantics). (An `of=` target
 # is a deferred follow-up — it must name the query's generated FROM alias, not yet exposed.)
-function select_for_update!(q::SQLObject; nowait::Bool=false, skip_locked::Bool=false, no_key::Bool=false)
+function _select_for_update!(q::SQLObject; nowait::Bool=false, skip_locked::Bool=false, no_key::Bool=false)
   if nowait && skip_locked
     throw(QueryBuildError("select_for_update: `nowait` and `skip_locked` are mutually exclusive — pass at most one."))
   end
@@ -265,7 +265,7 @@ function select_for_update!(q::SQLObject; nowait::Bool=false, skip_locked::Bool=
   return q
 end
 
-# function distinct!(q::SQLObject, value)
+# function _distinct!(q::SQLObject, value)
 #   throw("Invalid argument: $(value) (::$(typeof(value))); please use a boolean value (true or false)")
 # end
 
@@ -301,12 +301,12 @@ end
 
 
 # Backs `query.order_by(...)` through ChainCaller. Each call RESETS `q.order` — last-call-wins,
-# matching Django's "each order_by() call clears previous ordering" (#199) — unlike `up_filter!`,
+# matching Django's "each order_by() call clears previous ordering" (#199) — unlike `_filter!`,
 # which accumulates.
 #
-# No docstring on purpose (#281) — see the note on `up_values!` above. The user-facing contract
+# No docstring on purpose (#281) — see the note on `_values!` above. The user-facing contract
 # lives on the `object` docstring's `.order_by(...)` bullet.
-function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} where N)
+function _order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} where N)
   q.order = [] # every call of order_by, reset the order
   for v in values
     if isa(v, String)
@@ -326,7 +326,7 @@ function order_by!(q::SQLObject, values::NTuple{N,Union{String,SQLTypeOrder}} wh
   end
   return q
 end
-function order_by!(q::SQLObject, values)
+function _order_by!(q::SQLObject, values)
   throw(QueryBuildError("Invalid order_by() argument: $(values) (::$(typeof(values))) — use field-name Strings (\"-field\" for DESC) or SQLTypeOrder values."))
 end
 
@@ -341,18 +341,17 @@ struct ChainCaller{F,T}
   handler::T
 end
 
-# The fluent name the CALLER typed, recovered from the internal helper behind it: `up_filter!` →
-# "filter", `order_by!` → "order_by", `page!` → "page". Without this the kwarg error below could
-# only say "here", leaving the user to find which link of a long chain it meant (#281). The `up_`
-# alternative is what made #280 decline this — `nameof` alone yields `up_filter`, an internal
-# spelling that appears nowhere in the caller's code. Stripping both markers covers every current
-# helper, and the leading `_` branch keeps it correct if the internals are ever `_`-prefixed.
-_fluent_name(f) = replace(string(nameof(f)), r"^(up_|_)" => "", r"!$" => "")
+# The fluent name the CALLER typed, recovered from the internal helper behind it: `_filter!` →
+# "filter", `_order_by!` → "order_by", `_page!` → "page". Without this the kwarg error below could
+# only say "here", leaving the user to find which link of a long chain it meant (#281). Stripping
+# the two internal markers — the `_` prefix and the mutating `!` — is exactly the inverse of the
+# naming rule below, so it stays correct for every helper the rule covers.
+_fluent_name(f) = replace(string(nameof(f)), r"^_" => "", r"!$" => "")
 
 # When called (e.g., query.filter(...)), it executes and returns the handler itself.
 #
 # `kwargs...` is slurped only to REJECT it. Without it a keyword call dies on this functor with a
-# bare `MethodError` naming `ChainCaller{typeof(page!), ObjectHandler}` — outside the PormGError
+# bare `MethodError` naming `ChainCaller{typeof(_page!), ObjectHandler}` — outside the PormGError
 # taxonomy (#231/#239), and a spelling that appears nowhere in the caller's code (#272). Users reach
 # for it because the docs name the parameters (`.page(limit = 20)`) and because the sibling fluent
 # methods built from closures below — `.with`, `.cjoin`, `.cjoin_on`, `.on`, `.select_for_update` —
@@ -365,29 +364,77 @@ function (c::ChainCaller)(args...; kwargs...)
   return c.handler
 end
 
+# NAMING RULE for the helpers this dispatch chain routes to (#281):
+#
+#   Of the helpers PORMG ITSELF OWNS, one is `_`-prefixed unless the name is API in its own right —
+#   i.e. unless `Base.ispublic(QueryBuilder, name)`.
+#
+# The ownership clause is load-bearing, not a hedge — it is "a name PormG can rename". The chain
+# also routes to `first`, `last`, `get` and `deepcopy`, whose bindings resolve to **Base**; a rule
+# covering them would demand renaming `Base.deepcopy`, which is not a thing this package can do.
+# Note it is NOT "Base's names are fine": `first`/`last` pass `ispublic` because
+# `src/QueryBuilder.jl:135` declares `public first, last` and `get` because `:105` exports it, while
+# `deepcopy` and `copy` are equally Base's and are `ispublic == false`. Ownership is what puts a
+# name in or out of scope; `ispublic` decides the ones in scope. Rooted at PormG rather than at
+# QueryBuilder so that a helper defined in a sibling module and imported here — renameable, and
+# just as capable of leaking through `_fluent_name` — stays covered.
+#
+# The 29 branches below route to 29 targets, accounted for exhaustively:
+#
+#   16  `_`-prefixed, all `ispublic == false`: `_filter!`, `_db!`, `_values!`, `_order_by!`,
+#       `_limit!`, `_offset!`, `_page!`, `_distinct!`, `_select_for_update!`, `_create!`,
+#       `_update!`, `_update_or_create!`, `_get_or_create!`, `_count`, `_aggregate`, `_exists`
+#    7  bare and public, so the rule admits them: `list`, `delete`, `earliest`, `latest`,
+#       `inspect_query`, `With`, `cjoin`
+#    2  bare and NOT public — the stated exceptions, next paragraph: `on`, `cjoin_on`
+#    4  Base-owned, out of scope: `first`, `last`, `get`, `deepcopy`
+#
+# `ispublic` decides those 7 + 2 mechanically, which is the point: since #289 it is also the test
+# Documenter applies, so the rule is checkable rather than a matter of taste — and
+# `test/unit/test_docstring_coverage.jl` does check it, exceptions and all.
+#
+# **The two that do not fit, stated rather than hidden:** `on` and `cjoin_on` are PormG's and
+# `ispublic == false`, so the rule says prefix them. They stay bare because they are the
+# `SQLObjectHandler` overloads of the `ctes.jl` join-construction family, and their siblings `cjoin`
+# and `With` are public — splitting one family's spelling would trade this inconsistency for a worse
+# one. The rule's own second clause suggests the real fix is to declare them `public` (they are
+# documented in `docs/src/api.md` and `docs/src/read/custom_joins.md`); that is a docs-surface
+# decision in #289's territory, not a rename, so it is deliberately not made here. Those two are the
+# named exceptions in the guard.
+#
+# Note the rule is about the NAME, not about call sites: `_count`/`_exists` (deletion.jl),
+# `_values!`/`_filter!` (execution.jl) are all called from elsewhere inside `src/querybuilder/`.
+# Internal reuse does not make a helper API; being declared API does.
+#
+# The point is diagnostic, not cosmetic. These names are what a user SEES when a chain misfires —
+# #272 surfaced as `no method matching page!(::SQLObjectQuery, ::Tuple{Int64})` — and `_` is the
+# marker the rest of `src/` already uses for an internal (`_query_select`, `_validate_identifier`,
+# …). Before this there were four conventions in one chain (`up_*!`, bare `verb!`, `do_*`, plain)
+# with no rule separating them, so nothing signalled which spellings a user could not have typed.
+# `_fluent_name` above is the inverse of this rule and depends on it.
 function Base.getproperty(q::ObjectHandler, sym::Symbol)
   # === CATEGORY 1: Chainable methods (return 'q') ===
   # Allows: query.filter(...).order_by(...)
   if sym === :filter
-    return ChainCaller(up_filter!, q)
+    return ChainCaller(_filter!, q)
   elseif sym === :db
-    return ChainCaller(up_db!, q)
+    return ChainCaller(_db!, q)
   elseif sym === :values
-    return ChainCaller(up_values!, q)
+    return ChainCaller(_values!, q)
   elseif sym === :order_by
-    return ChainCaller(order_by!, q)
+    return ChainCaller(_order_by!, q)
   elseif sym === :limit
-    return ChainCaller(limit!, q)
+    return ChainCaller(_limit!, q)
   elseif sym === :offset
-    return ChainCaller(offset!, q)
+    return ChainCaller(_offset!, q)
   elseif sym === :page
-    return ChainCaller(page!, q)
+    return ChainCaller(_page!, q)
   elseif sym === :distinct
-    return ChainCaller(distinct!, q)
+    return ChainCaller(_distinct!, q)
   elseif sym === :select_for_update
     # Chainable: query.select_for_update(; nowait=false, skip_locked=false, no_key=false)
     # Closure (not ChainCaller) so keyword arguments are forwarded correctly (#26).
-    return (; kwargs...) -> (select_for_update!(q.object; kwargs...); q)
+    return (; kwargs...) -> (_select_for_update!(q.object; kwargs...); q)
   elseif sym === :with
     # Chainable: query.with("cte_name" => sub_query; join_field=..., join_type=...)
     # Uses closure (not ChainCaller) so keyword arguments are forwarded correctly.
@@ -411,34 +458,34 @@ function Base.getproperty(q::ObjectHandler, sym::Symbol)
     # `args...` is intentionally untyped: the execute path returns a PormGRow (#166), while
     # show_query=:sql/:dict/:params/:none return String/Dict/Vector/nothing. A typed
     # signature would force the inspect contract to fork, so the return stays `Any`.
-    return (args...; kwargs...) -> up_create!(q.object, args; kwargs...)
+    return (args...; kwargs...) -> _create!(q.object, args; kwargs...)
   elseif sym === :update
     # Same dual execute/inspect return contract as :create — see the note above.
-    return (args...; kwargs...) -> up_update!(q.object, args; kwargs...)
+    return (args...; kwargs...) -> _update!(q.object, args; kwargs...)
   elseif sym === :update_or_create
     # Row-level upsert (#30). Execute path returns (row::PormGRow, created::Bool);
     # show_query=:sql/:dict/:params return the inspection shape (String/Dict/Vector), same dual
     # contract as :create/:update. `args` = lookup pairs; `defaults=`/`show_query=` via kwargs.
-    return (args...; kwargs...) -> up_update_or_create!(q.object, args; kwargs...)
+    return (args...; kwargs...) -> _update_or_create!(q.object, args; kwargs...)
   elseif sym === :get_or_create
     # Django-style match-or-insert (#208), no update on a hit. Execute path returns
     # (row::PormGRow, created::Bool); show_query=:sql/:dict/:params return the inspection shape.
     # `args` = lookup pairs; `defaults=`/`show_query=` via kwargs.
-    return (args...; kwargs...) -> up_get_or_create!(q.object, args; kwargs...)
+    return (args...; kwargs...) -> _get_or_create!(q.object, args; kwargs...)
   elseif sym === :count
     # count()                         -> COUNT(*)              (total rows)
     # count(distinct=true)            -> distinct rows         (subquery COUNT(*) over SELECT DISTINCT *)
     # count("col")                    -> COUNT("col")          (non-null values of a column)
     # count("col", distinct=true)     -> COUNT(DISTINCT "col") (distinct values of a column, scalar)
     return (column=nothing; distinct::Bool=false, show_query::Symbol=:execute) ->
-      do_count(q; column=column, distinct=distinct, show_query=show_query)
+      _count(q; column=column, distinct=distinct, show_query=show_query)
   elseif sym === :aggregate
     # Whole-queryset aggregation with NO GROUP BY (#208). aggregate("total" => Sum("points"), …)
     # returns a single-row NamedTuple of scalars (dot-access r.total). Errors if the queryset
     # already carries values() grouping columns.
-    return (pairs...; show_query::Symbol=:execute) -> do_aggregate(q; pairs=pairs, show_query=show_query)
+    return (pairs...; show_query::Symbol=:execute) -> _aggregate(q; pairs=pairs, show_query=show_query)
   elseif sym === :exists
-    return (; show_query=:execute) -> do_exists(q; show_query=show_query)
+    return (; show_query=:execute) -> _exists(q; show_query=show_query)
   elseif sym === :first
     return (; kwargs...) -> first(q; kwargs...)
   elseif sym === :last
@@ -492,7 +539,7 @@ function Base.getproperty(m::Models.Model_Type, sym::Symbol)
   end
 end
 
-# NOTE: do NOT try to document a fluent method here with `@doc "…" ChainCaller(up_filter!, q)`.
+# NOTE: do NOT try to document a fluent method here with `@doc "…" ChainCaller(_filter!, q)`.
 # The docsystem does not evaluate that expression — it reads it as a method signature and binds the
 # text to `ChainCaller(::Any, ::Any)`, so the docstring documents the constructor, never `.filter`,
 # and `@autodocs` publishes it on the site under a heading that belongs to nothing (#212). There is

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -241,7 +241,7 @@ Base.deepcopy(x::SQLTypeOrder) = SQLOrder(x.field, x.order, x.orientation, x._as
 # #26: row-level locking clause carried on a SELECT. `nothing` on the query means no lock;
 # a `ForUpdateClause` renders `FOR [NO KEY] UPDATE [NOWAIT|SKIP LOCKED]` on PostgreSQL and is a
 # silent no-op on SQLite (which has no row-level locking). Immutable/set-once — the
-# `select_for_update!` mutator always builds a fresh clause, so it is shared by reference on copy.
+# `_select_for_update!` mutator always builds a fresh clause, so it is shared by reference on copy.
 # (An `OF <table>` target is a deferred follow-up: it must name the query's generated FROM alias,
 # which is not yet exposed — see the row-locking follow-up issue.)
 struct ForUpdateClause
@@ -1258,7 +1258,7 @@ mutable struct DeletionCollector{T}
   field_updates::Dict{Tuple{String,Any},Dict{PormGModel,Dict{Symbol,T}}}  # Field updates for SET_NULL etc.
   fast_deletes::Dict{PormGModel,Vector{Dict{Symbol,T}}}  # Objects that can be deleted directly
   sorted_models::Vector{PormGModel}  # Models in deletion order
-  show_query::Symbol  # Controls whether to execute or inspect; skips do_exists during inspection
+  show_query::Symbol  # Controls whether to execute or inspect; skips _exists during inspection
 
   DeletionCollector(model, settings, show_query=:execute) = new{Union{String,SQLObjectHandler}}(
     model,

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -308,7 +308,7 @@ end
     # ─────────────────────────────────────────────────────────────────────────
     # A filtered delete that matches no rows should short-circuit cleanly and
     # report zero work instead of warning, mutating state, or building a bogus
-    # deletion plan. This covers the execute-time do_exists early return.
+    # deletion plan. This covers the execute-time _exists early return.
     # ─────────────────────────────────────────────────────────────────────────
     @testset "Delete with No Matches: Returns Empty Count" begin
         # This slug cannot exist because the cleanup runs first and no seed

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -595,7 +595,7 @@ end
 
   @testset "page functor with limit only (#272)" begin
     # #272: `query.page(n)` — the single-argument form the docs had always advertised — raised a
-    # bare MethodError, because only page!(::SQLObject, ::Tuple{Integer, Integer}) existed. It sets
+    # bare MethodError, because only _page!(::SQLObject, ::Tuple{Integer, Integer}) existed. It sets
     # LIMIT and must leave any OFFSET already on the handler alone.
     query = M.Result.objects
     query.filter("statusid__status" => "Finished")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -2437,7 +2437,7 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 # Subquery (#92) - error paths: the one-column contract (0 or ≥2 projected
 # columns throw), alias is mandatory (bare Subquery in values throws), and the
-# up_values! silent-drop fix (an unsupported "alias" => value pair now throws
+# _values! silent-drop fix (an unsupported "alias" => value pair now throws
 # instead of silently vanishing from the projection).
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "Subquery projection (#92) - error paths" begin

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -134,7 +134,7 @@ end
     end
 
     # ─────────────────────────────────────────────────────────────────────────
-    # `ChainCaller` stays undocumented — the `@doc "…" ChainCaller(up_filter!, q)` trap
+    # `ChainCaller` stays undocumented — the `@doc "…" ChainCaller(_filter!, q)` trap
     # That form does not document `.filter`: the docsystem does not evaluate the expression, it
     # reads it as a signature and binds the text to `ChainCaller(::Any, ::Any)`, which then shows up
     # under a `filter(args...)` heading that belongs to nothing. It looked like it worked for as
@@ -153,8 +153,9 @@ end
     # …and neither do the helpers it dispatches to (#281)
     # Before #289, `api.md`'s `@autodocs` set no `Private` key, so Documenter's `Private = true`
     # default published EVERY docstring in `PormG.QueryBuilder` as a public API heading — a docstring
-    # on `up_filter!` shipped a heading for a function no user can name. Three had drifted in
-    # (`up_filter!`, `up_values!`, `order_by!`) before #281; `page` had it until #280. `Private =
+    # on one of these helpers shipped a heading for a function no user can name. Three had drifted
+    # in — under their pre-#281 spellings `up_filter!`, `up_values!` and `order_by!` (the rename to
+    # `_filter!`/`_values!`/`_order_by!` came later, with the rest of #281); `page` had it until #280. `Private =
     # false` now filters by `ispublic`, so this testset is no longer the thing keeping them off the
     # site — it is the sharper rule that they should carry no docstring at all, since there is no
     # USER-FACING binding to attach docs to (the helper is reachable by name, but only from inside
@@ -215,6 +216,100 @@ end
                 Base.Docs.Binding(PormG.QueryBuilder, sym).mod === PormG.QueryBuilder
         end
         @test documented == String[]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # The `getproperty` helpers follow one naming rule (#281)
+    #
+    #   Of the helpers PormG ITSELF OWNS, one is `_`-prefixed unless it is API in its own
+    #   right — unless `Base.ispublic(QueryBuilder, name)`.
+    #
+    # #281 unified four conventions (`up_*!`, bare `verb!`, `do_*`, plain) into this one. Without a
+    # guard the rule is prose, and the drift it prevents is silent: `_fluent_name` recovers the
+    # method the CALLER typed by stripping `^_` and `!$`, so a new helper named `do_thing` or
+    # `up_thing!` makes the kwarg-rejection message report the internal spelling — exactly the #272
+    # complaint #280/#281 closed. Nothing else catches that; the testset above is scoped to
+    # ChainCaller branches and `PUBLIC_SURFACE` below asserts the converse (no `_` name is public),
+    # which a new BARE helper passes trivially.
+    #
+    # The ownership scope ("a name PormG can rename") is explained where it is implemented, at
+    # `pormg_owned` below — deliberately in ONE place, since the accounting behind this rule has
+    # already gone stale in a second copy once. The canonical statement lives above
+    # `Base.getproperty` in `src/querybuilder/object_manager.jl`.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "getproperty helpers follow the #281 naming rule" begin
+        body = _doccov_getproperty_body()
+        # Two independent completeness checks on the extraction, because a count alone cannot tell
+        # a full scan from a truncated one: `_doccov_getproperty_body()` stops at the first
+        # column-0 `end`, and a body truncated as early as the `:first` branch still clears the
+        # floor below with 22 names. The anchor is what proves the scan reached the end.
+        #
+        # Anchored on the `else` fallthrough, not on the last branch. `sym === :delete` is last
+        # today, but only positionally — appending a branch after it would leave that anchor
+        # passing while it no longer proved end-of-scan. `getfield(q, sym)` is the final statement
+        # of the method by construction and cannot be outflanked.
+        @test !isempty(body)
+        @test occursin("return getfield(q, sym)", body)
+
+        code = replace(body, r"^[ \t]*#[^\n]*$"m => "")   # comments name old spellings on purpose
+        # Drop `:symbol` literals BEFORE scanning. The branch CONDITIONS (`sym === :page`,
+        # `sym === :update`) are not helper references, and both of those names also happen to be
+        # real QueryBuilder-owned, non-public functions — the parallel `page(::SQLObjectHandler)`
+        # (functions.jl) and `update(::SQLObject)` (execution.jl) function forms, which this rule
+        # does not govern because the chain routes to `_page!`/`_update!` instead. Leaving them in
+        # reported both as offenders. Also removes `:execute`/`:sql`/`:Symbol` noise.
+        # The strip is POSITIONAL — it deletes `:name`, never a bare `name` — so a helper called as
+        # `name(...)` still gets scanned even if `:name` appears elsewhere in the body.
+        code = replace(code, r":[A-Za-z_][A-Za-z0-9_]*" => "")
+
+        # Every identifier the branch bodies mention, narrowed to the ones that are functions PormG
+        # can actually rename. Deliberately broader than "parse each branch's target": branches take
+        # several shapes (`ChainCaller(f, q)`, `(args...) -> f(q, args...)`,
+        # `(; kw...) -> (f(q.object; kw...); q)`), and a shape-specific regex would go blind to a
+        # new one — which is how a helper would slip in unchecked.
+        #
+        # Ownership is rooted at PormG, not at QueryBuilder, and the difference is load-bearing in
+        # both directions. Base-owned bindings (`first`, `last`, `get`, `deepcopy` — all reached
+        # from closure branches) must be excluded: the rule cannot ask anyone to rename
+        # `Base.deepcopy`. But a helper defined in a SIBLING PormG module and imported here is
+        # renameable and must stay in scope — a `QueryBuilder`-only test passes a branch routing to,
+        # say, `PormG.Models.capitalize_symbol`, and if that branch were ChainCaller-backed
+        # `_fluent_name` would leak the internal spelling, which is the whole regression this guards.
+        pormg_owned(mod) = mod === PormG || startswith(string(mod), "PormG.")
+        idents = unique(m.match for m in eachmatch(r"[A-Za-z_][A-Za-z0-9_]*!?", code))
+        owned = filter(idents) do name
+            sym = Symbol(name)
+            isdefined(PormG.QueryBuilder, sym) || return false
+            getfield(PormG.QueryBuilder, sym) isa Function || return false
+            pormg_owned(Base.Docs.Binding(PormG.QueryBuilder, sym).mod)
+        end
+        # Floor: proves the extraction found the surface at all. 16 `_`-prefixed helpers + the
+        # bare owned ones; a regex that silently matched nothing would otherwise pass everything.
+        # Paired with the anchor above — neither is sufficient alone.
+        @test length(owned) >= 20
+
+        offenders = filter(n -> !startswith(n, "_") && !Base.ispublic(PormG.QueryBuilder, Symbol(n)), owned)
+
+        # `on` and `cjoin_on` are the two known exceptions, documented in `object_manager.jl` above
+        # `Base.getproperty`: they are the `SQLObjectHandler` overloads of the `ctes.jl` join family
+        # whose siblings `cjoin`/`With` ARE public, so prefixing only these two would trade one
+        # inconsistency for a worse one. The real fix is a `public` declaration (#289 territory) —
+        # if you make it, DELETE the name from this list rather than widening the list.
+        #
+        # EQUALITY, not `issubset`, on purpose: a subset check would pass silently once the list
+        # rots to `[]`, so it could never force that deletion.
+        #
+        # If a name lands here that is NOT a chain helper — a local, a kwarg name, a struct field
+        # that happens to shadow a non-public PormG function — exclude it from EXTRACTION the way
+        # `:symbol` literals are stripped above. Do NOT append it to this list: that converts the
+        # assertion into an allowlist and defeats it. (`page` and `update` were exactly this case.
+        # `object` and `show_query` reach `owned` incidentally too, via `q.object` and the kwarg
+        # name, and pass only because both are public — the next such name may not be.)
+        #
+        # The short, collision-prone PormG-owned names now in scope, worth recognising on sight:
+        # `add`, `build`, `clear`, `insert`, `page`, `query`, `remove`, `set`, `update`, `OP`. Any
+        # of them used as a local or kwarg in a future branch lands here without being a helper.
+        @test sort(offenders) == ["cjoin_on", "on"]
     end
 
     # ─────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_execution_show.jl
+++ b/test/unit/test_execution_show.jl
@@ -307,9 +307,9 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# do_exists error-propagation contract
+# _exists error-propagation contract
 #
-# Before the fix, do_exists caught ALL exceptions and returned false — meaning
+# Before the fix, _exists caught ALL exceptions and returned false — meaning
 # a connection failure, SQL error, or permission denial was silently reported
 # as "does not exist". That masks real infrastructure problems.
 #
@@ -318,14 +318,14 @@ end
 #   • Rethrow every other exception so the caller can handle real failures.
 #
 # The MockPostgres connection registered in this file has no real backend, so
-# any fetch() call inside do_exists will raise an exception. Before the fix,
+# any fetch() call inside _exists will raise an exception. Before the fix,
 # .exists() would swallow that and return false. After the fix, it rethrows.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "do_exists rethrows database errors instead of returning false" begin
+@testset "_exists rethrows database errors instead of returning false" begin
   q = TestDriver.objects.filter("forename" => "Lewis")
 
   # The MockPostgres backend has no real connection, so fetch() inside
-  # do_exists raises a backend exception (not an ArgumentError).
+  # _exists raises a backend exception (not an ArgumentError).
   # The fixed implementation must propagate that exception rather than
   # swallowing it and returning false.
   err = try
@@ -344,7 +344,7 @@ end
   @test !(err isa ArgumentError)
 end
 
-@testset "do_exists propagates ArgumentError from ORM validation" begin
+@testset "_exists propagates ArgumentError from ORM validation" begin
   # An __@in subquery that projects two columns is caught by ORM validation
   # and raises ArgumentError. Both the old and new code must propagate this.
   # This test ensures the fix did not inadvertently swallow ArgumentErrors.

--- a/test/unit/test_fluent_parity_208.jl
+++ b/test/unit/test_fluent_parity_208.jl
@@ -156,7 +156,7 @@ end
 
 @testset "page() fluent arities render LIMIT/OFFSET (#272)" begin
   # The `page` docstring had always advertised `query.page(20)`, but only
-  # page!(::SQLObject, ::Tuple{Integer, Integer}) existed, so the single-argument form raised a bare
+  # _page!(::SQLObject, ::Tuple{Integer, Integer}) existed, so the single-argument form raised a bare
   # MethodError. Asserted on the rendered statement, not just the handler field, because
   # execution.jl only emits each clause when the field is non-zero.
   q2 = GocPg.objects
@@ -192,7 +192,7 @@ end
 end
 
 @testset "fluent .page(...) and the internal page() stay in lockstep (#272)" begin
-  # ROOT CAUSE GUARD. `page` (SQLObjectHandler, functions.jl) and `page!` (SQLObject, behind the
+  # ROOT CAUSE GUARD. `page` (SQLObjectHandler, functions.jl) and `_page!` (SQLObject, behind the
   # ChainCaller) are two parallel implementations of one contract, and #272 *was* them drifting:
   # the free function grew a limit-only arity, the fluent one did not, and only the docstring
   # noticed. Nothing but this test ties them together — assert equal end state from equal start,
@@ -216,9 +216,9 @@ end
 end
 
 @testset "page()/limit()/offset() reject non-Integer and wrong-arity arguments (#272)" begin
-  # #231/#239: every PormG domain failure is a PormGError. `page!` had no ::Any fallback, so
+  # #231/#239: every PormG domain failure is a PormGError. `_page!` had no ::Any fallback, so
   # query.page("20","10"), query.page() and query.page(1,2,3) all escaped as raw MethodErrors
-  # naming a `page!` and a Tuple that appear nowhere in the caller's code.
+  # naming a `page!` (its spelling before #281) and a Tuple that appear nowhere in the caller's code.
   q = GocPg.objects
 
   @test_throws PormG.QueryBuildError q.page("20", "10")
@@ -236,7 +236,7 @@ end
   @test occursin("page(20, 40)", msg)     # …and the two-argument one
 
   # Sibling mutators share the contract and had NO coverage at all before #272 — their messages used
-  # to say "Error in page" even though they are thrown by limit!/offset!.
+  # to say "Error in page" even though they are thrown by _limit!/_offset!.
   @test occursin("limit()",  _p208_error(() -> q.limit("20")))
   @test occursin("offset()", _p208_error(() -> q.offset("40")))
   @test_throws PormG.QueryBuildError q.limit()
@@ -251,7 +251,8 @@ end
   # The docs name the parameters (`.page(limit = 20)`) and five sibling fluent methods (.with,
   # .cjoin, .cjoin_on, .on, .select_for_update) are closures that DO take keywords — so a keyword
   # call on a ChainCaller method is a natural user mistake. It used to die on the functor itself
-  # with a MethodError naming `ChainCaller{typeof(page!), ObjectHandler}`, outside the taxonomy and
+  # with a MethodError naming `ChainCaller{typeof(page!), ObjectHandler}` (the pre-#281 spelling of
+  # `_page!`), outside the taxonomy and
   # unrecognizable to the caller. Every ChainCaller-backed method shares the one functor, so this
   # is asserted across the family, not just page.
   qk = GocPg.objects
@@ -274,18 +275,23 @@ end
 
   # …and it names the method the CALLER typed, recovered from the internal helper (#281). Before
   # this the message could only say "here", leaving the user to find which link of a long chain it
-  # meant. Cover both prefix shapes: `.filter`/`.values` go through `up_*!` helpers, `.order_by`
-  # and `.page` do not — a strip that handled only one would pass on half the family.
-  @test occursin("page()", _p208_error(() -> qk.page(limit = 20)))
-  @test occursin("filter()", _p208_error(() -> qk.filter(code = "HAM")))
-  @test occursin("values()", _p208_error(() -> qk.values(fields = "code")))
-  @test occursin("order_by()", _p208_error(() -> qk.order_by(field = "points")))
-  # The internal spelling must NOT leak — that is the whole point (`up_filter`, `filter!`).
-  # Match the exact internal spellings, not a bare "!": punctuation added to the sentence later
-  # would fail that without anything being wrong.
-  fmsg = _p208_error(() -> qk.filter(code = "HAM"))
-  @test !occursin("up_", fmsg)
-  @test !occursin("filter!", fmsg)
+  # meant.
+  #
+  # Both halves run over the SAME four methods, and the negative half is the load-bearing one.
+  # Since #281 every helper is spelled `_verb!`, so the positive assertion alone is nearly blind:
+  # deleting the `^_` strip leaves `_page()` in the message, which still contains "page()" and still
+  # passes. Only the negative assertion catches it. Assert the full internal spellings (`_page`,
+  # `page!`) rather than a bare "_" or "!" — punctuation added to the sentence later would trip
+  # those without anything being wrong.
+  for (call, name) in ((() -> qk.page(limit = 20),        "page"),
+                       (() -> qk.filter(code = "HAM"),    "filter"),
+                       (() -> qk.values(fields = "code"), "values"),
+                       (() -> qk.order_by(field = "pts"), "order_by"))
+    msg_i = _p208_error(call)
+    @test occursin("$(name)()", msg_i)
+    @test !occursin("_$(name)", msg_i)
+    @test !occursin("$(name)!", msg_i)
+  end
 
   # Rejected before the mutator runs: nothing is half-applied.
   @test qk.object.limit == 0

--- a/test/unit/test_shared_state_readpath.jl
+++ b/test/unit/test_shared_state_readpath.jl
@@ -6,7 +6,7 @@ broke that:
 
 1. The read path (`query()` → `query_list`) wrote `q.object.parameters` back onto the
    caller and materialized the per-build CTE `"model"` into the caller's `ctes` dict — so
-   a plain `.list()` had a hidden write side effect (`do_count`/`do_exists`/`get` already
+   a plain `.list()` had a hidden write side effect (`_count`/`_exists`/`get` already
    `deepcopy` first; `.list()` did not).
 2. `deepcopy(::SQLObjectQuery)` shallow-copied `ctes` (`copy(obj.ctes)`), so `.copy()` and
    its inner `CTEDict` values were shared by reference — materializing the CTE model on one
@@ -146,7 +146,7 @@ end
 
   # ─────────────────────────────────────────────────────────────────────────────
   # count()/exists() build the CTE via build_cte_clause on their OWN deepcopy
-  # (do_count/do_exists), a DIFFERENT path than query_list. Pre-#43 that deepcopy was
+  # (_count/_exists), a DIFFERENT path than query_list. Pre-#43 that deepcopy was
   # shallow for ctes, so _build_cte_custom_model still wrote the transient "model" into
   # the caller's shared inner CTEDict. :dict mode short-circuits before fetch, so this
   # is deterministic without a live database.

--- a/test/unit/test_typed_exceptions.jl
+++ b/test/unit/test_typed_exceptions.jl
@@ -48,7 +48,7 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # values() misuse → QueryBuildError (projection-shape misuse)
-# Three rejection paths in up_values!/_up_values: a non-String pair key, an
+# Three rejection paths in _values!/_values_field: a non-String pair key, an
 # operator suffix inside a projection, and a value of an unsupported type.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "values() misuse is QueryBuildError" begin
@@ -63,7 +63,7 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # order_by() misuse → QueryBuildError
-# Both order_by! rejection paths: an operator suffix inside an ordering field,
+# Both _order_by! rejection paths: an operator suffix inside an ordering field,
 # and an argument that is neither String nor SQLTypeOrder.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "order_by() misuse is QueryBuildError" begin
@@ -86,7 +86,7 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # update() keyword misuse → QueryBuildError
-# up_update! validates keywords BEFORE any build/DB work, so a typo'd kwarg
+# _update! validates keywords BEFORE any build/DB work, so a typo'd kwarg
 # (only :show_query is supported) is rejected with no settings needed.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "update() bad keyword is QueryBuildError" begin


### PR DESCRIPTION
Closes #281 — the last open box. Three of the four shipped in #290; #289/#294 removed the docs-publishing motive (publication follows `Base.ispublic` now, which is name-agnostic) and #290 shipped the kwarg-message improvement without needing a rename. What remained rested on consistency alone.

## What changed

`Base.getproperty(q::ObjectHandler, sym)` routed to helpers following four naming conventions with no rule separating them, so nothing signalled which spellings a user could not have typed. 16 renamed:

| Before | After |
|---|---|
| `up_filter!` `up_db!` `up_values!` | `_filter!` `_db!` `_values!` |
| `up_create!` `up_update!` `up_update_or_create!` `up_get_or_create!` | `_create!` `_update!` `_update_or_create!` `_get_or_create!` |
| `order_by!` `limit!` `offset!` `page!` `distinct!` `select_for_update!` | `_order_by!` `_limit!` `_offset!` `_page!` `_distinct!` `_select_for_update!` |
| `do_count` `do_aggregate` `do_exists` | `_count` `_aggregate` `_exists` |

Plus `_up_values` → `_values_field`, the last trace of the old convention.

## The rule

Stated above `Base.getproperty` and mirrored in the querybuilder skill:

> Of the helpers **PormG itself owns**, one is `_`-prefixed unless the name is API in its own right — unless `Base.ispublic(QueryBuilder, name)`.

Ownership means *"a name PormG can rename"*. That is what puts the Base-owned targets out of scope rather than needing exceptions for them. The 29 branches account for exhaustively:

- **16** `_`-prefixed, all `ispublic == false`
- **7** bare and public: `list` `delete` `earliest` `latest` `inspect_query` `With` `cjoin`
- **2** bare and not public — the stated exceptions: `on` `cjoin_on`
- **4** Base-owned, out of scope: `first` `last` `get` `deepcopy`

## What I deliberately did NOT do

- **This is not "one rule, no exception list"**, which is how the issue framed it. It is one rule scoped by ownership with **two named exceptions**. `on` and `cjoin_on` are PormG's and `ispublic == false`, so the rule says prefix them; they stay bare because they are the `SQLObjectHandler` overloads of the `ctes.jl` join family whose siblings `cjoin`/`With` *are* public, and splitting one family's spelling trades this inconsistency for a worse one. The real fix is a `public` declaration — both are documented in `docs/src/api.md` and `docs/src/read/custom_joins.md` but were never declared, unlike `cjoin`. That is #289 docs-surface territory, not a rename, so it is left for a follow-up. Neither carries a docstring, so nothing is currently missing from the published page.
- **No `UPGRADING.md` entry, no `Project.toml` bump.** Every renamed name is un-exported, so nothing *forces* an app source edit. Stated precisely: un-exported is not un-nameable in Julia — `import PormG.QueryBuilder: do_count` works, as `test_public_exports.jl` itself notes. The justification is that no app *should* be reaching in, not that none *can*.
- **No integration run.** Unit-only change.

## The rule is enforced, not just documented

New testset `getproperty helpers follow the #281 naming rule` in `test_docstring_coverage.jl`: it extracts every PormG-owned function named in the `getproperty` body — shape-agnostic on purpose, since branches take three different forms — and pins the non-`_`, non-public ones to exactly `["cjoin_on", "on"]`.

Evidence it is not decorative:

- It **failed on its first run**, flagging `page` and `update`. Both come from the branch *conditions* (`sym === :page`) and are unrelated function-form implementations; fixed by stripping `:symbol` literals before scanning.
- Fails under mutation for a ChainCaller branch (`_distinct!` → `do_distinct`), for a closure branch (`_select_for_update!` → `do_select_for_update`), and for an imported sibling-module helper (`PormG.Models.capitalize_symbol`).
- Ownership is rooted at PormG rather than QueryBuilder precisely so that last case stays covered — a sibling-module helper is renameable and just as able to leak through `_fluent_name`.

## Two assertions the rename would otherwise have hollowed out

- `test_fluent_parity_208.jl` asserted `!occursin("up_", msg)` — nothing can produce `up_` any more, so it had become vacuous. Now a loop over `page`/`filter`/`values`/`order_by` asserting both markers. Deleting the `^_` strip from `_fluent_name` fails **4** assertions instead of 1.
- `_fluent_name` drops its now-dead `up_` alternative.

## Also

`@error` in `_exists` moves to the structured form AGENTS.md mandates, names `exists()` rather than the internal spelling, and passes `(e, catch_backtrace())` so a backtrace is actually logged (a bare `e` does not produce one).

Comment prose follows one policy: verbatim quotes of past output keep the old spelling, narration about a still-existing function uses its current name, and enumerations of what the old spellings were keep the old spellings.

## Verification

- `julia --project=. test/runtests.jl` → **4960/4960, exit 0**
- `using PormG` precompiles clean (`precompile.jl` names a helper directly)
- Rung-2 guards standalone: `test_docstring_coverage` (49/49), `test_public_exports` (81/81), `test_fluent_parity_208`, `test_typed_exceptions`, `test_execution_show`, `test_shared_state_readpath`
- Rebased on `ba6927a` (#298), which touches `test_docstring_coverage.jl` — clean, #298's changes intact

Reviewed independently over four rounds; every round found something real, including that the rule as originally written — taken from the phrasing in the issue's own comment — was false against the shipped code in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
