### PR TITLE
fix(#306): reject a leading-underscore positional model name

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -199,6 +199,77 @@ have, and the corrected declaration now points at it instead of at a table that 
 
 ---
 
+## A positional model name may not start with an underscore (#306)
+
+- **Version**: Unreleased
+- **PormG ref**: #306; `src/Models.jl`, `docs/src/schema_conventions.md`
+- **Recorded**: 2026-08-06
+- **Severity**: **breaking (definition time, narrow)** — only declarations using a leading-underscore
+  positional model name. Part of the `0.3.x` pre-publish wave.
+
+### What changed
+
+The same split as #300, one character away. `Models.Model("_order", …)` stored the name **verbatim**,
+but a `ForeignKey` targeting it renders its `REFERENCES` through `format_model_name`, which strips
+one leading underscore — inherited from the FIELD-name reserved-word escape hatch (`_end = ...`
+declares column `end`), which a positional model name never actually needed, since it is a plain
+string literal and never a Julia kwarg key. So the model created table `_order` while any foreign key
+pointing at it referenced `order` instead — **a different table**, or a failed constraint if `order`
+did not exist.
+
+On PostgreSQL this either fails the migration outright (`order` does not exist) or, worse, silently
+binds the foreign key to an unrelated table that happens to share that name. SQLite carries the same
+inline-FK split (see `create_table(::PormGSQLite, …)`), so it is not backend-specific the way #300 was.
+
+A positional name starting with `_` is now rejected at declaration:
+
+```
+ModelDefinitionError: The model name '_order' starts with '_'; a leading underscore is the escape
+hatch for FIELD names colliding with a reserved word, not model names. PormG's foreign-key REFERENCES
+target strips a leading underscore (format_model_name) but the table this creates keeps it verbatim,
+so this model would create table '_order' while a foreign key pointing at it references 'order'
+instead — a different table if one exists, a failed constraint if it doesn't. Declare it as 'order'.
+```
+
+It rejects rather than silently stripping, for the same reason as #300: PormG has no model-level
+`db_table` yet (#59), so folding the name would discard a stated intent with no way to express it and
+no signal it happened.
+
+**Only the positional form is affected.** `inspectdb` introspection and the Django importer still
+accept a leading-underscore name — they read it from a live database or a Python class, where it is
+legitimate — and `Model_to_str` round-trips it through the guarded path on reload, same as it does
+for case (#300).
+
+### Before → after
+
+```julia
+# before — created table `_order`, but a ForeignKey referencing it queried `"order"`
+Order = Models.Model("_order",
+  id = Models.IDField(),
+)
+
+# after — drop the leading underscore; there is no escape hatch for model names
+Order = Models.Model("order",
+  id = Models.IDField(),
+)
+```
+
+**If the physical table really is named with a leading underscore**, there is no mapping for it yet —
+that is [#59](https://github.com/PingoLee/PormG.jl/issues/59). Check what `makemigrations` actually
+created: it wrote the name **verbatim** (unlike the case split, nothing here folds it), so `_order` is
+the table you already have, and the rejected declaration was never able to reference it correctly in
+the first place.
+
+### How to find the calls to migrate
+
+```bash
+rg -nU --multiline-dotall -g '*.jl' '(^|[^A-Za-z_])Model\(\s*"_'
+```
+
+An app that follows the documented lowercase, no-leading-underscore house style has nothing to find.
+
+---
+
 ## Introspected foreign keys now carry `on_delete` (PostgreSQL) and the column default (SQLite) (#292)
 
 - **Version**: Unreleased

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -47,6 +47,22 @@ Models.Model("Driver_Profile", driverid = Models.IDField())
     `"Driver_Profile"` — two different tables on PostgreSQL. An explicit `db_table` option is
     [issue #59](https://github.com/PingoLee/PormG.jl/issues/59).
 
+A positional name given with a **leading underscore** is rejected the same way, and for a related
+reason (#306): a `ForeignKey` targeting the model renders its `REFERENCES` through
+`format_model_name`, which strips one leading underscore as the reserved-word escape hatch borrowed
+from field-name handling — but the table itself is created with the name as stored. `Model("_order",
+…)` would create table `_order` while a foreign key pointing at it referenced `order` instead:
+
+```julia
+Models.Model("_order", id = Models.IDField())
+# ModelDefinitionError: The model name '_order' starts with '_'; …
+```
+
+Unlike a field name, a positional model name is a plain string — never a Julia kwarg key — so it
+never needed the underscore escape hatch in the first place. That escape hatch is real for *field*
+names (`_end = ...` declares column `end`, documented on `Model`'s docstring) — it just does not
+extend to the model name itself.
+
 ### `django_prefix` interop
 
 A connection may set `django_prefix` in its `connection.yml` (default: unset). It is a convenience

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -555,28 +555,74 @@ function format_model_name(name::PormGModel)::String
   return name.name |> format_model_name
 end
 
-# A POSITIONAL model name must already be lowercase (#300). It is the one identifier in a `Model(...)`
-# call that nothing normalizes: the two callers that FILL `Model_Type.name` run it through
-# `format_model_name` but guard on `attr.name == ""`, so they only ever reach a binding-derived name
-# (`src/Models.jl` `get_all_models`, `src/migrations/planner.jl` `get_all_models`). Field names, by
-# contrast, are normalized by `format_fild_name` inside the constructor itself. Left unchecked, a
-# mixed-case name SPLITS the schema — `makemigrations` lowercases it into the DDL while the query
-# builder quotes it as declared — so the model migrates one table and then queries another: silent on
-# SQLite, fatal on PostgreSQL.
+# A POSITIONAL model name must already be lowercase (#300) and must not start with '_' (#306). It is
+# the one identifier in a `Model(...)` call that nothing normalizes: the two callers that FILL
+# `Model_Type.name` run it through `format_model_name` but guard on `attr.name == ""`, so they only
+# ever reach a binding-derived name (`src/Models.jl` `get_all_models`, `src/migrations/planner.jl`
+# `get_all_models`). Field names, by contrast, are normalized by `format_fild_name` inside the
+# constructor itself.
 #
-# Scope: this checks CASE only. It is NOT `format_model_name`, whose other callers re-normalize the
-# STORED name at render time (FK `REFERENCES`, model-reference comparison), and it applies no
-# identifier-shape validation — a reserved word or a name with a space still renders invalid bare DDL.
+# Left unchecked, a mixed-case name SPLITS the schema — `makemigrations` lowercases it into the DDL
+# while the query builder quotes it as declared — so the model migrates one table and then queries
+# another: silent on SQLite, fatal on PostgreSQL (#300).
 #
-# Reject rather than fold. PormG has no model-level `db_table` yet (#59), so quietly lowercasing would
-# discard a stated intent with no way to express it and no signal that it happened.
+# A leading underscore splits it differently: `format_model_name` (used to render an FK `REFERENCES`
+# target and to resolve a model reference by name) strips ONE leading underscore, inherited from
+# `format_fild_name`'s reserved-word escape hatch for FIELD names — but `create_table` writes the
+# stored name as-is. So `Model("_order", …)` creates table `_order` while a `ForeignKey` pointing at
+# it renders `REFERENCES "order"` — a different table, or a failed constraint if `order` doesn't
+# exist (#306). Unlike field names, a positional model name is a plain string literal, never a Julia
+# kwarg key, so it never had a syntactic reason to need that escape hatch in the first place — nothing
+# legitimate is lost by rejecting it.
+#
+# Scope: this checks CASE and a LEADING UNDERSCORE only. It is NOT `format_model_name`, whose other
+# callers re-normalize the STORED name at render time (FK `REFERENCES`, model-reference comparison),
+# and it applies no other identifier-shape validation — a reserved word or a name with a space still
+# renders invalid bare DDL.
+#
+# Reject rather than fold, in both cases. PormG has no model-level `db_table` yet (#59), so quietly
+# lowercasing or stripping would discard a stated intent with no way to express it and no signal that
+# it happened.
+#
+# Two message-accuracy subtleties, both about the SUGGESTED spelling rather than the rejection itself
+# (found on independent review of this fix):
+#
+# 1. A name can fail BOTH checks (`"_Driver_Scratch"`). If the case message suggested only
+#    `lowercase(name)`, that suggestion would still start with '_' and fail again on retry. `hint`
+#    below is computed underscore-aware so whichever check fires first, "Declare it as" already names
+#    a spelling that passes both.
+# 2. `format_model_name`/`format_fild_name` strip exactly ONE leading underscore, then reject if a
+#    second one remains (`^_` in `format_fild_name`'s own regex) — so a name with 2+ leading
+#    underscores, or a bare `"_"`, would not actually reach the "creates X, references Y" split this
+#    guard warns about: `format_model_name` would itself raise a different, unrelated error first.
+#    Claiming the split for those names would be describing behavior that can't happen, so they get a
+#    narrower message with no specific "declare it as" spelling instead of an unusable
+#    `"Declare it as ''."` (an all-underscore name strips to the empty string).
 function _validate_positional_model_name(name::AbstractString)::Nothing
-  name == lowercase(name) && return nothing
-  throw(ModelDefinitionError(
-    "The model name '$(name)' must be lowercase; PormG lowercases table names when generating DDL " *
-    "but quotes them as declared in queries, so this model would migrate the table " *
-    "'$(lowercase(name))' and then query '$(name)'. Declare it as '$(lowercase(name))'. " *
-    "Mapping a model to a fixed mixed-case table is issue #59."))
+  if startswith(name, "_") && (length(name) < 2 || name[2] == '_')
+    throw(ModelDefinitionError(
+      "The model name '$(name)' starts with '_'; PormG does not support a leading underscore in a " *
+      "model name — unlike a field name, where exactly one is the reserved-word escape hatch " *
+      "(`_end` declares column `end`). Remove the leading underscore(s)."))
+  end
+  hint = startswith(name, "_") ? lowercase(name[2:end]) : lowercase(name)
+  if name != lowercase(name)
+    throw(ModelDefinitionError(
+      "The model name '$(name)' must be lowercase; PormG lowercases table names when generating DDL " *
+      "but quotes them as declared in queries, so this model would migrate the table " *
+      "'$(lowercase(name))' and then query '$(name)'. Declare it as '$(hint)'. " *
+      "Mapping a model to a fixed mixed-case table is issue #59."))
+  end
+  if startswith(name, "_")
+    throw(ModelDefinitionError(
+      "The model name '$(name)' starts with '_'; a leading underscore is the escape hatch for FIELD " *
+      "names colliding with a reserved word, not model names. PormG's foreign-key REFERENCES target " *
+      "strips a leading underscore (format_model_name) but the table this creates keeps it verbatim, " *
+      "so this model would create table '$(name)' while a foreign key pointing at it references " *
+      "'$(hint)' instead — a different table if one exists, a failed constraint if it doesn't. " *
+      "Declare it as '$(hint)'."))
+  end
+  return nothing
 end
 
 # Physical SQL column for a field given its declared identity `name` (#50). Returns
@@ -837,7 +883,7 @@ module. Both forms are idiomatic and `Race = Model(...)` and `Race = Model("race
 same table, because a binding-derived name is lowercased as it is filled in. Reach for the
 positional form when the binding name is not the table name you want.
 
-!!! warning "A positional name must be lowercase"
+!!! warning "A positional name must be lowercase and may not start with '_'"
     `Model("Driver_Profile", …)` raises `ModelDefinitionError`. A positional name is stored
     **verbatim**, and the two groups of consumers disagree about case: `makemigrations` lowercases it
     into the DDL, while the query builder quotes it as declared. Left unchecked, that model migrated
@@ -846,14 +892,22 @@ positional form when the binding name is not the table name you want.
     is case-sensitive, as it is on PostgreSQL. Rejecting the name at declaration (#300) turns that
     silent production failure into an error you get at load time.
 
+    `Model("_order", …)` raises the same error, for a related reason (#306): a foreign key that
+    targets the model renders its `REFERENCES` through `format_model_name`, which strips a leading
+    underscore — but `create_table` writes the stored name as-is. So the model would create table
+    `_order` while any `ForeignKey` pointing at it referenced `order` instead — a different table, or
+    a failed constraint. Unlike a field name, a positional model name is a plain string, never a
+    Julia kwarg key, so it never needed the leading-underscore escape hatch described below.
+
     Mapping a model to a fixed mixed-case table is
     [issue #59](https://github.com/PingoLee/PormG.jl/issues/59); until it lands, declare table names
-    in lowercase.
+    in lowercase, without a leading underscore.
 
 **Field names keep the case you declare** and are case-sensitive in queries, so a legacy `driverId`
 column is addressed as `driverId`. One leading underscore is stripped as the escape hatch for names
-that are Julia keywords or SQL reserved words (`_end = ...` declares the column `end`); a name
-containing `__` is rejected, since that is the lookup separator.
+that are Julia keywords or SQL reserved words (`_end = ...` declares the column `end`) — this applies
+to field names only, not the model name above; a name containing `__` is rejected, since that is the
+lookup separator.
 
 A `ManyToManyField` is stored on the model but owns no column of its own, so it is absent from
 `field_names` and from the created table.

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -171,6 +171,11 @@ const DOCERR_CASES = [
         ModelDefinitionError,
         () -> Model("Driver_Profile", driverid = IDField()),
     ),
+    (
+        "schema_conventions.md + src/Models.jl — Model docstring: a positional name may not start with '_' (#306)",
+        ModelDefinitionError,
+        () -> Model("_docerr_underscore_probe", driverid = IDField()),
+    ),
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_model_name_case.jl
+++ b/test/unit/test_model_name_case.jl
@@ -1,5 +1,5 @@
 """
-Unit coverage for model-name case handling (#300).
+Unit coverage for model-name case handling (#300) and leading-underscore handling (#306).
 
 A model's positional name used to be stored VERBATIM while the two groups of consumers disagreed
 about its case: `makemigrations` lowercased it into the DDL, and the query builder quoted it as
@@ -7,11 +7,18 @@ declared. So `Model("Driver_Profile", …)` migrated the table `driver_profile` 
 `"Driver_Profile"` in every SELECT/INSERT/UPDATE — a table that does not exist on PostgreSQL, where a
 quoted identifier is case-sensitive. SQLite's case-insensitive identifiers masked it entirely.
 
-Since #300 the split is unreachable from a user declaration: a non-lowercase positional name is
-rejected at construction. This file **pins the rejection** (the only assertions here that go red
-without the guard), **documents** the DDL/query agreement it buys, and **characterizes** the split as
-it still stands on the paths deliberately left exempt. It also records two limits of the guard: it
-checks case only, so it neither strips a leading underscore nor rejects an invalid bare identifier.
+A leading underscore split the schema the same way, one character away from #300: `format_model_name`
+(used to render an FK `REFERENCES` target and to resolve a model reference by name) strips ONE leading
+underscore, inherited from the FIELD-name reserved-word escape hatch — but `create_table` writes the
+stored name as-is. So `Model("_order", …)` created table `_order` while a `ForeignKey` pointing at it
+referenced `"order"` — a different table, or a failed constraint if `order` didn't exist.
+
+Since #300 (case) and #306 (leading underscore) the split is unreachable from a user declaration: a
+non-lowercase or underscore-prefixed positional name is rejected at construction. This file **pins
+the rejection** (the only assertions here that go red without the guards), **documents** the
+DDL/query agreement it buys, and **characterizes** the split as it still stands on the paths
+deliberately left exempt. It also records one remaining limit of the guard: it does not reject an
+invalid bare identifier (a reserved word or a name containing a space).
 
 All assertions render via mock PostgreSQL/SQLite connections; no live database.
 """
@@ -38,7 +45,7 @@ NameCaseDriver = Model("name_case_driver_scratch",
 )
 NameCaseDriver.connect_key = "model_name_case_mock"
 
-@testset "Model-name case (#300)" begin
+@testset "Model-name case and leading-underscore handling (#300, #306)" begin
 
   # ─────────────────────────────────────────────────────────────────────────────
   # The guard: a positional name needing a fold is a declaration-time error.
@@ -63,23 +70,63 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     @test Model("name_case_ok_scratch", id = IDField()).name == "name_case_ok_scratch"
     @test Model("f1_results_2024", id = IDField()).name == "f1_results_2024"
 
-    # The guard checks CASE and nothing else — it is NOT `format_model_name`, and it applies no
-    # identifier-shape validation. Two consequences, pinned here so they are deliberate:
-    #
-    # (a) A positional name keeps its leading underscore, where `format_model_name` strips it as the
-    #     reserved-word escape hatch. This is NOT harmless: FK targets are rendered through
-    #     `format_model_name` (`Dialect.jl` inline FK, `planner.jl` ADD CONSTRAINT), so a model named
-    #     "_order" is created as `_order` and referenced as `"order"` — a split of the same shape as
-    #     #300, one character away. Out of scope here (it is an underscore split, not a case split);
-    #     see the follow-up noted on the issue.
-    # (b) The guard accepts names that are lowercase but not valid bare identifiers — `"order"` is a
-    #     reserved word, `"driver profile"` contains a space — and the DDL writes the table bare, so
-    #     those render invalid SQL. Also pre-existing and out of scope; recorded so nobody reads the
-    #     guard as "the model name is now safe".
-    @test Model("_driver_scratch", id = IDField()).name == "_driver_scratch"
-    @test Models.format_model_name("_driver_scratch") == "driver_scratch"   # (a): the two disagree
-    @test Model("order", id = IDField()).name == "order"                    # (b): accepted as-is
+    # The guard checks CASE and a LEADING UNDERSCORE (#306) — and nothing else. It is NOT
+    # `format_model_name`, and it applies no other identifier-shape validation. One consequence
+    # remains, pinned here so it stays deliberate: the guard accepts names that are lowercase and
+    # underscore-free at the front but are not valid bare identifiers — `"order"` is a reserved word,
+    # `"driver profile"` contains a space — and the DDL writes the table bare, so those render invalid
+    # SQL. Pre-existing and out of scope; recorded so nobody reads the guard as "the model name is now
+    # safe". (A leading underscore used to be a second such gap here — see the rejection testset below.)
+    @test Model("order", id = IDField()).name == "order"                    # accepted as-is
     @test Model("driver profile", id = IDField()).name == "driver profile"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The guard, extended (#306): a positional name starting with '_' is also a declaration-time error.
+  # This is the assertion that was RED before #306 — the declaration used to succeed and produce a
+  # model whose created table and FK `REFERENCES` target disagreed, one character away from #300.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "positional name with a leading underscore is rejected (#306)" begin
+    @test_throws PormG.ModelDefinitionError Model("_driver_scratch", id = IDField())
+    @test_throws PormG.ModelDefinitionError Model("_order", id = IDField())
+
+    # Same actionability requirement as the case guard: the message names the offending value AND the
+    # spelling to declare instead (the same spelling the FK `REFERENCES` target would have used).
+    err = try
+      Model("_order", id = IDField()); nothing
+    catch e; e end
+    @test err isa PormG.ModelDefinitionError
+    @test occursin("_order", err.msg)     # the name the user wrote
+    @test occursin("order", err.msg)      # the name they should write
+
+    # A name failing BOTH checks (case AND underscore) must still suggest a spelling that passes on
+    # RETRY — not just fix the one problem its own message names. Before this was pinned, the case
+    # message suggested `lowercase(name)` alone, which for "_Driver_Scratch" is "_driver_scratch" —
+    # still underscore-prefixed, so a user "fixing" it per the message would be rejected again.
+    err_both = try
+      Model("_Driver_Scratch", id = IDField()); nothing
+    catch e; e end
+    @test err_both isa PormG.ModelDefinitionError
+    # The "would migrate the table '_driver_scratch'" clause legitimately still names the lowercased-
+    # but-underscored spelling (that IS what makemigrations would emit) — the precise claim under test
+    # is the "Declare it as" suggestion specifically, which must be the ONE-SHOT correct spelling.
+    @test occursin("Declare it as 'driver_scratch'", err_both.msg)
+    @test !occursin("Declare it as '_driver_scratch'", err_both.msg)   # not the still-broken half-fix
+
+    # A double leading underscore (or a bare "_") is not one strip away from a valid FK reference the
+    # way a single underscore is: `format_model_name` strips only ONE, then itself rejects what's left
+    # if it still starts with '_' — so the "creates X, references Y" divergence this guard warns about
+    # can never actually happen for these names. The message says so instead of making that (wrong)
+    # claim, and never emits the unusable "Declare it as ''." that a naive full-strip would produce.
+    for bad in ("__order", "_", "___")
+      err_multi = try
+        Model(bad, id = IDField()); nothing
+      catch e; e end
+      @test err_multi isa PormG.ModelDefinitionError
+      @test occursin(bad, err_multi.msg)
+      @test !occursin("Declare it as ''", err_multi.msg)
+      @test !occursin("REFERENCES", err_multi.msg)   # not the single-underscore FK-divergence story
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -153,6 +200,31 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     del = del_raw isa Vector ? first(del_raw) : del_raw
     @test occursin("DELETE FROM driver_profile", del[:sql_text])   # bare + folded
     @test occursin("\"Driver_Profile\"", del[:sql_text])           # …and quoted verbatim, same string
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CHARACTERIZATION (#306): the create/REFERENCES split the underscore guard prevents is real, and
+  # still reachable through the exempt `Dict` path — the issue's own repro, DB-free via SQLite's inline
+  # FK. `create_table` writes the PARENT's name verbatim (`_fk306_driver_scratch`); the CHILD's
+  # `ForeignKey` renders through `format_model_name`, which strips the leading underscore
+  # (`fk306_driver_scratch`) — a table one character removed from the one actually created.
+  #
+  # This is a characterization test, not an endorsement. If this split is ever closed for the exempt
+  # path too, THIS TESTSET IS SUPPOSED TO FAIL.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "characterize: the create/REFERENCES split is real on the exempt path (#306)" begin
+    fk_parent = Model("_fk306_driver_scratch", Dict{String, PormG.PormGField}("id" => IDField()))
+    fk_child = Model("fk306_child_scratch",
+      id       = IDField(),
+      driverid = Models.ForeignKey(fk_parent, pk_field = "id", on_delete = "CASCADE"),
+    )
+
+    parent_ddl = PormG.Dialect.create_table(MockSQLiteNameCase(), fk_parent)
+    child_ddl  = PormG.Dialect.create_table(MockSQLiteNameCase(), fk_child)
+
+    @test occursin("_fk306_driver_scratch", parent_ddl)                    # the table actually created…
+    @test occursin("REFERENCES \"fk306_driver_scratch\"", child_ddl)       # …a DIFFERENT table referenced
+    @test !occursin("REFERENCES \"_fk306_driver_scratch\"", child_ddl)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #306.

## The defect

Follow-up found during independent review of #307 (which fixed the same defect class for **case**, #300). This is the same split, one character away, caused by a **leading underscore**.

`format_fild_name`/`format_model_name` strip one leading underscore as the documented escape hatch for a name colliding with a reserved word — but that stripping only happens where a model is *referenced* (`ForeignKey` `REFERENCES`, model-reference lookups). `create_table` writes the stored positional name as-is:

```julia
Parent = Models.Model("_driver_scratch", id = Models.IDField())
Child  = Models.Model("child_scratch",
  id       = Models.IDField(),
  driverid = Models.ForeignKey(Parent, pk_field = "id", on_delete = "CASCADE"),
)
```

creates table `_driver_scratch` but emits `FOREIGN KEY ("driverid") REFERENCES "driver_scratch"(...)` — a different table. On PostgreSQL this either fails the migration (if `driver_scratch` doesn't exist) or, worse, silently binds the FK to an unrelated table that happens to share that name.

## The fix

The issue laid out three resolutions without a recommendation (normalize / reject / stop stripping). **Reject**, mirroring #300/#307's "reject rather than fold" policy: `_validate_positional_model_name` in `src/Models.jl` (the single gate #300 added) now also rejects a positional name starting with `_`, throwing the same `ModelDefinitionError`.

Unlike a field name, a positional model name is a plain string literal — never a Julia kwarg key — so it never had a *syntactic* reason to need the leading-underscore escape hatch in the first place. Nothing legitimate is lost by rejecting it, and PormG still has no model-level `db_table` (#59), so silently stripping would discard a stated intent with no signal it happened.

`src/Dialect.jl` / `src/migrations/planner.jl` FK-rendering sites need no changes — the split becomes unreachable from a valid declaration, the same way #307 left the ~20 case-lowercasing sites untouched. Same exemption as #300: the two `Dict`-taking `Model` constructors (introspection / Django import) stay unguarded, since a live table can legitimately be named `_something`.

## Independent review

A fresh subagent reviewed the diff with no memory of writing it, per `pormg-changed-code-review`. It found the fix itself correct but flagged two message-quality bugs in the new guard's error text, both fixed:

1. **Not one-shot correct.** A name failing both checks (e.g. `"_Driver_Scratch"`) had the case-check message suggest `lowercase(name)` alone — still underscore-prefixed, so retrying with it would fail again. The suggested spelling is now computed underscore-aware, so whichever check fires first already names a spelling that passes both.
2. **Inaccurate for 2+ leading underscores.** `format_model_name` strips only ONE leading underscore, then itself rejects what's left if it still starts with `_` — so a name like `"__order"` (or a bare `"_"`) can never actually reach the create/REFERENCES split this guard describes; `format_model_name` would raise a different, unrelated error first. Claiming the split for those names was describing behavior that can't happen (and for an all-underscore name produced the unusable `"Declare it as ''."`). They now get a narrower, accurate message instead.

## Tests

Extended `test/unit/test_model_name_case.jl` (already scaffolded for this exact follow-up, per its #300-era comments):

- Removed the stale pin of the old (buggy) behavior.
- New rejection testset, mirroring the case-rejection testset, including the two review-finding regressions above (one-shot-correct hint on a combined case+underscore failure; accurate, non-`REFERENCES` message for 2+ leading underscores / bare `"_"`).
- New DB-free characterization testset exercising the FK path specifically (via the exempt `Dict` constructor + `PormG.Dialect.create_table` against a mock SQLite connection) — the create/REFERENCES divergence the issue's own repro shows.

One new `DOCERR_CASES` entry in `test/unit/test_docs_error_types.jl` pins the new docstring claim.

**Verified**: `test_model_name_case.jl` alone 51/51; guard tests (`test_docs_error_types.jl`) 68/68 + 3/3; full unit suite 5236/5236; docs build clean (no cross-reference warnings).

## Docs

`Model`'s docstring warning admonition and `docs/src/schema_conventions.md` both extended to cover the underscore rejection alongside the existing case rule. `UPGRADING.md` gets a new `## Unreleased` entry, same shape as the adjacent #300 entry.

## Deliberately not done

- No change to the `ManyToManyField(db_table = …)` vs `Model(...)` policy split — already flagged as a design note for #59.
- No reserved-word / space validation for model names (`Model("order", …)`) — pre-existing gap, unchanged, same as #300 left it.
- No integration run (not requested; this is a construction-time, DB-free guard).

## Test plan

- [x] `julia --project=. test/unit/test_model_name_case.jl` — 51/51
- [x] `julia --project=. test/unit/test_docs_error_types.jl` — 68/68 + 3/3
- [x] `julia --project=. test/runtests.jl` — 5236/5236
- [x] `julia --project=docs -e '...; include("docs/make.jl")'` — clean build
- [x] Independent review (fresh subagent) + fixes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)