### PR TITLE
feat(#303): collect every on_delete contradiction in one set_models error

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -876,7 +876,9 @@ Omitting `on_delete` is also valid and is the default — PormG then emits no st
 relation and the column renders `ON DELETE NO ACTION`, so the dependent row is **not** cascaded.
 
 The two "requires" above are enforced, not advisory: registering a model with `SET_NULL` on a
-`null=false` field, or `SET_DEFAULT` with no `default`, raises `ModelDefinitionError`.
+`null=false` field, or `SET_DEFAULT` with no `default`, raises `ModelDefinitionError` — and every
+such contradiction in the module is reported in that one error, naming each offending model, field
+and fix, so a schema carrying several of them is fixed in a single pass.
 
 ### OneToOneField(to_model)
 

--- a/docs/src/write/delete.md
+++ b/docs/src/write/delete.md
@@ -209,4 +209,11 @@ WHERE "Tb"."name" = $1
     schema fails as soon as the models load rather than at the first delete. `delete()` keeps its own
     copy of both checks as a backstop for models built without going through registration.
 
+    Every contradiction *of these two kinds* in the module is collected and reported in a single
+    `ModelDefinitionError` naming each offending model, field and fix, so a legacy schema carrying
+    several of them is diagnosed in one pass rather than one registration per field. Only these two
+    are aggregated: every *other* registration error — an unresolvable foreign-key or many-to-many
+    target, a duplicate `related_name`, a model without exactly one primary key, an unusable
+    explicit `through` model — still raises on the first occurrence and preempts that report.
+
 See [Models and Fields](../fields.md) for more details on configuring deletion behavior (CASCADE, PROTECT, SET_NULL, etc.).

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -236,6 +236,106 @@ function get_model_name(model::PormGModel, settings::PormGSettings, symbol::Bool
   end
 end
 
+# ── Registration-time contradiction collector (#303) ────────────────────────────────────────
+# A field declaration can contradict itself in ways only registration can see, and a database
+# introspected into models can carry several at once — #292 taught PostgreSQL introspection to
+# emit `on_delete` for the first time, so a legacy schema now arrives with every one of its
+# SET_NULL/SET_DEFAULT mismatches intact. Both shapes are legal DDL on both backends (the
+# referential action is only enforced at delete time), so they really do coexist in the wild.
+# Throwing on the first turned N problems into N generate → set_models → fix one column →
+# regenerate cycles, for problems that were all visible on the first pass. So `set_models`
+# ACCUMULATES and raises once, with the whole list.
+#
+# The struct is deliberately rule-agnostic: WHERE (model, field), WHAT (`problem`), and the
+# REMEDY (`fix`). It knows nothing about `on_delete`. Adding a rule is one `push!` — the struct,
+# the sort key and the renderer are all untouched. It is a struct rather than a vector of
+# pre-rendered sentences because a frozen sentence has no sort key and no format seam: changing
+# the layout, or letting a future `check_models()`-style API consume the data, would become a
+# shotgun edit across every rule.
+#
+# The one shape not covered is a MODEL-level rule (e.g. the multiple-primary-key check in
+# `get_model_pk_field`): it would need a `field == ""` convention plus a one-line ternary in the
+# renderer. Not built now — that check is raised from a different function and would be a larger
+# change regardless.
+struct ModelContradiction
+  model::String    # model.name — where the offending field lives
+  field::String    # the offending field's declared name
+  problem::String  # "declares on_delete SET_NULL but has null=false"    (may carry ANSI)
+  fix::String      # "Declare the field with null=true, or use ..."      (may carry ANSI)
+end
+
+# Per-field contradiction rules. Runs for every FK/O2O field `set_models` walks; each rule that
+# fires appends one `ModelContradiction`. NOTHING throws here — that is the point: the walk always
+# reaches the next field and the next model. Today the two rules are mutually exclusive (`on_delete`
+# holds one sentinel), so a field yields at most one entry; the collector does not assume that, so a
+# future rule family can add a second entry for the same field without changing this signature.
+#
+# `field` is left untyped for the same reason `resolve_fk_target!`'s is: `sForeignKey` and
+# `sOneToOneField` are defined later in the load order (`models/fields.jl`). The only call site
+# already guards with `field isa sForeignKey || field isa sOneToOneField`.
+#
+# `src/querybuilder/deletion.jl` keeps its own copies of both rules, for models that never pass
+# through registration. Those stay per-field and IMMEDIATE on purpose — read the comment there
+# before considering a merge.
+function _collect_field_contradictions!(out::Vector{ModelContradiction},
+                                        model::PormGModel, field_name::AbstractString, field)
+  # SET_NULL needs a column that can hold NULL. Until #287 this was an `@error` log: it named the
+  # problem, let the broken model through, and the contradiction resurfaced later as a mangled
+  # UPDATE or a database-level constraint violation.
+  if field.on_delete == SET_NULL && field.null == false
+    push!(out, ModelContradiction(model.name, field_name,
+      "declares on_delete SET_NULL but has null=false",
+      "Declare the field with \e[1mnull=true\e[0m, or use a different on_delete."))
+  end
+  # The mirror image: SET_DEFAULT needs something to set. With no default, `field.default` flows
+  # into update_field as a bare NULL, so SET_DEFAULT silently behaved as SET_NULL and then died
+  # on the column's NOT NULL constraint.
+  if field.on_delete == SET_DEFAULT && field.default === nothing
+    push!(out, ModelContradiction(model.name, field_name,
+      "declares on_delete SET_DEFAULT but has no default",
+      "Give the field a \e[1mdefault=\e[0m, or use a different on_delete."))
+  end
+  return out
+end
+
+"""
+    _render_contradictions(cs::Vector{ModelContradiction}, mod::Module) -> String
+
+Compose every collected contradiction into ONE error message (#303). Returns the `String`; the
+call site wraps it in `ModelDefinitionError` so the thrown type is named where it is thrown (see
+`src/querybuilder/error_funnels.jl` — a helper that only maps a message to a type is an alias,
+not an abstraction).
+
+**Ordering is fixed here, not by the caller.** `set_models` walks `pairs(model.fields)`, which is
+`Dict` hash order and carries no meaning, so entries are sorted by `(model, field, problem)`
+before rendering. The third key is forward-looking rather than load-bearing today: `(model, field)`
+is already unique, because the two current rules are mutually exclusive on one field — but it keeps
+the order *total*, so a future rule family that can fire alongside them stays byte-stable without
+revisiting this. `model.field_names` is deliberately NOT the order — it defaults to empty on a
+hand-built `Model_Type` and is itself hash-ordered from the `Model(name, ::Dict)` constructors, so
+it is a meaningful order only sometimes. `sort` (not `sort!`) because this runs on the error path and must not reorder a vector
+the caller — or a debugger stopped at the throw — still holds.
+
+The line prefix stays ANSI-free on purpose: `showerror` prints `.msg` verbatim and `.msg` keeps
+its escapes in color mode, so an escape wedged into the prefix would break anything matching on
+line structure.
+
+Pure — no globals, no side effects — so the ordering guarantee is unit-testable by handing it
+contradictions in deliberately wrong order (`test/unit/test_alignment_sqlite.jl`). That test is
+the only thing that fails if the sort is dropped: `Dict` iteration is deterministic for a fixed
+insertion sequence, so going through `set_models` would not reliably notice.
+"""
+function _render_contradictions(cs::Vector{ModelContradiction}, mod::Module)::String
+  ordered = sort(cs; by = c -> (c.model, c.field, c.problem))
+  n = length(ordered)
+  header = n == 1 ?
+    "set_models($(nameof(mod))) rejected the models: 1 contradictory field declaration." :
+    "set_models($(nameof(mod))) rejected the models: $(n) contradictory field declarations — " *
+    "every one found is listed below, so they can be fixed in a single pass."
+  return header * join("\n  → \e[4m\e[31m$(c.model).$(c.field)\e[0m $(c.problem) — " *
+                       "the schema contradicts itself. $(c.fix)" for c in ordered)
+end
+
 # TODO add related_name (like django validation) to check if the field is a ForeignKey and the related_name model is defined when models has more than one foreign key to the same model
 #
 # NOTE: keep this comment ABOVE the docstring. A comment between a docstring and the definition it
@@ -270,8 +370,19 @@ Registration does four things:
    metadata built and cached.
 4. **Rejects contradictions.** `on_delete = SET_NULL` on a `null = false` field, or `SET_DEFAULT`
    with no `default`, raises `ModelDefinitionError` here — at declaration, rather than later as a
-   mangled `UPDATE`. An unresolvable foreign-key target and a duplicate `related_name` raise the
-   same type.
+   mangled `UPDATE`. **Every** such contradiction in the module is collected and reported in that
+   one error, naming each offending model, field and fix, so a legacy schema carrying several of
+   them is diagnosed in a single pass instead of one registration per field (#303). Only these two
+   are aggregated: every *other* registration error — an unresolvable foreign-key or many-to-many
+   target, a duplicate `related_name`, a model without exactly one primary key, an unusable
+   explicit `through` model — raises the same type but still on the first occurrence, and preempts
+   the aggregated report when present.
+
+   Because the aggregated throw comes after every model is wired, a **swallowed** failure leaves a
+   fully-wired, queryable graph. The `__init__` that `@import_models` and `@models_module` inject,
+   and the Revise reload callback, all `catch` — though the first load of either macro still
+   surfaces the error. `delete()` keeps its own copy of both checks, and that is what still raises
+   for a contradiction the caller never saw.
 
 Calling it again is safe and is the supported way to pick up edits: reverse relations and
 many-to-many caches are cleared before being rebuilt, so a reload cannot accumulate duplicates.
@@ -343,6 +454,10 @@ function set_models(_module::Module, path::String)::Nothing
     empty!(model.related_objects)
     haskey(model.cache, "many_to_many") && delete!(model.cache, "many_to_many")
   end
+  # #303: self-contradicting field declarations are ACCUMULATED across every model and every
+  # field, then raised once below. See `_render_contradictions` for the ordering contract.
+  contradictions = ModelContradiction[]
+
   # Validate like django related_name, if the model has more than one foreign key to the same model the related_name must be defined
   for model in models
     dict_tables_c = Dict{String, Int}()
@@ -355,6 +470,13 @@ function set_models(_module::Module, path::String)::Nothing
         # #65: single-sourced FK/O2O resolution + pk_field defaulting, shared with the migration
         # prelude via `resolve_fk_target!`. strict=true throws on an unresolvable target, so the
         # returned value is always a resolved model here; it drives the reverse-relation wiring below.
+        #
+        # This one stays IMMEDIATE and out of #303's collector, permanently. Structurally, the
+        # return drives every line of wiring below it, so collecting would mean strict=false plus a
+        # `continue` that silently skips it — and it would change how the runtime path uses a helper
+        # SHARED with the migration prelude (`planner.jl` calls it strict=false). Semantically, a
+        # missing referent is not a contradiction between two settings on one field: the model graph
+        # cannot be built at all, so walking on produces cascading noise, not more signal.
         field_to::PormGModel = resolve_fk_target!(field, field_name, model.name, _module; strict=true)
         if haskey(dict_tables_c, field_to.name)
           dict_tables_c[field_to.name] += 1
@@ -393,19 +515,38 @@ function set_models(_module::Module, path::String)::Nothing
         # through, so the contradiction resurfaced later as a mangled UPDATE or a database-level
         # constraint violation. The delete collector keeps its own copies of both guards for models
         # that never pass through `set_models`; this is the layer that catches them at declaration.
-        if field.on_delete == SET_NULL && field.null == false
-          throw(ModelDefinitionError("The field \e[4m\e[31m$(field_name)\e[0m in the model \e[4m\e[31m$(model.name)\e[0m declares on_delete SET_NULL but has null=false — the schema contradicts itself. Declare the field with null=true or use a different on_delete."))
-        end
-        if field.on_delete == SET_DEFAULT && field.default === nothing
-          throw(ModelDefinitionError("The field \e[4m\e[31m$(field_name)\e[0m in the model \e[4m\e[31m$(model.name)\e[0m declares on_delete SET_DEFAULT but has no default — the schema contradicts itself. Give the field a default= or use a different on_delete."))
-        end
-                 
+        #
+        # #303 COLLECTS instead of throwing, so ONE run reports every contradiction in the module.
+        # Nothing after this line depends on the result — the reverse-relation wiring above is
+        # already done — so a field that fails here still leaves the model graph in exactly the
+        # state a clean run would produce.
+        _collect_field_contradictions!(contradictions, model, field_name, field)
+
       elseif is_many_to_many_field(field)
         _register_many_to_many_relation!(_module, settings, model, field_name, field)
       end
     end
   end
- 
+
+  # Registration FAILS — informatively, not downgraded to a warning (#303). Deferring the throw to
+  # here means every model is wired before it fires, which is strictly more wiring than the
+  # pre-#303 mid-loop abort did. That is safe: the wiring performed is exactly what a SUCCESSFUL
+  # run performs (no half-state a success would not also produce), and every `set_models` call
+  # `empty!`s `related_objects` and drops the many-to-many cache before rebuilding (see the loop
+  # above), so a re-run cannot accumulate.
+  #
+  # One consequence worth knowing, because it is uniform now rather than order-dependent: every
+  # model comes out of a run that fails HERE with a valid `connect_key`, so
+  # `ensure_model_initialized`'s fast path reports it initialized. Pre-#303 that depended on whether
+  # the model happened to be walked before the throwing one — i.e. on Dict/`names` order. (A run
+  # that fails at one of the earlier in-loop throws still leaves the models after it unbound.)
+  # So a caller that swallows this throw — the `__init__` injected by `@import_models` /
+  # `@models_module`, or the Revise reload callback — is left with a fully-wired, queryable graph
+  # rather than a partly-wired one, and `deletion.jl`'s own copies of these two guards are what
+  # still catch the contradiction at delete time.
+  isempty(contradictions) ||
+    throw(ModelDefinitionError(_render_contradictions(contradictions, _module)))
+
   return nothing
 end
 

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -416,7 +416,17 @@ function handle_on_delete!(collector::DeletionCollector, field_name::Union{Strin
     throw(ProtectedError("Cannot delete \e[4m\e[31m$(model.name)\e[0m because it is referenced by \e[4m\e[31m$(related_model.name).$(field_name)\e[0m with ON DELETE \e[4m\e[31m$(constraint_type)\e[0m constraint"))
   elseif field.on_delete == SET_NULL
     @pormg_debug false
-    # check if the field allow null
+    # Backstop copy of `set_models`' SET_NULL guard, for models that never passed registration —
+    # see the fixtures in test/integration/common_delete_setup.jl, which register a VALID model and
+    # then flip the field, so this path is the only thing left to catch it.
+    #
+    # This one stays PER-FIELD and IMMEDIATE. Do NOT "unify" it with the aggregating collector
+    # `set_models` grew in #303. There, N models are being registered at once and reporting all N
+    # contradictions in one error saves N import cycles — the whole point. Here we are inside one
+    # delete, resolving one referencing field, with nothing to aggregate: deferring the throw would
+    # only let the collector keep building statements against a schema already known to be
+    # unsatisfiable, and then report them alongside an error we could have raised immediately.
+    # Fail on the field in hand.
     if !field.null
       throw(ModelDefinitionError("Error in delete: ON DELETE SET_NULL is declared on \e[4m\e[31m$(field_name)\e[0m, but the field has null=false — the schema contradicts itself. Declare the FK with null=true or use a different on_delete."))
     end
@@ -431,7 +441,8 @@ function handle_on_delete!(collector::DeletionCollector, field_name::Union{Strin
     collector.field_updates[(field_name |> string, nothing)][related_model] = prepare_related_query(keys, related_model, field_name)
 
   elseif field.on_delete == SET_DEFAULT
-    # check that there is a default to set — symmetric with the SET_NULL guard above (#287).
+    # check that there is a default to set — symmetric with the SET_NULL guard above (#287), and
+    # per-field/immediate for the same reason spelled out there (#303).
     # Without it `field.default === nothing` flows into update_field, which renders a bare NULL,
     # so SET_DEFAULT silently behaved as SET_NULL and then died on the column's NOT NULL constraint.
     if field.default === nothing

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1935,6 +1935,19 @@ end
     @test_throws PormG.ModelDefinitionError PormG.Models.set_models(bad_mod, "mock_sl_path")
 end
 
+# `set_models` has several other ModelDefinitionError sites (duplicate related_name, strict FK
+# target resolution), so a bare @test_throws would pass on a fixture typo for the wrong reason.
+# Assert the cause, not just the type. At file scope because both the #287 testset below and the
+# #303 aggregation testsets after it use it.
+function _set_models_error(mod)
+    try
+        PormG.Models.set_models(mod, "mock_sl_path")
+        nothing
+    catch e
+        e
+    end
+end
+
 @testset "set_models rejects contradictory on_delete declarations (#287)" begin
     # Both checks existed in set_models as `@error` logs: they named the contradiction and then
     # let the broken model through, so it resurfaced later as a mangled UPDATE (SET_DEFAULT with
@@ -1955,18 +1968,6 @@ end
         Core.eval(mod, :(const Parent = $parent))
         Core.eval(mod, :(const Child = $child))
         return mod
-    end
-
-    # `set_models` has several other ModelDefinitionError sites (duplicate related_name, strict FK
-    # target resolution), so a bare @test_throws would pass on a fixture typo for the wrong reason.
-    # Assert the cause, not just the type.
-    function _set_models_error(mod)
-        try
-            PormG.Models.set_models(mod, "mock_sl_path")
-            nothing
-        catch e
-            e
-        end
     end
 
     # SET_NULL on a field that cannot hold NULL.
@@ -1994,6 +1995,125 @@ end
     sd_ok = _on_delete_mod(:od_set_default_ok, p -> PormG.Models.ForeignKey(p,
         pk_field = "id", on_delete = "SET_DEFAULT", default = 1, null = true, related_name = "od_sd_ok"))
     @test PormG.Models.set_models(sd_ok, "mock_sl_path") === nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# set_models: every on_delete contradiction is reported in ONE error (#303)
+# #287 made the two guards throw, but on the FIRST contradiction — so a legacy database
+# introspected into models (#292 gave PostgreSQL introspection `on_delete` for the first time)
+# took one generate → set_models → fix one column → regenerate cycle per contradiction, for
+# problems that were all visible on the first pass. The fixture below carries THREE contradictions
+# across TWO models, and the assertions demand all three by name plus the count: an assertion that
+# only checked the first name would pass against the pre-#303 first-throw behaviour and prove
+# nothing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "set_models reports every on_delete contradiction at once (#303)" begin
+    parent = PormG.Models.Model_Type(
+        name = "od303_parent",
+        fields = Dict("id" => PormG.Models.IDField()),
+        field_names = ["id"]
+    )
+    # Model A: TWO contradictions on ONE model — one of each rule. Proves the walk does not stop
+    # at the first offending FIELD. `ok_fk` is the discrimination control (assertion 5).
+    child_a = PormG.Models.Model_Type(
+        name = "od303_child_a",
+        fields = Dict(
+            "id"        => PormG.Models.IDField(),
+            "bad_null"  => PormG.Models.ForeignKey(parent, pk_field = "id",
+                             on_delete = "SET_NULL",    null = false, related_name = "od303_a_null"),
+            "bad_deflt" => PormG.Models.ForeignKey(parent, pk_field = "id",
+                             on_delete = "SET_DEFAULT", null = true,  related_name = "od303_a_deflt"),
+            "ok_fk"     => PormG.Models.ForeignKey(parent, pk_field = "id",
+                             on_delete = "CASCADE",     null = true,  related_name = "od303_a_ok"),
+        ),
+        field_names = ["id", "bad_null", "bad_deflt", "ok_fk"]
+    )
+    # Model B: a THIRD contradiction on a DIFFERENT model. Proves the walk does not stop at the
+    # first offending MODEL either — the two axes fail independently.
+    child_b = PormG.Models.Model_Type(
+        name = "od303_child_b",
+        fields = Dict(
+            "id"       => PormG.Models.IDField(),
+            "bad_null" => PormG.Models.ForeignKey(parent, pk_field = "id",
+                            on_delete = "SET_NULL", null = false, related_name = "od303_b_null"),
+        ),
+        field_names = ["id", "bad_null"]
+    )
+    mod = Module(:od303_many_contradictions)
+    Core.eval(mod, :(const Parent  = $parent))
+    Core.eval(mod, :(const Child_a = $child_a))
+    Core.eval(mod, :(const Child_b = $child_b))
+
+    err = _set_models_error(mod)
+    # Registration must still FAIL, and with the same type — #303 changed the message, not the
+    # taxonomy. A collector downgraded to `@warn` returns nothing here and fails on this line.
+    @test err isa PormG.ModelDefinitionError
+    # `showerror` prints `.msg` verbatim (exceptions.jl); ANSI is decided once in the constructor
+    # from `Base.have_color`, and `Pkg.test` forwards --color=yes. So every token matched below
+    # must be CONTIGUOUS in the message — never split by an escape sequence.
+    msg = sprint(showerror, err)
+
+    # 1. EVERY offending model.field pair is named. Asserting only one would pass against the
+    #    pre-#303 first-throw behaviour, which is exactly the trap #303 calls out.
+    @test occursin("od303_child_a.bad_null",  msg)
+    @test occursin("od303_child_a.bad_deflt", msg)
+    @test occursin("od303_child_b.bad_null",  msg)
+
+    # 2. The COUNT is right AND is stated. One `→` per entry (the same list shape
+    #    DestructiveMigrationError uses), so counting the bullets counts the contradictions.
+    #    Pre-#303 there are no bullets at all, so both of these fail hard.
+    @test count(==('→'), msg) == 3
+    @test occursin("3 contradictory field declarations", msg)
+
+    # 3. Both rules and both remedies survive aggregation — the #287 message content is not lost
+    #    when it becomes a list entry.
+    @test occursin("SET_NULL", msg)    && occursin("null=true", msg)
+    @test occursin("SET_DEFAULT", msg) && occursin("default", msg)
+
+    # 4. Discrimination: the CLEAN foreign key is not listed. A collector that reported every FK
+    #    would satisfy every assertion above and be worthless.
+    @test !occursin("ok_fk", msg)
+
+    # 5. The rendered (model, field) order. NOT a real pin on the sort: this fixture's natural
+    #    walk order already happens to match the sorted order, so it passes with the sort removed
+    #    (measured). It documents the expected shape end-to-end; the testset below is what
+    #    actually fails when the sort goes, by feeding the renderer an order a Dict walk cannot
+    #    produce on demand.
+    @test findfirst("od303_child_a.bad_deflt", msg).start <
+          findfirst("od303_child_a.bad_null",  msg).start <
+          findfirst("od303_child_b.bad_null",  msg).start
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# set_models: the aggregated message has a deterministic order (#303)
+# The order cannot be pinned through `set_models` alone: Julia's Dict iteration is deterministic
+# for a fixed insertion sequence, so dropping the sort might well reproduce the same order there
+# and leave the end-to-end ordering assertion inert. The sort therefore lives in
+# `_render_contradictions`, which is pure, and this testset feeds it a deliberately WRONG order —
+# the one input a Dict walk can never produce on demand. Removing the `sort` fails here every run.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "aggregated contradictions render in a deterministic order (#303)" begin
+    MC = PormG.Models.ModelContradiction
+    cs = [
+        MC("od_z_model", "a_field", "problem Z", "Fix Z."),   # wrong model first
+        MC("od_a_model", "z_field", "problem Y", "Fix Y."),   # wrong field order within a model
+        MC("od_a_model", "a_field", "problem X", "Fix X."),
+    ]
+    msg = PormG.Models._render_contradictions(cs, @__MODULE__)
+
+    @test findfirst("od_a_model.a_field", msg).start <
+          findfirst("od_a_model.z_field", msg).start <
+          findfirst("od_z_model.a_field", msg).start
+
+    # `sort`, not `sort!`: this runs on the error path and must not reorder a vector the caller
+    # (or a debugger stopped at the throw) still holds.
+    @test cs[1].model == "od_z_model"
+
+    # Single-violation rendering keeps the same list shape — one entry is still a list, so there
+    # is no second code path that only the rare case exercises and only the rare case can rot.
+    one = PormG.Models._render_contradictions([cs[1]], @__MODULE__)
+    @test count(==('→'), one) == 1
+    @test occursin("1 contradictory field declaration.", one)
 end
 
 # ── #64: db_column on M2M / CTE join keys (DB-free render asserts) ─────────────────────────


### PR DESCRIPTION
Closes #303

## Problem

`Models.set_models` threw `ModelDefinitionError` on the **first** contradiction it met — the two guards added in #287:

- `on_delete = SET_NULL` on a field declared `null = false`
- `on_delete = SET_DEFAULT` on a field with no `default`

Both rejections are correct. The problem was that they raised one at a time. Both shapes are **legal DDL on both backends** (the referential action is only enforced at delete time), and #292 made PostgreSQL introspection carry `on_delete` for the first time — so an introspected legacy schema can now reach these guards carrying several at once.

That made importing such a database a loop: `generate_models_from_db` → `set_models` → error naming **one** field → fix that column → regenerate → the next one. N bad foreign keys meant N import cycles to discover N problems that were all visible on the first pass.

## Approach

Collect, then throw once. Registration still **fails**, with the **same** exception type — the aim is to fail informatively, never to downgrade to a warning.

```
set_models(legacy_models) rejected the models: 3 contradictory field declarations — every one found is listed below, so they can be fixed in a single pass.
  → od303_child_a.bad_deflt declares on_delete SET_DEFAULT but has no default — the schema contradicts itself. Give the field a default=, or use a different on_delete.
  → od303_child_a.bad_null declares on_delete SET_NULL but has null=false — the schema contradicts itself. Declare the field with null=true, or use a different on_delete.
  → od303_child_b.bad_null declares on_delete SET_NULL but has null=false — the schema contradicts itself. Declare the field with null=true, or use a different on_delete.
```

Three pieces in `src/Models.jl`:

- **`ModelContradiction`** — WHERE (model, field), WHAT (`problem`), REMEDY (`fix`). Rule-agnostic; it knows nothing about `on_delete`. A struct rather than pre-rendered sentences because a frozen sentence has no sort key and no format seam.
- **`_collect_field_contradictions!`** — never throws, so the walk always reaches the next field and the next model.
- **`_render_contradictions`** — pure, sorts by `(model, field, problem)`.

One uniform format for both the 1- and N-violation cases, so there is no rarely-exercised second code path to rot.

### Why the sort lives in the renderer

`pairs(model.fields)` is `Dict` hash order and carries no meaning. `model.field_names` is not usable either — it defaults to empty on a hand-built `Model_Type` and is itself hash-ordered from the `Model(name, ::Dict)` constructors. Keeping the renderer **pure** is what makes the ordering testable: a `Dict` walk cannot produce a wrong order on demand, so the guard feeds `_render_contradictions` a deliberately wrong-ordered vector directly.

## Scope — deliberately the two `on_delete` guards

The duplicate-`related_name` throws and `resolve_fk_target!`'s strict throw stay immediate. `resolve_fk_target!` permanently so: its return drives every line of the wiring below it, it is **shared** with the migration planner prelude, and a missing referent is a different failure class — walking on produces cascading noise, not more signal.

The collector is shaped so widening it later is one `push!` replacing one `throw` — no rewrite of the struct, the sort key, or the renderer.

**Known limitation, documented in the docstring and in `delete.md`:** a module carrying one of the preempting errors *and* N contradictions still reports that one first, so it takes two runs rather than one.

## `deletion.jl` is comment-only

Both backstop guards are byte-identical to `main`. The comments now say **why** they must stay per-field and immediate: one delete resolves one referencing field and has nothing to aggregate — deferring would only build statements against a schema already known to be unsatisfiable. Added so the two do not get "unified" later by mistake.

## Verification

Full unit suite **5375/5375, exit 0**. Docs build clean. Green: `test_introspection_guards`, `test_import_django_models`, `test_error_message_ansi`, `test_error_taxonomy`, `test_docs_error_type_drift`, `test_docs_error_types`, `test_docstring_coverage`, `test_kernel_layering`.

The regression test carries **three** contradictions across **two** models and asserts the count *and* every field name, plus a clean FK that must **not** be listed. Proven by mutation, not by assertion count:

| | Mutation | Result |
|---|---|---|
| **M1** | restore first-throw | testset A → 4 pass / 5 fail / 1 error, with **exactly one** locator surviving — the precise trap the issue warns about. #287 stayed 8/8, so the new format is a strict superset. |
| **M2** | drop the `sort` | testset A **still passed 10/10**; the dedicated ordering testset failed. This is the empirical justification for pinning order at the pure renderer rather than end-to-end. |
| **M3** | downgrade to `@warn` | caught hard. |

## Review

Two independent review passes found **eight** issues, all comment/doc accuracy, none behavioral — each verified before being accepted. The substantive one: a note claiming `ensure_model_initialized` branch 2b "reports success every time" was false twice over (the throw jumps to the bare `catch`, so the success check never runs; the real effect lands at the fast path). Deleted, and an accurate version placed at the throw site. Also corrected: an incomplete preempting-error list, and a swallowing-caller list that implied `@import_models` swallows on first load — it does not, `_post_import_setup` calls `set_models` bare.

## Deliberately not done

- **No `UPGRADING.md` entry** — same input, same exception type, only a fuller message. Forces no app source edit.
- **No `Project.toml` bump** — release trains.
- **Not fixed, pre-existing and out of scope:** `Models.jl` ~2030 raises a bare `KeyError` when an explicit `source_field`/`target_field` names a missing column, which violates the #239 "every domain error is a `PormGError` subtype" rule. Flagged by review so it is not mistaken for something this PR introduced; happy to file it separately.
- **Integration not run** — `deletion.jl` is comment-only and the `set_models` behavior is fully covered by the unit layer. Say the word and I'll run it against a free database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
