### PR TITLE
fix(#310): correct convertSQLToModel(::String) nullability inversion

### DIFF
--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -269,7 +269,7 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
     normalized_default = _normalize_sqlite_default(default_value, type_sym)
     # check if column_name is a primary key
     if haskey(pk_map, column_name)
-      field_instance = Models.IDField(null=!(nullable === nothing), auto_increment=pk_map[column_name]["auto_increment"])
+      field_instance = Models.IDField(null=(nullable === nothing), auto_increment=pk_map[column_name]["auto_increment"])
     elseif haskey(fk_map, column_name)
       # `default=` was computed above but never reached this branch before #292, so an FK declared
       # ON DELETE SET DEFAULT introspected to `SET_DEFAULT` with no default — which since #287
@@ -278,10 +278,10 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
       # rather than throwing from inside introspection.
       field_instance = Models.ForeignKey(uppercasefirst(fk_map[column_name]["fk_table"] |> string); pk_field=fk_map[column_name]["fk_column"] |> string,
       on_delete=_normalize_introspected_on_delete(fk_map[column_name]["on_delete"]),
-      on_update=fk_map[column_name]["on_update"], deferrable=!(fk_map[column_name]["on_deferable"] === nothing), null=!(nullable === nothing),
+      on_update=fk_map[column_name]["on_update"], deferrable=!(fk_map[column_name]["on_deferable"] === nothing), null=(nullable === nothing),
       default=_fk_default_or_warn(normalized_default, table_name, column_name))
     else
-      field_instance = getfield(Models, type_sym)(null=!(nullable === nothing), default=normalized_default)
+      field_instance = getfield(Models, type_sym)(null=(nullable === nothing), default=normalized_default)
       # BLOB carries no length suffix, so a BinaryField's byte bound comes from its CHECK (#296).
       if type_sym == :BinaryField && haskey(byte_bounds, column_name)
         field_instance.max_length = byte_bounds[column_name]

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -320,4 +320,40 @@ using PormG.Migrations: _pg_confdeltype_to_on_delete, _normalize_introspected_on
     @test model.fields["raceid"].on_delete === nothing
   end
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # The SQLite DDL-regex path reads nullability the right way round (#310)
+  # The column regex captures `(NOT NULL)?` into `nullable`, which holds the literal string
+  # "NOT NULL" when the column IS NOT NULL, and `nothing` when it IS nullable. Every field branch
+  # (IDField, ForeignKey, and the general/default branch) used to write `null=!(nullable ===
+  # nothing)`, inverting it: a NOT NULL column round-tripped as `null=true` and a nullable column
+  # as `null=false` — backwards against `src/Dialect.jl`, where `field.null == true` renders NULL.
+  # A fixture that only used one polarity would pass against either the correct or the inverted
+  # implementation, so this one mixes NOT NULL and nullable columns across all three branches.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the SQLite DDL-regex path reads nullability the right way round" begin
+    sql = """
+    CREATE TABLE "results" (
+      "id" INTEGER NOT NULL,
+      "points" REAL NOT NULL,
+      "notes" TEXT,
+      "statusid" INTEGER NOT NULL,
+      "raceid" INTEGER,
+      PRIMARY KEY("id"),
+      FOREIGN KEY("statusid") REFERENCES "status"("statusid"),
+      FOREIGN KEY("raceid") REFERENCES "races"("raceid")
+    )"""
+    model = convertSQLToModel(sql)
+
+    # IDField branch: a NOT NULL primary key must not come back nullable.
+    @test model.fields["id"].null == false
+
+    # General/default branch: NOT NULL and nullable plain columns, both polarities.
+    @test model.fields["points"].null == false
+    @test model.fields["notes"].null == true
+
+    # ForeignKey branch: NOT NULL and nullable FK columns, both polarities.
+    @test model.fields["statusid"].null == false
+    @test model.fields["raceid"].null == true
+  end
+
 end


### PR DESCRIPTION
## Summary

- `convertSQLToModel(sql::String)` (the DDL-text-parsing overload in `src/migrations/introspection.jl`) captures `(NOT NULL)?` from a `CREATE TABLE` statement into `nullable`, which holds the literal `"NOT NULL"` when the column IS NOT NULL, and `nothing` when it's nullable.
- All three field-construction branches (IDField, ForeignKey, general/default) wrote `null=!(nullable === nothing)`, inverting it against `src/Dialect.jl`'s rendering rule (`field.null == true` → `NULL`, `false` → `NOT NULL`). A `NOT NULL` column round-tripped as `null=true`; a nullable column as `null=false`.
- Inverted all three occurrences to `null=(nullable === nothing)`.

Closes #310

## Test plan

- [x] `julia --project=. test/unit/test_introspection_guards.jl` — new testset covers all three branches (IDField, ForeignKey, general) at both polarities (NOT NULL and nullable) in one fixture; all assertions pass
- [x] `julia --project=. test/runtests.jl` (full unit suite) — 5241/5241 pass
- [x] Independent review by a fresh subagent: re-derived the regex/polarity logic independently, verified via grep that the buggy overload has zero callers in `src/` (production SQLite introspection uses the separate, already-correct PRAGMA-based `convertSQLToModel(db, table_name)`), and independently reverted + reran the new test to confirm it fails against the pre-fix polarity — no blocking findings.
- No integration test: the buggy path is unreachable from any production code path, so there's no live-DB-observable behavior for an integration regression to cover.

## Deliberately not done

- **The issue's own "worth considering" aside** — whether the DDL-text parser should delegate to the PRAGMA-based path so the two can't drift again. The two functions are structurally very different (regex/text-capture vs. `PRAGMA`-DataFrame-rows); the issue explicitly hedged this as optional, not a fix requirement. Left as a possible follow-up, not done here.
- **No `UPGRADING.md` entry.** The reviewer flagged this as advisory, citing #292 (same file) as precedent. Checked: #292 changed the *production* introspection path apps use to reverse-engineer model files, which changes what `makemigrations` proposes for real apps. This fix's overload is never reached by that workflow, so no consuming app's actual generated models or migrations change — per `UPGRADING.md`'s own rule ("only what **forces** an app edit"), no entry is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)