### PR TITLE
fix(#292): carry on_delete and the FK default through introspection

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,105 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Introspected foreign keys now carry `on_delete` (PostgreSQL) and the column default (SQLite) (#292)
+
+- **Version**: Unreleased
+- **PormG ref**: #292; `src/migrations/introspection.jl`, `UPGRADING.md`
+- **Recorded**: 2026-08-04
+- **Severity**: **breaking (generated model files change; a contradictory PostgreSQL schema now
+  fails at registration)** — narrow: it affects only apps that generate models by introspecting a
+  database. Part of the `0.3.x` pre-publish wave.
+
+### What changed
+
+Introspection lost a different half of each foreign-key declaration per backend, and the two halves
+were mirror images:
+
+- **PostgreSQL never queried the referential action at all.** A table whose FK was
+  `ON DELETE CASCADE` introspected to a model claiming no cascade, and a migration generated from
+  that model dropped the action from the schema. Silent round-trip infidelity.
+- **SQLite carried the action but dropped the column default.** Since #287 that is a hard failure:
+  an `ON DELETE SET DEFAULT` FK introspected to `on_delete=SET_DEFAULT` with no `default=`, which
+  `set_models` rejects — and regenerating produced the identical broken file.
+
+Both are fixed. `OneToOneField` had the same omission as `ForeignKey` and is fixed with it.
+
+Two consequences for existing apps:
+
+**1. Regenerated model files change.** PostgreSQL-generated files gain `on_delete=` on every FK that
+declares an action. SQLite-generated files lose a spurious `on_delete=DO_NOTHING` on FKs that never
+declared one — both backends now render "no action declared" as an omitted `on_delete`, which is
+what PormG already emitted as SQL (`ON DELETE NO ACTION`) for both spellings. `makemigrations` does
+not diff `on_delete`, so **regenerating produces no `ALTER` and no migration**; it is a source-file
+change only.
+
+One narrow exception, on SQLite: the *field-rename* path does compare the action. So an app that
+keeps an explicit `on_delete=DO_NOTHING` in its models file instead of regenerating, and then renames
+that FK field, now gets a table rebuild it would not have got before. It is data- and
+index-preserving, and it disappears as soon as the file is regenerated.
+
+**2. A self-contradictory PostgreSQL schema now fails at registration.** Because the PostgreSQL path
+never emitted `on_delete` before, it could not contradict anything. Now it can, and #287's guards
+apply to introspected models as they already did to hand-written ones:
+
+- `ON DELETE SET NULL` on a `NOT NULL` column → `ModelDefinitionError` at `set_models`
+- `ON DELETE SET DEFAULT` on a column with no default (or a default PormG cannot represent as an
+  `Int64` — a text default, a `nextval(...)` expression) → `ModelDefinitionError`
+
+Both are legal PostgreSQL DDL that only fails at delete time, so a database can genuinely be in this
+state. Introspection **warns** naming the table and column when it drops an unrepresentable default,
+and never throws from inside the import itself.
+
+### How to find the calls to migrate
+
+```bash
+# 1. Regenerate your models and diff — expect on_delete= to appear (PostgreSQL) or a spurious
+#    DO_NOTHING to disappear (SQLite). No migration is generated either way.
+git diff -- <your models file>
+```
+
+```sql
+-- 2. Contradictory FKs, if your generated module now fails to register. Run against the DATABASE,
+--    not the model file — these are schema states, not code. Reports the two columns you need to
+--    judge each row: `attnotnull` and the column default.
+--      * confdeltype 'n' (SET NULL)    + attnotnull = t          → contradictory
+--      * confdeltype 'd' (SET DEFAULT) + col_default NULL, or a
+--        default PormG cannot read as an Int64 (text, nextval)   → contradictory
+--    A multi-column FK yields one row per column.
+SELECT c.relname, a.attname, con.confdeltype, a.attnotnull,
+       pg_get_expr(ad.adbin, ad.adrelid) AS col_default
+FROM pg_constraint con
+JOIN pg_class c ON c.oid = con.conrelid
+JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
+LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+WHERE con.contype = 'f' AND con.confdeltype IN ('n', 'd');
+```
+
+### Before → after
+
+Copy-exact `Model_to_str` output — kwarg order is struct-field order and there are no spaces around
+`=`, so this is what `git diff` on a regenerated file actually shows:
+
+```julia
+# before — PostgreSQL introspection produced this for an ON DELETE CASCADE column
+fk_cascade = Models.ForeignKey("Pormg_it_fk_parent", null=true, pk_field="id")
+
+# after — the action it actually declared is carried through
+fk_cascade = Models.ForeignKey("Pormg_it_fk_parent", null=true, pk_field="id", on_delete=CASCADE)
+```
+
+If a regenerated model now raises `ModelDefinitionError`, fix the **schema**, not the generated file
+— the alternative is re-editing it by hand after every regeneration:
+
+```sql
+-- SET NULL needs a nullable column
+ALTER TABLE results ALTER COLUMN driverid DROP NOT NULL;
+-- SET DEFAULT needs something to set
+ALTER TABLE results ALTER COLUMN statusid SET DEFAULT 1;
+```
+
+---
+
 ## SQLite now enforces foreign keys (#276)
 
 - **Version**: Unreleased
@@ -172,10 +271,13 @@ unaffected.
 **Generated model files are affected, though.** Django's `on_delete=models.SET_DEFAULT, default=None`
 on a nullable FK used to import verbatim as `SET_DEFAULT` with no default — a shape that now fails at
 registration, so the generated file would not load and regenerating produced the identical broken file.
-The importer translates it to `SET_NULL` (which is what Django's combination denotes) and warns. If you
-import from a database rather than from Django, check any FK the introspector renders as
-`on_delete=SET_DEFAULT`: it does not carry the column default through, so you may need to add a
-`default=` by hand before the generated module will register.
+The importer translates it to `SET_NULL` (which is what Django's combination denotes) and warns.
+
+Importing from a **database** needed a hand edit for a while: the introspector rendered
+`on_delete=SET_DEFAULT` without carrying the column default through, so the generated module failed
+to register and regenerating reproduced the same broken file. #292 fixed that — introspection now
+carries the default (and, on PostgreSQL, the referential action it never used to query), so no hand
+edit is required.
 
 ### How to find the calls to migrate
 

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -5,6 +5,91 @@
 # ==============================================================================
 
 # ---
+# Shared FK helpers (both backends)
+# ---
+
+# A foreign key's column default, coerced to what `ForeignKey`/`OneToOneField` accept, or `nothing`.
+#
+# FAILURE POLICY (#292): introspection NEVER throws over a default it cannot represent. The field
+# constructors run `validate_default(default, Union{Int64, Nothing}, …, format2int64)`, which raises
+# `FieldValidationError` on anything non-numeric — a text default on a text FK column, a PostgreSQL
+# expression default like `nextval(...)`. Letting that escape would abort an entire
+# `convert_schema_to_models` run over one odd column, with no way to skip past it. So: warn, naming
+# the table, column and raw value, and emit the FK without a `default=`.
+#
+# THE RESIDUAL, stated rather than hidden. This policy covers the *default*, not a self-contradictory
+# *action*, so `set_models` still rejects two shapes — deliberately, because the database really is
+# in a state PormG cannot express and silently dropping the action would hide it:
+#
+#   1. `SET_DEFAULT` on a column with no default (or an unrepresentable one) — #287's guard.
+#   2. `SET_NULL` on a NOT NULL column — #287's other guard.
+#
+# Both are legal DDL on both backends (the action is only enforced at delete time), and PostgreSQL
+# reaches them for the first time as of #292, because before it the PostgreSQL path never emitted
+# `on_delete` at all and so could not contradict anything. The `@warn` above is what names the
+# column for case 1; case 2 surfaces at registration with the model and field named. See the
+# `## Unreleased` entry in UPGRADING.md.
+#
+# Shared by all three FK branches — the two SQLite ones and the PostgreSQL one. Before #292 the
+# SQLite branches dropped the default silently and PostgreSQL passed it through unguarded, so this
+# closes an existing PostgreSQL exposure as well as the SQLite gap it was written for.
+function _fk_default_or_warn(default_val, table_name, column_name)
+  default_val === nothing && return nothing
+  ismissing(default_val) && return nothing
+
+  try
+    # `Bool <: Integer`, so a SQLite 0/1 boolean default converts to 0/1 — which is what the
+    # column actually stores. Inside the `try` on purpose: `Int64(::UInt64)` past `typemax(Int64)`
+    # raises `InexactError`, and the whole point of this helper is that no input escapes as a throw.
+    default_val isa Integer && return Int64(default_val)
+    return Models.format2int64(default_val)
+  catch e
+    # Program-state failures are not "this default is unrepresentable" — same carve-out the
+    # `Model_to_str` render-failure path uses (Models.jl), so Ctrl-C during a large
+    # `convert_schema_to_models` run aborts instead of being reported as a bad default.
+    (e isa InterruptException || e isa StackOverflowError) && rethrow()
+    # The value is shown as introspection received it. On PostgreSQL that is the column regex's
+    # already-cleaned form, so an expression default can appear truncated at a `::` cast — enough
+    # to identify the column, not a faithful reproduction of the DDL.
+    @warn "Foreign key default could not be represented as a field default; emitting the relation without it." table = string(table_name) column = string(column_name) default = string(default_val)
+    return nothing
+  end
+end
+
+# PormG's `on_delete === nothing` and `DO_NOTHING` both render as SQL `ON DELETE NO ACTION`
+# (`_foreign_key_on_delete_sql`, Dialect.jl), so a "NO ACTION" read back out of a database is
+# ambiguous — and `NO ACTION` is also what a backend stores when no action was declared at all.
+# Introspecting it as `DO_NOTHING` would therefore stamp an explicit `on_delete=DO_NOTHING` onto
+# EVERY plain foreign key in every generated model. Mapping it to `nothing` is lossless (the
+# re-emitted DDL is identical either way) and keeps the two backends agreeing: PostgreSQL stores
+# `confdeltype = 'a'` for the same two cases.
+#
+# `PROTECT` is not recoverable — it renders as SQL `RESTRICT`, so a round trip can only ever return
+# `RESTRICT`. One-way by construction, not an oversight.
+#
+# PostgreSQL stores the action as a single char in `pg_constraint.confdeltype`. `'a'` (NO ACTION)
+# maps to `nothing` for the reason above; an empty/unknown code does too, so a schema-query result
+# predating #292 degrades to today's behaviour instead of erroring.
+function _pg_confdeltype_to_on_delete(code)
+  code === nothing && return nothing
+  ismissing(code) && return nothing
+  c = strip(string(code))
+  c == "c" && return "CASCADE"
+  c == "r" && return "RESTRICT"
+  c == "n" && return "SET NULL"
+  c == "d" && return "SET DEFAULT"
+  return nothing   # 'a' (NO ACTION) and anything unrecognised
+end
+
+function _normalize_introspected_on_delete(action)
+  action === nothing && return nothing
+  ismissing(action) && return nothing
+  normalized = uppercase(replace(strip(string(action)), r"\s+" => "_"))
+  (isempty(normalized) || normalized == "NO_ACTION") && return nothing
+  return normalized
+end
+
+# ---
 # SQLite Introspection
 # ---
 
@@ -128,8 +213,15 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
     if haskey(pk_map, column_name)
       field_instance = Models.IDField(null=!(nullable === nothing), auto_increment=pk_map[column_name]["auto_increment"])
     elseif haskey(fk_map, column_name)
-      field_instance = Models.ForeignKey(uppercasefirst(fk_map[column_name]["fk_table"] |> string); pk_field=fk_map[column_name]["fk_column"] |> string, on_delete=fk_map[column_name]["on_delete"], 
-      on_update=fk_map[column_name]["on_update"], deferrable=!(fk_map[column_name]["on_deferable"] === nothing), null=!(nullable === nothing))
+      # `default=` was computed above but never reached this branch before #292, so an FK declared
+      # ON DELETE SET DEFAULT introspected to `SET_DEFAULT` with no default — which since #287
+      # throws `ModelDefinitionError` at `set_models`, and regenerating produced the identical
+      # broken file. Routed through `_fk_default_or_warn` so an unrepresentable default warns
+      # rather than throwing from inside introspection.
+      field_instance = Models.ForeignKey(uppercasefirst(fk_map[column_name]["fk_table"] |> string); pk_field=fk_map[column_name]["fk_column"] |> string,
+      on_delete=_normalize_introspected_on_delete(fk_map[column_name]["on_delete"]),
+      on_update=fk_map[column_name]["on_update"], deferrable=!(fk_map[column_name]["on_deferable"] === nothing), null=!(nullable === nothing),
+      default=_fk_default_or_warn(normalized_default, table_name, column_name))
     else
       field_instance = getfield(Models, type_sym)(null=!(nullable === nothing), default=normalized_default)
     end
@@ -172,7 +264,14 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
         field = Models.IDField(null=false, primary_key=true, auto_increment=(base_type == "INTEGER"))
     elseif haskey(fk_map, col_name)
         fk_info = fk_map[col_name]
-        field = Models.ForeignKey(uppercasefirst(fk_info.table); pk_field=fk_info.to, on_delete=fk_info.on_delete, null=nullable)
+        # Same #292 gap as the DDL-regex path above: `default_val` was in scope and used two
+        # branches down, but never passed to the FK. This is the path the live
+        # `convert_schema_to_models(::PormGSQLite)` actually reaches. The FK column's declared type
+        # drives normalization the same way a non-FK column's does.
+        fk_type_sym = get(type_map, base_type, :TextField)
+        field = Models.ForeignKey(uppercasefirst(fk_info.table); pk_field=fk_info.to,
+            on_delete=_normalize_introspected_on_delete(fk_info.on_delete), null=nullable,
+            default=_fk_default_or_warn(_normalize_sqlite_default(default_val, fk_type_sym), table_name, col_name))
     else
         type_sym = get(type_map, base_type, :TextField)
         # Handle decimal precision if present
@@ -297,7 +396,12 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
             array_to_string(array_agg(quote_ident(cf.relname)), ', ') AS fk_tables,
             array_to_string(array_agg(quote_ident(pk_att.attname)), ', ') AS referenced_primary_keys,
             array_to_string(array_agg(con.condeferrable::text), ', ') AS deferrable,
-            array_to_string(array_agg(con.condeferred::text), ', ') AS initially_deferred
+            array_to_string(array_agg(con.condeferred::text), ', ') AS initially_deferred,
+            -- #292: the referential action was never selected, so every introspected PostgreSQL FK
+            -- came back claiming no ON DELETE. Single-char codes: a=NO ACTION, r=RESTRICT,
+            -- c=CASCADE, n=SET NULL, d=SET DEFAULT. Aggregated in the same order as fk_cols so the
+            -- zip in convertSQLToModel stays aligned.
+            array_to_string(array_agg(con.confdeltype::text), ', ') AS delete_rules
         FROM pg_constraint con
         JOIN pg_attribute att2 ON att2.attnum = ANY(con.conkey) AND att2.attrelid = con.conrelid
         JOIN pg_class cf ON cf.oid = con.confrelid
@@ -355,6 +459,7 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
         fk.referenced_primary_keys AS referenced_primary_keys,
         fk.deferrable AS deferrable,
         fk.initially_deferred AS initially_deferred,
+        fk.delete_rules AS delete_rules,
         ix.index_columns AS index_columns,
         ix.index_names AS index_names
     FROM pg_class c
@@ -377,7 +482,7 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
       $(table === nothing ? "" : "AND c.relname = '$(table)'")
       AND a.attnum > 0
       AND NOT a.attisdropped
-    GROUP BY n.nspname, c.relname, pk.pk_cols, fk.fk_cols, fk.fk_tables, fk.referenced_primary_keys, fk.deferrable, fk.initially_deferred, ix.index_columns, ix.index_names, u.unique_cols, nn.check_cols
+    GROUP BY n.nspname, c.relname, pk.pk_cols, fk.fk_cols, fk.fk_tables, fk.referenced_primary_keys, fk.deferrable, fk.initially_deferred, fk.delete_rules, ix.index_columns, ix.index_names, u.unique_cols, nn.check_cols
     ORDER BY table_schema, table_name;
     """
 
@@ -622,13 +727,22 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
   pk_set = ismissing(row[:primary_keys]) ? Set{String}() : Set(split(row[:primary_keys], ", "))
     
   # Extract foreign key constraints
-  fk_map = Dict{String, Tuple{String, String}}()
+  # Widened past `(table, pk)` for #292 to carry the referential action, which the schema query
+  # never selected — so every introspected FK claimed no ON DELETE and a migration generated from
+  # it silently dropped the action from the schema.
+  fk_map = Dict{String, NamedTuple{(:table, :pk, :on_delete), Tuple{String, String, Union{String, Nothing}}}}()
   if row[:foreign_keys] |> !ismissing
     fk_columns = split(row[:foreign_keys], ", ")
     fk_tables = split(row[:foreign_tables], ", ")
-    fk_pk_columns = split(row[:referenced_primary_keys], ", ")  
-    for (fk_col, fk_table, fk_pk) in zip(fk_columns, fk_tables, fk_pk_columns)
-        fk_map[fk_col] = (fk_table, fk_pk) 
+    fk_pk_columns = split(row[:referenced_primary_keys], ", ")
+    # `delete_rules` is absent on a schema-query result produced before #292 (and on the synthetic
+    # rows some unit tests build), so degrade to "no action recorded" rather than throwing.
+    delete_rules = (:delete_rules in propertynames(row) && !ismissing(row[:delete_rules])) ?
+      split(row[:delete_rules], ", ") : fill("", length(fk_columns))
+    for (i, (fk_col, fk_table, fk_pk)) in enumerate(zip(fk_columns, fk_tables, fk_pk_columns))
+        rule = i <= length(delete_rules) ? delete_rules[i] : ""
+        fk_map[fk_col] = (table = String(fk_table), pk = String(fk_pk),
+                          on_delete = _pg_confdeltype_to_on_delete(rule))
     end
   end
 
@@ -732,12 +846,19 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       field = if primary_key
           Models.IDField(generated=generated, generated_always=generated_always, unique=true, null=false, db_index=true)
       elseif haskey(fk_map, col_name)
-        fk_table, fk_column = fk_map[col_name]
-        fk_table = uppercasefirst(fk_table)
+        fk_info = fk_map[col_name]
+        fk_table = uppercasefirst(fk_info.table)
+        fk_column = fk_info.pk
+        # #292: `on_delete` is now carried (it was never even queried), and `default_value` goes
+        # through the shared failure policy — this branch passed it unguarded, so a column default
+        # that cannot be an Int64 raised FieldValidationError from inside introspection.
+        # `OneToOneField` had the identical omission and is fixed with `ForeignKey`.
+        fk_default = _fk_default_or_warn(default_value, table_name, col_name)
+        fk_on_delete = _normalize_introspected_on_delete(fk_info.on_delete)
         if unique
-          Models.OneToOneField(fk_table, pk_field=fk_column, null=!not_null, default=default_value, db_index=true)
+          Models.OneToOneField(fk_table, pk_field=fk_column, null=!not_null, default=fk_default, on_delete=fk_on_delete, db_index=true)
         else
-          Models.ForeignKey(fk_table, pk_field=fk_column, null=!not_null, default=default_value, db_index=true)
+          Models.ForeignKey(fk_table, pk_field=fk_column, null=!not_null, default=fk_default, on_delete=fk_on_delete, db_index=true)
         end
       else
         field_type(unique=unique, null=!not_null, default=default_value, db_index=db_index)

--- a/test/integration/test_importers_introspection.jl
+++ b/test/integration/test_importers_introspection.jl
@@ -29,7 +29,10 @@
   is_pg = adapter_name == "PostgreSQL"
 
   ddl(sql) = PormG.ConnectionPool.fetch(pool, sql)
-  fixtures = ("pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored")
+  # Child before parent: since #276 SQLite enforces foreign keys, so dropping the parent while the
+  # child still references it raises instead of silently succeeding.
+  fixtures = ("pormg_it_fk_child", "pormg_it_fk_parent",
+              "pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored")
   drop_fixtures() = for t in fixtures
     try; ddl("DROP TABLE IF EXISTS \"$(t)\""); catch; end
   end
@@ -47,10 +50,39 @@
     """CREATE TABLE "pormg_it_ignored" (id INTEGER PRIMARY KEY, note VARCHAR(50))""" :
     """CREATE TABLE "pormg_it_ignored" (id INTEGER PRIMARY KEY, note TEXT)"""
 
+  # #292 fixture: one parent plus a child carrying one FK per referential action. The SET DEFAULT
+  # column has a REAL column default, which is the combination #287 made a hard failure and #291
+  # documented a hand-edit remedy for. `fk_o2o` is UNIQUE so the PostgreSQL path builds an
+  # OneToOneField — it had the identical on_delete omission as ForeignKey.
+  fk_parent_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_fk_parent" (id BIGINT PRIMARY KEY, label VARCHAR(50))""" :
+    """CREATE TABLE "pormg_it_fk_parent" (id INTEGER PRIMARY KEY, label TEXT)"""
+  fk_child_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_fk_child" (
+         id            BIGINT PRIMARY KEY,
+         fk_cascade    BIGINT REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE,
+         fk_restrict   BIGINT REFERENCES "pormg_it_fk_parent"(id) ON DELETE RESTRICT,
+         fk_setnull    BIGINT REFERENCES "pormg_it_fk_parent"(id) ON DELETE SET NULL,
+         fk_setdefault BIGINT DEFAULT 1 REFERENCES "pormg_it_fk_parent"(id) ON DELETE SET DEFAULT,
+         fk_plain      BIGINT REFERENCES "pormg_it_fk_parent"(id),
+         fk_o2o        BIGINT UNIQUE REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE
+       )""" :
+    """CREATE TABLE "pormg_it_fk_child" (
+         id            INTEGER PRIMARY KEY,
+         fk_cascade    INTEGER REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE,
+         fk_restrict   INTEGER REFERENCES "pormg_it_fk_parent"(id) ON DELETE RESTRICT,
+         fk_setnull    INTEGER REFERENCES "pormg_it_fk_parent"(id) ON DELETE SET NULL,
+         fk_setdefault INTEGER DEFAULT 1 REFERENCES "pormg_it_fk_parent"(id) ON DELETE SET DEFAULT,
+         fk_plain      INTEGER REFERENCES "pormg_it_fk_parent"(id),
+         fk_o2o        INTEGER UNIQUE REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE
+       )"""
+
   drop_fixtures()                      # clean slate if a prior run aborted mid-test
   ddl(natural_pk_ddl)
   ddl(numeric_pk_ddl)
   ddl(ignored_ddl)
+  ddl(fk_parent_ddl)
+  ddl(fk_child_ddl)
 
   saved_ignore = copy(PormG._EXTRA_IGNORE_TABLES[])
   try
@@ -79,6 +111,100 @@
 
     @test "pormg_it_natural_key" in names2     # ordinary table still imported
     @test !("pormg_it_ignored" in names2)      # registered table skipped on the real path
+
+    # ── 3. FK round-trip: on_delete AND the column default survive (#292) ────
+    # The two halves of the bug were mirror images. PostgreSQL never QUERIED the delete rule, so
+    # every FK introspected as "no action" and a migration generated from the model silently
+    # dropped the cascade. SQLite carried the action but dropped the default, so a SET DEFAULT FK
+    # produced a model that #287 rejects at `set_models` — and regenerating produced the identical
+    # broken file. Run against a real engine on both backends because the PostgreSQL half is a SQL
+    # query change that nothing hermetic can exercise.
+    fk_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_fk_parent", "pormg_it_fk_child"])
+    fk_by_name = Dict(lowercase(string(m.name)) => m for m in fk_models)
+    @test haskey(fk_by_name, "pormg_it_fk_child")
+    child = fk_by_name["pormg_it_fk_child"]
+
+    # Each declared action comes back as the PormG sentinel it was declared with.
+    @test child.fields["fk_cascade"].on_delete === PormG.Models.CASCADE
+    @test child.fields["fk_restrict"].on_delete === PormG.Models.RESTRICT
+    @test child.fields["fk_setnull"].on_delete === PormG.Models.SET_NULL
+    @test child.fields["fk_setdefault"].on_delete === PormG.Models.SET_DEFAULT
+
+    # A foreign key that declared NO action must not gain one. Both backends store this
+    # indistinguishably from an explicit NO ACTION, so introspecting it as DO_NOTHING would stamp
+    # an on_delete onto every plain FK in every regenerated model file.
+    @test child.fields["fk_plain"].on_delete === nothing
+
+    # The SQLite half: SET DEFAULT keeps the column default, which is exactly what makes the pair
+    # self-consistent enough to register.
+    @test child.fields["fk_setdefault"].default == 1
+
+    # OneToOneField had the identical omission and is fixed with ForeignKey. PostgreSQL-only: the
+    # SQLite PRAGMA path does not read UNIQUE, so `fk_o2o` stays a plain ForeignKey there — a
+    # pre-existing divergence this issue does not change.
+    if is_pg
+      @test child.fields["fk_o2o"] isa PormG.Models.sOneToOneField
+      @test child.fields["fk_o2o"].on_delete === PormG.Models.CASCADE
+    end
+
+    # ── 4. The regenerated module registers via set_models (#287/#291) ───────
+    # THE regression assertion. Before #292 this threw ModelDefinitionError ("declares on_delete
+    # SET_DEFAULT but has no default"), with no way out but editing the generated source by hand —
+    # the remedy #291 had to document. Goes through `Model_to_str`, so it also proves the default
+    # and the action survive the model → source → module round trip a user actually performs.
+    instructions = [PormG.Models.Model_to_str(fk_by_name[t], settings)
+                    for t in ("pormg_it_fk_parent", "pormg_it_fk_child")]
+    src = join(instructions, "\n\n")
+    @test occursin("SET_DEFAULT", src)          # the action reached the generated source…
+    @test occursin(r"default\s*=\s*1", src)     # …and so did the default that makes it valid
+
+    mod_name = "PormGIt292Models"
+    generated = include_string(Main, """
+      module $(mod_name)
+      import PormG.Models
+      import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING, PROTECT
+      $(src)
+      end
+      """)
+    try
+      # EVERY access to the generated module goes through `invokelatest`, and that is load-bearing
+      # rather than decoration. `include_string` defined the module DURING this call, so its
+      # bindings are newer than the world age this block is running in — the same world-age
+      # constraint `set_models` handles internally and that pins the Julia 1.12 floor (#211).
+      #
+      # Getting this wrong is silent, not loud. Without `invokelatest` here, `set_models`'
+      # `get_all_models(generated)` sees ZERO models, so it iterates nothing, validates nothing and
+      # returns `nothing` anyway — the assertion passes while checking absolutely nothing. Verified
+      # by mutation: with a plain call, deleting the `default=` fix from the SQLite FK branch left
+      # this line green.
+      #
+      # `set_models` is where #287's SET_DEFAULT guard lives, so this is the real check rather than
+      # a re-implementation of it: it must not throw.
+      @test Base.invokelatest(PormG.Models.set_models, generated, PORMG_DB_FOLDER) === nothing
+
+      # …and registration preserved the action rather than merely tolerating it. `Model_to_str`
+      # emits the binding as `uppercasefirst(model.name)`, so derive the name from the model
+      # rather than hard-coding a spelling that would drift.
+      registered = Base.invokelatest(getglobal, generated, Symbol(uppercasefirst(child.name)))
+
+      # PROOF THAT `set_models` ACTUALLY RAN OVER THESE MODELS, asserted through side effects it
+      # leaves behind. A separate `get_all_models(generated)` call cannot do this job: it resolves
+      # in the latest world either way and returns 2 even when `set_models` iterated nothing, so it
+      # would pass while the assertion above was still vacuous. Both fields below are `nothing`/
+      # `false` on a no-op registration and set on a real one — measured both ways.
+      @test registered.connect_key == PORMG_DB_FOLDER
+      # Doubles as coverage for `resolve_fk_target!`: registration resolves the FK's string target
+      # to the actual parent model object.
+      @test registered.fields["fk_cascade"].to isa PormG.PormGModel
+      @test registered.fields["fk_setdefault"].on_delete === PormG.Models.SET_DEFAULT
+      @test registered.fields["fk_setdefault"].default == 1
+      @test registered.fields["fk_cascade"].on_delete === PormG.Models.CASCADE
+    finally
+      # `set_models` records the module for lazy self-healing; drop it so a later test in the same
+      # session cannot resolve models through this throwaway module.
+      delete!(PormG.Models.REGISTERED_MODULES, generated)
+    end
   finally
     PormG._EXTRA_IGNORE_TABLES[] = saved_ignore   # never leak registry state
     drop_fixtures()

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -19,15 +19,38 @@ using PormG
 using PormG.Migrations: convertSQLToModel
 
 # One-row "introspection result" carrying the columns convertSQLToModel(row) reads. The optional
-# FK/index columns are `missing`, matching a table that has none.
-function _introspection_row(; table_name, columns, primary_keys)
+# FK/index columns default to `missing`, matching a table that has none. The FK keywords let a test
+# describe a foreign key without a live database: `delete_rules` carries the raw
+# `pg_constraint.confdeltype` codes, comma-joined in the same order as `foreign_keys` (#292).
+function _introspection_row(; table_name, columns, primary_keys,
+                              foreign_keys = missing, foreign_tables = missing,
+                              referenced_primary_keys = missing, delete_rules = missing)
   df = DataFrame(
     table_name              = [table_name],
     columns                 = [columns],
     primary_keys            = [primary_keys],
-    foreign_keys            = [missing],
-    foreign_tables          = [missing],
-    referenced_primary_keys = [missing],
+    foreign_keys            = [foreign_keys],
+    foreign_tables          = [foreign_tables],
+    referenced_primary_keys = [referenced_primary_keys],
+    delete_rules            = [delete_rules],
+    index_columns           = [missing],
+    index_names             = [missing],
+  )
+  return df[1, :]
+end
+
+# The same row WITHOUT a `delete_rules` column at all — the shape a schema query produced before
+# #292 added it. Used to prove the reader degrades instead of throwing on a missing column.
+function _introspection_row_without_delete_rules(; table_name, columns, primary_keys,
+                                                   foreign_keys, foreign_tables,
+                                                   referenced_primary_keys)
+  df = DataFrame(
+    table_name              = [table_name],
+    columns                 = [columns],
+    primary_keys            = [primary_keys],
+    foreign_keys            = [foreign_keys],
+    foreign_tables          = [foreign_tables],
+    referenced_primary_keys = [referenced_primary_keys],
     index_columns           = [missing],
     index_names             = [missing],
   )
@@ -68,6 +91,233 @@ end
 
     @test model.fields["id"] isa PormG.Models.sIDField
     @test !hasfield(typeof(model.fields["id"]), :max_digits)
+  end
+
+end
+
+# ═════════════════════════════════════════════════════════════════════════════
+# #292 — foreign keys must round-trip their referential action and their default
+#
+# Introspection lost a different half of the FK declaration on each backend, and the two halves
+# were mirror images. PostgreSQL carried the `default` but never even QUERIED `on_delete`, so a
+# table whose FK was `ON DELETE CASCADE` introspected to a model claiming no cascade and a
+# migration generated from it silently dropped the action. SQLite carried `on_delete` but dropped
+# the `default`, which since #287 is a HARD failure: `SET_DEFAULT` with no default throws
+# `ModelDefinitionError` at `set_models`, and regenerating produced the identical broken file.
+#
+# These are the hermetic halves — the `confdeltype` mapping and the failure policy, both reachable
+# through a synthetic `DataFrameRow` with no database. The end-to-end round trip (create table →
+# introspect → regenerate → `set_models`) lives in `test/integration/test_importers_introspection.jl`
+# because it needs a real engine on both backends.
+# ═════════════════════════════════════════════════════════════════════════════
+
+using PormG.Migrations: _pg_confdeltype_to_on_delete, _normalize_introspected_on_delete,
+                        _fk_default_or_warn
+
+@testset "Introspection carries on_delete and the FK default (#292)" begin
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: every `pg_constraint.confdeltype` code maps to the PormG spelling
+  # PostgreSQL stores the action as a single char. Asserted as a full table rather than one
+  # sample, because a partial mapping is what the bug was — the column was never selected at all.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "confdeltype codes map to PormG on_delete spellings" begin
+    @test _pg_confdeltype_to_on_delete("c") == "CASCADE"
+    @test _pg_confdeltype_to_on_delete("r") == "RESTRICT"
+    @test _pg_confdeltype_to_on_delete("n") == "SET NULL"
+    @test _pg_confdeltype_to_on_delete("d") == "SET DEFAULT"
+
+    # 'a' is NO ACTION — which PostgreSQL stores BOTH for an explicit NO ACTION and for a foreign
+    # key that declared no action at all. Mapping it to DO_NOTHING would stamp an explicit
+    # `on_delete=DO_NOTHING` onto every plain FK in every generated model. `nothing` is lossless:
+    # `_foreign_key_on_delete_sql(nothing)` and the DO_NOTHING branch both emit `ON DELETE NO
+    # ACTION`, so the re-emitted DDL is byte-identical either way.
+    @test _pg_confdeltype_to_on_delete("a") === nothing
+
+    # Degradation, not an error: an unknown/blank code (a row from a pre-#292 schema query, a
+    # future PostgreSQL code) behaves as "no action recorded" rather than throwing mid-import.
+    @test _pg_confdeltype_to_on_delete("") === nothing
+    @test _pg_confdeltype_to_on_delete("?") === nothing
+    @test _pg_confdeltype_to_on_delete(missing) === nothing
+    @test _pg_confdeltype_to_on_delete(nothing) === nothing
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: the SQLite spelling normalizes to the same values as PostgreSQL
+  # SQLite reports the action as text ("SET NULL"), PostgreSQL as a code ('n'). Both must land on
+  # the same PormG spelling or the two backends generate different models from the same schema —
+  # the "keep PostgreSQL and SQLite aligned" rule.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "SQLite action text normalizes to the PostgreSQL result" begin
+    @test _normalize_introspected_on_delete("CASCADE") == "CASCADE"
+    @test _normalize_introspected_on_delete("SET NULL") == "SET_NULL"
+    @test _normalize_introspected_on_delete("SET DEFAULT") == "SET_DEFAULT"
+    @test _normalize_introspected_on_delete("RESTRICT") == "RESTRICT"
+
+    # The alignment case. SQLite's DDL spells PormG's `on_delete === nothing` as the literal
+    # "ON DELETE NO ACTION", so the regex path reads back "NO ACTION" for a foreign key that
+    # declared nothing. Before #292 that became DO_NOTHING on SQLite while PostgreSQL produced
+    # nothing at all — the same table, two different models.
+    @test _normalize_introspected_on_delete("NO ACTION") === nothing
+    @test _normalize_introspected_on_delete(nothing) === nothing
+    @test _normalize_introspected_on_delete(missing) === nothing
+
+    # Both backends agree for every action a round trip can preserve. PROTECT is absent on
+    # purpose: it renders as SQL RESTRICT, so introspection can only ever return RESTRICT.
+    for (sqlite_text, pg_code) in (("CASCADE", "c"), ("RESTRICT", "r"),
+                                   ("SET NULL", "n"), ("SET DEFAULT", "d"), ("NO ACTION", "a"))
+      @test _normalize_introspected_on_delete(sqlite_text) ==
+            _normalize_introspected_on_delete(_pg_confdeltype_to_on_delete(pg_code))
+    end
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: an unrepresentable column default warns instead of throwing
+  # `ForeignKey` runs `validate_default(…, Union{Int64,Nothing}, …, format2int64)`, which raises
+  # `FieldValidationError` on anything non-numeric. Letting that escape would abort an entire
+  # `convert_schema_to_models` run over one odd column with no way to skip it, so the policy is
+  # warn-and-omit. This is the decision #291 deferred and #292 had to make.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "unrepresentable FK default warns and is omitted, never throws" begin
+    # Representable: passes straight through, in both the integer and the string spelling the two
+    # backends produce (SQLite PRAGMA yields a value, the PostgreSQL column regex yields text).
+    @test _fk_default_or_warn(7, "results", "driverid") == 7
+    @test _fk_default_or_warn("7", "results", "driverid") == 7
+    @test _fk_default_or_warn(nothing, "results", "driverid") === nothing
+    @test _fk_default_or_warn(missing, "results", "driverid") === nothing
+
+    # Unrepresentable: a text default on a text FK column, and a PostgreSQL expression default.
+    # Must WARN and return nothing. `@test_logs` fails if no warning is emitted, so this pins the
+    # diagnostic too — a silent drop is what SQLite did before #292 and is what made the
+    # SET_DEFAULT failure unexplainable.
+    @test (@test_logs (:warn,) match_mode = :any _fk_default_or_warn("unknown", "drivers", "code")) === nothing
+    @test (@test_logs (:warn,) match_mode = :any _fk_default_or_warn("nextval('s'::regclass)", "t", "c")) === nothing
+
+    # The guarantee that matters: introspection does not throw on any of them.
+    for bad in ("unknown", "nextval('s'::regclass)", "", "3.5")
+      @test _fk_default_or_warn(bad, "t", "c") === nothing
+    end
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: a CASCADE foreign key survives the PostgreSQL row → model conversion
+  # The end-to-end assertion for the PostgreSQL half, minus the database: before #292 `fk_map` was
+  # a `(table, pk)` tuple with nowhere to put the action, so this came back `nothing`.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "on_delete survives convertSQLToModel(::DataFrameRow)" begin
+    row = _introspection_row(
+      table_name              = "results",
+      columns                 = "id bigint NOT NULL, driverid bigint, raceid bigint",
+      primary_keys            = "id",
+      foreign_keys            = "driverid, raceid",
+      foreign_tables          = "drivers, races",
+      referenced_primary_keys = "driverid, raceid",
+      delete_rules            = "c, n",          # CASCADE, SET NULL — order matches foreign_keys
+    )
+    model = convertSQLToModel(row)
+
+    @test model.fields["driverid"] isa PormG.Models.sForeignKey
+    @test model.fields["driverid"].on_delete === PormG.Models.CASCADE
+    # The second FK proves the zip stays aligned rather than applying one action to every column.
+    @test model.fields["raceid"].on_delete === PormG.Models.SET_NULL
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: a plain foreign key stays free of an invented on_delete
+  # Guards the churn side of the 'a' → nothing decision. If this ever returns DO_NOTHING, every
+  # regenerated model file gains an `on_delete=DO_NOTHING` on every FK that never declared one.
+  #
+  # Second line of defence, not the first: the two normalizers compose, so making
+  # `_pg_confdeltype_to_on_delete("a")` return "NO_ACTION" is caught by the direct assertion in the
+  # confdeltype testset above but NOT here — `_normalize_introspected_on_delete` collapses
+  # "NO_ACTION" back to `nothing`. What this pins is the end-to-end result through both.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "NO ACTION introspects as no declaration, not DO_NOTHING" begin
+    row = _introspection_row(
+      table_name              = "results",
+      columns                 = "id bigint NOT NULL, raceid bigint",
+      primary_keys            = "id",
+      foreign_keys            = "raceid",
+      foreign_tables          = "races",
+      referenced_primary_keys = "raceid",
+      delete_rules            = "a",
+    )
+    model = convertSQLToModel(row)
+    @test model.fields["raceid"].on_delete === nothing
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: a schema-query row with no delete_rules column still converts
+  # `delete_rules` is new in #292. A caller holding an older row — or a unit fixture that predates
+  # it — must degrade to "no action recorded" rather than raising a KeyError mid-import.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "a row without delete_rules degrades instead of throwing" begin
+    row = _introspection_row_without_delete_rules(
+      table_name              = "results",
+      columns                 = "id bigint NOT NULL, raceid bigint",
+      primary_keys            = "id",
+      foreign_keys            = "raceid",
+      foreign_tables          = "races",
+      referenced_primary_keys = "raceid",
+    )
+    model = convertSQLToModel(row)     # must not throw
+    @test model.fields["raceid"] isa PormG.Models.sForeignKey
+    @test model.fields["raceid"].on_delete === nothing
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: a SET DEFAULT foreign key carries its default through registration
+  # This is the #287/#291 regression in one assertion. `SET_DEFAULT` with no `default` raises
+  # `ModelDefinitionError` at `set_models`; before #292 introspection produced exactly that shape
+  # and regenerating produced the identical broken file, so there was no way out but a hand edit.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "SET DEFAULT FK keeps its default so the model can register" begin
+    row = _introspection_row(
+      table_name              = "results",
+      columns                 = "id bigint NOT NULL, statusid bigint DEFAULT 1",
+      primary_keys            = "id",
+      foreign_keys            = "statusid",
+      foreign_tables          = "status",
+      referenced_primary_keys = "statusid",
+      delete_rules            = "d",
+    )
+    model = convertSQLToModel(row)
+
+    @test model.fields["statusid"].on_delete === PormG.Models.SET_DEFAULT
+    # The default is what makes the pair self-consistent — without it `set_models` rejects the
+    # model, which is the whole failure #292 exists to end.
+    @test model.fields["statusid"].default == 1
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # FK introspection: the SQLite DDL-regex path carries both halves too
+  # `convertSQLToModel(sql::String)` parses a CREATE TABLE statement and is a SEPARATE
+  # implementation from the `PRAGMA` path that `convert_schema_to_models` actually calls. It is
+  # public API with no caller in `src/`, so nothing else exercises its FK branch — reverting that
+  # branch's #292 fix left the whole unit suite AND the SQLite integration suite green. This is the
+  # test that makes it defended rather than incidentally correct.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the SQLite DDL-regex path carries on_delete and the default" begin
+    sql = """
+    CREATE TABLE "results" (
+      "id" INTEGER NOT NULL,
+      "statusid" INTEGER DEFAULT 1,
+      "raceid" INTEGER,
+      PRIMARY KEY("id"),
+      FOREIGN KEY("statusid") REFERENCES "status"("statusid") ON DELETE SET DEFAULT,
+      FOREIGN KEY("raceid") REFERENCES "races"("raceid") ON DELETE NO ACTION
+    )"""
+    model = convertSQLToModel(sql)
+
+    # The SET DEFAULT half: action AND default, the pair #287 requires to be consistent.
+    @test model.fields["statusid"] isa PormG.Models.sForeignKey
+    @test model.fields["statusid"].on_delete === PormG.Models.SET_DEFAULT
+    @test model.fields["statusid"].default == 1
+
+    # The alignment half: this path reads back the literal "NO ACTION" that PormG's own DDL emits
+    # for an undeclared action, so without normalization it produced DO_NOTHING here while
+    # PostgreSQL produced nothing for the identical schema.
+    @test model.fields["raceid"].on_delete === nothing
   end
 
 end


### PR DESCRIPTION
Closes #292.

Introspection lost a different half of each foreign-key declaration per backend, and the two halves were mirror images.

| Backend | Carried | Dropped | Failure mode |
|---|---|---|---|
| PostgreSQL | the `default` | `on_delete` — **never even queried** | **silent**: an `ON DELETE CASCADE` table introspects to a model claiming no cascade, and a migration generated from it strips the action from the schema |
| SQLite | `on_delete` | the column `default` | **hard**: `SET DEFAULT` → `on_delete=SET_DEFAULT` with no `default=`, which `set_models` rejects since #287 — and regenerating produced the identical broken file |

Both fixed. `OneToOneField` had the identical omission as `ForeignKey` and is fixed with it.

## Failure policy (issue task 1)

**Introspection never throws over a default it cannot represent.** `ForeignKey` runs `validate_default(…, Union{Int64,Nothing}, format2int64)`, which raises on anything non-numeric — a text default on a text FK, a `nextval(...)` expression. Letting that escape would abort a whole `convert_schema_to_models` run over one odd column with no way to skip past it. `_fk_default_or_warn` warns naming table/column/value and emits the relation without the default.

This also closes an **existing PostgreSQL exposure**: that path already passed `default=` unguarded, so it could already throw from inside introspection.

## `NO ACTION` now means "no declaration" on both backends

Both PormG spellings — `on_delete = nothing` and `DO_NOTHING` — render as SQL `ON DELETE NO ACTION` (`Dialect._foreign_key_on_delete_sql`), and `NO ACTION` is also what a backend stores when nothing was declared. So reading it back as `DO_NOTHING` would stamp an explicit `on_delete` onto **every plain FK in every generated model**. Mapping it to `nothing` is lossless — the re-emitted DDL is identical either way.

Before this, SQLite produced `DO_NOTHING` while PostgreSQL produced nothing for the identical schema. This is scope the fix *forced* rather than scope I chose, and it is why generated SQLite files change.

`PROTECT` is not recoverable — it renders as SQL `RESTRICT`, so a round trip can only ever return `RESTRICT`. One-way by construction, noted in the code rather than left as a surprise.

## What I deliberately did NOT do

**The residual is stated, not hidden.** `set_models` still rejects two shapes, and PostgreSQL reaches them *for the first time* here because it previously never emitted `on_delete` and so could not contradict anything:

- `SET_DEFAULT` on a column with no usable default
- `SET_NULL` on a `NOT NULL` column

Both are legal DDL on both backends — the action is only enforced at delete time — so a real legacy database can contain them. The maintainer chose this explicitly when picking the failure policy: *"the database really is in a state PormG cannot express."* Dropping the action instead would hide a genuine schema problem.

**That is why this carries an `UPGRADING.md` entry.** It forces a source edit for apps whose PostgreSQL schema is in either state. The entry includes a `psql` query that reports `attnotnull` and the column default so each row can actually be judged, and recommends fixing the **schema** rather than the generated file — a hand-edited generated file has to be re-edited after every regeneration, which is the trap #291 had to document.

**#303** was filed for the follow-up: collect *every* contradiction into one `set_models` error instead of one per run, so importing a legacy database with N bad FKs takes one cycle rather than N.

## Tests — every guard mutation-verified

Each was checked by reverting the fix and confirming the test fails:

| Guard | Reverting it |
|---|---|
| PG `on_delete` pass-through | fails 3 unit assertions |
| SQLite PRAGMA `default=` | fails 3 integration assertions, incl. the real `ModelDefinitionError` |
| SQLite DDL-regex FK branch | fails 2 unit assertions — **previously zero coverage anywhere** |
| `NO ACTION` alignment | fails on `DO_NOTHING === nothing` |

**Two rounds of independent review, and each caught green theater I would have shipped:**

1. The headline `set_models` assertion validated *nothing*. The module is built by `include_string` inside the testset, so its bindings are in a newer world age — `get_all_models` returned an empty vector, `set_models` iterated zero models and returned `nothing` regardless. Proven by mutation: deleting the SQLite `default=` fix left that line green.
2. My *fix* for it added `length(get_all_models(generated)) == 2`, which was equally vacuous — an independent `invokelatest` call returns 2 either way. Now replaced with side effects only a real registration leaves: `registered.connect_key` and `fields["fk_cascade"].to isa PormGModel`, both `nothing`/`false` under a no-op.

The review also cleared the thing I most expected to be wrong: the `array_agg` positional zip. Composite-PK fan-out, multi-column FKs and multi-FK tables all stay aligned, because PostgreSQL advances every aggregate from the same tuple in one pass.

## Verification

- Unit: **5036/5036**, exit 0
- SQLite (`db_sl`): **1884 pass** + 1 pre-existing broken, exit 0, zero failures
- PostgreSQL (`db_2`): **1914/1914**, exit 0, zero failures — the PG half is a live SQL change and cannot be validated any other way
- Shared PG server confirmed clean of `pormg_it_%` fixtures afterwards
- Rebased onto `21fa20a` (#302) and re-verified all three suites on that base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
