### PR TITLE
fix(#299): remove the dead Model_Type.verbose_name slot

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -86,15 +86,10 @@ state treated as an immutable shared reference, and recursion would otherwise de
 `_module::Module` and throw. The query builder relies on this — copying a query copies its state but
 keeps the same model.
 
-`verbose_name` is inert: no `Model` method accepts it, and nothing consumes it — it is only ever
-copied from one model to another. It does not reach the DDL and does not appear in generated model
-files.
-
 See also [`Model`](@ref), [`set_models`](@ref), [`UniqueConstraint`](@ref).
 """
 @kwdef mutable struct Model_Type <: PormGModel
   name::AbstractString
-  verbose_name::Union{String, Nothing} = nothing
   fields::Dict{String, PormGField}
   field_names::Vector{String} = [] # needed to create sql queries with joins
   related_objects::Dict{String, Any} = Dict{String, Any}() # needed to create sql queries with joins
@@ -1766,7 +1761,6 @@ function strip_many_to_many_fields(model::PormGModel)::PormGModel
   physical_field_names = [field_name for field_name in model.field_names if haskey(physical_fields, field_name)]
   return Model_Type(
     name=model.name,
-    verbose_name=model.verbose_name,
     fields=physical_fields,
     field_names=physical_field_names,
     related_objects=copy(model.related_objects),

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -95,6 +95,111 @@ end
   @test occursin("CREATE UNIQUE INDEX", through_sql)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField migration synthesis: `strip_many_to_many_fields` returns a physical-only clone
+# Every model in `current_schema` passes through this helper before the planner diffs it
+# (`get_migration_plan` → `synthesize_many_to_many_through_models`, first loop), because a
+# ManyToManyField owns no column and must never reach CREATE TABLE. So it owes two things: rebuild
+# `fields`/`field_names` filtered, and carry the untouched slots onto the clone the planner then
+# works from — `name`, `related_objects`, `_module`, `connect_key` and `cache`. The one carried
+# slot with a proven downstream reader is `cache`: `_add_unique_constraints`
+# (`src/migrations/planner.jl:206`) pulls `cache["unique_constraints"]` off this returned model, so
+# dropping the copy silently deletes every user-declared UniqueConstraint from the CREATE TABLE plan
+# — a regression `test_unique_constraints.jl` catches and this file's assertions below also trip.
+# It must also leave its input alone: that input is the user's live registered model, which the
+# session treats as immutable shared schema state (`deepcopy` SHARES it, #157).
+# The function had no direct test until #299 removed the dead `verbose_name` slot from its copy list.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "strip_many_to_many_fields returns a physical-only clone" begin
+  source = M2M.Driver_championship
+
+  # Preconditions — plus one explicit vacuity note. Without these, assertions below would pass
+  # vacuously: a "preserved" connect_key proves nothing if both sides are `nothing`.
+  @test haskey(source.fields, "drivers")      # there IS a M2M field to drop
+  @test source._module !== nothing            # set_models ran, so the carried slots hold real values
+  @test source.connect_key !== nothing
+  # The relation cache is populated. This key is query-builder state, NOT something the planner
+  # reads — planner code touches only "many_to_many_auto", "unique_constraints" and "index".
+  @test haskey(source.cache, "many_to_many")
+  # This model's `related_objects` is EMPTY: nothing points an FK at `driver_championships`, and a
+  # M2M installs its reverse accessor on the *related* model (`src/Models.jl:1733`), i.e. on `Driver`.
+  # So any `related_objects` assertion here would pass vacuously — the honest carry-over check for
+  # that slot is on the `Driver` side below, and this precondition is what says so out loud.
+  @test isempty(source.related_objects)
+  names_before = copy(source.field_names)
+
+  stripped = Models.strip_many_to_many_fields(source)
+
+  # ── The M2M field is dropped from `fields` (an `identity` implementation fails right here) ──
+  @test !haskey(stripped.fields, "drivers")
+  @test haskey(stripped.fields, "id")
+  @test haskey(stripped.fields, "name")
+  @test length(stripped.fields) == length(source.fields) - 1
+
+  # ── `field_names` holds exactly the physical columns ──
+  # It never contained "drivers" to begin with (`Model(...)` excludes M2M at construction), so this
+  # pins the invariant, not the drop; the drop itself is exercised on a dirty input further down.
+  @test Set(stripped.field_names) == Set(["id", "name"])
+  @test all(n -> haskey(stripped.fields, n), stripped.field_names)
+
+  # ── Every remaining slot is carried onto the clone ──
+  @test stripped.name == "driver_championships"
+  @test stripped._module === source._module
+  @test stripped.connect_key === source.connect_key
+  # `copy(model.cache)` is shallow, so the inner relation table is the SAME object — which is why the
+  # relation still resolves off the stripped model even though the field that declared it is gone.
+  # (The through table itself does NOT depend on this: the second loop of
+  # `synthesize_many_to_many_through_models` rebuilds it from the ORIGINAL unstripped model and sets
+  # `cache["many_to_many_auto"]` on a freshly-built through model. Nor does `_add_unique_constraints`
+  # depend on identity — it needs only that the outer Dict was copied at all. Inner-table identity is
+  # what the next two assertions pin, and nothing else.)
+  @test stripped.cache["many_to_many"] === source.cache["many_to_many"]
+  @test Models.get_many_to_many_relation(stripped, "drivers") ===
+        Models.get_many_to_many_relation(source, "drivers")
+
+  # ── It is a clone: distinct model, distinct containers ──
+  # `related_objects` is deliberately absent here — empty on this model, so `!==` would hold for any
+  # freshly-allocated Dict and prove nothing. It is checked on the populated `Driver` side below.
+  @test stripped !== source
+  @test stripped.fields !== source.fields
+  @test stripped.field_names !== source.field_names
+  @test stripped.cache !== source.cache      # outer Dict copied; inner tables shared, asserted above
+
+  # ── …and the live input is untouched ──
+  @test sort(collect(keys(source.fields))) == ["drivers", "id", "name"]
+  @test source.field_names == names_before
+
+  # ── The target side: no M2M field of its own, but the reverse accessor must survive the copy ──
+  # `Driver` holds the reverse relation in `related_objects["championships"]` rather than in `cache`,
+  # so this is the only place the `related_objects` copy can be checked non-vacuously. Nothing under
+  # `src/migrations/` reads `related_objects` today; this pins the clone's fidelity, so a caller that
+  # keeps hold of a stripped model still resolves the same reverse accessor as the original.
+  driver_stripped = Models.strip_many_to_many_fields(M2M.Driver)
+  @test haskey(M2M.Driver.related_objects, "championships")             # precondition
+  @test driver_stripped.related_objects !== M2M.Driver.related_objects  # copied container…
+  @test driver_stripped.related_objects["championships"] ===
+        M2M.Driver.related_objects["championships"]                     # …sharing the relation object
+  @test Models.has_many_to_many_accessor(driver_stripped, "championships")
+  @test Set(driver_stripped.field_names) == Set(["id", "surname"])      # nothing to drop on this side
+  @test driver_stripped._module === M2M.Driver._module
+
+  # ── The `field_names` filter itself, on an input only a hand-built model can produce ──
+  # The filter keeps a name by membership in the SURVIVING `fields`, it does not re-test the field
+  # type. No production path puts a M2M name into `field_names` (`Model(...)` and `add_field!` both
+  # exclude it), so without this synthetic input the filter itself is never exercised: every
+  # `field_names` *content* assertion above holds just as well for a function that drops the filter
+  # and copies `field_names` verbatim. This is the assertion that catches that.
+  dirty = Models.Model_Type(
+    name = "dirty_championships",
+    fields = copy(source.fields),
+    field_names = ["id", "drivers", "name"],
+  )
+  dirty_stripped = Models.strip_many_to_many_fields(dirty)
+  @test dirty_stripped.field_names == ["id", "name"]    # dropped in place, surrounding order kept
+  @test !haskey(dirty_stripped.fields, "drivers")
+  @test dirty.field_names == ["id", "drivers", "name"]  # the input is still untouched
+end
+
 @testset "add_field! ManyToManyField registration" begin
   orphan = Models.Model("orphan_team",
     id = Models.IDField(),


### PR DESCRIPTION
Closes #299.

## What

`Model_Type` carried a `verbose_name` slot that was write-never / read-never:

- **0 producers.** All three `Model_Type(...)` calls inside the `Model(...)` constructors pass only `name`/`fields`/`field_names`; `constraints` is the only model-level keyword any `Model` method peels, so `Model("race", verbose_name = "Races", …)` fell into the `fields...` slurp and raised `ModelDefinitionError`. The synthetic CTE pseudo-model (`src/querybuilder/ctes.jl`) never passed it either, and all 47 `Model_Type(...)` sites across `test/` omitted it.
- **1 consumer, and it was a copy.** `strip_many_to_many_fields` propagated `nothing` from one model to another. Nothing read it downstream — not the DDL, not the planner, not `Model_to_str`.

This removes the slot, that copy, and the docstring paragraph that documented its inertness.

The **field-level** `verbose_name` kwarg — real and accepted on every field constructor — is deliberately untouched, including its exclusion from field diffing in `src/migrations/planner.jl`.

## Why remove rather than wire it up

Considered and rejected during review. A working model-level `verbose_name` needs the kwarg peeled on both kwargs `Model` methods, threaded through the three inner methods, **emitted in `Model_to_str`** (or `makemigrations` silently drops it on every regenerated model file), a `verbose_name_plural` decision, plus docs and tests. The struct line was ~1 line of that work, so keeping it saved nothing while remaining a standing trap for the next reader.

The candidate consumer was checked explicitly: `Nitro.jl` is an API/SPA framework, `verbose_name` appears zero times in it, its own rules forbid importing PormG from `src/`, and its PormG extension is session-store and task-queue plumbing over tables it asks PormG to *hide* from users.

Note for whoever picks up #59 (model-level `db_table`): its task list says *"currently only `name` / `verbose_name` exist in `src/Models.jl`"*, which this PR makes stale by one word. I did not edit that issue — that is a separate backlog decision.

## Tests

Adds the first direct test for `strip_many_to_many_fields`, which this PR edits and which previously had **no coverage of its own** — the existing M2M synthesis test only reached it indirectly through `get_migration_plan`.

The removal itself has no observable behavior to assert (that is the point), so the testset is a characterization net over the function: it pins the M2M-field drop, the `field_names` filter, every carried slot, clone-vs-mutation semantics, and the reverse-accessor side.

Mutation-tested — each of these breaks it:

| Mutation | Caught by |
|---|---|
| drop the `related_objects` copy | `Driver`-side accessor assertions |
| drop the `cache` copy | `cache["many_to_many"]` identity |
| remove the `field_names` filter | the synthetic `dirty` probe **only** |

Results: new testset 31/31; guards `test_model_deepcopy` 9/9, `test_unique_constraints` 12/12, `test_migration_diff_failsafe` 7/7, `test_docstring_coverage` 49/49, `test_public_exports` 81/81; full unit suite **4991/4991**, exit 0.

## Deliberately not done

- **No `UPGRADING.md` entry** — the value was unconditionally `nothing` and unreachable from outside PormG, so no consuming app can observe the change; it forces no source edit, which is the only bar that file tracks.
- **No `Project.toml` bump** — release trains.
- **No integration run.** No DDL, query, or runtime surface is touched and no integration test references model-level `verbose_name`. Flagged to the maintainer, who approved landing without it.
- **No `:verbose_name ∉ fieldnames(Model_Type)` drift guard.** It would have been the only red-before/green-after assertion, but asserting a field's *absence* on a non-public struct pins shape rather than behavior, and would fire spuriously if #59's work later adds a real `verbose_name` with a consumer.
- **No `docs/src/` edit** — model-level `verbose_name` appears nowhere there; the two hits are field-level.

## Review notes

Two independent review rounds. Round 1 raised three findings; round 2 (reviewing the fixes) raised two more that were introduced *by* those fixes. All six were comment accuracy or vacuous assertions — zero code defects — and all are fixed. The substantive corrections: the carried `cache` was credited to `_add_many_to_many_auto_constraints`, but that key is only ever set on the freshly-built through model, never on a stripped one (the real reader is `_add_unique_constraints` via `cache["unique_constraints"]`); and two `related_objects` assertions were vacuous because that dict is empty on the owner side, so the honest check now lives on the `Driver` side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
