### PR TITLE
fix(#309): cast bulk_update source columns to the rendered type, not field.type

### DIFF
--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -962,20 +962,26 @@ _bulk_copy_cell(value::PormGBytes) = "\\x" * bytes2hex(value.bytes)
 _bulk_copy_cell(value) = value
 
 """
-    _pg_bulk_cast_type(field) -> String
+    _pg_bulk_cast_type(field, conn::PormGPostgres) -> String
 
 The PostgreSQL type name used to cast a `source.<col>` reference in `bulk_update`'s CTE.
 
-A field's `.type` is its canonical (SQLite-flavoured) spelling, and for every field except one it
-happens to lowercase into a real PostgreSQL type — `varchar`, `jsonb`, `timestamptz`, `decimal`,
-`interval`. `BinaryField` is the exception: its `.type` is `"BLOB"`, and `::blob` is not a
-PostgreSQL type at all, so the statement fails with *type "blob" does not exist* (#296).
+Delegates to `Dialect._get_column_type` — the same function that renders the column's actual DDL
+type — rather than re-deriving a cast from `field.type` (the SQLite-flavoured spelling). That
+independent re-derivation is what caused #296 (`BinaryField.type == "BLOB"` cast to the nonexistent
+`::blob`) and its untouched sibling #309 (`ImageField`/`FileField` share `.type == "BLOB"` but
+render as `TEXT`, and were still cast to `::blob`). Keying on the rendered type instead of `.type`
+means a field's type rendering can never drift out of sync with its `bulk_update` cast again — there
+is nothing left in this file to keep in step by hand.
 
-Deliberately keyed on `sBinaryField` rather than on the `"BLOB"` string: `ImageField` and
-`FileField` share that `.type` but render as `TEXT`, so mapping the string would cast a text column
-to `bytea`. Their own `::blob` cast is a separate pre-existing bug and is left alone here.
+A length/precision modifier (`VARCHAR(250)`, `DECIMAL(10,2)`) is stripped: the bare type is
+sufficient for a `source.<col>::<type>` cast and keeps prior behavior for `CharField`/`URLField`/
+`SlugField`/`DecimalField` unchanged.
 """
-_pg_bulk_cast_type(field)::String = field isa sBinaryField ? "bytea" : lowercase(field.type)
+function _pg_bulk_cast_type(field::PormGField, conn::PormGPostgres)::String
+  rendered = Dialect._get_column_type(field, conn)
+  return lowercase(replace(rendered, r"\(.*\)" => ""))
+end
 
 # bulk_copy NULL sentinel (#86) — PostgreSQL's conventional NULL marker. Safe because bulk_copy
 # force-quotes every string value (CSV.write quotestrings=true): a genuine string equal to this
@@ -1405,8 +1411,8 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
       # VALUES/CTE source column list stay the field name (#50).
       quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)
       quoted_source_field = quote_identifier(field, connection)
-      field_type = _pg_bulk_cast_type(model.fields[field])
       if connection isa PormGPostgres
+        field_type = _pg_bulk_cast_type(model.fields[field], connection)
         push!(safe_set_parts, "$quoted_field = source.$quoted_source_field::$field_type")
       else
         push!(safe_set_parts, "$quoted_field = source.$quoted_source_field")
@@ -1515,8 +1521,8 @@ function _bulk_update(model::PormGModel,
     # and the source column list stay the field name (#50).
     quoted_tb_field = quote_identifier(Models.field_db_column(model.fields[filter], filter), connection)
     quoted_source_field = quote_identifier(filter, connection)
-    field_type = _pg_bulk_cast_type(model.fields[filter])
     if connection isa PormGPostgres
+      field_type = _pg_bulk_cast_type(model.fields[filter], connection)
       push!(safe_where_conditions, "\"Tb\".$quoted_tb_field = source.$quoted_source_field::$field_type")
     else
       push!(safe_where_conditions, "\"Tb\".$quoted_tb_field = source.$quoted_source_field")

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -234,7 +234,11 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   event_date = Models.DateField(null = true),
   is_active = Models.BooleanField(default = false),
   event_time = Models.DateTimeField(null = true),
-  nullable_int = Models.IntegerField(null = true)
+  nullable_int = Models.IntegerField(null = true),
+  # ImageField/FileField regression (#309): `bulk_update` used to cast this column to the
+  # nonexistent `::blob` on PostgreSQL because its `.type` ("BLOB") was cast verbatim instead of
+  # via the field's actual rendered column type (`TEXT`).
+  photo = Models.ImageField(null = true)
 )
 
 # Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -234,7 +234,11 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   event_date = Models.DateField(null = true),
   is_active = Models.BooleanField(default = false),
   event_time = Models.DateTimeField(null = true),
-  nullable_int = Models.IntegerField(null = true)
+  nullable_int = Models.IntegerField(null = true),
+  # ImageField/FileField regression (#309): `bulk_update` used to cast this column to the
+  # nonexistent `::blob` on PostgreSQL because its `.type` ("BLOB") was cast verbatim instead of
+  # via the field's actual rendered column type (`TEXT`).
+  photo = Models.ImageField(null = true)
 )
 
 # Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME

--- a/test/integration/test_updates.jl
+++ b/test/integration/test_updates.jl
@@ -837,6 +837,48 @@ end
         end
 
         # ─────────────────────────────────────────────────────────────────────────────
+        # Bulk Update: ImageField/FileField source column casts correctly (#309)
+        #
+        # `bulk_update`'s CTE used to cast every source column to `field.type` lowercased.
+        # ImageField/FileField's `.type` is "BLOB" (shared with BinaryField) but the column
+        # itself renders as TEXT — casting to the literal `::blob` fails outright on
+        # PostgreSQL with `type "blob" does not exist`. This reproduces that statement
+        # end-to-end; SQLite emits no cast at all, so it was never affected and must keep
+        # passing unchanged.
+        # ─────────────────────────────────────────────────────────────────────────────
+        @testset "Bulk Update casts an ImageField/FileField source column correctly" begin
+            _clear_bulk_update_scratch_rows!()
+
+            try
+                required_ids, _ = _seed_bulk_update_scratch_parents!(["req-photo"], String[])
+
+                row = M.Bulk_update_payload_scratch.objects.create(
+                    "label" => "payload-photo",
+                    "required_parent_id" => required_ids["req-photo"],
+                    "photo" => "uploads/before.jpg",
+                )
+
+                update_df = DataFrame(
+                    id = [row[:id]],
+                    photo = ["uploads/after.jpg"],
+                )
+
+                bulk_update(
+                    M.Bulk_update_payload_scratch.objects,
+                    update_df,
+                    columns = ["photo"],
+                    match_on = ["id"],
+                )
+
+                persisted = M.Bulk_update_payload_scratch.objects.order_by("id").list()
+                by_id = Dict(Int64(persisted_row[:id]) => persisted_row for persisted_row in persisted)
+                @test by_id[row[:id]][:photo] == "uploads/after.jpg"
+            finally
+                _clear_bulk_update_scratch_rows!()
+            end
+        end
+
+        # ─────────────────────────────────────────────────────────────────────────────
         # Bulk Update: chunk_size splits one payload across multiple statements
         #
         # The production call uses chunk_size=500. This regression forces the same code

--- a/test/unit/test_binary_field_bytes.jl
+++ b/test/unit/test_binary_field_bytes.jl
@@ -309,28 +309,29 @@ PormG.get_constraints_byte_length_check(::MockPGBinNamed, table_name::String, fi
   end
 
   # ───────────────────────────────────────────────────────────────────────────
-  # bulk_update casts source columns by field type, and "BLOB" is not a PG type
-  # Its CTE renders `SET "col" = source."col"::<type>` from `field.type` lowercased. Every
-  # other field's `.type` happens to spell a real PostgreSQL type (varchar, jsonb,
-  # timestamptz, decimal, interval) — `BLOB` does not exist in PostgreSQL, so the
-  # statement failed outright with `type "blob" does not exist`.
+  # bulk_update casts source columns by the field's rendered column type
+  # Its CTE renders `SET "col" = source."col"::<type>` from `Dialect._get_column_type`, the same
+  # function that renders the column's real DDL type — not from `field.type` (the SQLite-flavoured
+  # spelling), so the cast can never drift out of sync with the actual column type again. `BLOB`
+  # (BinaryField's, and ImageField/FileField's, `.type`) is not a PostgreSQL type at all: casting to
+  # it verbatim used to fail with `type "blob" does not exist` (#296, #309).
   # ───────────────────────────────────────────────────────────────────────────
   @testset "bulk_update casts a BinaryField source column to bytea" begin
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.BinaryField()) == "bytea"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.BinaryField(), MockPGBin()) == "bytea"
     # Never the raw `.type`, which is the SQLite spelling and invalid on PostgreSQL.
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.BinaryField()) != "blob"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.BinaryField(), MockPGBin()) != "blob"
 
     # Every other field keeps the existing behaviour exactly.
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.JSONField()) == "jsonb"
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.DateTimeField()) == "timestamptz"
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.CharField()) == "varchar"
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.IntegerField()) == "integer"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.JSONField(), MockPGBin()) == "jsonb"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.DateTimeField(), MockPGBin()) == "timestamptz"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.CharField(), MockPGBin()) == "varchar"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.IntegerField(), MockPGBin()) == "integer"
 
-    # ImageField/FileField share `.type == "BLOB"` but render as TEXT, so they must NOT be
-    # remapped to bytea — keying this on the struct rather than the type string is what keeps
-    # them out. (Their own `::blob` cast is a separate pre-existing bug, untouched here.)
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.ImageField()) == "blob"
-    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.FileField()) == "blob"
+    # ImageField/FileField share `.type == "BLOB"` but render as TEXT (#309, fixed): delegating to
+    # `Dialect._get_column_type` — which has no ImageField/FileField branch and falls through to
+    # `TEXT` — casts them to `text`, not `bytea` and not the old, invalid `blob`.
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.ImageField(), MockPGBin()) == "text"
+    @test PormG.QueryBuilder._pg_bulk_cast_type(Models.FileField(), MockPGBin()) == "text"
   end
 
   # ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `bulk_update`'s generated CTE cast every `source.<col>` reference to `field.type` lowercased. `ImageField`/`FileField` share `BinaryField`'s `.type == "BLOB"`, so `bulk_update` on any PostgreSQL table with an `ImageField`/`FileField` column failed outright with `type "blob" does not exist`.
- `_pg_bulk_cast_type` now delegates to `Dialect._get_column_type` — the same function that already renders these columns as `TEXT` — instead of re-deriving the cast independently. This also drops the now-redundant `sBinaryField` special case (`_get_column_type` already has its own branch for it), so the cast can't drift out of sync with the real column type again.
- Both `bulk_update` call sites now compute the cast only inside their existing `if connection isa PormGPostgres` branch (was computed unconditionally and discarded on SQLite before).

Closes #309

## Test plan

- [x] `julia --project=. test/unit/test_binary_field_bytes.jl` — 104/104 pass (flipped the two previously-pinned `"blob"` assertions to `"text"`)
- [x] `julia --project=. test/runtests.jl` (full unit suite) — 5211/5211 pass
- [x] `julia -t auto --project=. test/integration/runtests.jl` on `db_2` (PostgreSQL) — 1942/1942 pass, 0 errors
- [x] `julia -t auto --project=. test/integration/runtests.jl` on `db_sl` (SQLite) — 1910 pass, 1 pre-existing unrelated `Broken`, 0 errors
- [x] New integration regression (`test/integration/test_updates.jl`) reproduces the actual failing SQL end-to-end via a real `bulk_update` on an `ImageField` column
- [x] Independent review by a fresh subagent against the changed-code-review checklist — no blocking findings

## Deliberately not done

- No `UPGRADING.md` entry — this only fixes behavior that was already broken (a `bulk_update` call that previously crashed), nothing forces a consuming-app source edit.
- The reviewer noted the new docstring's claim that the cast is unchanged for `URLField`/`SlugField`/`DecimalField` was verified by code inspection rather than a pre-existing unit test (only `CharField` had one before this PR). Not a regression introduced here, so left as-is per the reviewer's own recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)