### PR TITLE
feat(#59): model-level db_table pins an explicit physical table name

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,99 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Model-level `db_table`, and DDL now quotes the table identifier (#59)
+
+- **Version**: Unreleased
+- **PormG ref**: #59; `src/Kernel.jl`, `src/Models.jl`, `src/Dialect.jl`, `src/migrations/planner.jl`,
+  `src/querybuilder/{execution,build_joins,deletion,execution_bulk}.jl`, `src/Configuration.jl`,
+  `src/models/fields.jl`, `docs/src/schema_conventions.md`, `docs/src/fields.md`
+- **Recorded**: 2026-08-06
+- **Severity**: **mostly additive**, with two narrow behavior changes — a `ManyToManyField(db_table =
+  …)` that was relying on being silently lowercased, and generated model files for
+  **introspected mixed-case tables**. Neither requires a source edit for a schema that follows the
+  documented lowercase house style.
+
+### What changed
+
+**The feature (additive).** A model can now pin its physical table name:
+
+```julia
+DriverProfile = Models.Model("driver_profile",
+  db_table = "Driver_Profile_Legacy",   # ← the table that actually exists
+  driverid = Models.IDField(),
+)
+```
+
+The positional name stays the lowercase logical identifier; `db_table` carries the physical one,
+**verbatim** — no case fold, no leading-underscore strip. It is authoritative in DDL, in
+`SELECT`/`INSERT`/`UPDATE`/`DELETE`, in `JOIN` targets, in a `ForeignKey`'s `REFERENCES` target, and
+in migration add/drop/rename detection. A model that does not set it derives its table name exactly
+as before, so **no existing schema changes and nothing needs re-migrating**.
+
+This is the escape valve #300 and #306 were built to point at: a positional name that is mixed-case
+or underscore-prefixed is still rejected, and `db_table` is now where that intent goes.
+
+**DDL quotes the table identifier.** `CREATE TABLE IF NOT EXISTS driver (…)` is now
+`CREATE TABLE IF NOT EXISTS "driver" (…)`. Necessary for the feature — an unquoted mixed-case name
+folds to lowercase on PostgreSQL, which would have split the DDL from every (already-quoted)
+query-side site. Semantically identical for a lowercase name on both backends. Only affects code that
+**string-matches generated DDL**; migrations themselves are unchanged in effect.
+
+**`ManyToManyField(db_table = …)` now preserves case.** It previously ran the value through
+`format_model_name`, silently lowercasing it (and stripping a leading underscore) — the opposite
+policy from the new model-level option, for the same user intent. Both now carry the value verbatim.
+
+```julia
+Models.ManyToManyField(Driver, db_table = "Driver_Races")
+# before → through table `driver_races`
+# after  → through table `Driver_Races`
+```
+
+**Generated model files pin an introspected mixed-case table.** `inspectdb` on a table named
+`Driver_Profile` used to generate `Models.Model("driver_profile", …)` — a declaration addressing a
+*different* table than the one it was read from. It now also emits the original spelling:
+
+```julia
+Driver_profile = Models.Model("driver_profile", db_table = "Driver_Profile", …)
+```
+
+**A field named `db_table` must now use the underscore escape hatch.** `db_table` is peeled off
+before the `fields...` slurp (exactly like `constraints`), so it is read as the option:
+
+```julia
+# before — declared a column called `db_table`
+Models.Model("thing", id = Models.IDField(), db_table = Models.CharField())
+# after  → ModelDefinitionError: The 'db_table' option on model 'thing' must be a String or nothing,
+#          got PormG.Models.sCharField
+
+# migrate to the leading-underscore escape hatch — still the column `db_table`:
+Models.Model("thing", id = Models.IDField(), _db_table = Models.CharField())
+```
+
+It fails loudly at load time, never silently. A *table* named `db_table` is unaffected —
+`Models.Model("db_table", …)` needs no change.
+
+### How to find the calls to migrate
+
+```bash
+# 1. M2M through-table overrides whose value is not already lowercase — the only ones whose
+#    physical table name changes.
+rg -n 'ManyToManyField\([^)]*db_table\s*=\s*"[^"]*[A-Z_]' --glob '*.jl'
+
+# 2. Anything asserting on generated DDL text (the quoting change).
+rg -n 'CREATE TABLE IF NOT EXISTS [a-z_]' --glob '*.jl'
+
+# 3. A FIELD named db_table — now read as the model option. Matches `db_table = <something>(`,
+#    i.e. a field constructor rather than a string literal, so it does not flag legitimate uses.
+rg -n 'db_table\s*=\s*Models\.' --glob '*.jl'
+```
+
+An app whose M2M `db_table` values are already lowercase, and which does not string-match DDL, has
+nothing to change. If hit 1 returns a match, the through table it names is being renamed — either
+lowercase the value to keep the current table, or migrate the table to the new spelling.
+
+---
+
 ## The join/CTE free-function form is withdrawn — fluent only (#305)
 
 - **Version**: Unreleased
@@ -137,8 +230,10 @@ names when generating DDL but quotes them as declared in queries, so this model 
 table 'driver_profile' and then query 'Driver_Profile'. Declare it as 'driver_profile'.
 ```
 
-It rejects rather than silently lowercasing because PormG has no model-level `db_table` yet (#59):
-folding the name would discard a stated intent with no way to express it and no signal it happened.
+It rejects rather than silently lowercasing because folding the name would discard a stated intent
+with no signal it happened. At the time there was also no way to *express* that intent; #59 has since
+added model-level `db_table`, which is where it goes: `Model("driver_profile", db_table =
+"Driver_Profile", …)`.
 
 **Only the positional form is affected.** A name derived from the Julia binding
 (`Race = Models.Model(…)`) was already lowercased when `set_models` filled it in, and is unchanged.
@@ -231,9 +326,9 @@ so this model would create table '_order' while a foreign key pointing at it ref
 instead — a different table if one exists, a failed constraint if it doesn't. Declare it as 'order'.
 ```
 
-It rejects rather than silently stripping, for the same reason as #300: PormG has no model-level
-`db_table` yet (#59), so folding the name would discard a stated intent with no way to express it and
-no signal it happened.
+It rejects rather than silently stripping, for the same reason as #300: folding the name would
+discard a stated intent with no signal it happened. Model-level `db_table` (#59) has since landed as
+the way to express a physical name PormG's own naming rules would not produce.
 
 **Only the positional form is affected.** `inspectdb` introspection and the Django importer still
 accept a leading-underscore name — they read it from a live database or a Python class, where it is

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -29,6 +29,10 @@ This comprehensive guide covers all field types available in PormG, inspired by 
   queries, and migrations (#50) — e.g. `chassis = CharField(db_column="chassis_code")` keeps the field
   `chassis` but targets the column `"chassis_code"`. Supported on all field types except `ManyToManyField`;
   see [Schema Conventions](schema_conventions.md).
+- **`db_table` is the same idea one level up** — a *model* option, not a field one, mapping a model to
+  a differently-named (and, unlike a model name, arbitrarily-cased) table: `Models.Model("driver_profile",
+  db_table = "Driver_Profile_Legacy", …)`. Also authoritative across DDL, queries, and migrations (#59);
+  see [Pinning an explicit table name](schema_conventions.md#Pinning-an-explicit-table-name-with-db_table).
 
 ### Examples of Good Naming
 

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -42,10 +42,10 @@ Models.Model("Driver_Profile", driverid = Models.IDField())
 ```
 
 !!! note "Mapping a model to a mixed-case legacy table"
-    There is no way to do this today, which is why the name is rejected rather than quietly folded:
+    Use [`db_table`](#Pinning-an-explicit-table-name-with-db_table) (below). The positional name is
+    rejected rather than quietly folded precisely so that this intent has one unambiguous spelling:
     before the check existed, such a model migrated `driver_profile` and then queried
-    `"Driver_Profile"` — two different tables on PostgreSQL. An explicit `db_table` option is
-    [issue #59](https://github.com/PingoLee/PormG.jl/issues/59).
+    `"Driver_Profile"` — two different tables on PostgreSQL.
 
 A positional name given with a **leading underscore** is rejected the same way, and for a related
 reason (#306): a `ForeignKey` targeting the model renders its `REFERENCES` through
@@ -62,6 +62,47 @@ Unlike a field name, a positional model name is a plain string — never a Julia
 never needed the underscore escape hatch in the first place. That escape hatch is real for *field*
 names (`_end = ...` declares column `end`, documented on `Model`'s docstring) — it just does not
 extend to the model name itself.
+
+### Pinning an explicit table name with `db_table`
+
+The rules above constrain the **logical** model name. When the physical table is something those
+rules would reject — a mixed-case legacy table, a name PormG would never generate — pass `db_table`.
+It is the table-level sibling of [`db_column`](fields.md#Database-Column-Mapping) (#50): the model
+name stays a lowercase logical identifier, and `db_table` carries the physical one, **verbatim**.
+
+```julia
+DriverProfile = Models.Model("driver_profile",
+  db_table  = "Driver_Profile_Legacy",   # ← the table that actually exists
+  driverid  = Models.IDField(),
+  surname   = Models.CharField(max_length = 100),
+)
+```
+
+`db_table` is **authoritative** wherever a table identifier is rendered:
+
+| Path | Uses `db_table` |
+| :--- | :--- |
+| `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX`, `ADD CONSTRAINT` | ✔ |
+| `SELECT` / `INSERT` / `UPDATE` / `DELETE` | ✔ |
+| `JOIN` targets, including through a foreign key | ✔ |
+| A `ForeignKey`'s `REFERENCES` target, when it points at this model | ✔ |
+| Migration add/drop/rename detection | ✔ |
+
+The value is stored exactly as written — no case fold, no leading-underscore strip, no identifier
+validation. That is deliberate: the option exists to name a table PormG's own conventions could not
+produce. It is also **purely opt-in** — a model that does not set `db_table` derives its table name
+exactly as it always has, so no existing schema changes and nothing needs re-migrating.
+
+!!! note "Changing `db_table` on a migrated model is a table rename"
+    The migration planner matches the live schema against your models by **physical** table name, so
+    editing `db_table` on a model that is already migrated presents as "one table disappeared, another
+    appeared" — the same prompt you get for any table rename. Answer it as a rename to keep your data.
+
+!!! note "`ManyToManyField` takes its own `db_table`"
+    That option names the auto-generated **through** table, not the model's own table, and follows the
+    same case-preserving rule. An auto-derived through-table name (no `db_table` given) is still built
+    from the models' *logical* names, so pinning `db_table` on a model does not silently rename a join
+    table PormG generated for you.
 
 ### `django_prefix` interop
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -2,6 +2,7 @@ module Configuration
 
 import YAML, Logging
 import PormG: PormGSettings, PormGBackend, PormGPostgres, PormGPostgresParam, PormGSQLite, config, PormGModel
+import PormG: model_table_name  # physical table name (db_table when set, #59) — defined in Kernel
 import PormG: ConfigurationError, InvalidConfigurationError  # semantic error taxonomy (#239); defined in Kernel
 import PormG: TransactionError  # cross-connection transaction misuse (#268); the config is valid, the call pattern is not
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
@@ -237,14 +238,16 @@ end
 function get_sqlite_reserved_primary_key_max(model::PormGModel, pk_field::String)
   ctx = _tx_context[]
   ctx.depth > 0 || return nothing
-  return get(ctx.sqlite_reserved_primary_keys, (string(model.name |> lowercase), pk_field), nothing)
+  # Keyed on the PHYSICAL table (#59): the reservation is about that table's PK sequence, and two
+  # models whose logical names fold together would otherwise share one overlay entry.
+  return get(ctx.sqlite_reserved_primary_keys, (model_table_name(model), pk_field), nothing)
 end
 
 function register_sqlite_reserved_primary_key_max!(model::PormGModel, pk_field::String, max_id::Integer)
   ctx = _tx_context[]
   ctx.depth > 0 || return Int64(max_id)
 
-  key = (string(model.name |> lowercase), pk_field)
+  key = (model_table_name(model), pk_field)  # physical table (#59) — must match the reader above
   current_max = get(ctx.sqlite_reserved_primary_keys, key, typemin(Int64))
   new_max = max(current_max, Int64(max_id))
   ctx.sqlite_reserved_primary_keys[key] = new_max

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -13,7 +13,7 @@ import PormG: InvalidValueError, BackendCapabilityError, QueryBuildError
 import PormG.ConnectionPool: fetch
 import PormG: postgres_type_map, postgres_type_map_reverse, sqlite_date_format_map, sqlite_type_map_reverse
 import PormG: get_constraints_pk, get_constraints_unique, get_constraints_check, get_constraints_byte_length_check
-import PormG.Models: Migration, get_model_pk_field, format_model_name, field_db_column, fk_target_column, format_timezone_sql
+import PormG.Models: Migration, get_model_pk_field, format_model_name, field_db_column, fk_target_column, format_timezone_sql, model_table_name, fk_target_table
 
 import PormG: @pormg_debug
 
@@ -761,13 +761,30 @@ end
 # Functions to create migration queries
 #
 
+# Escape a table identifier for interpolation between double quotes (#59). `db_table` carries an
+# arbitrary user-supplied spelling and is deliberately not shape-validated (mirroring `db_column`), so
+# an embedded `"` would otherwise close the quoted identifier early. Doubling is the standard SQL
+# escape on both backends. A no-op for every name that does not contain a quote.
+#
+# NOTE for anyone adding a DDL renderer: this is applied at the interpolation site, so a NEW statement
+# that writes `"$table_name"` without it is unescaped again. The functions that emit several
+# statements (`alter_field`, the SQLite rebuild) escape ONCE into the local at the top for exactly
+# that reason — prefer that shape over sprinkling calls.
+_quote_table_ddl(table_name::AbstractString)::String = replace(String(table_name), "\"" => "\"\"")
+# Several renderers declare `table_name::Union{String,Symbol}` (the planner keys its plan by Symbol),
+# so accept both rather than making every call site stringify.
+_quote_table_ddl(table_name::Symbol)::String = _quote_table_ddl(String(table_name))
+
+# Quoted (#59) — table_name is rendered as given, no case fold. Previously bare/unquoted, which was
+# harmless while every table name was lowercase-enforced; an unquoted mixed-case db_table would
+# otherwise fold to lowercase on PostgreSQL, splitting DDL from every already-quoted query-side site.
 function create_table(conn::PormGPostgres, table_name::String, columns::Vector{String})
-  return """CREATE TABLE IF NOT EXISTS $(table_name) (\n  $(join(columns, ",\n  "))
+  return """CREATE TABLE IF NOT EXISTS "$(_quote_table_ddl(table_name))" (\n  $(join(columns, ",\n  "))
     );"""
 end
 
 function create_table(conn::PormGSQLite, table_name::String, columns::Vector{String})
-  return """CREATE TABLE IF NOT EXISTS $(table_name) (\n  $(join(columns, ",\n  "))
+  return """CREATE TABLE IF NOT EXISTS "$(_quote_table_ddl(table_name))" (\n  $(join(columns, ",\n  "))
     );"""
 end
 
@@ -799,7 +816,7 @@ function create_table(conn::PormGPostgres, model::PormGModel)
     push!(columns, field_to_column(field_name |> string, field, conn))
   end
 
-  return create_table(conn, model.name |> lowercase, columns)
+  return create_table(conn, model_table_name(model), columns)
 end
 
 function create_table(conn::PormGSQLite, model::PormGModel)
@@ -816,11 +833,12 @@ function create_table(conn::PormGSQLite, model::PormGModel)
       # Local FK column and referenced parent column both honor db_column (#50).
       local_col = field_db_column(field, string(field_name))
       target_pk = fk_target_column(field)
-      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(field.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
+      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table.
+      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(fk_target_table(field))\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 
-  return create_table(conn, model.name |> lowercase, columns)
+  return create_table(conn, model_table_name(model), columns)
 end
 
 function create_index(conn::PormGPostgres, index_name::String, table_name::String, columns::Vector{String})
@@ -887,9 +905,13 @@ function for_update_clause(nowait::Bool, skip_locked::Bool, no_key::Bool, conn::
   return ""  # SQLite: no row-level locking — silent no-op (documented divergence, #26)
 end
 
+# `table_name` is QUOTED here (#59) — the caller pre-quotes every other identifier it passes but not
+# this one, which made it the last bare `ALTER TABLE` target in this file. Harmless while every table
+# name was lowercase; a mixed-case `db_table` would fold to lowercase on PostgreSQL and the statement
+# would target a table that does not exist.
 function add_foreign_key(conn::PormGPostgres, table_name::Union{Symbol,String}, constraint_name::String, field_name::String, ref_table_name::String, ref_field_name::String; on_delete::Union{String,Nothing}=nothing)
   on_delete_clause = on_delete !== nothing ? " ON DELETE $on_delete" : ""
-  return """ALTER TABLE $table_name ADD CONSTRAINT $constraint_name FOREIGN KEY ($field_name) REFERENCES $ref_table_name ($ref_field_name)$on_delete_clause DEFERRABLE INITIALLY DEFERRED;"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" ADD CONSTRAINT $constraint_name FOREIGN KEY ($field_name) REFERENCES $ref_table_name ($ref_field_name)$on_delete_clause DEFERRABLE INITIALLY DEFERRED;"""
 end
 # function add_foreign_key(conn::PormGPostgres, model::PormGModel, constraint_name::String, field_name::String, ref_model::PormGModel, ref_field_name::String)
 #   return add_foreign_key(model.name, model.name, constraint_name, field_name, ref_model.name, ref_field_name)
@@ -900,6 +922,9 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   # column even when called with the field-name key (e.g. the temporary-default cleanup in
   # _add_new_field). Idempotent when callers already pass the physical column (#50).
   field_name = field_db_column(new_field, string(field_name))
+  # Escape ONCE here (#59) rather than at each of the ~20 `"$table_name"` interpolations below, so a
+  # statement added later cannot forget it. A no-op for every name without an embedded quote.
+  table_name = _quote_table_ddl(string(table_name))
   sql_statements = []
 
   # Non-negative CHECK constraint diffing on a type transition (Django-style).
@@ -1039,29 +1064,31 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
 end
 
 function add_field(conn::PormGPostgres, table_name::Union{String,Symbol}, field_name::String, field::PormGField; temporary_default::Any=nothing)
-  return """ALTER TABLE "$table_name" ADD COLUMN $(field_to_column(field_name, field, conn, temporary_default=temporary_default));"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" ADD COLUMN $(field_to_column(field_name, field, conn, temporary_default=temporary_default));"""
 end
 
 function add_field(conn::PormGSQLite, table_name::Union{String,Symbol}, field_name::String, field::PormGField; temporary_default::Any=nothing)
-  return """ALTER TABLE "$table_name" ADD COLUMN $(field_to_column(field_name, field, conn, temporary_default=temporary_default));"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" ADD COLUMN $(field_to_column(field_name, field, conn, temporary_default=temporary_default));"""
 end
 
 function drop_field(conn::PormGPostgres, table_name::Union{String,Symbol}, field_name::Union{String,Symbol})
-  return """ALTER TABLE "$table_name" DROP COLUMN "$field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$field_name";"""
 end
 
 function drop_field(conn::PormGSQLite, table_name::Union{String,Symbol}, field_name::Union{String,Symbol})
   # Modern SQLite supports DROP COLUMN. If not, we'd need recreation.
-  return """ALTER TABLE "$table_name" DROP COLUMN "$field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$field_name";"""
 end
 
 function alter_field(conn::PormGPostgres, model::PormGModel, field_name::Union{Symbol,String}, new_field::PormGField, old_field::Union{Nothing,PormGField}, colect_not_equal::Vector{Symbol})
-  return alter_field(conn, model.name |> lowercase, field_name, new_field, old_field, colect_not_equal)
+  return alter_field(conn, model_table_name(model), field_name, new_field, old_field, colect_not_equal)
 end
 
 function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Symbol,String}, new_field::PormGField, old_field::Union{Nothing,PormGField}, colect_not_equal::Vector{Symbol})
-  # SQLite implementation using table recreation
-  table_name = model.name |> lowercase
+  # SQLite implementation using table recreation.
+  # Escaped ONCE here (#59) — this function interpolates the name into five statements below, and
+  # `new_table_name` is derived from it. A no-op for every name without an embedded quote.
+  table_name = _quote_table_ddl(model_table_name(model))
   new_table_name = "$(table_name)_new"
 
   # 1. Define columns for the NEW table (using current model state)
@@ -1076,7 +1103,8 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
       on_delete_str = _foreign_key_on_delete_sql(f.on_delete)
       local_col = field_db_column(f, string(f_name))
       target_pk = fk_target_column(f)
-      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(f.to |> format_model_name)\"(\"$target_pk\") ON DELETE $on_delete_str")
+      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table.
+      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(fk_target_table(f))\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 
@@ -1129,11 +1157,11 @@ ALTER TABLE "$new_table_name" RENAME TO "$table_name";"""
 end
 
 function rename_field(conn::Union{PormGSQLite,PormGPostgres}, table_name::Union{String,Symbol}, old_field_name::Union{String,Symbol}, new_field_name::Union{String,Symbol})
-  return """ALTER TABLE "$table_name" RENAME COLUMN "$old_field_name" TO "$new_field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" RENAME COLUMN "$old_field_name" TO "$new_field_name";"""
 end
 
 function drop_foreign_key(conn::PormGPostgres, table_name::Symbol, constraint_name::String)
-  return """ALTER TABLE "$table_name" DROP CONSTRAINT "$constraint_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP CONSTRAINT "$constraint_name";"""
 end
 
 # NOTE (#83): there is intentionally no `drop_foreign_key(::PormGSQLite, …)`. SQLite has no
@@ -1149,14 +1177,14 @@ function drop_index(conn::PormGSQLite, index_name::String)
 end
 
 function rename_table(conn::Union{PormGSQLite,PormGPostgres}, old_table_name::String, new_table_name::String)
-  return """ALTER TABLE "$old_table_name" RENAME TO "$new_table_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(old_table_name))" RENAME TO "$(_quote_table_ddl(new_table_name))";"""
 end
 
 function drop_table(conn::PormGPostgres, table_name::Union{String,Symbol})
-  return """DROP TABLE IF EXISTS "$table_name" CASCADE;"""
+  return """DROP TABLE IF EXISTS "$(_quote_table_ddl(table_name))" CASCADE;"""
 end
 function drop_table(conn::PormGSQLite, table_name::Union{String,Symbol})
-  return """DROP TABLE IF EXISTS "$table_name";"""
+  return """DROP TABLE IF EXISTS "$(_quote_table_ddl(table_name))";"""
 end
 
 function alter_sequence_name(conn::PormGPostgres, old_sequence_name::String, new_sequence_name::String)
@@ -1175,11 +1203,15 @@ end
 # Function to deal with deletion objects
 #
 
+# NOTE: this function currently has NO callers anywhere in `src/` or `test/` — the live delete path
+# is `querybuilder/deletion.jl`. The table identifier is resolved through `model_table_name` and
+# quoted anyway (#59) so it is not left as a landmine for whoever revives it; deciding whether to
+# delete it outright is out of scope for this issue.
 function get_objects_to_delete(connection::PormGPostgres, model::PormGModel, instruction::SQLInstruction)::Vector{NamedTuple}
   # Get the SQL that identifies objects to be deleted
   sql_to_delete = """
     SELECT "$(get_model_pk_field(model))"
-    FROM $(model.name |> lowercase) as $(instruction.alias)
+    FROM "$(_quote_table_ddl(model_table_name(model)))" as $(instruction.alias)
     $(join(instruction.join, "\n"))
     $(instruction._where |> length > 0 ? "WHERE" : "") $(join(instruction._where, " AND \n   "))
   """

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -162,6 +162,31 @@ abstract type PormGField <: PormGAbstractType end # define the type of the colum
 
 abstract type Migration <: PormGAbstractType end
 
+# Physical SQL table for `model` (#59) — `db_table` when the model declares a non-empty one, else
+# `model.name` unchanged. The table-level mirror of `Models.field_db_column`.
+#
+# Lives in Kernel, not Models, because layer-2 `Configuration` needs it (the SQLite reserved-PK
+# overlay keys on the physical table) and is included BEFORE Models — the shared-vocabulary rule.
+# It is pure property access with a fallback, so it carries no dependency on anything in Models.
+#
+# A model that never sets `db_table` resolves to `model.name` exactly as before this option existed,
+# so every call site is a no-op on the common path. `hasproperty` keeps it safe for any PormGModel
+# implementation that does not carry the field at all.
+function model_table_name(model::PormGModel)::String
+  hasproperty(model, :db_table) || return String(model.name)
+  dbt = getproperty(model, :db_table)
+  dbt isa AbstractString && !isempty(dbt) && return String(dbt)
+  return String(model.name)
+end
+
+# True when `model` declares a non-empty db_table (#59) — fast-path gate for call sites that want to
+# branch without building the resolved string. Mirrors `Models.model_has_db_column`'s shape.
+function model_has_db_table(model::PormGModel)::Bool
+  hasproperty(model, :db_table) || return false
+  dbt = getproperty(model, :db_table)
+  return dbt isa AbstractString && !isempty(dbt)
+end
+
 """
     PormGError <: Exception
 

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -34,7 +34,7 @@ import PormG: BackendCapabilityError
 import PormG.Configuration: MissingConfigurationError
 
 import PormG: Models, Migration, Dialect
-import PormG.Models: format_model_name
+import PormG.Models: format_model_name, model_table_name, fk_target_table
 import PormG: connection, config, get_constraints_pk, get_constraints_unique, get_constraints_check, get_constraints_byte_length_check
 import PormG: PormGModel, PormGField, PormGSettings, PormGBackend, PormGPostgres, PormGSQLite
 import PormG: sqlite_type_map, postgres_type_map, sqlite_ignore_schema, postgres_ignore_table, _EXTRA_IGNORE_TABLES

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -5,6 +5,8 @@ using Base64
 using UUIDs
 import JSON
 import PormG: PormGField, PormGModel, reserved_words, Migration
+# Physical-table-name resolution (#59) — defined in Kernel so layer-2 Configuration can reach it too.
+import PormG: model_table_name, model_has_db_table
 import PormG: DATETIME_FORMAT
 import PormG: PormGBytes  # binary-payload wrapper the parameter collectors bind as one blob (#296)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (Kernel)
@@ -91,6 +93,7 @@ See also [`Model`](@ref), [`set_models`](@ref), [`UniqueConstraint`](@ref).
 """
 @kwdef mutable struct Model_Type <: PormGModel
   name::AbstractString
+  db_table::Union{String, Nothing} = nothing # explicit physical table name override (#59)
   fields::Dict{String, PormGField}
   field_names::Vector{String} = [] # needed to create sql queries with joins
   related_objects::Dict{String, Any} = Dict{String, Any}() # needed to create sql queries with joins
@@ -580,9 +583,9 @@ end
 # and it applies no other identifier-shape validation — a reserved word or a name with a space still
 # renders invalid bare DDL.
 #
-# Reject rather than fold, in both cases. PormG has no model-level `db_table` yet (#59), so quietly
-# lowercasing or stripping would discard a stated intent with no way to express it and no signal that
-# it happened.
+# Reject rather than fold, in both cases — even now that model-level `db_table` (#59) exists as the
+# escape valve. Folding here would still discard a stated intent silently; `db_table` is how that
+# intent gets expressed instead: `Model("driver_races", db_table = "Driver_Races", …)`.
 #
 # Two message-accuracy subtleties, both about the SUGGESTED spelling rather than the rejection itself
 # (found on independent review of this fix):
@@ -611,7 +614,7 @@ function _validate_positional_model_name(name::AbstractString)::Nothing
       "The model name '$(name)' must be lowercase; PormG lowercases table names when generating DDL " *
       "but quotes them as declared in queries, so this model would migrate the table " *
       "'$(lowercase(name))' and then query '$(name)'. Declare it as '$(hint)'. " *
-      "Mapping a model to a fixed mixed-case table is issue #59."))
+      "Mapping a model to a fixed mixed-case table: pass db_table = '$(name)' instead."))
   end
   if startswith(name, "_")
     throw(ModelDefinitionError(
@@ -640,6 +643,10 @@ function field_db_column(field::PormGField, name::AbstractString)::String
 end
 field_db_column(field::PormGField, name::Symbol)::String = field_db_column(field, String(name))
 
+# `model_table_name` / `model_has_db_table` (#59) — the table-level mirror of `field_db_column`
+# above — live in `Kernel` and are imported at the top of this module, because layer-2
+# `Configuration` needs them and is included before `Models`. See Kernel.jl for the definitions.
+
 # Referenced (parent) physical column for a ForeignKey (#50). `pk_field` names a
 # field on the target model; resolve it to that field's `db_column` when the target
 # model is in scope (the normal query/migration path, where `to` is a resolved
@@ -651,6 +658,15 @@ function fk_target_column(field::PormGField)::String
   tgt = field.to
   (tgt isa PormGModel && haskey(tgt.fields, pk)) && return field_db_column(tgt.fields[pk], pk)
   return pk
+end
+
+# Referenced (parent) physical TABLE for a ForeignKey (#59) — the table-level sibling of
+# fk_target_column above. A resolved PormGModel target goes through model_table_name (so it
+# honors the target's db_table); a still-unresolved String target falls back to
+# format_model_name, matching fk_target_column's own verbatim-fallback shape for that case.
+function fk_target_table(field::PormGField)::String
+  tgt = field.to
+  return tgt isa PormGModel ? model_table_name(tgt) : format_model_name(tgt)
 end
 
 # Resolve a string FK/O2O target to its model object within `mod` (#62). Returns the
@@ -862,6 +878,20 @@ function _apply_unique_constraints!(model::Model_Type, constraints)::Model_Type
   return model
 end
 
+# Store an explicit physical table name override (#59). Mirrors db_column's precedent
+# (field_db_column, below): type-check + empty-string-as-unset only, no identifier-shape
+# validation, no forced case fold — the whole point is to carry an arbitrary legacy spelling
+# (including mixed case) through DDL/queries/migrations verbatim. `nothing` (the default) is a
+# no-op, so a model that never sets `db_table` behaves exactly as before this option existed.
+function _apply_db_table!(model::Model_Type, db_table)::Model_Type
+  db_table === nothing && return model
+  db_table isa AbstractString || throw(ModelDefinitionError(
+    "The 'db_table' option on model '$(model.name)' must be a String or nothing, got $(typeof(db_table))"))
+  isempty(db_table) && return model
+  model.db_table = String(db_table)
+  return model
+end
+
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Model Constructors
 #═══════════════════════════════════════════════════════════════════════════════
@@ -872,8 +902,8 @@ end
 Define a model — one database table, described by its fields. Returns a `Model_Type`: the object the
 query builder starts from, as in `M.Driver.objects`.
 
-Every keyword other than `constraints` declares a field: `field_name = FieldType(...)`, where the
-field types are the constructors in this module ([`IDField`](@ref), [`CharField`](@ref),
+Every keyword other than `constraints`/`db_table` declares a field: `field_name = FieldType(...)`,
+where the field types are the constructors in this module ([`IDField`](@ref), [`CharField`](@ref),
 [`ForeignKey`](@ref), …). Declaring a keyword whose value is not a field raises
 `ModelDefinitionError` — see the note below, which is the usual reason that happens.
 
@@ -881,7 +911,8 @@ The **table name** comes from the positional string when given, and otherwise fr
 the model is assigned to, filled in when [`set_models`](@ref) (or `@import_models`) registers the
 module. Both forms are idiomatic and `Race = Model(...)` and `Race = Model("race", ...)` name the
 same table, because a binding-derived name is lowercased as it is filled in. Reach for the
-positional form when the binding name is not the table name you want.
+positional form when the binding name is not the table name you want — and `db_table` (below) when
+even that isn't enough, because the physical table isn't a valid PormG model name at all.
 
 !!! warning "A positional name must be lowercase and may not start with '_'"
     `Model("Driver_Profile", …)` raises `ModelDefinitionError`. A positional name is stored
@@ -899,9 +930,8 @@ positional form when the binding name is not the table name you want.
     a failed constraint. Unlike a field name, a positional model name is a plain string, never a
     Julia kwarg key, so it never needed the leading-underscore escape hatch described below.
 
-    Mapping a model to a fixed mixed-case table is
-    [issue #59](https://github.com/PingoLee/PormG.jl/issues/59); until it lands, declare table names
-    in lowercase, without a leading underscore.
+    Mapping a model to a fixed, arbitrarily-cased table is `db_table` (below) — the positional name
+    stays the lowercase logical identifier either way.
 
 **Field names keep the case you declare** and are case-sensitive in queries, so a legacy `driverId`
 column is addressed as `driverId`. One leading underscore is stripped as the escape hatch for names
@@ -913,19 +943,39 @@ A `ManyToManyField` is stored on the model but owns no column of its own, so it 
 `field_names` and from the created table.
 
 `constraints` takes [`UniqueConstraint`](@ref) objects — one, or a collection — for uniqueness
-spanning more than one column. It is the **only** model-level option.
+spanning more than one column. `db_table` (#59) pins an explicit physical table name, **preserved
+verbatim** — no case fold, no validation beyond "is it a non-empty String" — overriding the name
+otherwise derived from the positional argument or the binding. It is authoritative everywhere a table
+identifier is rendered: DDL, `SELECT`/`INSERT`/`UPDATE`/`DELETE`, `JOIN`, foreign-key `REFERENCES`
+targets, and migration diffing. Unset (the default), a model behaves exactly as it did before this
+option existed. This is the table-level sibling of [`CharField`](@ref)'s `db_column` (#50):
+
+```julia
+# The logical name stays lowercase; db_table carries the exact legacy spelling.
+DriverRaces = Models.Model("driver_races", db_table = "Driver_Races_Legacy",
+  id = Models.IDField(),
+)
+```
+
+`constraints` and `db_table` are the **only** model-level options.
+
+!!! warning "`constraints` and `db_table` are not field names"
+    Both are peeled off before the field keywords, so `db_table = CharField()` declares the *option*
+    (and raises, since a field is not a String) rather than a column called `db_table`. To declare a
+    column with one of those names, use the leading-underscore escape hatch: `_db_table =
+    CharField()` gives you the column `db_table` and leaves the option unset. A *table* named
+    `db_table` needs nothing special — `Model("db_table", …)` is fine.
 
 !!! note "PormG has no Django `Meta` block"
-    There is no model-level `db_table`, `ordering`, or `verbose_name`. Each of those is a keyword
-    like any other, so it is read as a field declaration and raises:
+    There is no model-level `ordering` or `verbose_name` — `db_table` (above) is the one model-level
+    physical-naming option. Any other keyword is read as a field declaration and raises:
 
     ```julia
     Models.Model("race", ordering = ["-year"], raceid = Models.IDField())
     # ModelDefinitionError: All fields must be of type PormGField, exemple: …
     ```
 
-    Instead: order at query time with `order_by()` — there is no per-model default sort; pin the
-    table name with the positional argument, which must be lowercase (see the warning above); and set
+    Instead: order at query time with `order_by()` — there is no per-model default sort; and set
     `verbose_name` per field, where it is accepted, rather than per model.
 
 # Examples
@@ -947,15 +997,23 @@ Race = Models.Model(
     Models.UniqueConstraint(fields = ("year", "round"), name = "race_year_round_uniq"),
   ],
 )
+
+# Porting a legacy schema PormG doesn't control: the live table is `Constructor_Standings`.
+ConstructorStandings = Models.Model("constructor_standings",
+  db_table = "Constructor_Standings",
+  id = Models.IDField(),
+)
 ```
 
 See also [`set_models`](@ref), [`UniqueConstraint`](@ref), [`ForeignKey`](@ref).
 """
-function Model(name::AbstractString; constraints = nothing, fields...)
-  # Peel `constraints` off BEFORE the `fields...` slurp — otherwise it would flow into the
-  # `NTuple{Pair{Symbol}}` method below and trip its `isa PormGField` check (#19). Generated
-  # model files (Model_to_str) reload through this kwargs form, so this is the round-trip seam.
+function Model(name::AbstractString; constraints = nothing, db_table = nothing, fields...)
+  # Peel `constraints`/`db_table` off BEFORE the `fields...` slurp — otherwise either would flow
+  # into the `NTuple{Pair{Symbol}}` method below and trip its `isa PormGField` check (#19).
+  # Generated model files (Model_to_str) reload through this kwargs form, so this is the
+  # round-trip seam.
   model = Model(name, Tuple(pairs(fields)))
+  model = _apply_db_table!(model, db_table)
   return _apply_unique_constraints!(model, constraints)
 end
 
@@ -1008,11 +1066,12 @@ function Model(name::String)
   example_usage = "\e[32musers = Models.PormGModel(\"users\", name = Models.CharField(), age = Models.IntegerField())\e[0m"
   throw(ModelDefinitionError("You need to add fields to the model, example: $example_usage"))
 end
-function Model(; constraints = nothing, fields...)
+function Model(; constraints = nothing, db_table = nothing, fields...)
   # No-positional-name form (the idiomatic style — the table name is inferred from the binding
-  # via set_models). `constraints=` must work here too, so peel it before the `fields...` slurp
-  # exactly like the named form above.
+  # via set_models). `constraints=`/`db_table=` must work here too, so peel them before the
+  # `fields...` slurp exactly like the named form above.
   model = Model("", Tuple(pairs(fields)))
+  model = _apply_db_table!(model, db_table)
   return _apply_unique_constraints!(model, constraints)
 end
 
@@ -1058,10 +1117,17 @@ end
 Converts a model object to a string representation to create the model.
 
 # Arguments
-    Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words)::String
+    Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false)::String
 - `model::Union{Model_Type, PormGModel}`: The model object to convert.
 - `settings::PormGSettings`: Connection settings; supplies `django_prefix` and the target output folder.
 - `contants_julia::Vector{String}=reserved_words`: A vector of reserved words in Julia.
+- `name_is_physical_table::Bool=false`: whether `model.name` is a **live table name** rather than a
+  logical identifier. `true` for database introspection (`inspectdb`), where a name that is not
+  already lowercase must be pinned as `db_table` so the generated declaration addresses the table it
+  was read from (#59) — the positional slot is lowercased and would otherwise name a different table.
+  `false` for the Django importer, whose `model.name` is a **Python class name**: there the physical
+  table genuinely is the lowercased form, and pinning the class spelling would invent a table that
+  does not exist. The two are indistinguishable from the name alone, so the caller states which it has.
 
 # Returns
 - `String`: The string representation of the model object. A field whose rendering fails is
@@ -1081,7 +1147,7 @@ users = Models.Model("users",
 )
 ```
 """
-function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words)::String
+function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false)::String
   fields::String = ""
   render_failures::Vector{String} = String[]
   django_prefix::Bool = settings.django_prefix === nothing ? false : true
@@ -1128,8 +1194,44 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSetti
       fields *= ",\n  constraints = [$(join(rendered, ", "))]"
     end
   end
-  model_name_abs = django_prefix ? string(settings.django_prefix, "_", model.name |> lowercase) : model.name |> lowercase
   model_var_name = uppercasefirst(model.name)
+  # Round-trip the physical table name as `db_table=` (#59). Two sources, one kwarg:
+  #
+  #  1. An explicit `db_table` on the model — emitted verbatim so a reload reproduces it.
+  #  2. An INTROSPECTED name (`name_is_physical_table`) that the positional slot would not reproduce:
+  #     not already lowercase, or leading-underscore. On that path `model.name` IS the live table
+  #     name, so before `db_table` existed `inspectdb` on `Driver_Profile` generated
+  #     `Model("driver_profile", …)` — a declaration pointing at a *different* table (the #300 split,
+  #     arrived at from the other end), and on `_order` it generated a file that would not even load
+  #     (the #306 guard). Pinning the original spelling fixes both.
+  #
+  # The caller must SAY which it has: the Django importer's `model.name` is a Python CLASS name, not
+  # a table name — its physical table genuinely IS the lowercased form — so inferring "not lowercase
+  # ⇒ physical" from the string would make it pin a table that does not exist. Skipped under
+  # `django_prefix` too, where the prefixed lowercase name IS the physical one.
+  #
+  # `model_has_db_table`/`model_table_name` rather than `model.db_table`: the signature accepts any
+  # `PormGModel`, and only `Model_Type` is guaranteed to carry the field.
+  pin_introspected = name_is_physical_table && !django_prefix &&
+                     (model.name != lowercase(model.name) || startswith(model.name, "_"))
+  db_table_abs = if model_has_db_table(model)
+    model_table_name(model)
+  elseif pin_introspected
+    String(model.name)
+  else
+    nothing
+  end
+  db_table_part = db_table_abs === nothing ? "" : ", db_table = $(format_string(db_table_abs))"
+  # The positional slot drops leading underscores ONLY when the original is being pinned as
+  # `db_table` above — the two are one decision, not two. Stripping without pinning is precisely the
+  # "generated declaration silently addresses a different table" defect the `name_is_physical_table`
+  # gate exists to prevent: the Django importer's `_InternalThing` maps to table `_internalthing`,
+  # so emitting `internalthing` there would be wrong. Declines to strip an ALL-underscore name rather
+  # than emit an empty positional name (which silently means "derive from the binding").
+  _lowered = model.name |> lowercase
+  _stripped_name = pin_introspected ? lstrip(_lowered, '_') : _lowered
+  model_name_abs = django_prefix ? string(settings.django_prefix, "_", _lowered) :
+                                   (isempty(_stripped_name) ? _lowered : String(_stripped_name))
   # Marker comments sit directly above the model definition in the generated file (#70).
   marker = isempty(render_failures) ? "" : join(render_failures, "\n") * "\n"
   if fields == ""
@@ -1139,9 +1241,9 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSetti
     # marker — so the file still loads and the user sees exactly which model to fix by hand. Mirrors
     # Rails' SchemaDumper, which comments out a table it can't dump so schema.rb stays loadable.
     note = "# PormG: model '$(model_name_abs)' had no renderable fields — definition commented out."
-    result = """$(marker)$(note)\n# $(model_var_name) = Models.Model("$(model_name_abs)")"""
+    result = """$(marker)$(note)\n# $(model_var_name) = Models.Model("$(model_name_abs)"$db_table_part)"""
   else
-    result = """$(marker)$(model_var_name) = Models.Model("$(model_name_abs)"$fields)"""
+    result = """$(marker)$(model_var_name) = Models.Model("$(model_name_abs)"$db_table_part$fields)"""
   end
   @info(result)
 
@@ -1887,6 +1989,17 @@ function strip_many_to_many_fields(model::PormGModel)::PormGModel
   physical_field_names = [field_name for field_name in model.field_names if haskey(physical_fields, field_name)]
   return Model_Type(
     name=model.name,
+    # MUST be carried (#59). This rebuilds a Model_Type field by field, so an omitted slot silently
+    # @kwdef-defaults — and every model reaching the migration planner passes through here
+    # (`synthesize_many_to_many_through_models`). Dropping `db_table` left the plan keyed by the
+    # physical name while the model it renders from had reverted to the logical one, so
+    # `CREATE TABLE` and the FK `REFERENCES` disagreed — the exact split this option closes — and a
+    # second `makemigrations` proposed dropping the live table.
+    #
+    # Gated on `model_has_db_table` rather than reading `model.db_table`: the signature accepts any
+    # `PormGModel`, and a bare `model_table_name` would wrongly PIN the logical name onto every model
+    # that declares no override.
+    db_table=(model_has_db_table(model) ? model_table_name(model) : nothing),
     fields=physical_fields,
     field_names=physical_field_names,
     related_objects=copy(model.related_objects),
@@ -1908,7 +2021,11 @@ function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dic
 
   for (model_name, model_info) in current_schema
     source_model = model_info[:model]
-    owner_binding = uppercasefirst(String(model_name))
+    # Derive from the model's LOGICAL name, symmetric with `related_binding` below — not from the
+    # dict key, which is the resolved PHYSICAL table name (#59) and so would carry a `db_table`
+    # spelling into a Julia-side binding label. Identical output for every model without `db_table`,
+    # since the key is that same logical name lowercased.
+    owner_binding = uppercasefirst(format_model_name(source_model.name))
     for (field_name, field) in source_model.fields
       is_many_to_many_field(field) || continue
       field.through === nothing || continue

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -48,6 +48,10 @@ using .Kernel
 # Underscore-private members are not exported by Kernel; import the two that are reached as
 # `PormG._emsg` / `PormG._EXTRA_IGNORE_TABLES` (both pinned by tests).
 import .Kernel: _emsg, _EXTRA_IGNORE_TABLES
+# Physical-table-name resolution (#59). Deliberately NOT exported — internal plumbing reached as
+# `PormG.model_table_name`, so it stays off the public surface guard. Lives in Kernel because
+# layer-2 `Configuration` needs it and is included before `Models`.
+import .Kernel: model_table_name, model_has_db_table
 # Part of the documented downstream-extension surface (Nitro et al. call it from an ext `__init__`).
 export register_ignore_tables!
 

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -72,7 +72,7 @@ function import_models_from_sqlite(db::String = "db";
   # Collect all create instructions
   Instructions::Vector{Any} = []
   for model in models_array
-    push!(Instructions, Models.Model_to_str(model, settings))
+    push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
   end
 
   generate_models_from_db(file, Instructions, settings; path=model_path)
@@ -142,7 +142,7 @@ function import_models_from_postgres(db::String;
   # Convert each model to string representation
   Instructions::Vector{Any} = []
   for model in models_array
-      push!(Instructions, Models.Model_to_str(model, settings))
+      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
   end
   
   # Generate the models file
@@ -180,7 +180,7 @@ function import_models_from_postgres(;db::PormGPostgres = connection(),
   # Convert each model to string representation
   Instructions::Vector{Any} = []
   for model in models_array
-      push!(Instructions, Models.Model_to_str(model, settings))
+      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
   end
   
   # Generate the models file

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -120,7 +120,10 @@ function _drop_index(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::Or
   # PostgreSQL: a UNIQUE constraint creates a backing index with the same name.
   # DROP INDEX fails when the index backs a constraint, so drop the constraint first.
   if conn isa PormGPostgres
-    table_name = format_model_name(model_name)
+    # `model_name` is already the RESOLVED physical table name (db_table when set, #59) — every
+    # producer of this Symbol keys on `model_table_name`. Do NOT re-normalize it through
+    # `format_model_name`, which would lowercase a mixed-case db_table back into a different table.
+    table_name = Dialect._quote_table_ddl(string(model_name))
     drop_sql = """ALTER TABLE \"$table_name\" DROP CONSTRAINT IF EXISTS \"$index_name\";\nDROP INDEX IF EXISTS \"$index_name\";"""
     _configure_order_dict_migration_plan(migration_plan, model_name, "Remove index on $field_name", drop_sql)
   else
@@ -146,7 +149,7 @@ function _add_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite
     local_col = Models.field_db_column(new_field, string(field_name))
     on_delete_sql = hasfield(typeof(new_field), :on_delete) ? Dialect._foreign_key_on_delete_sql(new_field.on_delete) : nothing
     _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
-    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(new_field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(fk_target_table(new_field))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
   end
   return nothing
 end
@@ -164,7 +167,7 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
       local_col = Models.field_db_column(field, string(field_name))
       on_delete_sql = hasfield(typeof(field), :on_delete) ? Dialect._foreign_key_on_delete_sql(field.on_delete) : nothing
       _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
-      Dialect.add_foreign_key(conn, model.name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(field.to |> format_model_name)\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+      Dialect.add_foreign_key(conn, model_table_name(model), "\"$constraint_name\"", "\"$local_col\"",  "\"$(fk_target_table(field))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
     # For SQLite, FKs are added in CREATE TABLE, so if we are adding a field to an existing table, 
     # we might need recreation if it's a FK.
     end
@@ -175,7 +178,7 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
     index_name = name * "_idx" |> lowercase
     index_col = Models.field_db_column(field, string(field_name))
     _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name",
-    Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$index_col\""]))
+    Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$index_col\""]))
   end
   nothing
 end
@@ -191,7 +194,7 @@ function _add_many_to_many_auto_constraints(conn::Union{PormGPostgres, PormGSQLi
     migration_plan,
     model_name,
     "Create many-to-many unique index",
-    Dialect.create_unique_index(conn, "\"$unique_index\"", "\"$(model.name |> lowercase)\"", ["\"$owner_column\"", "\"$related_column\""])
+    Dialect.create_unique_index(conn, "\"$unique_index\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$owner_column\"", "\"$related_column\""])
   )
   return nothing
 end
@@ -206,7 +209,7 @@ function _add_unique_constraints(conn::Union{PormGPostgres, PormGSQLite}, migrat
   haskey(model.cache, "unique_constraints") || return nothing
   constraints = get(model.cache["unique_constraints"], "constraints", nothing)
   constraints === nothing && return nothing
-  table = model.name |> lowercase
+  table = model_table_name(model)
   seen = Set{String}()
   for c in constraints
     # Resolve declared field names to physical columns (honors db_column #50; PormG adds no
@@ -260,7 +263,7 @@ function _add_new_field(conn::Union{PormGPostgres, PormGSQLite}, migration_plan:
     # #82: this add-NOT-NULL-with-default path also rebuilds the table on SQLite, so it must preserve the
     # existing secondary indexes too (no-op on PostgreSQL).
     _configure_order_dict_migration_plan(migration_plan, model_name, alter_key,
-      _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
+      _sqlite_rebuild_preserving_indexes(conn, model_table_name(model),
         Dialect.alter_field(conn, model, field_name, field, nothing, [:default]);
         surviving_columns = _model_physical_columns(model)))
   end
@@ -363,7 +366,7 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
         alter_key = conn isa PormGSQLite ? "Alter table: $model_name" : "Alter field: $field_name_stripped"
         # #82: on SQLite this preserves the table's secondary indexes across the rebuild and gates on
         # foreign_key_check (no-op on PostgreSQL). See _sqlite_rebuild_preserving_indexes.
-        alter_sql = _sqlite_rebuild_preserving_indexes(conn, model.name |> lowercase,
+        alter_sql = _sqlite_rebuild_preserving_indexes(conn, model_table_name(model),
           Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal);
           surviving_columns = _model_physical_columns(current_schema[model_name][:model]))
         _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, alter_sql)
@@ -381,7 +384,7 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
           if !(conn isa PormGSQLite && get_constraints_index(conn, model_name, field_name_stripped) !== nothing)
             index_name = "$(name)_idx"
             _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name_stripped",
-            Dialect.create_index(conn, "\"$index_name\"", "\"$(model.name |> lowercase)\"", ["\"$field_name_stripped\""]))
+            Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$field_name_stripped\""]))
           end
         end
 
@@ -460,7 +463,7 @@ function _resolve_table_fields(
           _configure_order_dict_migration_plan(migration_plan, model_name, "Rename field: $field_name",
           Dialect.rename_field(conn, model_name, old_field_name, field_name))
           _configure_order_dict_migration_plan(migration_plan, model_name, "Alter table: $model_name",
-          _sqlite_rebuild_preserving_indexes(conn, current_model.name |> lowercase,
+          _sqlite_rebuild_preserving_indexes(conn, model_table_name(current_model),
             Dialect.alter_field(conn, current_model, field_name, new_field, old_field, Symbol[]);
             surviving_columns = _model_physical_columns(current_model),
             column_renames = Dict(old_phys => field_name)))
@@ -540,7 +543,7 @@ function _resolve_table_fields(
       # idempotent recreation from the same desired model.
       rebuild_field = model.fields[model_fields_map[string(colect_deletion[rebuild_delete_idx])]]
       _configure_order_dict_migration_plan(migration_plan, model_name, "Alter table: $model_name",
-        _sqlite_rebuild_preserving_indexes(conn, current_model.name |> lowercase,
+        _sqlite_rebuild_preserving_indexes(conn, model_table_name(current_model),
           Dialect.alter_field(conn, current_model, string(colect_deletion[rebuild_delete_idx]), rebuild_field, rebuild_field, Symbol[]);
           surviving_columns = _model_physical_columns(current_model)))
     else
@@ -627,8 +630,10 @@ end
 @pormg_debug false
 
 for model in models # models is olds models
-  model_name = model.name |> Symbol
-  # model_name = lowercase(string(model.name)) |> Symbol
+  # Resolved physical name (#59), symmetric with how `get_all_models` keys `current_schema`. A no-op
+  # for genuinely-introspected models (they carry no db_table, so this is `model.name` — already the
+  # exact live table name), but it keeps the two sides of the diff keyed the same way.
+  model_name = Symbol(model_table_name(model))
   @pormg_debug false
   if haskey(current_schema, model_name)
     current_schema[model_name][:exist] = true
@@ -837,7 +842,14 @@ for name in names(mod, all = true)
       if obj.name == ""
         obj.name = name |> string |> format_model_name
       end
-      models[name |> string |> lowercase |> Symbol] = Dict{Symbol, Union{Bool, PormGModel}}(:model => obj, :exist => false) # TODO: change model.name to lowercase in all project
+      # Key by the RESOLVED PHYSICAL table name (#59): `db_table` when the model sets one, else the
+      # (now-filled) `obj.name`. The old key was the lowercased Julia BINDING name, which only ever
+      # agreed with the physical name by convention — a `db_table` model would key as `:driver_races`
+      # (binding) while its live table is `Driver_Races`, so the diff below would find no match and
+      # drop+recreate a live table that had not structurally changed. Keying both sides on
+      # `model_table_name` also retires the long-standing "lowercase model.name everywhere" TODO that
+      # sat on this line: the identity is now the resolved name, not an ad hoc fold of the binding.
+      models[Symbol(model_table_name(obj))] = Dict{Symbol, Union{Bool, PormGModel}}(:model => obj, :exist => false)
     end
   end
 end

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -519,7 +519,12 @@ function ManyToManyField(to::Union{String, PormGModel}; kwargs...)
     to,
     through,
     related_name === nothing ? nothing : String(related_name),
-    db_table === nothing ? nothing : format_model_name(String(db_table)),
+    # Case-PRESERVING (#59): this used to run through `format_model_name`, which silently lowercased
+    # (and stripped a leading underscore from) a user-supplied physical through-table name — the
+    # opposite policy from model-level `db_table`, which carries an arbitrary legacy spelling
+    # verbatim. Both seams express the same intent ("this table is called X"), so they now behave the
+    # same way. Empty-string-as-unset mirrors `_apply_db_table!`.
+    db_table === nothing ? nothing : (isempty(String(db_table)) ? nothing : String(db_table)),
     source_field === nothing ? nothing : format_fild_name(source_field),
     target_field === nothing ? nothing : format_fild_name(target_field),
     "MANYTOMANY",

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -857,7 +857,7 @@ function _build_exists_query(subquery::SQLObjectHandler, instruc::SQLInstruction
     old_context !== nothing && set_context!(instruc.parameters, old_context)
   end
 
-  safe_table_name = safe_table_identifier(q.object.model.name, instruction.connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(q.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
 
   io = IOBuffer()

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -54,9 +54,9 @@ function _build_cjoin_on_row_join(config::Dict{String,Any}, join_path::String, i
   target_model = getfield(instruct.object.model._module, Symbol(config["target_model"]::String))::PormGModel
   user_alias = config["user_alias"]::String
   row_join = Dict{String,Union{String,Vector{FilterType}}}(
-    "a"         => instruct.object.model.name,
+    "a"         => Models.model_table_name(instruct.object.model),
     "alias_a"   => instruct.alias,
-    "b"         => target_model.name,
+    "b"         => Models.model_table_name(target_model),
     "alias_b"   => user_alias,
     "key_a"     => user_alias,   # dedup discriminator (never rendered for no_anchor)
     "key_b"     => "",
@@ -158,7 +158,9 @@ function _insert_many_to_many_joins(
   related_row["a"] = relation.through_model
   related_row["alias_a"] = through_alias
   related_row["key_a"] = relation.related_column
-  related_row["b"] = relation.related_model
+  # The related side's PHYSICAL table (db_table when set, #59). `relation.related_model` carries the
+  # LOGICAL name, which is what identifies the model — but this slot is rendered as a table.
+  related_row["b"] = Models.model_table_name(related_model)
   related_row["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
   related_row["key_b"] = Models.model_column(related_model, relation.related_pk)
   related_row["how"] = join_type
@@ -171,6 +173,16 @@ function _row_join_for_alias(row_join::Vector{Dict{String, Union{String, Vector{
     row["alias_b"] == alias && return row
   end
   error(_emsg("PormG internal error: join alias $(alias) was not found in row_join — this should not happen; please report it."))
+end
+
+# Physical table for a REVERSE join target (#59). The reverse path reaches its target through
+# `related_objects`, which stores the model's LOGICAL name — so the resolved model is the only place
+# a `db_table` can be read from, and it must win. Without an override this reproduces the previous
+# derivation byte for byte, including the `django_prefix` arm: a prefixed deployment's physical table
+# IS `<prefix>_<logical>`, which no model declares as `db_table`.
+function _reverse_join_table(reverse_model::PormGModel, logical_name::AbstractString, django)::String
+  Models.model_has_db_table(reverse_model) && return Models.model_table_name(reverse_model)
+  return django !== nothing ? string(django, lowercase(logical_name)) : lowercase(logical_name)
 end
 
 # Shared helper used at the four sites in `_build_row_join` where a many-to-many
@@ -279,7 +291,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
         available = join(collect(keys(cte_model.fields)), ", ")
         throw(UnknownFieldError("CTE field '$(vector[2])' not found in '$(cte_name)'; available fields: $(available)"))
       end
-      row_join["a"] = instruct.object.model.name
+      row_join["a"] = Models.model_table_name(instruct.object.model)
       row_join["alias_a"] = instruct.alias
       row_join["b"] = cte_name  # CTE name becomes the table name
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
@@ -321,7 +333,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       end
 
       # Set up the join with the CTE
-      row_join["a"] = instruct.object.model.name
+      row_join["a"] = Models.model_table_name(instruct.object.model)
 
       row_join["b"] = cte_name  # CTE name becomes the table name
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
@@ -342,12 +354,12 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
   elseif haskey(instruct.object.model.fields, first_column) && Models.is_many_to_many_field(instruct.object.model.fields[first_column])
     relation = Models.get_many_to_many_relation(instruct.object.model, first_column)
     tb_alias, row_join, foreign_model, last_field = _apply_many_to_many_branch(
-      relation, instruct, instruct.object.model.name, instruct.alias, join_path, vector
+      relation, instruct, Models.model_table_name(instruct.object.model), instruct.alias, join_path, vector
     )
     foreign_table_name = foreign_model
     m2m_inserted = true
   elseif first_column in instruct.object.model.field_names || _get_join_field(instruct.object, join_path) !== nothing
-    row_join["a"] = instruct.object.model.name
+    row_join["a"] = Models.model_table_name(instruct.object.model)
     row_join["alias_a"] = instruct.alias
     # @pormg_debug
     first_field = _get_join_field(instruct.object, join_path) !== nothing ? _get_join_field(instruct.object, join_path) : instruct.object.model.fields[first_column]
@@ -357,7 +369,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     if foreign_table_name === nothing
       throw(QueryBuildError("Invalid field path: the column $(first_column) does not have a foreign key"))
     elseif isa(foreign_table_name, PormGModel)
-      row_join["b"] = foreign_table_name.name
+      row_join["b"] = Models.model_table_name(foreign_table_name)
       size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
     else
       row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
@@ -373,7 +385,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     if related_object isa Models.ManyToManyRelation
       relation = related_object::Models.ManyToManyRelation
       tb_alias, row_join, foreign_model, last_field = _apply_many_to_many_branch(
-        relation, instruct, instruct.object.model.name, instruct.alias, join_path, vector; reverse=true
+        relation, instruct, Models.model_table_name(instruct.object.model), instruct.alias, join_path, vector; reverse=true
       )
       foreign_table_name = foreign_model
       m2m_inserted = true
@@ -383,7 +395,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     reverse_model = getfield(foreing_table_module, s_model)
     length(vector) == 1 && throw(QueryBuildError("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
     # !(vector[2] in reverse_model.field_names) && throw("Error in _build_row_join, the column $(vector[2]) not found in $(reverse_model.name)")
-    row_join["a"] = instruct.object.model.name
+    row_join["a"] = Models.model_table_name(instruct.object.model)
     row_join["alias_a"] = instruct.alias
     join_field = reverse_model.fields[instruct.object.model.related_objects[vector[1]][1] |> String]
     row_join["how"] = _determine_join_type(join_field, second_fild_name= vector[2])
@@ -391,7 +403,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
     # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
     foreign_table_name = instruct.object.model.related_objects[vector[1]][3] |> String
-    row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
+    row_join["b"] = _reverse_join_table(reverse_model, foreign_table_name, instruct.django)
 
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
     # Reverse join: key_a is the parent's referenced column, key_b the child's FK
@@ -466,7 +478,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
         # #197: this used to blame `vector[2]`, but the FK-less column is `first_column`.
         throw(QueryBuildError("Invalid field path: the column $(first_column) in $(new_object.name) does not have a foreign key target"))
       elseif isa(foreign_table_name, PormGModel)
-        row_join["b"] = foreign_table_name.name
+        row_join["b"] = Models.model_table_name(foreign_table_name)
         size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
       else
         row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
@@ -498,7 +510,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
       # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
       foreign_table_name = new_object.related_objects[vector[1]][3] |> String
-      row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
+      row_join["b"] = _reverse_join_table(reverse_model, foreign_table_name, instruct.django)
 
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
       # Reverse join: key_a is the parent's referenced column, key_b the child's FK

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -515,7 +515,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     isempty(objct.object.filter) || throw(QueryBuildError("Delete on keyless model $(model.name) with filters is not supported; define a primary key or delete all rows explicitly"))
 
     deleted_counter[model.name] = show_query === :execute ? (objct |> _count) : 0
-    sql = "DELETE FROM $(model.name |> lowercase)"
+    sql = "DELETE FROM $(safe_table_identifier(Models.model_table_name(model), connection))"
 
     if show_query !== :execute
       return _show_query_result(show_query, sql, connection, model, :delete, parameters=nothing)
@@ -538,7 +538,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
   sql::String = ""
   if size(keys, 1) == 1
     deleted_counter[model.name] = show_query === :execute ? (keys[1][:objct] |> _count) : 0
-    sql = "DELETE FROM $(model.name |> lowercase) WHERE $(join(_where, " OR "))"
+    sql = "DELETE FROM $(safe_table_identifier(Models.model_table_name(model), connection)) WHERE $(join(_where, " OR "))"
   else
     # Multi-path merge: all entries for the same model share the same resolved key field.
     # Keyless (sentinel) models reaching this path are not supported.
@@ -556,7 +556,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     deleted_counter[model.name] = show_query === :execute ? (_query |> _count) : 0
     _query.values(pk_field) # Ensure the query is built
     @pormg_debug false
-    sql = "DELETE FROM $(model.name |> lowercase) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
+    sql = "DELETE FROM $(safe_table_identifier(Models.model_table_name(model), connection)) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   end
 
   sql == "" && error(_emsg("PormG internal error in delete(): the generated SQL is empty — this should not happen; please report it."))
@@ -578,7 +578,7 @@ function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::Porm
   parameters = get_parameter(connection)
   value_sql = value === nothing ? "NULL" : model.fields[field].formatter(value)
   # SET column and outer WHERE key both target the physical column (db_column) — #50.
-  sql = "UPDATE $(model.name |> lowercase) SET \"$(Models.model_column(model, field))\" = $(value_sql) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
+  sql = "UPDATE $(safe_table_identifier(Models.model_table_name(model), connection)) SET \"$(Models.model_column(model, field))\" = $(value_sql) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
   if show_query !== :execute
     return _show_query_result(show_query, sql, connection, model, :update, parameters=parameters)
   end

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -204,7 +204,7 @@ function query(q::SQLObjectHandler;
   end
   
   # Quote table name and alias to prevent SQL injection
-  safe_table_name = safe_table_identifier(q.object.model.name, instruction.connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(q.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)  
   
   io = IOBuffer()
@@ -385,7 +385,7 @@ function _count(oq::SQLObjectHandler; column::Union{Nothing, AbstractString} = n
   instruction = build(q.object, table_alias=table_alias, connection=connection, parameters=parameters)
   
   # Quote table name and alias to prevent SQL injection
-  safe_table_name = safe_table_identifier(q.object.model.name, instruction.connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(q.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
   
   # Shared FROM / JOIN / WHERE / GROUP BY body for both count forms.
@@ -494,7 +494,7 @@ function _exists(oq::SQLObjectHandler; table_alias::Union{Nothing, SQLTableAlias
     offset_clause = q.object.offset > 0 ? "OFFSET $(q.object.offset)" : ""
     
     # Quote table name and alias to prevent SQL injection
-    safe_table_name = safe_table_identifier(q.object.model.name, instruction.connection)
+    safe_table_name = safe_table_identifier(Models.model_table_name(q.object.model), instruction.connection)
     safe_alias = quote_identifier(instruction.alias, instruction.connection)
     
     sql = """
@@ -632,7 +632,7 @@ real_obj = objct isa SQLObjectHandler ? objct.object : objct
     _prepare_row_insert!(real_obj, model, settings, connection, parameters)
 
   # construct the SQL statement
-  safe_table_name = safe_table_identifier(string(model.name), connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   sql = """
   INSERT INTO $(safe_table_name) (
     $(join(quoted_field_columns, ", "))
@@ -724,7 +724,7 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
   quoted_field_columns, param_values, pk_exist, pk_field =
     _prepare_row_insert!(real_obj, model, settings, connection, parameters)
 
-  safe_table_name = safe_table_identifier(string(model.name), connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
 
   # Logical → quoted physical (db_column-aware), exactly as bulk_insert renders its clause.
   qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
@@ -853,7 +853,7 @@ function _get_or_create(objct::SQLObject; target_fields::Vector{String}, show_qu
     set_context!(parameters, :select)
     quoted_field_columns, param_values, pk_exist, pk_field =
       _prepare_row_insert!(real_obj, model, settings, connection, parameters)
-    safe_table_name = safe_table_identifier(string(model.name), connection)
+    safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
     qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
     clause  = Dialect.on_conflict_clause(:nothing, qtarget, String[], connection)
     sql = """
@@ -928,10 +928,25 @@ function _get_or_create(objct::SQLObject; target_fields::Vector{String}, show_qu
   return do_goc()
 end
 
+# Escape a value for interpolation inside a single-quoted SQL literal (#59). `db_table` is
+# user-supplied and deliberately not shape-validated, so an embedded `'` would otherwise close the
+# literal early. A no-op for every name that does not contain one.
+_sql_literal(value::AbstractString)::String = replace(String(value), "'" => "''")
+
+# Quote an identifier WITHOUT charset validation (#59) — escape-only, unlike `quote_identifier`,
+# which also rejects anything outside SAFE_IDENTIFIER_PATTERN. For identifiers that come from the
+# database catalog (a `pg_sequences` row) or that PormG constructs itself: they are not user input,
+# and validating them would newly reject legacy names that previously worked.
+_quote_ident_raw(name::AbstractString)::String = "\"$(replace(String(name), "\"" => "\"\""))\""
+
 function _get_owned_sequence_name(connection::PormGPostgres, model::PormGModel, field::String; ignore_tx::Bool = false)
+  # `pg_get_serial_sequence` takes TEXT that it re-parses as an identifier, so an unquoted
+  # mixed-case table folds to lowercase and resolves to nothing. Pass the double-quoted form inside
+  # the literal — `'"Db_Table"'` — which is also correct for an all-lowercase name (#59).
+  table_literal = _sql_literal("\"$(replace(Models.model_table_name(model), "\"" => "\"\""))\"")
   sequence_df = fetch(
     connection,
-    "SELECT pg_get_serial_sequence('$(string(model.name))', '$(field)');";
+    "SELECT pg_get_serial_sequence('$(table_literal)', '$(_sql_literal(field))');";
     ignore_tx=ignore_tx,
   ) |> DataFrames.DataFrame
 
@@ -958,7 +973,10 @@ function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field
       # scan pg_sequences for any sequence whose name starts with the table name.
       seqs_df = fetch(
         connection,
-        "SELECT sequencename FROM pg_sequences WHERE sequencename LIKE '$(string(model.name) |> lowercase)%'";
+        # NOT lowercased (#59): PostgreSQL names the implicit sequence for a quoted `"Db_Table"` as
+        # `Db_Table_id_seq`, and LIKE is case-sensitive — folding here would match nothing and the
+        # sequence would silently never sync. Matches `_fix_sequence_name`'s pattern below.
+        "SELECT sequencename FROM pg_sequences WHERE sequencename LIKE '$(_sql_literal(Models.model_table_name(model)))%'";
         ignore_tx=ignore_tx,
       ) |> DataFrames.DataFrame
       
@@ -967,7 +985,7 @@ function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field
     end
 
     safe_field_name = quote_identifier(col, connection)
-    safe_table_name = safe_table_identifier(string(model.name), connection)
+    safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
     fetch(
       connection,
       "SELECT setval('$sequence_name', COALESCE((SELECT MAX($safe_field_name) FROM $safe_table_name), 0) + 1, false)";
@@ -982,14 +1000,24 @@ function _fix_sequence_name(connection::PormGPostgres, model::PormGModel; ignore
   # after an indexing condition, so BoundsError always won and the guard could never fire.
   length(pk_field) == 0 && throw(QueryBuildError("Cannot fix the PK sequence for model $(model.name): the model does not define a primary key."))
   length(pk_field) > 1 && throw(QueryBuildError("Cannot fix the PK sequence for model $(model.name): composite primary keys are not supported here."))
+  # PostgreSQL names a table's implicit sequence after the table itself, so the pattern and the
+  # rename target both follow the RESOLVED physical name (db_table when set, #59). Byte-identical to
+  # the previous `model.name |> lowercase` for every already-lowercase model.
+  table_name = Models.model_table_name(model)
   sequences = fetch(connection, """SELECT *
       FROM pg_sequences
-      WHERE sequencename LIKE '$(model.name |> lowercase)%';"""; ignore_tx=ignore_tx) |> DataFrames.DataFrame
+      WHERE sequencename LIKE '$(_sql_literal(table_name))%';"""; ignore_tx=ignore_tx) |> DataFrames.DataFrame
   for (index, row) in enumerate(eachrow(sequences))
-    if index == 1 && row.sequencename != "$(model.name |> lowercase)_$(pk_field[1])_seq"
-      fetch(connection, "ALTER SEQUENCE $(row.sequencename) RENAME TO $(model.name |> lowercase)_$(pk_field[1])_seq;"; ignore_tx=ignore_tx)
+    if index == 1 && row.sequencename != "$(table_name)_$(pk_field[1])_seq"
+      # Both sequence names are IDENTIFIERS, so they are quoted rather than escaped as literals — but
+      # via `_quote_ident_raw`, NOT `quote_identifier`. The latter also *validates* the charset and
+      # throws, which would newly abort this call for a legacy sequence named with a `-`, a space or
+      # a leading digit that previously interpolated bare and worked. `row.sequencename` comes from
+      # the `pg_sequences` catalog, not from user input, so escaping is the correct posture here.
+      new_seq = _quote_ident_raw("$(table_name)_$(pk_field[1])_seq")
+      fetch(connection, "ALTER SEQUENCE $(_quote_ident_raw(row.sequencename)) RENAME TO $(new_seq);"; ignore_tx=ignore_tx)
     else
-      fetch(connection, "DROP SEQUENCE $(row.sequencename);"; ignore_tx=ignore_tx)
+      fetch(connection, "DROP SEQUENCE $(_quote_ident_raw(row.sequencename));"; ignore_tx=ignore_tx)
     end
   end
 end
@@ -1007,8 +1035,10 @@ end
 function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::PormGSettings)
   for field in pk_field
     safe_field_name = quote_identifier(Models.model_column(model, field), connection)  # db_column (#50)
-    safe_table_name = safe_table_identifier(string(model.name), connection)
-    safe_table_literal = replace(string(model.name |> lowercase), "'" => "''")
+    safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
+    # Matched against `sqlite_sequence.name`, which holds the table's ACTUAL name — so it must be
+    # the resolved physical name (db_table when set, #59), not a fold of the logical one.
+    safe_table_literal = replace(Models.model_table_name(model), "'" => "''")
     max_id_query = "SELECT MAX($(safe_field_name)) as m FROM $(safe_table_name);"
     # Execute query and convert to DataFrame to safely access the result
     df = fetch(connection, max_id_query) |> DataFrames.DataFrame
@@ -1341,7 +1371,7 @@ function _build_update_target_pk_subquery(instruction::SQLInstruction)::Union{St
   pk_field_sym = get_model_pk_field(instruction.object.model)
   pk_field_sym === nothing && return nothing
 
-  safe_table_name = safe_table_identifier(instruction.object.model.name, instruction.connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(instruction.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
   quoted_pk = quote_identifier(Models.model_column(instruction.object.model, String(pk_field_sym)), instruction.connection)  # db_column (#50)
 
@@ -1467,7 +1497,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   set_clause = join(set_clause_parts, ", ")   
 
   # Build secure UPDATE SQL with JOIN support
-  safe_table_name = safe_table_identifier(string(model.name), connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   safe_alias = quote_identifier(instruction.alias, connection)
   pk_field_sym = get_model_pk_field(model)
   

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -315,7 +315,10 @@ end
 # Reserves n ids from the PostgreSQL sequence associated with pk_field.
 # Uses nextval() inside generate_series so the allocation is a single atomic roundtrip.
 function _allocate_pg_ids(model::PormGModel, connection::PormGPostgres, pk_field::String, n::Int)
-  safe_table = string(model.name |> lowercase)
+  # `pg_get_serial_sequence` re-parses its first argument as an identifier, so an unquoted
+  # mixed-case table folds to lowercase and resolves to nothing. Bind the DOUBLE-QUOTED form; it is
+  # equally correct for an all-lowercase name (#59). Still a bound parameter, not interpolation.
+  safe_table = "\"$(replace(Models.model_table_name(model), "\"" => "\"\""))\""
   parameters = get_parameter(connection)
   set_context!(parameters, :select)
   table_placeholder = add_parameter!(parameters, safe_table)
@@ -344,7 +347,7 @@ end
 # when get_sqlite_reserved_primary_key_max returned non-nothing, which already implies an
 # open transaction (reservation overlay is a no-op at depth 0).
 function _allocate_sqlite_ids(model::PormGModel, connection::PormGSQLite, pk_field::String, n::Int, settings::PormGSettings)
-  safe_table = string(model.name |> lowercase)
+  safe_table = Models.model_table_name(model)
   safe_table_name = safe_table_identifier(safe_table, connection)
   safe_table_literal = replace(safe_table, "'" => "''")
   safe_field = quote_identifier(Models.model_column(model, pk_field), connection)  # db_column (#50)
@@ -1042,7 +1045,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
 
   # Security: Quote table name and physical column names (db_column when set, #50).
   # The CSV is positional (HEADER FALSE), so the data order still matches.
-  safe_table_name = safe_table_identifier(string(model.name), connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields_df]
 
   # Construct the COPY command (CSV format for safety). NULL marker disambiguates ""
@@ -1224,7 +1227,7 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
 
   # Security: Quote table name and physical column names (db_column when set, #50).
   # VALUES rows are positional and built in `fields` order, so they still align.
-  safe_table_name = safe_table_identifier(string(model.name), connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields]
 
   # Construct the bulk insert SQL. The ON CONFLICT clause (#123) is rendered once by the caller
@@ -1511,7 +1514,7 @@ function _bulk_update(model::PormGModel,
   end
 
   # Security: Quote table name and field names
-  safe_table_name = safe_table_identifier(model.name, connection)
+  safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   quoted_fields = [quote_identifier(field, connection) for field in fields]
 
   # Security: Build safe WHERE conditions with quoted identifiers

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -410,4 +410,33 @@ M2m_rpk_driver_scratch = Models.Model("m2m_rpk_driver_scratch",
   sponsors = Models.ManyToManyField(M2m_rpk_sponsor_scratch, related_name="rpkdrivers"),
 )
 
+# #59 — model-level db_table. The LOGICAL name is lowercase (as every model name must be); the
+# PHYSICAL table is mixed-case, which is the spelling PormG could not express before this option.
+# On PostgreSQL a quoted identifier is case-sensitive, so this fixture only round-trips if every
+# renderer — DDL, SELECT/INSERT/UPDATE/DELETE, FK REFERENCES, migration diffing — agrees on
+# "Db_Table_Scratch". SQLite folds case and so cannot catch a disagreement here; that asymmetry is
+# the whole reason these live on both backends.
+Db_table_scratch = Models.Model("db_table_scratch",
+  db_table = "Db_Table_Scratch",
+  id = Models.IDField(),
+  name = Models.CharField(null=true),
+)
+
+# A child whose FK targets the db_table-mapped parent — the REFERENCES clause must name the
+# parent's PHYSICAL table, not its logical name. This is the half that failed silently before #300
+# (the constraint can bind to a different table that merely happens to exist).
+Db_table_child_scratch = Models.Model("db_table_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_table_scratch, on_delete="CASCADE", related_name="dbtchildren", null=true),
+  note = Models.CharField(null=true),
+)
+
+# db_table AND db_column together: the two overrides are independent axes (table vs column) and
+# must both apply to the same statements.
+Db_table_col_scratch = Models.Model("db_table_col_scratch",
+  db_table = "Db_Table_Col_Scratch",
+  id = Models.IDField(),
+  sku = Models.CharField(db_column="product_sku", null=true),
+)
+
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -410,4 +410,32 @@ M2m_rpk_driver_scratch = Models.Model("m2m_rpk_driver_scratch",
   sponsors = Models.ManyToManyField(M2m_rpk_sponsor_scratch, related_name="rpkdrivers"),
 )
 
+# #59 — model-level db_table. The LOGICAL name is lowercase (as every model name must be); the
+# PHYSICAL table is mixed-case, which is the spelling PormG could not express before this option.
+# SQLite's identifiers compare case-insensitively, so this fixture CANNOT prove the mixed-case
+# behavior the way the PostgreSQL side does — it is here to prove the feature does not break the
+# backend that masks it, which is exactly the wrong-way-round shape #276/#300 warn about.
+Db_table_scratch = Models.Model("db_table_scratch",
+  db_table = "Db_Table_Scratch",
+  id = Models.IDField(),
+  name = Models.CharField(null=true),
+)
+
+# A child whose FK targets the db_table-mapped parent — the REFERENCES clause must name the
+# parent's PHYSICAL table. SQLite carries FKs inline in CREATE TABLE, so a mismatch here surfaces
+# as a failed table creation rather than a deferred constraint error.
+Db_table_child_scratch = Models.Model("db_table_child_scratch",
+  id = Models.IDField(),
+  parent = Models.ForeignKey(Db_table_scratch, on_delete="CASCADE", related_name="dbtchildren", null=true),
+  note = Models.CharField(null=true),
+)
+
+# db_table AND db_column together: the two overrides are independent axes (table vs column) and
+# must both apply to the same statements.
+Db_table_col_scratch = Models.Model("db_table_col_scratch",
+  db_table = "Db_Table_Col_Scratch",
+  id = Models.IDField(),
+  sku = Models.CharField(db_column="product_sku", null=true),
+)
+
 end

--- a/test/integration/runtests.jl
+++ b/test/integration/runtests.jl
@@ -32,6 +32,7 @@ include("common_bulk_scratch_setup.jl")
     @testset "PormGRow Mutation"            begin include("test_row_mutation.jl")       end
     @testset "Field-name Case Preservation" begin include("test_field_name_case_db.jl") end
     @testset "db_column Authoritative"       begin include("test_db_column_db.jl")       end
+    @testset "db_table Authoritative"        begin include("test_db_table_db.jl")        end
     @testset "Field Expressions"            begin include("test_field_expressions.jl")  end
     @testset "Updates"                      begin include("test_updates.jl")            end
     @testset "Deletes"                      begin include("test_deletes.jl")            end

--- a/test/integration/test_db_table_db.jl
+++ b/test/integration/test_db_table_db.jl
@@ -1,0 +1,140 @@
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+# column_names()/table_exists() live in the migration setup helpers.
+if !isdefined(Main, :column_names)
+    include("common_migration_setup.jl")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_table (#59) — end-to-end against a live database.
+#
+# The Db_table_scratch / Db_table_child_scratch / Db_table_col_scratch fixtures declare a LOGICAL
+# model name that is lowercase (as every model name must be, #300) and a PHYSICAL table that is
+# mixed-case — the spelling PormG had no way to express before this option.
+#
+# What only a live database can prove, and the unit layer cannot:
+#
+#   * the table is CREATED under the mixed-case name (not a folded twin);
+#   * every subsequent statement finds it — on PostgreSQL a quoted identifier is case-sensitive, so
+#     any renderer still emitting the logical name fails loudly with `relation … does not exist`
+#     rather than rendering a plausible-looking string; and
+#   * the FK constraint actually binds, which is the half that could silently attach to a DIFFERENT
+#     table when the CREATE and the REFERENCES disagreed.
+#
+# SQLite's identifiers compare case-insensitively and so CANNOT distinguish the two spellings. It is
+# covered anyway — the point is that the backend which masks the bug does not regress — but the
+# case-sensitivity assertions below are meaningful only on PostgreSQL.
+# ─────────────────────────────────────────────────────────────────────────────
+
+const DBT_IS_PG = PormG.config[PORMG_DB_FOLDER].connections isa PormG.PormGPostgres
+
+@testset "db_table: the physical table is created under the db_table name" begin
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+
+    # The mixed-case physical table exists and has the declared columns. `column_names` returning a
+    # non-empty set IS the existence proof — a missing table yields an empty result.
+    cols = column_names(pool, "Db_Table_Scratch")
+    @test "id" in cols
+    @test "name" in cols
+
+    # db_table and db_column compose: mixed-case TABLE, renamed COLUMN, same model.
+    ccols = column_names(pool, "Db_Table_Col_Scratch")
+    @test "product_sku" in ccols
+    @test !("sku" in ccols)
+
+    # The LOGICAL name must not exist as a second, folded table. On PostgreSQL these are genuinely
+    # distinct identifiers, so a stray unquoted-DDL path would have created `db_table_scratch`
+    # alongside `Db_Table_Scratch` — exactly the "one declaration, two tables" split #300 describes.
+    # Skipped on SQLite, where the two names address the same table by definition.
+    if DBT_IS_PG
+        @test isempty(column_names(pool, "db_table_scratch"))
+    end
+end
+
+@testset "db_table: CRUD round-trips against the mixed-case table" begin
+    M.Db_table_scratch.objects.delete(allow_delete_all=true)
+
+    created = M.Db_table_scratch.objects.create("name" => "senna")
+    @test created[:name] == "senna"
+
+    # Read back through the normal query path — this is the assertion that fails with
+    # `relation "db_table_scratch" does not exist` if any renderer kept the logical name.
+    row = M.Db_table_scratch.objects.filter("name" => "senna").values("id", "name").first()
+    @test row.name == "senna"
+
+    M.Db_table_scratch.objects.filter("name" => "senna").update("name" => "prost")
+    @test M.Db_table_scratch.objects.filter("name" => "prost").count() == 1
+
+    # DELETE has its own renderer (deletion.jl), which used to write the table bare and lowercased
+    # while its `IN (…)` subquery quoted it — one statement, two spellings.
+    M.Db_table_scratch.objects.filter("name" => "prost").delete()
+    @test M.Db_table_scratch.objects.count() == 0
+end
+
+@testset "db_table: foreign keys bind to the parent's physical table" begin
+    M.Db_table_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_table_scratch.objects.delete(allow_delete_all=true)
+
+    parent = M.Db_table_scratch.objects.create("name" => "ferrari")
+    pid = parent[:id]
+
+    # The INSERT only succeeds if the FK constraint points at the table the parent actually lives
+    # in. A constraint bound to a folded twin would reject this row.
+    child = M.Db_table_child_scratch.objects.create("parent" => pid, "note" => "sf90")
+    @test child[:note] == "sf90"
+
+    # Forward join CHILD → PARENT puts the parent's physical table in the JOIN clause.
+    joined = M.Db_table_child_scratch.objects.filter("note" => "sf90").values("note", "parent__name").first()
+    @test joined.parent__name == "ferrari"
+
+    # Reverse traversal PARENT → CHILD, the other direction through the same relation.
+    back = M.Db_table_scratch.objects.filter("dbtchildren__note" => "sf90").values("name").first()
+    @test back.name == "ferrari"
+
+    # ON DELETE CASCADE reaches the child through the FK — proving the constraint is live in the
+    # database, not merely rendered into the DDL text.
+    M.Db_table_scratch.objects.filter("id" => pid).delete()
+    @test M.Db_table_child_scratch.objects.count() == 0
+end
+
+@testset "db_table: bulk paths and PK allocation target the physical table" begin
+    M.Db_table_scratch.objects.delete(allow_delete_all=true)
+
+    # bulk_insert goes through its own INSERT builder, and PK allocation queries the sequence
+    # (PostgreSQL) / sqlite_sequence (SQLite) named after the PHYSICAL table.
+    bulk_insert(M.Db_table_scratch.objects, DataFrame(name=["a", "b", "c"]))
+    @test M.Db_table_scratch.objects.count() == 3
+
+    # A subsequent auto-PK create must not collide, which means the sequence was found and advanced
+    # — the lookup is built from the table name, so a wrong name silently no-ops instead of erroring.
+    extra = M.Db_table_scratch.objects.create("name" => "d")
+    @test extra[:name] == "d"
+    @test M.Db_table_scratch.objects.count() == 4
+
+    M.Db_table_scratch.objects.delete(allow_delete_all=true)
+end
+
+# The failure with the worst blast radius: the planner matches the LIVE schema (keyed by the
+# physical table name read from the database) against the DECLARED schema. If the declared side
+# keyed on anything else, a db_table model would read as "a table to create" PLUS "a live table
+# nobody declared" — a CREATE and a DROP of a live table that did not change at all.
+#
+# The db_table fixtures were migrated by the same bootstrap as every other model here, so a re-diff
+# must propose NOTHING for them. Scoped to those tables on purpose: asserting global
+# `status().pending` would fold in unrelated drift from other fixtures in this shared database and
+# report a #59 regression that isn't one.
+@testset "db_table: a re-diff proposes nothing for the db_table-mapped tables" begin
+    settings = PormG.config[PORMG_DB_FOLDER]
+    conn = settings.connections
+    live = PormG.Migrations.convert_schema_to_models(conn)
+    declared = PormG.Migrations.get_all_models(M)
+    plan = PormG.Migrations.get_migration_plan(live, declared, conn, settings; interactive = false)
+
+    # No plan entry under EITHER spelling: the physical name (a create/alter the planner thinks it
+    # needs) or the logical one (proof the two sides were keyed differently).
+    for name in (:Db_Table_Scratch, :db_table_scratch, :Db_Table_Col_Scratch, :db_table_col_scratch,
+                 :db_table_child_scratch)
+        @test !haskey(plan, name)
+    end
+end

--- a/test/integration/test_deletes.jl
+++ b/test/integration/test_deletes.jl
@@ -370,7 +370,7 @@ end
     # Keyless fixture tables have a dedicated delete path:
     #   • A filtered delete on a keyless model must be rejected with
     #     ArgumentError (no PK to build a WHERE … IN subquery).
-    #   • allow_delete_all=true must emit a bare DELETE FROM … and remove all rows.
+    #   • allow_delete_all=true must emit an unfiltered DELETE FROM … (no WHERE) and remove all rows.
     #   • show_query=:dict on the unfiltered path must return meaningful SQL
     #     without touching data.
     # ─────────────────────────────────────────────────────────────────────────
@@ -390,7 +390,9 @@ end
         @test inspection[:operation] === :delete
         @test inspection[:parameter_count] == 0
         @test isempty(inspection[:parameters])
-        @test occursin("delete from lap_times", lowercase(inspection[:sql_text]))
+        # Table identifier is QUOTED since #59 (db_table) — it used to be written bare, which was
+        # indistinguishable from this while every table name was lowercase.
+        @test occursin("delete from \"lap_times\"", lowercase(inspection[:sql_text]))
 
         # Now exercise the actual delete-all path against the scratch table so
         # we do not touch the seeded F1 fixture data.
@@ -483,7 +485,7 @@ end
 
             @test inspection isa Dict
             @test inspection[:operation] == :delete
-            @test occursin("delete from do_nothing_parent_scratch", lowercase(inspection[:sql_text]))
+            @test occursin("delete from \"do_nothing_parent_scratch\"", lowercase(inspection[:sql_text]))
 
             # Live delete — the database refuses it on both backends since #276.
             delete_q = DoNothingM.Do_nothing_parent_scratch.objects
@@ -828,7 +830,7 @@ end
 
             @test inspection isa Dict
             @test inspection[:operation] == :delete
-            @test occursin("delete from delete_protect_parent_scratch", lowercase(inspection[:sql_text]))
+            @test occursin("delete from \"delete_protect_parent_scratch\"", lowercase(inspection[:sql_text]))
 
             # Live delete of the orphaned parent must succeed.
             delete_q = ProtectM.Delete_protect_parent_scratch.objects

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
     @testset "Field-name Case Preservation (#57)" include("unit/test_field_name_case.jl")
     @testset "Model-name Case (#300)" include("unit/test_model_name_case.jl")
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
+    @testset "db_table Authoritative (#59)" include("unit/test_db_table.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
     @testset "JSON Path Lookups (#27)" include("unit/test_json_lookups.jl")

--- a/test/unit/test_db_table.jl
+++ b/test/unit/test_db_table.jl
@@ -1,0 +1,405 @@
+"""
+Unit coverage for the model-level `db_table` option (#59).
+
+`db_table` makes the physical SQL table name differ from the model's declared (logical) name,
+Django `Meta.db_table`-style: `Model("driver_races", db_table = "Driver_Races", …)` keeps model
+identity `driver_races` but renders the table `"Driver_Races"` in DDL, SELECT/INSERT/UPDATE/DELETE,
+JOINs, foreign-key `REFERENCES` targets, and migration diffing. It is the table-level sibling of
+`db_column` (#50), and its value is carried **verbatim** — no case fold, no underscore strip.
+
+The default (table == model name) is unchanged, so existing schemas are unaffected (non-breaking).
+
+Two things this file deliberately pins beyond the happy path:
+
+  * the resolution seam is ONE function (`model_table_name`), so a renderer that forgets it shows up
+    as a spelling mismatch here rather than as a wrong-table write in production; and
+  * `ManyToManyField(db_table = …)`, which pre-dates this option and used to silently lowercase its
+    argument, now follows the same case-preserving policy — the two seams express the same intent.
+
+All assertions render via mock PostgreSQL/SQLite connections (no live database required).
+"""
+
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, ManyToManyField,
+                    UniqueConstraint, model_table_name, model_has_db_table, fk_target_table,
+                    Model_to_str
+using PormG.QueryBuilder: inspect_query
+
+# Dedicated mock connections + config key — uniquely named so they never clash with other unit
+# files' mock structs when runtests.jl includes them all into the same module.
+struct MockPostgresDbTable <: PormG.PormGPostgres end
+struct MockSQLiteDbTable <: PormG.PormGSQLite end
+PormG.config["db_table_mock"] = PormG.Configuration.Settings(
+  connections = MockPostgresDbTable(),
+  change_data = true,
+)
+
+# The headline fixture: logical name `dbt_driver_scratch`, physical table `Dbt_Driver_Scratch`.
+# The two differ in case ONLY, which is the case that used to be unrepresentable — a positional
+# mixed-case name is rejected (#300) and there was nowhere else to put the physical spelling.
+DbtDriver = Model("dbt_driver_scratch",
+  db_table = "Dbt_Driver_Scratch",
+  id      = IDField(),
+  surname = CharField(),
+)
+DbtDriver.connect_key = "db_table_mock"
+
+# A child whose FK targets the db_table-mapped parent — exercises fk_target_table.
+DbtResult = Model("dbt_result_scratch",
+  id       = IDField(),
+  driverid = ForeignKey(DbtDriver, pk_field = "id", on_delete = "CASCADE"),
+  points   = IntegerField(),
+)
+DbtResult.connect_key = "db_table_mock"
+
+# Control: no db_table at all. Every assertion about this model is an assertion that the option is
+# inert when unused.
+DbtPlain = Model("dbt_plain_scratch",
+  id   = IDField(),
+  nome = CharField(),
+)
+DbtPlain.connect_key = "db_table_mock"
+
+@testset "db_table authoritative (#59)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # model_table_name: db_table when set & non-empty, else model.name. The single seam every
+  # renderer resolves through — if this is wrong, everything below is wrong in the same direction.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "model_table_name / model_has_db_table" begin
+    @test model_table_name(DbtDriver) == "Dbt_Driver_Scratch"
+    @test model_table_name(DbtPlain)  == "dbt_plain_scratch"   # falls back to the logical name
+    @test model_has_db_table(DbtDriver)
+    @test !model_has_db_table(DbtPlain)
+
+    # The logical name is untouched — db_table is an override, not a rename.
+    @test DbtDriver.name == "dbt_driver_scratch"
+
+    # An empty string is "unset", mirroring `field_db_column`'s (#50) treatment of an empty
+    # db_column — so it falls back rather than producing a nameless table.
+    empty_dbt = Model("dbt_empty_scratch", db_table = "", id = IDField())
+    @test empty_dbt.db_table === nothing
+    @test model_table_name(empty_dbt) == "dbt_empty_scratch"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Constructor plumbing. `db_table` has to be peeled off BEFORE the `fields...` slurp, exactly
+  # like `constraints` — otherwise it reaches the field loop and trips the `isa PormGField` check
+  # with a message about field types, which is the confusing failure the peel exists to prevent.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "constructor accepts and validates db_table" begin
+    # Both entry points take it: positional-name and no-positional-name (binding-derived) forms.
+    @test Model("dbt_named_scratch", db_table = "X_Named", id = IDField()).db_table == "X_Named"
+    @test Model(db_table = "X_Anon", id = IDField()).db_table == "X_Anon"
+
+    # It composes with `constraints`, the other model-level option — neither peel eats the other.
+    both = Model("dbt_both_scratch", db_table = "X_Both",
+      id = IDField(), a = IntegerField(), b = IntegerField(),
+      constraints = [UniqueConstraint(fields = ("a", "b"), name = "dbt_both_uniq")],
+    )
+    @test both.db_table == "X_Both"
+    @test haskey(both.cache, "unique_constraints")
+
+    # A non-String is a definition-time error naming the option, not a field-type error.
+    err = try
+      Model("dbt_bad_scratch", db_table = 42, id = IDField()); nothing
+    catch e; e end
+    @test err isa PormG.ModelDefinitionError
+    @test occursin("db_table", err.msg)
+
+    # NOT normalized: no case fold, no leading-underscore strip, no identifier-shape check. The
+    # whole point is to carry an arbitrary legacy spelling the ORM would never generate itself.
+    @test Model("dbt_verbatim_scratch", db_table = "MiXeD_CaSe", id = IDField()).db_table == "MiXeD_CaSe"
+    @test Model("dbt_underscore_scratch", db_table = "_leading", id = IDField()).db_table == "_leading"
+
+    # …while the POSITIONAL name keeps its own rules (#300/#306) — db_table is the escape valve for
+    # a physical name those rules reject, not a way to relax them. Assert on the CAUSE, so this
+    # cannot pass because the db_table validator happened to throw for an unrelated reason.
+    case_err = try
+      Model("Mixed_Case", db_table = "whatever", id = IDField()); nothing
+    catch e; e end
+    @test case_err isa PormG.ModelDefinitionError
+    @test occursin("must be lowercase", case_err.msg)
+
+    # NAME COLLISION. Because `db_table` is peeled off before the `fields...` slurp, a FIELD named
+    # `db_table` can no longer be declared that way — it is read as the option and fails the type
+    # check. Loud, not silent, which is the point (the older `constraints` peel dies with a raw
+    # MethodError instead). The underscore escape hatch is the supported spelling.
+    field_err = try
+      Model("dbt_collide_scratch", id = IDField(), db_table = CharField()); nothing
+    catch e; e end
+    @test field_err isa PormG.ModelDefinitionError
+    @test occursin("db_table", field_err.msg)
+
+    escaped = Model("dbt_escape_scratch", id = IDField(), _db_table = CharField())
+    @test haskey(escaped.fields, "db_table")          # the COLUMN is named db_table…
+    @test escaped.db_table === nothing                # …and the OPTION is untouched
+    @test occursin("\"db_table\"", PormG.Dialect.create_table(MockPostgresDbTable(), escaped))
+
+    # A TABLE named `db_table` collides with nothing — the option's name and a table's name live in
+    # different places entirely.
+    @test model_table_name(Model("db_table", id = IDField())) == "db_table"
+    @test model_table_name(Model("dbt_alias_scratch", db_table = "db_table", id = IDField())) == "db_table"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # DDL. The table identifier is QUOTED (#59) — it used to be written bare, which was invisible
+  # while every name was lowercase but would silently fold a mixed-case db_table on PostgreSQL.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "create_table renders db_table on both backends" begin
+    for conn in (MockPostgresDbTable(), MockSQLiteDbTable())
+      ddl = PormG.Dialect.create_table(conn, DbtDriver)
+      @test occursin("CREATE TABLE IF NOT EXISTS \"Dbt_Driver_Scratch\"", ddl)
+      @test !occursin("dbt_driver_scratch", ddl)   # the logical name never reaches the DDL
+
+      # Columns are unaffected — db_table is a table-level option and touches nothing below it.
+      @test occursin("\"surname\"", ddl)
+
+      # Unset db_table still renders the logical name, quoted the same way.
+      plain_ddl = PormG.Dialect.create_table(conn, DbtPlain)
+      @test occursin("CREATE TABLE IF NOT EXISTS \"dbt_plain_scratch\"", plain_ddl)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Foreign keys. This is the half that made the mixed-case model name a SILENT bug rather than a
+  # loud one before #300: a FK renders its target through a different code path than the one that
+  # creates the table, so the two could disagree and bind to a table that merely happens to exist.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "FK REFERENCES resolves to the target's db_table" begin
+    @test fk_target_table(DbtResult.fields["driverid"]) == "Dbt_Driver_Scratch"
+
+    # SQLite carries FKs inline in CREATE TABLE — the created table and the referenced one are
+    # rendered by the same call here, so this asserts they agree as ONE string.
+    child_ddl = PormG.Dialect.create_table(MockSQLiteDbTable(), DbtResult)
+    @test occursin("REFERENCES \"Dbt_Driver_Scratch\"(\"id\")", child_ddl)
+    @test !occursin("REFERENCES \"dbt_driver_scratch\"", child_ddl)
+
+    # An UNRESOLVED (String) target keeps the pre-existing format_model_name fallback — that is the
+    # introspection/pre-set_models shape, where there is no model object to read a db_table off.
+    strfk = Model("dbt_strfk_scratch",
+      id = IDField(), other = ForeignKey("Some_Model", pk_field = "id", on_delete = "CASCADE"))
+    @test fk_target_table(strfk.fields["other"]) == "some_model"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Reads. The base table and any JOIN target both resolve through the same seam.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "SELECT and JOIN render db_table" begin
+    sel = inspect_query(DbtDriver.objects)[:sql_text]
+    @test occursin("FROM \"Dbt_Driver_Scratch\"", sel)
+    @test !occursin("dbt_driver_scratch", sel)
+
+    # A JOIN resolves the FK target through the model's owning module, so the fixtures need one.
+    # Wiring `_module`/`connect_key` by hand rather than calling `set_models`, which would try to
+    # LOAD a connection folder off disk — this file is deliberately DB-free.
+    jmod = Module(:DbtJoinScratch)
+    Base.eval(jmod, :(using PormG))
+    jdriver = Model("dbtj_driver_scratch",
+      db_table = "Dbtj_Driver_Scratch", id = IDField(), surname = CharField())
+    jresult = Model("dbtj_result_scratch",
+      id = IDField(), points = IntegerField(),
+      driverid = ForeignKey(jdriver, pk_field = "id", on_delete = "CASCADE"))
+    for (bind, m) in ((:Dbtj_driver_scratch, jdriver), (:Dbtj_result_scratch, jresult))
+      m._module = jmod
+      m.connect_key = "db_table_mock"
+      Base.eval(jmod, :(const $bind = $m))
+    end
+
+    # Joining CHILD → PARENT puts the PARENT's db_table in the JOIN clause, while the child (which
+    # declares none) keeps its logical name — both resolved through the same seam.
+    joined = inspect_query(jresult.objects.values("points", "driverid__surname"))[:sql_text]
+    @test occursin("\"Dbtj_Driver_Scratch\"", joined)
+    @test !occursin("dbtj_driver_scratch", joined)
+    @test occursin("\"dbtj_result_scratch\"", joined)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Writes. INSERT/UPDATE go through the query builder; DELETE has its own renderer in deletion.jl
+  # which used to write the table BARE and lowercased — a second spelling of the same table in the
+  # same statement as its (quoted) subquery.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "INSERT, UPDATE and DELETE render db_table" begin
+    ins = DbtDriver.objects.create("id" => 1, "surname" => "Senna", show_query = :sql)
+    @test occursin("INSERT INTO \"Dbt_Driver_Scratch\"", ins)
+
+    upd = DbtDriver.objects.filter("id" => 1).update("surname" => "Prost", show_query = :sql)
+    @test occursin("UPDATE \"Dbt_Driver_Scratch\"", upd)
+
+    del_raw = DbtDriver.objects.filter("id" => 1).delete(show_query = :dict)
+    del = del_raw isa Vector ? first(del_raw) : del_raw
+    @test occursin("DELETE FROM \"Dbt_Driver_Scratch\"", del[:sql_text])
+    # The outer DELETE and its `IN (...)` subquery are rendered by two different code paths; the
+    # whole point of the single seam is that they cannot disagree. Assert the logical name appears
+    # NOWHERE in the statement, which is what "they agree" means here.
+    @test !occursin("dbt_driver_scratch", del[:sql_text])
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Migration diffing. This is the failure with the worst blast radius: the planner matches the
+  # LIVE schema (keyed by the physical table name it read from the database) against the DECLARED
+  # schema. If the declared side keys on anything else, a db_table model looks like "a table that
+  # does not exist yet" plus "a live table nobody declared" — i.e. CREATE + DROP of a live table
+  # that did not structurally change at all.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "planner keys the declared schema on the physical table name" begin
+    mod = Module(:DbtPlannerScratch)
+    Base.eval(mod, :(using PormG))
+    # Binding name, logical name and physical name are all DIFFERENT here on purpose — only a
+    # db_table-aware key lands on the physical one.
+    Base.eval(mod, :(Whatever = PormG.Models.Model("dbt_logical_scratch",
+      db_table = "Dbt_Physical_Scratch", id = PormG.Models.IDField())))
+
+    declared = PormG.Migrations.get_all_models(mod)
+    @test haskey(declared, Symbol("Dbt_Physical_Scratch"))
+    @test !haskey(declared, :dbt_logical_scratch)   # not the logical name
+    @test !haskey(declared, :whatever)              # and not the Julia binding
+
+    # A model WITHOUT db_table still keys on its own name, exactly as before.
+    Base.eval(mod, :(Plain = PormG.Models.Model("dbt_plain_keyed_scratch", id = PormG.Models.IDField())))
+    @test haskey(PormG.Migrations.get_all_models(mod), :dbt_plain_keyed_scratch)
+
+    # …and the RENDERED PLAN must agree with that key. Asserting only on `get_all_models` is not
+    # enough: `get_migration_plan` funnels every model through `strip_many_to_many_fields`, which
+    # rebuilds `Model_Type` field by field — an omitted slot silently defaults. When `db_table` was
+    # dropped there, the plan key was the physical name while the DDL it rendered used the logical
+    # one, so `CREATE TABLE` and the FK `REFERENCES` disagreed and a second `makemigrations`
+    # proposed dropping the live table. This is the assertion that would have caught it.
+    settings = PormG.Configuration.Settings(connections = MockPostgresDbTable(), change_data = true)
+    plan = PormG.Migrations.get_migration_plan(
+      PormG.PormGModel[], PormG.Migrations.get_all_models(mod), MockPostgresDbTable(), settings;
+      interactive = false)
+    ddl = join(values(plan[Symbol("Dbt_Physical_Scratch")]), "\n")
+    @test occursin("\"Dbt_Physical_Scratch\"", ddl)
+    @test !occursin("dbt_logical_scratch", ddl)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # strip_many_to_many_fields rebuilds a Model_Type slot by slot, so anything it forgets is silently
+  # lost — and EVERY model on the migration path goes through it. Pinned directly, because the
+  # symptom (a plan that creates the wrong table) is several layers away from the cause.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "strip_many_to_many_fields carries db_table" begin
+    stripped = PormG.Models.strip_many_to_many_fields(DbtDriver)
+    @test model_table_name(stripped) == "Dbt_Driver_Scratch"
+    @test stripped.name == "dbt_driver_scratch"   # …and the logical name is still intact
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Two renderers reach a model's table through paths the forward-FK JOIN does not: a REVERSE
+  # relation (which stores only the LOGICAL name in `related_objects`, so the resolved model is the
+  # sole source of a db_table) and an `Exists()` subquery (its own FROM builder). Both were missed
+  # on the first pass and are asserted here with the db_table on the model being *reached*.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "reverse joins and Exists() subqueries render db_table" begin
+    rmod = Module(:DbtReverseScratch)
+    Base.eval(rmod, :(using PormG))
+    rparent = Model("dbtr_parent_scratch", id = IDField(), nome = CharField())
+    # The CHILD is the one carrying db_table here — it is the table a reverse traversal reaches.
+    rchild = Model("dbtr_child_scratch", db_table = "Dbtr_Child_Legacy",
+      id = IDField(), note = CharField(),
+      parentid = ForeignKey(rparent, pk_field = "id", on_delete = "CASCADE", related_name = "kids"))
+    for (bind, m) in ((:Dbtr_parent_scratch, rparent), (:Dbtr_child_scratch, rchild))
+      m._module = rmod
+      m.connect_key = "db_table_mock"
+      Base.eval(rmod, :(const $bind = $m))
+    end
+    # The reverse-accessor tuple `set_models` would install: (child FK field, parent's referenced
+    # field, child model's LOGICAL name, child PK). Note the third slot is the logical name — which
+    # is precisely why the reverse renderer must consult the resolved model for a db_table.
+    rparent.related_objects["kids"] = (:parentid, :id, :dbtr_child_scratch, :id)
+
+    rev = inspect_query(rparent.objects.values("nome", "kids__note"))[:sql_text]
+    @test occursin("\"Dbtr_Child_Legacy\"", rev)
+    @test !occursin("\"dbtr_child_scratch\"", rev)
+
+    ex = inspect_query(rparent.objects.filter(
+      PormG.QueryBuilder.Exists(rchild.objects.filter("note" => "x"))))[:sql_text]
+    @test occursin("\"Dbtr_Child_Legacy\"", ex)
+    @test !occursin("\"dbtr_child_scratch\"", ex)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Round-trip through the generated model file. `inspectdb` and the Django importer write a model
+  # file that must re-declare the SAME physical table when it is loaded back.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "Model_to_str round-trips db_table" begin
+    settings = PormG.Configuration.Settings(connections = MockPostgresDbTable(), change_data = true)
+
+    generated = Model_to_str(DbtDriver, settings)
+    @test occursin("db_table = \"Dbt_Driver_Scratch\"", generated)
+    @test occursin("Models.Model(\"dbt_driver_scratch\"", generated)   # logical name stays positional
+
+    # ACTUALLY round-trip it, rather than string-matching the text: evaluating the generated
+    # declaration must produce a model resolving to the SAME physical table. That is the property
+    # the testset name claims, and string assertions alone cannot establish it.
+    rmod = Module(:DbtRoundTripScratch)
+    Base.eval(rmod, :(using PormG))
+    Base.eval(rmod, :(const Models = PormG.Models))
+    reloaded = Base.eval(rmod, Meta.parse(generated))
+    @test model_table_name(reloaded) == "Dbt_Driver_Scratch"
+    @test reloaded.name == "dbt_driver_scratch"
+
+    # No db_table declared → no db_table emitted. A redundant override would be noise in every
+    # generated file and would freeze a name the user never pinned.
+    @test !occursin("db_table", Model_to_str(DbtPlain, settings))
+
+    # An introspected LEADING-UNDERSCORE table (#306 rejects that spelling positionally): the name is
+    # stripped for the positional slot and pinned as db_table, so the file both LOADS and addresses
+    # the right table. Before, it generated `Model("_order", …)` — which threw on reload.
+    underscore_tbl = Model("_dbt_order_scratch", Dict{String, PormG.PormGField}("id" => IDField()))
+    ugen = Model_to_str(underscore_tbl, settings; name_is_physical_table = true)
+    @test occursin("db_table = \"_dbt_order_scratch\"", ugen)
+    ureloaded = Base.eval(rmod, Meta.parse(ugen))
+    @test model_table_name(ureloaded) == "_dbt_order_scratch"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # `db_table` is an IDENTIFIER, so it is quoted rather than bound as a parameter — and it is
+  # deliberately not shape-validated, so an embedded `"` must be escaped or it closes the quoted
+  # identifier early and the rest of the value becomes SQL. Asserted across every DDL renderer that
+  # writes a table name, since escaping at one site and not the next is the shape this can regress to.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "an embedded quote in db_table cannot break out of the identifier" begin
+    evil = "x\" (id int); DROP TABLE drivers; --"
+    m = Model("dbt_evil_scratch", db_table = evil, id = IDField())
+    tbl = PormG.Models.model_table_name(m)
+    # These renderers declare `table_name::Union{String,Symbol}` and the MIGRATION path reaches them
+    # with a Symbol (the planner keys its plan by one) while every unit fixture passed a String — so
+    # a String-only escape helper compiled fine and blew up only under a live migration. Both types
+    # are exercised here for that reason.
+    for conn in (MockPostgresDbTable(), MockSQLiteDbTable()), t in (tbl, Symbol(tbl))
+      stmts = String[
+        PormG.Dialect.create_table(conn, m),
+        PormG.Dialect.drop_table(conn, t),
+        PormG.Dialect.add_field(conn, t, "c", CharField()),
+        PormG.Dialect.drop_field(conn, t, "c"),
+        PormG.Dialect.rename_field(conn, t, "c", "d"),
+        PormG.Dialect.rename_table(conn, tbl, "z"),
+      ]
+      for sql in stmts
+        # The `"` that would have terminated the identifier is DOUBLED, so the payload stays inside
+        # it as data rather than becoming statements.
+        @test occursin("x\"\" (id int); DROP TABLE drivers; --", sql)
+        # …and the un-doubled form — the one that would close the identifier and let `DROP TABLE
+        # drivers` execute — appears nowhere. `x" (` can only occur if a renderer skipped escaping.
+        @test !occursin("x\" (", sql)
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # ManyToManyField(db_table = …) predates this option and applied the OPPOSITE policy: it ran the
+  # value through `format_model_name`, silently lowercasing it (and stripping a leading
+  # underscore). Same user intent — "this table is called X" — so it now behaves the same way.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "ManyToManyField db_table preserves case too" begin
+    m2m = ManyToManyField("dbt_driver_scratch", db_table = "Dbt_Driver_Races")
+    @test m2m.db_table == "Dbt_Driver_Races"      # was "dbt_driver_races" before #59
+
+    # Empty-as-unset, matching the model-level option.
+    @test ManyToManyField("dbt_driver_scratch", db_table = "").db_table === nothing
+    @test ManyToManyField("dbt_driver_scratch").db_table === nothing
+  end
+end

--- a/test/unit/test_model_name_case.jl
+++ b/test/unit/test_model_name_case.jl
@@ -168,17 +168,16 @@ NameCaseDriver.connect_key = "model_name_case_mock"
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # CHARACTERIZATION: the split the guard prevents is real, and still reachable through the exempt
-  # `Dict` path. Without this, every assertion above is compatible with the split never having
-  # existed — the guard would look like cargo cult. Here the same model renders `driver_profile` in
-  # the DDL and `"Driver_Profile"` in the SELECT: one declaration, two tables.
+  # CLOSED (#59). This testset used to CHARACTERIZE the DDL/query split on the exempt `Dict` path —
+  # `create_table` folded `Driver_Profile` to `driver_profile` while the query builder quoted it as
+  # declared, so one model addressed two tables. Its own comment said it was "SUPPOSED TO FAIL" once
+  # the split was closed properly, naming #59's `db_table` as one of the ways that could happen.
   #
-  # This is a characterization test, not an endorsement. If the split is ever closed properly
-  # (folding or preserving case across both paths — options A/B/D on #300, or #59's `db_table`),
-  # THIS TESTSET IS SUPPOSED TO FAIL, and updating it is the deliberate signal that the scope limit
-  # documented above no longer applies.
+  # That is what happened. `model_table_name` is now the single seam every renderer resolves through
+  # and it applies NO case fold, so the DDL and the query agree by construction — on this exempt path
+  # too, where `model.name` IS the live physical name read out of a database.
   # ─────────────────────────────────────────────────────────────────────────────
-  @testset "characterize: the DDL/query split is real on the exempt path" begin
+  @testset "the DDL/query split is CLOSED, including on the exempt path (#59)" begin
     split_model = Model("Driver_Profile", Dict{String, PormG.PormGField}(
       "id" => IDField(), "surname" => CharField()))
     split_model.connect_key = "model_name_case_mock"
@@ -186,33 +185,32 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     ddl = PormG.Dialect.create_table(MockPostgresNameCase(), split_model)
     sel = inspect_query(split_model.objects)[:sql_text]
 
-    @test occursin("driver_profile", ddl)          # DDL folds…
-    @test !occursin("Driver_Profile", ddl)
-    @test occursin("\"Driver_Profile\"", sel)      # …the query quotes it as declared
+    @test occursin("\"Driver_Profile\"", ddl)      # DDL preserves the name it was given…
+    @test !occursin("driver_profile", ddl)         # …and no longer folds it into a second table
+    @test occursin("\"Driver_Profile\"", sel)      # …which is the SAME string the query addresses
     @test !occursin("\"driver_profile\"", sel)
 
-    # The sharpest illustration, and the reason DELETE is characterized here rather than asserted as
-    # "agreeing" anywhere: ONE statement carries BOTH spellings. `deletion.jl` writes the outer table
-    # bare and lowercased, while the `IN (...)` subquery is rendered by the normal builder and quoted
-    # verbatim — so the DELETE targets `driver_profile` by way of a subquery reading
-    # `"Driver_Profile"`, a table that does not exist on PostgreSQL.
+    # DELETE was the sharpest illustration of the defect — ONE statement carrying BOTH spellings,
+    # because `deletion.jl` wrote the outer table bare+folded while the `IN (...)` subquery went
+    # through the normal (quoting) builder. Both halves now resolve through `model_table_name`.
     del_raw = split_model.objects.filter("id" => 1).delete(show_query = :dict)
     del = del_raw isa Vector ? first(del_raw) : del_raw
-    @test occursin("DELETE FROM driver_profile", del[:sql_text])   # bare + folded
-    @test occursin("\"Driver_Profile\"", del[:sql_text])           # …and quoted verbatim, same string
+    @test occursin("DELETE FROM \"Driver_Profile\"", del[:sql_text])   # quoted + unfolded
+    @test !occursin("DELETE FROM driver_profile", del[:sql_text])      # the old bare+folded spelling
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # CHARACTERIZATION (#306): the create/REFERENCES split the underscore guard prevents is real, and
-  # still reachable through the exempt `Dict` path — the issue's own repro, DB-free via SQLite's inline
-  # FK. `create_table` writes the PARENT's name verbatim (`_fk306_driver_scratch`); the CHILD's
-  # `ForeignKey` renders through `format_model_name`, which strips the leading underscore
-  # (`fk306_driver_scratch`) — a table one character removed from the one actually created.
+  # CLOSED (#59), same story one character over. This used to characterize the create/REFERENCES
+  # split from #306: `create_table` wrote the parent's name verbatim while a child's `ForeignKey`
+  # rendered its target through `format_model_name`, which strips a leading underscore — so the FK
+  # pointed at a table one character removed from the one created. Its comment likewise said it was
+  # "SUPPOSED TO FAIL" once the split closed for the exempt path.
   #
-  # This is a characterization test, not an endorsement. If this split is ever closed for the exempt
-  # path too, THIS TESTSET IS SUPPOSED TO FAIL.
+  # `fk_target_table` now resolves a RESOLVED model target through `model_table_name` (no strip, no
+  # fold), so both sides agree. Declaring such a name positionally is still rejected (#306) — this is
+  # the introspection path, where the name is read from a live database and must survive verbatim.
   # ─────────────────────────────────────────────────────────────────────────────
-  @testset "characterize: the create/REFERENCES split is real on the exempt path (#306)" begin
+  @testset "the create/REFERENCES split is CLOSED on the exempt path (#306 → #59)" begin
     fk_parent = Model("_fk306_driver_scratch", Dict{String, PormG.PormGField}("id" => IDField()))
     fk_child = Model("fk306_child_scratch",
       id       = IDField(),
@@ -222,9 +220,9 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     parent_ddl = PormG.Dialect.create_table(MockSQLiteNameCase(), fk_parent)
     child_ddl  = PormG.Dialect.create_table(MockSQLiteNameCase(), fk_child)
 
-    @test occursin("_fk306_driver_scratch", parent_ddl)                    # the table actually created…
-    @test occursin("REFERENCES \"fk306_driver_scratch\"", child_ddl)       # …a DIFFERENT table referenced
-    @test !occursin("REFERENCES \"_fk306_driver_scratch\"", child_ddl)
+    @test occursin("\"_fk306_driver_scratch\"", parent_ddl)                # the table actually created…
+    @test occursin("REFERENCES \"_fk306_driver_scratch\"", child_ddl)      # …is the one referenced
+    @test !occursin("REFERENCES \"fk306_driver_scratch\"", child_ddl)      # not the stripped spelling
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -243,11 +241,31 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     introspected = Model("Driver_Profile", Dict{String, PormG.PormGField}("id" => IDField()))
     @test introspected.name == "Driver_Profile"
 
-    # …and the generated model file lowercases it, so the round-trip produces a declaration that the
-    # guard above accepts rather than one that would throw on reload.
+    # …and the generated model file lowercases the POSITIONAL name, so the round-trip produces a
+    # declaration the guard above accepts rather than one that would throw on reload.
+    #
+    # The two exempt paths diverge HERE, and the difference is load-bearing (#59). `model.name` is a
+    # Python CLASS name for the Django importer and a LIVE TABLE name for `inspectdb` — identical as
+    # strings, opposite in meaning — so `Model_to_str` is TOLD which it has rather than guessing.
     settings = PormG.Configuration.Settings(connections = MockPostgresNameCase(), change_data = true)
+
+    # Django importer (name_is_physical_table = false, the default): the physical table genuinely IS
+    # the lowercased class name. Pinning `db_table = "CustomUser"` here would invent a table that
+    # does not exist and break every query against it.
     generated = Models.Model_to_str(django_like, settings)
     @test occursin("Models.Model(\"customuser\"", generated)
     @test !occursin("Models.Model(\"CustomUser\"", generated)
+    @test !occursin("db_table", generated)
+
+    # inspectdb (name_is_physical_table = true): the name came off a live database, so the original
+    # spelling MUST be pinned — otherwise the generated declaration addresses `driver_profile`, a
+    # different table from the `Driver_Profile` it was read from (the #300 split, from the other end).
+    introspected_gen = Models.Model_to_str(introspected, settings; name_is_physical_table = true)
+    @test occursin("Models.Model(\"driver_profile\"", introspected_gen)
+    @test occursin("db_table = \"Driver_Profile\"", introspected_gen)
+
+    # An already-lowercase live table needs no override, and must not grow a redundant one.
+    plain = Model("plain_scratch", Dict{String, PormG.PormGField}("id" => IDField()))
+    @test !occursin("db_table", Models.Model_to_str(plain, settings; name_is_physical_table = true))
   end
 end

--- a/test/unit/test_schema_conventions.jl
+++ b/test/unit/test_schema_conventions.jl
@@ -35,14 +35,26 @@ _fk_ddl(; fk_kw...) = PormG.Dialect.create_table(MockSLConv(),
     # in the DDL — but it is now guaranteed at declaration instead of by folding downstream.
     @testset "Table name is the model name, verbatim and unpluralized" begin
         ddl = PormG.Dialect.create_table(MockSLConv(), Models.Model("driver", driverid = Models.IDField()))
-        @test occursin("CREATE TABLE IF NOT EXISTS driver (", ddl)
+        # QUOTED since #59: `create_table` used to write the table identifier bare, which was
+        # indistinguishable from this while every table name was lowercase — but an unquoted
+        # mixed-case `db_table` would fold to lowercase on PostgreSQL and split the DDL from every
+        # (already-quoted) query-side site. The CONVENTION under freeze here is the NAME — verbatim,
+        # unpluralized — not the quoting style, which is now uniform with column identifiers.
+        @test occursin("CREATE TABLE IF NOT EXISTS \"driver\" (", ddl)
         @test !occursin("drivers", ddl)   # no pluralization, no Inflector
     end
 
     # The other half of the same convention, post-#300: a name that WOULD have needed folding is a
-    # declaration-time error rather than a schema that half-works.
+    # declaration-time error rather than a schema that half-works. Since #59 the escape valve is
+    # `db_table`, which carries the physical spelling while the positional name stays logical.
     @testset "A non-lowercase positional name is rejected (#300)" begin
         @test_throws PormG.ModelDefinitionError Models.Model("Driver", driverid = Models.IDField())
+
+        # …and `db_table` is how that intent is expressed instead (#59): one declaration, one table,
+        # spelled exactly as given.
+        pinned = Models.Model("driver_legacy", db_table = "Driver_Legacy", driverid = Models.IDField())
+        @test occursin("CREATE TABLE IF NOT EXISTS \"Driver_Legacy\" (",
+                       PormG.Dialect.create_table(MockSLConv(), pinned))
     end
 
     # FK column = the declared field name, verbatim. PormG never appends `_id` (that is the Django

--- a/test/unit/test_sequence_sync.jl
+++ b/test/unit/test_sequence_sync.jl
@@ -48,7 +48,11 @@ end
   PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
 
   @test length(SEQUENCE_SYNC_SQL) == 2
-  @test SEQUENCE_SYNC_SQL[1] == "SELECT pg_get_serial_sequence('drivers', 'id');"
+  # The table argument is passed DOUBLE-QUOTED inside the literal since #59. `pg_get_serial_sequence`
+  # takes text that it re-parses as an identifier, so an unquoted argument is lowercased — which
+  # resolves to nothing for a mixed-case `db_table`. `'"drivers"'` is exactly the identifier
+  # `drivers`, so this is semantically identical for an all-lowercase table like this fixture.
+  @test SEQUENCE_SYNC_SQL[1] == "SELECT pg_get_serial_sequence('\"drivers\"', 'id');"
   @test occursin("setval('public.legacy_driver_id_seq'", SEQUENCE_SYNC_SQL[2])
   @test occursin("COALESCE((SELECT MAX(\"id\") FROM \"drivers\"), 0) + 1, false", SEQUENCE_SYNC_SQL[2])
 end


### PR DESCRIPTION
Closes #59.

## What this adds

```julia
DriverProfile = Models.Model("driver_profile",
  db_table = "Driver_Profile_Legacy",   # ← the table that actually exists
  driverid = Models.IDField(),
)
```

The positional name stays a lowercase **logical** identifier; `db_table` carries the **physical** one, **verbatim** — no case fold, no leading-underscore strip. It is the table-level sibling of `db_column` (#50), and the escape valve #300 and #306 were deliberately built to point at.

Authoritative wherever a table identifier is rendered: DDL, `SELECT`/`INSERT`/`UPDATE`/`DELETE`, `JOIN` targets, a `ForeignKey`'s `REFERENCES` target, and migration add/drop/rename detection.

**Purely opt-in.** A model that does not set `db_table` derives its table name exactly as before — no existing schema changes, nothing needs re-migrating.

## Why it touches so much

Nothing in the codebase resolved a table name through a single seam: every DDL, query and migration site independently did `model.name |> lowercase` or `format_model_name(...)`. Making `db_table` authoritative meant introducing that seam (`model_table_name`) and redirecting ~30 sites through it. A missed site does not fail loudly — it silently reads or writes a *different* table.

`model_table_name`/`model_has_db_table` live in `Kernel` (layer 1) because layer-2 `Configuration` needs them and is included before `Models`; they are deliberately **not** exported, so the public surface is unchanged. `fk_target_table` stays in `Models` (it needs `format_model_name`).

## Bundled changes — required, not incidental

**DDL now quotes the table identifier.** `CREATE TABLE IF NOT EXISTS driver (…)` becomes `… "driver" (…)`. An unquoted mixed-case name folds to lowercase on PostgreSQL, which would split the DDL from every already-quoted query-side site — #300 one layer up. Semantically identical for a lowercase name.

**`ManyToManyField(db_table = …)` stops silently lowercasing.** It ran the value through `format_model_name`; the new model-level option preserves case. Same user intent, so both seams now behave the same way (the design note on #59 asks for exactly this).

**The migration planner keys both sides of its diff by the resolved physical name**, retiring the long-standing `# TODO: change model.name to lowercase in all project`. Keying the declared side on the Julia binding would have read a `db_table` model as "a table to create" **plus** "a live table nobody declared" — a `CREATE` and a `DROP` of a live, structurally-unchanged table.

Also swept, same defect class, beyond the issue's literal task list: `deletion.jl` (DELETE/UPDATE, previously bare **and** lowercased), `execution_bulk.jl` (bulk + PK allocation), `execution.jl` (PostgreSQL sequence maintenance), `Configuration.jl` (SQLite reserved-PK cache key).

## Independent review — two rounds, both found real bugs

A fresh reviewer with no memory of writing the code reviewed the diff, then re-reviewed the delta after fixes.

**Round 1 (10 findings).** The headline was a **blocker**: `strip_many_to_many_fields` rebuilds `Model_Type` slot-by-slot and silently dropped `db_table` — and *every* model on the migration path goes through it. `makemigrations` created the table under the logical name while the FK `REFERENCES` used the physical one, and a second run proposed **dropping the live table**. Also: reverse-FK joins and `Exists()` subqueries were missed seams; `Model_to_str`'s new introspection branch misfired on the **Django importer**, whose `model.name` is a Python *class* name — fixed by having the caller state which it has (`name_is_physical_table`) rather than inferring from the string; plus the last unquoted `ALTER TABLE` target and several escaping gaps.

**Round 2 (4 residual defects in the fixes).** My escaping was applied at 3 of ~30 DDL sites; the leading-underscore strip wasn't gated on `name_is_physical_table`, re-opening the finding it had just fixed; `_update_sequence`'s PostgreSQL `LIKE` pattern still lowercased (sequence names are case-sensitive); and one fix had switched to the *validating* quote helper, which would newly abort on legacy sequence names containing a `-`.

Round 2 also **proved** the pre-existing `db_sl` migration drift is not from this PR, by diffing planner keys across all 48 SQLite fixtures: only the two new `db_table` fixtures changed.

## Behavior changes worth calling out

- **A *field* named `db_table` must now use the underscore escape hatch.** `db_table` is peeled before the `fields...` slurp (like `constraints`), so `db_table = CharField()` is read as the option and raises `ModelDefinitionError` — loudly, never silently. Write `_db_table = CharField()` for the column. A *table* named `db_table` is unaffected.
- **`inspectdb` on a mixed-case or leading-underscore table** now pins the original spelling as `db_table`. Previously it generated a declaration addressing a *different* table (or, for `_order`, a file that would not load at all).

## Tests

New `test/unit/test_db_table.jl` (**115 assertions**) mirroring `test_db_column.jl`'s structure, plus `test/integration/test_db_table_db.jl` with fixtures on both backends.

Two characterization testsets in `test_model_name_case.jl` whose own comments said they were "SUPPOSED TO FAIL" once this split closed have been rewritten to assert the closed state — the deliberate signal they asked for.

Notable coverage added in response to review: the planner testset now renders an **actual migration plan** (asserting only on `get_all_models` keys is what let the blocker ship green); `Model_to_str` genuinely round-trips by evaluating its own generated source; and DDL escaping is asserted across six renderers for **both `String` and `Symbol`** table arguments — the `Symbol` path is how the migration engine calls them, and a `String`-only helper compiled fine while blowing up under a live migration.

## Verification

- Full unit suite: **5361/5361**
- `test/unit/test_db_table.jl`: **115/115**
- PostgreSQL integration (`db_2`): **1963/1963**
- SQLite integration (`db_sl`): **1930/1931** (1 pre-existing broken)
- Docs build: exit 0, no cross-reference warnings

PostgreSQL is the run that matters here — SQLite folds identifier case and structurally cannot distinguish `Db_Table_Scratch` from `db_table_scratch`.

## Docs

`docs/src/schema_conventions.md` gains a *Pinning an explicit table name* section (authority table, the rename caveat, the M2M interaction); `docs/src/fields.md` cross-references it next to `db_column`; the `Model` docstring documents the option, the field-name collision, and the escape hatch. `UPGRADING.md` gets an `## Unreleased` entry with migration greps, and the two stale "PormG has no model-level `db_table` yet" claims in the #300/#306 entries are corrected.

## Deliberately not done

- **M2M auto-derived through-table names stay based on the logical name.** An auto-derived join table has no legacy name to match, and this avoids a surprise rename cascade when someone adds `db_table`. The explicit `ManyToManyField(db_table = …)` covers the "I need this exact join table name" case.
- **No identifier-shape validation on `db_table`** — type-check + empty-as-unset only, matching `db_column`'s precedent. Embedded quotes are escaped at every DDL site rather than rejected.
- **The planner's duplicated `get_all_models` was fixed in place**, not unified with the runtime one — that refactor has its own blast radius and is not required here.
- **Pre-existing `db_sl` schema drift is untouched.** It predates this PR (proven above) and deserves its own issue rather than being absorbed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
