### PR TITLE
fix(#315): an abandoned await must not return its connection to the pool

### DIFF
--- a/docs/src/async.md
+++ b/docs/src/async.md
@@ -106,6 +106,16 @@ Because the placeholder style is backend-native, a manual-params string is **not
 !!! warning "An un-awaited `FetchTask` holds a pool connection"
     `fetch_async` checks its connection out *synchronously*; only `await_result` (or the owning transaction's cleanup) returns it. Always await every task you start — including fire-and-forget writes. The opt-in [`leak_detection_threshold`](configuration/advanced.md) logs a warning when a connection is held suspiciously long, which almost always means an un-awaited `FetchTask`.
 
+## Cancelling a query with `Ctrl+C`
+
+Interrupting a running query in the REPL is safe: PormG asks the database to abandon the statement, waits for the driver to let go of the connection, and only then decides what to do with the pool slot. A connection that comes back clean is reused; one that does not is renewed or dropped, and a fresh connection takes its place. Either way the *next* query gets a healthy connection — the pool cannot be left in a state where every later query fails.
+
+!!! note "Recovery runs in the background"
+    Control returns to the REPL immediately; the cancel-and-clean happens on its own task, and the pool slot stays checked out while it does — so a query issued in the meantime may be served by a different connection. If the database never releases the connection, the slot is dropped from the pool anyway after a few seconds and the next query opens a fresh one. Under `julia -t 1` the driver's cancel and reconnect calls block the single worker thread while they run, so a heavily-loaded single-threaded session may pause briefly — start Julia with `-t auto` if that matters.
+
+!!! warning "An interrupt currently arrives as a `StatementError`"
+    Today the `InterruptException` reaches you wrapped in a `StatementError`, carried on its `cause` — so a `catch DatabaseError` around a query swallows your `Ctrl+C`. That wrapping is a known wart rather than a designed contract, and it is expected to change: a cancellation will propagate past `catch DatabaseError` altogether, which is what you want from `Ctrl+C`. So write the `catch` you would want *after* that change — let the interrupt escape — rather than reaching for `e.cause isa InterruptException` today, because that test will stop matching silently once the interrupt no longer arrives as a `DatabaseError` at all.
+
 ## Transactions and concurrency
 
 The transaction context is a `ScopedValue`, so tasks spawned **inside** `run_in_transaction` inherit it — every query they run targets the transaction's **single pinned connection** (see [Async Context Propagation](write/transaction.md#Async-Context-Propagation)). That is exactly what you want for *correctness*: child tasks participate in the same transaction.

--- a/ext/PormGLibPQExt.jl
+++ b/ext/PormGLibPQExt.jl
@@ -113,7 +113,17 @@ end
 PormG.backend_num_affected_rows(pool::PormGPostgres, result) = LibPQ.num_affected_rows(result)
 PormG.backend_num_rows(pool::PormGPostgres, result) = LibPQ.num_rows(result)
 
-function _drain_postgres_connection!(conn::LibPQ.Connection)
+# Consume every PGresult still queued on `conn` until the wire is clean. Returns `true` when it
+# drained, `false` when `deadline` (an absolute `time()`) elapsed with a result still pending.
+#
+# Still THROWS `PQConnectionError` when `PQconsumeInput` fails: that means the socket is gone, which
+# `backend_copy_in!` has always propagated and must keep propagating. `deadline = Inf` — the default,
+# and what the COPY path passes — is exactly the pre-#315 behaviour.
+#
+# The bound matters only for the abandoned-await caller (#315). `PQisBusy` spins on `yield()` rather
+# than waiting on the socket, so it is a HOT loop, and a result stream the driver task abandoned
+# half-read can take as long as the query itself did.
+function _drain_postgres_connection!(conn::LibPQ.Connection; deadline::Float64 = Inf)::Bool
   LibPQ.lock(conn) do
     while true
       # COPY can leave a trailing PGresult pending on the connection even after
@@ -121,14 +131,62 @@ function _drain_postgres_connection!(conn::LibPQ.Connection)
       LibPQ.libpq_c.PQconsumeInput(conn.conn) == 1 || throw(LibPQ.Errors.PQConnectionError(conn))
 
       if LibPQ.libpq_c.PQisBusy(conn.conn) == 1
+        time() > deadline && return false
         yield()
         continue
       end
 
       result_ptr = LibPQ.libpq_c.PQgetResult(conn.conn)
-      result_ptr == C_NULL && return nothing
+      result_ptr == C_NULL && return true
       LibPQ.libpq_c.PQclear(result_ptr)
     end
+  end
+end
+
+# ── Abandoned-await recovery (#315) ──────────────────────────────────────────
+#
+# A Ctrl-C during a query leaves libpq with an unconsumed result queued on the socket. Nothing in
+# the pool can see that: `backend_is_alive` is `PQstatus(conn) == CONNECTION_OK`, which stays true
+# for a connection carrying a pending result — so the slot went back into circulation and every
+# later statement on it failed with "another command is already in progress", permanently.
+
+# How long the drain may spin on a still-busy socket before the caller gives up and renews the
+# connection instead. Generous: `PQcancel` normally aborts within milliseconds, so reaching this
+# means the server never acknowledged the cancel.
+const _PG_ABANDON_DRAIN_SECONDS = 5.0
+
+# Ask PostgreSQL to abandon the statement currently running on `conn` (#315).
+#
+# NOT `LibPQ.cancel(async_result)`: that only sets the AsyncResult's `should_cancel` flag, and the
+# flag is read by the `_consume` loop INSIDE the driver's own result task. In the case this exists
+# for, the SIGINT killed that task — the loop is gone, the flag is never read, and nothing is
+# cancelled. The out-of-band request below is the only one that reaches the server: libpq builds a
+# separate `PGcancel` and sends it on its OWN socket. That is also why this is the one libpq call
+# safe to issue while another task may still hold the `PGconn`.
+function PormG.backend_cancel_query!(pool::PormGPostgres, conn::LibPQ.Connection)
+  isopen(conn) || return nothing
+  cancel_ptr = LibPQ.libpq_c.PQgetCancel(conn.conn)
+  cancel_ptr == C_NULL && return nothing
+  try
+    errbuf = zeros(UInt8, 256)
+    if LibPQ.libpq_c.PQcancel(cancel_ptr, pointer(errbuf), Cint(length(errbuf))) != 1
+      @debug "PostgreSQL refused the cancel request" reason=unsafe_string(pointer(errbuf))
+    end
+  finally
+    LibPQ.libpq_c.PQfreeCancel(cancel_ptr)
+  end
+  return nothing
+end
+
+# Is `conn` clean enough to hand back to the pool? Never throws: the caller is a detached recovery
+# task, where an escaping failure would surface as an unhandled task error instead of a renewed
+# connection. A `false` here routes the connection to `_renew_or_discard_connection!`.
+function PormG.backend_drain_connection!(pool::PormGPostgres, conn::LibPQ.Connection)
+  try
+    return _drain_postgres_connection!(conn; deadline = time() + _PG_ABANDON_DRAIN_SECONDS)
+  catch drain_failure
+    @debug "PostgreSQL connection could not be drained; it will be renewed or discarded" exception=drain_failure
+    return false
   end
 end
 

--- a/ext/PormGSQLiteExt.jl
+++ b/ext/PormGSQLiteExt.jl
@@ -153,6 +153,31 @@ function PormG.backend_is_permanent_connect_error(pool::PormGSQLite, e)
   return occursin("unable to open database file", msg)
 end
 
+# ── Abandoned-await recovery (#315) ──────────────────────────────────────────
+
+# Ask SQLite to abort whatever statement is running on `conn`.
+#
+# `sqlite3_interrupt` is the right primitive for all three states the recovery cannot distinguish
+# between: it is explicitly documented as safe to call from a thread other than the one running the
+# statement (which is always the case here — the global worker owns the handle, the caller does
+# not), it is a no-op when nothing is running, and since SQLite 3.8 it provably does not affect
+# statements started after it returns. The interrupted statement fails with SQLITE_INTERRUPT and
+# the worker's own `finally` finalizes it, so the handle is left consistent.
+function PormG.backend_cancel_query!(pool::PormGSQLite, conn::SQLite.DB)
+  isopen(conn) || return nothing
+  SQLite.C.sqlite3_interrupt(conn.handle)
+  return nothing
+end
+
+# SQLite has no wire protocol to leave half-consumed, so there is nothing to drain: every statement
+# is prepared, stepped and finalized inside ONE `_sqlite_execute_materialized` call above, and the
+# async worker only answers its caller AFTER that call returns. So by the time core has seen the
+# handle settle, the worker is already off this connection.
+#
+# The generic exists so the recovery path in core stays backend-agnostic; the PostgreSQL twin is
+# the half that does real work.
+PormG.backend_drain_connection!(pool::PormGSQLite, conn::SQLite.DB) = true
+
 # ── Error classification (#268) ──────────────────────────────────────────────
 #
 # SQLite is the imprecise half of the boundary, and the asymmetry with PostgreSQL is deliberate —

--- a/src/Backend.jl
+++ b/src/Backend.jl
@@ -34,13 +34,24 @@ const _SQLITE_DRIVER_HINT = "PormG: the SQLite backend requires SQLite. Run `usi
 #   backend_execute_async(pool, conn, sql, params)     -> async handle (PG: LibPQ.AsyncResult)
 #   backend_is_connection_error(pool, e)               -> Bool: is `e` a dropped-connection error
 #   backend_is_permanent_connect_error(pool, e)        -> Bool: is `e` a permanent connect failure (auth/cantopen) vs transient
+#   backend_cancel_query!(pool, conn)                  -> best-effort: stop the statement running on `conn` (#315)
+#   backend_drain_connection!(pool, conn)              -> Bool: is `conn` back to a clean, reusable state (#315)
 #   backend_num_affected_rows(pool, result)            -> Int matched-row count (PG)
 #   backend_num_rows(pool, result)                     -> Int row count (PG)
 #   backend_copy_in!(pool, conn, sql, data_itr)        -> PostgreSQL COPY FROM STDIN
 #   backend_sqlite_version(pool)                        -> Int SQLite library version number
+#
+# `backend_cancel_query!` and `backend_drain_connection!` are the abandoned-await pair (#315) —
+# named rather than positioned, because this list grows. A Ctrl-C leaves the driver mid-operation, and
+# neither state — libpq's unconsumed result, SQLite's worker still stepping — is visible to
+# `backend_is_alive`, so the pool cannot tell a poisoned connection from a healthy one. They are in
+# the loop below on purpose: the throwing "load the driver" fallback is a perfectly good answer for
+# `ConnectionPool._recover_abandoned_connection!`, which catches both and treats a throw as
+# "not clean" → renew or discard.
 for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
            :backend_execute, :backend_execute_async, :backend_is_connection_error,
            :backend_is_permanent_connect_error,
+           :backend_cancel_query!, :backend_drain_connection!,
            :backend_num_affected_rows, :backend_num_rows, :backend_copy_in!,
            :backend_sqlite_version)
   @eval begin

--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -24,6 +24,7 @@ import PormG: DatabaseError, IntegrityError, OperationalError, StatementError
 # Backend generics — driver bodies live in ext/PormGLibPQExt.jl / ext/PormGSQLiteExt.jl.
 import PormG: backend_connect, backend_renew_connection, backend_is_alive, backend_execute,
               backend_execute_async, backend_is_connection_error, backend_is_permanent_connect_error,
+              backend_cancel_query!, backend_drain_connection!,
               backend_copy_in!, backend_classify_error
 
 export fetch, fetch_async, await_result, FetchTask, fetch_copy
@@ -150,6 +151,38 @@ function _unwrap_async_exception(exception)
       return current
     end
   end
+end
+
+"""
+    _await_abandoned(e) -> Bool
+
+Was this await cut short by a *cancellation*, rather than by the database refusing the statement
+(#315)? Two shapes reach `await_result` and both must answer `true`:
+
+  * the SIGINT was force-thrown into the driver's own result task, so `Base.fetch` raises a
+    `TaskFailedException` wrapping the `InterruptException` — this is the shape in the issue report;
+  * the SIGINT hit the task doing the awaiting, so `e` IS the `InterruptException` and the driver
+    task is still running on the connection.
+
+The distinction is what decides the connection's fate: a refused statement leaves the connection
+clean, an abandoned one does not.
+
+Deliberately **not** built on [`_unwrap_async_exception`](@ref). That helper stops at a
+`CompositeException` carrying more than one exception — which is exactly what LibPQ's
+`handle_result` throws when several results errored, one of which can be the interrupt. The
+recursion below finds it anywhere in the tree. It sees through a [`DatabaseError`](@ref) too, so a
+caller that already crossed the taxonomy seam can ask the same question.
+"""
+function _await_abandoned(e, depth::Int = 0)::Bool
+  depth > 8 && return false                       # cheap guard against pathological nesting
+  e isa InterruptException && return true
+  if e isa TaskFailedException
+    nested = e.task.exception
+    return nested !== e && _await_abandoned(nested, depth + 1)
+  end
+  e isa CompositeException && return any(x -> x !== e && _await_abandoned(x, depth + 1), e.exceptions)
+  e isa DatabaseError && return _await_abandoned(_driver_cause(e), depth + 1)
+  return false
 end
 
 """
@@ -1179,8 +1212,14 @@ next `acquire_connection` opens a fresh physical connection through the empty-sl
 best-effort `close` it. Used when a connection is known-dirty — e.g. a failed ROLLBACK (#71)
 — and renewal via `reconnect_db` also failed. Returns whether the slot was found. Never
 throws (callers run it while an original error is propagating).
+
+`close_handle = false` empties the slot but leaves the handle open. It exists for one caller —
+[`_recover_abandoned_connection!`](@ref)'s timeout branch, which is reached *precisely because* the
+driver is still on the connection — and closing there would free a SQLite handle the global worker
+may be inside `sqlite3_step` on. That caller takes the slot out of circulation now and closes the
+doomed handle later, once the driver has let go.
 """
-function _discard_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn)::Bool
+function _discard_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn; close_handle::Bool = true)::Bool
   found = Base.lock(pool.lock) do
     for i in 1:length(pool.connections)
       if pool.connections[i] === conn
@@ -1194,10 +1233,12 @@ function _discard_connection!(pool::Union{PormGPostgres, PormGSQLite}, conn)::Bo
   end
   # Close OUTSIDE the pool lock: a driver close can block on I/O. On SQLite this also
   # releases the database file write-lock an aborted `BEGIN IMMEDIATE` may still hold.
-  try
-    close(conn)
-  catch close_error
-    @debug "Error closing discarded connection" exception=close_error
+  if close_handle
+    try
+      close(conn)
+    catch close_error
+      @debug "Error closing discarded connection" exception=close_error
+    end
   end
   found || @warn "Connection to discard not found in the pool - it may already have been replaced"
   return found
@@ -1399,6 +1440,9 @@ Use `await_result(task)` to get the result and properly release the connection.
 - `completed::Bool`: Whether the async result has been awaited
 - `result_cache::Union{Nothing, Any}`: Cached result for multiple `await_result` calls
 - `in_transaction::Bool`: Whether this task is part of a transaction (don't release connection)
+- `abandoned::Bool`: Whether the await was cut short by a cancellation rather than a database
+  failure (#315). Set by `await_result`; it routes the connection to
+  [`_recover_abandoned_connection!`](@ref) instead of a plain release.
 """
 mutable struct FetchTask
   async_result::Any  # LibPQ.AsyncResult (PG) or Task (SQLite)
@@ -1407,14 +1451,181 @@ mutable struct FetchTask
   completed::Bool
   result_cache::Union{Nothing, Any}
   in_transaction::Bool  # Whether this task is part of a transaction context
+  abandoned::Bool       # Await cut short by a cancellation — connection is NOT returnable as-is (#315)
 
   # Constructor for transaction-aware fetch
   FetchTask(async_result, pool::Union{PormGPostgres, PormGSQLite}, conn, in_transaction::Bool) =
-    new(async_result, pool, conn, false, nothing, in_transaction)
+    new(async_result, pool, conn, false, nothing, in_transaction, false)
 
   # Legacy constructor (defaults to not in transaction)
   FetchTask(async_result, pool::Union{PormGPostgres, PormGSQLite}, conn) =
-    new(async_result, pool, conn, false, nothing, false)
+    new(async_result, pool, conn, false, nothing, false, false)
+end
+
+# Abandoned-await recovery budgets (#315), in seconds. Exposed as `_recover_abandoned_connection!`
+# kwargs so a unit test can drive the timeout branch in milliseconds instead of waiting one out.
+#
+#   settle — how long the slot stays leased hoping the connection can be recovered in place. Both
+#            cancels normally abort within milliseconds, so reaching this means the engine never
+#            acknowledged one.
+#   close  — how long a detached, doomed handle is kept alive waiting for the driver to let go
+#            before `close` is attempted regardless. Long on purpose: the cost of waiting is one
+#            parked task, the cost of closing early is a use-after-free. Note that expiry does not
+#            make the close itself bounded — `close(::LibPQ.Connection)` takes the same per-connection
+#            semaphore the running result task holds (it does set libpq's cancel flag first), and
+#            SQLite's `sqlite3_close_v2` defers while a statement is live. Expiry only stops this
+#            task polling; the handle is still closed in driver order.
+const _ABANDON_SETTLE_SECONDS = 5.0
+const _ABANDON_CLOSE_SECONDS = 300.0
+
+"""
+    _settle_probe(handle) -> Function
+
+Park ONE detached waiter on the driver handle and return a zero-argument predicate answering
+"has the driver let go of this connection?" (#315).
+
+`Base.wait` is the only settle test that spans both backends without core naming a driver type:
+LibPQ defines it on its `AsyncResult` as `wait(result_task)`, and SQLite's handle *is* a `Task`.
+(`Base.isready` is not usable — LibPQ defines it on `AsyncResult`, `Task` does not have it.) It
+**throws** when that task failed, which is a *settled* outcome and all we asked, so the throw is
+swallowed. Waiting here also CONSUMES that failure, which is what stops Julia printing an
+"Unhandled Task Error" for a query nobody is listening to any more.
+
+One waiter, reused by every deadline: a query that never returns leaks exactly one parked task
+rather than one per wait, and it exits the moment the driver finally lets go.
+"""
+function _settle_probe(handle)
+  settled = Threads.Atomic{Bool}(false)
+  Threads.@spawn begin
+    try
+      Base.wait(handle)
+    catch
+      # Failed, cancelled, interrupted — every one of those means the driver is done with it.
+    finally
+      settled[] = true
+    end
+  end
+  return () -> settled[]
+end
+
+# Bounded, non-throwing settle wait. `timedwait` polls the predicate on its own Timer and never
+# touches the driver, so a handle that never settles costs a bounded wait rather than a wedged
+# recovery task.
+_wait_settled(probe, seconds::Real)::Bool =
+  timedwait(probe, max(0.0, Float64(seconds)); pollint = 0.05) === :ok
+
+"""
+    _recover_abandoned_connection!(ft::FetchTask; settle_seconds, close_seconds) -> Nothing
+
+Recover the pool slot of a [`FetchTask`](@ref) whose await was abandoned by a cancellation (#315).
+
+Replaces the plain [`release_connection`](@ref) that used to run unconditionally. A connection whose
+driver operation is still in flight, or which has an unconsumed result queued on it, must never go
+back into the pool: neither state is visible to `backend_is_alive` — PostgreSQL still reports
+`CONNECTION_OK` — so the next borrower inherits it and every later statement on that slot fails
+with *"another command is already in progress"*, for the life of the process.
+
+Runs on a DETACHED task, for three separate reasons:
+
+  * Ctrl-C has to give the REPL back immediately, and every step below can block for seconds
+    (`PQcancel` opens its own socket; `LibPQ.reset!` is a synchronous reconnect).
+  * On SQLite the connection cannot be touched AT ALL until the global worker is off it, so doing
+    this in the caller would make Ctrl-C wait for the very query it just cancelled.
+  * A second Ctrl-C would abort a synchronous cleanup half-way and re-poison the slot. A detached
+    task does not receive the REPL's interrupt.
+
+The slot stays LEASED for the whole routine. That is the point: it becomes available again only
+once the connection is proven clean, and otherwise it is renewed or emptied. Never throws — an
+escaping error here would surface as an unhandled task error instead of a recovered slot.
+
+This is the same shape Go's `pgxpool` uses (`Conn.Release` destroys a connection that is busy or
+not idle, and does it off the caller's goroutine) and psycopg's pool (state is verified on return;
+a broken connection is discarded and replaced).
+"""
+function _recover_abandoned_connection!(ft::FetchTask;
+                                        settle_seconds::Real = _ABANDON_SETTLE_SECONDS,
+                                        close_seconds::Real = _ABANDON_CLOSE_SECONDS)
+  pool, conn, handle = ft.pool, ft.conn, ft.async_result
+  Threads.@spawn begin
+    try
+      # 1. Best-effort stop signal, and the ONLY driver call allowed to run while the operation may
+      #    still be in flight: PQcancel uses a separate PGcancel on its own socket, and
+      #    sqlite3_interrupt is documented cross-thread-safe. Never allowed to escape — a missing
+      #    driver hits Backend.jl's throwing fallback, and a closed handle can raise too.
+      try
+        backend_cancel_query!(pool, conn)
+      catch cancel_failure
+        @debug "Cancel of an abandoned query failed" exception=cancel_failure
+      end
+
+      # 2. Bounded wait for the driver to let go. LOAD-BEARING, not an optimization: LibPQ's
+      #    `lock(::Connection)` is a plain `Semaphore(1)` held by the result task for the whole
+      #    query, so draining before it settles would block for the query's full remaining life.
+      probe = _settle_probe(handle)
+      if _wait_settled(probe, settle_seconds)
+        clean = try
+          backend_drain_connection!(pool, conn)
+        catch drain_failure
+          @debug "Drain of an abandoned connection failed" exception=drain_failure
+          false
+        end
+        # `=== true`, not a bare `clean ?`: `backend_drain_connection!` is a documented-Bool generic
+        # that nothing enforces, and a downstream override returning anything else would raise a
+        # TypeError here — landing in the outer catch and costing the slot. Anything that is not a
+        # definite "clean" takes the safe branch.
+        clean === true ? release_connection(pool, conn) : _renew_or_discard_connection!(pool, conn)
+      else
+        # 3. Still in flight past the budget. Take the slot out of the pool WITHOUT closing — the
+        #    next acquire materializes a fresh connection into it — then keep the doomed handle
+        #    alive until the driver is finally off it, and only then close.
+        _discard_connection!(pool, conn; close_handle = false)
+        _wait_settled(probe, close_seconds)
+        try
+          Base.invokelatest(close, conn)
+        catch close_failure
+          @debug "Error closing an abandoned connection" exception=close_failure
+        end
+      end
+    catch recovery_failure
+      # Nothing may escape: this task has no owner, so an escape prints an unhandled task error to
+      # stderr at finalization — which looks like a crash and pollutes unrelated `@test_logs`.
+      #
+      # But swallowing alone would re-create #315 in a new place: every branch above ends by
+      # releasing, renewing or detaching the slot, so a failure BETWEEN them leaves it leased with
+      # nothing scheduled to free it — silently, for the life of the process. The old code could not
+      # do that, because its `release_connection` was unconditional. So bail out to the one action
+      # that is always safe here: empty the slot so the next borrower opens a fresh connection, and
+      # do NOT close the handle — reaching this branch means we do not know whether the driver is
+      # still on it. The orphaned handle is left to the driver's own finalizer.
+      #
+      # Act only while the slot is still OURS. `_discard_connection!` matches by identity, so once an
+      # earlier branch has handed the slot back — released it, emptied it, or had `reconnect_db` swap
+      # a fresh handle into it — `conn` is no longer there, and blindly discarding would both warn
+      # untruthfully and (worse) risk nilling a slot a new borrower already holds.
+      #
+      # Known gap, deliberately not plumbed: if the failure came from inside
+      # `_renew_or_discard_connection!` AFTER its swap, the slot is leased around a handle we cannot
+      # name from here, and this bails out to the `@debug` below instead of freeing it. That needs
+      # `release_connection` to throw, whose every internal step is itself guarded — so the cost of
+      # threading the renewed handle out here is not worth paying for it.
+      still_ours = try
+        Base.lock(() -> any(c -> c === conn, pool.connections), pool.lock)
+      catch
+        false
+      end
+      if still_ours
+        @warn "Abandoned-connection recovery failed; emptying the pool slot" exception=recovery_failure
+        try
+          _discard_connection!(pool, conn; close_handle = false)
+        catch discard_failure
+          @debug "Emptying the slot after a failed recovery also failed" exception=discard_failure
+        end
+      else
+        @debug "Abandoned-connection recovery failed after the slot was already handed back" exception=recovery_failure
+      end
+    end
+  end
+  return nothing
 end
 
 """
@@ -1440,16 +1651,30 @@ function await_result(ft::FetchTask)
     return result
   catch e
     ft.completed = true
+    # Did the await END, or was it ABANDONED? Only the second leaves the driver mid-operation, and
+    # only it must keep the connection out of the pool (#315). Deliberately does not change what
+    # this throws — see below.
+    ft.abandoned = _await_abandoned(e)
     # `rethrow()` when nothing changed: PormG's own errors (DoesNotExist, QueryBuildError,
     # PoolTimeoutError…) pass through `_as_database_error` untouched, and re-`throw`ing the same
     # object would discard the backtrace saying where it came from.
+    #
+    # An abandoned await still goes through here, so a cancellation still surfaces as a
+    # `StatementError` wrapping the `InterruptException`, exactly as before this fix. That
+    # relabelling is its own defect — `_as_database_error`'s docstring above forbids it — but
+    # correcting it changes a caller-visible error contract, so it is tracked separately.
     err = _as_database_error(ft.pool, e)
     err === e ? rethrow() : throw(err)
   finally
     # Only release connection if we're not in a transaction context
     # Transaction context manages its own connection lifecycle
     if ft.completed && !ft.in_transaction
-      release_connection(ft.pool, ft.conn)
+      # An abandoned await must NOT hand the connection back: the driver may still be writing to it
+      # (SQLite's global worker) or have left an unconsumed result on the socket (libpq), and
+      # NEITHER state is visible to `backend_is_alive` — so the next borrower would inherit a
+      # connection on which every statement fails. Recovery runs detached and owns the
+      # release/renew/discard decision from here (#315).
+      ft.abandoned ? _recover_abandoned_connection!(ft) : release_connection(ft.pool, ft.conn)
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,7 @@ end
     @testset "Module Init & atexit Cleanup (#203)" include("unit/test_module_init.jl")
     @testset "Failed Rollback → Connection Renewed/Discarded (#71)" include("unit/test_transaction_rollback_renewal.jl")
     @testset "No Lost-Connection Retry Inside Transactions (#138)" include("unit/test_fetch_retry_transaction.jl")
+    @testset "Abandoned Await Never Releases a Dirty Connection (#315)" include("unit/test_await_result_interrupt.jl")
     @testset "Failed COMMIT Holds Conn Until Rollback (#139)" include("unit/test_commit_failure_release.jl")
     @testset "Direct-Handoff Pool Wait (#124)" include("unit/test_connection_pool_handoff.jl")
     @testset "Idle-Reaping + Max-Lifetime Pool (#125)" include("unit/test_connection_pool_reaping.jl")

--- a/test/unit/test_await_result_interrupt.jl
+++ b/test/unit/test_await_result_interrupt.jl
@@ -1,0 +1,489 @@
+# ============================================================
+# test/unit/test_await_result_interrupt.jl
+#
+# An ABANDONED await must never return its connection to the pool (#315).
+#
+# CONTRACT being tested:
+#   `await_result` releases the pooled connection in its `finally`. That is correct when the await
+#   ENDED — the query returned rows, or the database refused the statement — because the driver is
+#   then done with the connection. It is wrong when the await was ABANDONED by a cancellation
+#   (Ctrl-C), because the driver is still mid-operation:
+#
+#     * PostgreSQL — libpq has an unconsumed result queued on the socket. `backend_is_alive` is
+#       `PQstatus(conn) == CONNECTION_OK`, which stays TRUE for such a connection, so neither
+#       `release_connection` nor the next `acquire_connection` can tell it apart from a healthy one.
+#       The next borrower then fails with "another command is already in progress" — forever.
+#     * SQLite — the global async worker is still binding/stepping on that very handle. Handing it
+#       back lets a second borrower run statements on it concurrently, and closing it (renew or
+#       discard) frees it under the worker. That is the use-after-free class that produced an
+#       EXCEPTION_ACCESS_VIOLATION on Windows once already.
+#
+#   So an abandoned await hands the connection to `_recover_abandoned_connection!` instead:
+#   cancel → bounded wait for the driver to let go → drain → release if clean, renew/discard if not,
+#   and if it never lets go, empty the slot WITHOUT closing the handle and close it later.
+#
+# Deterministic and DB-free: behavioral mock pools carry the exact fields the pool machinery reads
+# (see test_fetch_retry_transaction.jl for the pattern) and gate every asynchronous step, so no
+# assertion races the detached recovery task. The SQLite testset drives the REAL global worker.
+#
+# Reverting the fix (restoring the unconditional `release_connection` in await_result's `finally`)
+# fails these synchronously — the old release happened INSIDE the finally, before `await_result`
+# returned, so there is no race to lose. Each testset names its own revert signature below.
+# ============================================================
+
+using Test
+using PormG
+
+# No DB drivers needed: every backend_* call in these flows dispatches to the mock methods below,
+# so this file runs without the LibPQ/SQLite weakdep extensions.
+
+const CP = PormG.ConnectionPool
+
+# ── Fake driver handle: tracks close, AND whether the driver was still on it at close time ──
+# (structs live at file top level — Julia forbids type definitions inside @testset blocks)
+#
+# `closed_while_busy` is the use-after-free assertion in mock form. `busy` is set by the mock
+# "driver" for as long as it is using the handle; a `close` landing in that window is exactly what
+# frees a SQLite handle out from under `sqlite3_step`.
+mutable struct FakeConn315
+  id::Int
+  closed::Bool
+  closed_while_busy::Bool
+  busy::Threads.Atomic{Bool}
+end
+FakeConn315(id::Int) = FakeConn315(id, false, false, Threads.Atomic{Bool}(false))
+function Base.close(c::FakeConn315)
+  c.busy[] && (c.closed_while_busy = true)
+  c.closed = true
+  return nothing
+end
+
+# ── PG-shaped mock: PostgresConnectionPool's exact fields + recovery knobs ──
+#
+# Counters are atomic because the recovery routine runs on a DETACHED task, so the test task reads
+# them concurrently. `drain_gate`, when non-nothing, parks the recovery inside the drain — that is
+# how the assertions below observe the slot mid-recovery instead of racing it.
+mutable struct MockPGPool315 <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+  cancels::Threads.Atomic{Int}          # backend_cancel_query! calls
+  drains::Threads.Atomic{Int}           # backend_drain_connection! calls
+  renewals::Threads.Atomic{Int}         # backend_renew_connection calls
+  drain_clean::Any                      # what backend_drain_connection! reports (Any: a contract-
+                                        # violating non-Bool is one of the cases under test)
+  drain_gate::Union{Nothing, Channel{Nothing}}
+  next_id::Threads.Atomic{Int}
+end
+MockPGPool315(; drain_clean = true, drain_gate = nothing) =
+  MockPGPool315(Any[FakeConn315(1)], [true], "mock://pg", 1, ReentrantLock(),
+                Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
+                drain_clean, drain_gate, Threads.Atomic{Int}(1))
+
+PormG.backend_is_alive(::MockPGPool315, conn) = conn isa FakeConn315 && !conn.closed
+PormG.backend_connect(pool::MockPGPool315; kwargs...) =
+  FakeConn315(Threads.atomic_add!(pool.next_id, 1) + 1)
+function PormG.backend_renew_connection(pool::MockPGPool315, conn; kwargs...)
+  Threads.atomic_add!(pool.renewals, 1)
+  return FakeConn315(Threads.atomic_add!(pool.next_id, 1) + 1)
+end
+PormG.backend_cancel_query!(pool::MockPGPool315, conn) =
+  (Threads.atomic_add!(pool.cancels, 1); nothing)
+function PormG.backend_drain_connection!(pool::MockPGPool315, conn)
+  Threads.atomic_add!(pool.drains, 1)
+  pool.drain_gate === nothing || take!(pool.drain_gate)   # park the recovery here on demand
+  return pool.drain_clean
+end
+
+# ── SQLite-shaped mock: SQLiteConnectionPool's exact fields + the same knobs ──
+# Statements funnel through the REAL global async worker → backend_execute, so the abandoned-await
+# behaviour is proven on the actual SQLite code path rather than a stand-in.
+mutable struct MockSQLitePool315 <: PormG.PormGSQLite
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  split_read_write::Bool
+  writer_slot::Int
+  reader_cursor::Int
+  lock::ReentrantLock
+  write_lock::ReentrantLock
+  cancels::Threads.Atomic{Int}
+  drains::Threads.Atomic{Int}
+  renewals::Threads.Atomic{Int}
+  drain_clean::Bool
+  work_gate::Union{Nothing, Channel{Nothing}}   # blocks the worker INSIDE backend_execute
+  next_id::Threads.Atomic{Int}
+end
+MockSQLitePool315(; drain_clean::Bool = true, work_gate = nothing) =
+  MockSQLitePool315(Any[FakeConn315(1)], [true], "mock://sqlite", 1, false, 1, 0,
+                    ReentrantLock(), ReentrantLock(),
+                    Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0),
+                    drain_clean, work_gate, Threads.Atomic{Int}(1))
+
+PormG.backend_is_alive(::MockSQLitePool315, conn) = conn isa FakeConn315 && !conn.closed
+PormG.backend_connect(pool::MockSQLitePool315; read_only::Bool = false) =
+  FakeConn315(Threads.atomic_add!(pool.next_id, 1) + 1)
+function PormG.backend_renew_connection(pool::MockSQLitePool315, conn; read_only::Bool = false)
+  Threads.atomic_add!(pool.renewals, 1)
+  return FakeConn315(Threads.atomic_add!(pool.next_id, 1) + 1)
+end
+PormG.backend_cancel_query!(pool::MockSQLitePool315, conn) =
+  (Threads.atomic_add!(pool.cancels, 1); nothing)
+function PormG.backend_drain_connection!(pool::MockSQLitePool315, conn)
+  Threads.atomic_add!(pool.drains, 1)
+  return pool.drain_clean
+end
+# Runs on the global SQLite worker thread — keep it pure (no @test in here). `conn.busy` is set for
+# exactly as long as the worker is on the handle, which is the window a release or close must not
+# land in.
+function PormG.backend_execute(pool::MockSQLitePool315, conn, sql::String, params)
+  conn.busy[] = true
+  try
+    pool.work_gate === nothing || take!(pool.work_gate)
+    return NamedTuple[]
+  finally
+    conn.busy[] = false
+  end
+end
+
+# Busy-wait until `pred()` or a deadline; returns whether it became true. (Named for this file so it
+# cannot collide with the sibling pool tests' copy when the whole suite runs in one process.)
+function _wait_until_315(pred; timeout = 5.0, step = 0.005)
+  t0 = time()
+  while time() - t0 < timeout
+    pred() && return true
+    sleep(step)
+  end
+  return pred()
+end
+
+# The shape a SIGINT force-thrown into the driver's own result task produces: `Base.fetch` on it
+# raises `TaskFailedException` wrapping the `InterruptException`. This is literally the trace in the
+# #315 report ("nested task error: InterruptException").
+_interrupted_handle() = @async throw(InterruptException())
+
+# Run `await_result` on a fresh abandoned FetchTask and return the error it raised.
+function _abandon_via_await_315(pool)
+  ft = CP.fetch_async(pool, "SELECT surname FROM drivers;")
+  try
+    CP.await_result(ft)
+    return (ft, nothing)
+  catch e
+    return (ft, e)
+  end
+end
+PormG.backend_execute_async(pool::MockPGPool315, conn, sql::String, params) = _interrupted_handle()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Detection (#315): both real cancellation shapes must be recognised, and nothing else
+# `_await_abandoned` is what decides the connection's fate, so it is unit-tested on its own before
+# any pool is involved. The multi-element CompositeException case is why it cannot simply reuse
+# `_unwrap_async_exception`, which stops at one.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_await_abandoned recognises a cancellation, not a refused statement (#315)" begin
+  # Shape (b): the SIGINT hit the task doing the awaiting.
+  @test CP._await_abandoned(InterruptException())
+
+  # Shape (a): the SIGINT was force-thrown into the driver's result task.
+  t = @async throw(InterruptException())
+  wrapped = try; Base.fetch(t); catch e; e; end
+  @test wrapped isa TaskFailedException
+  @test CP._await_abandoned(wrapped)
+
+  # LibPQ's handle_result bundles several failed results into ONE CompositeException; the interrupt
+  # can be any member. `_unwrap_async_exception` gives up on a multi-element composite — this must not.
+  @test CP._await_abandoned(CompositeException([ErrorException("boom"), InterruptException()]))
+  @test !CP._await_abandoned(CompositeException([ErrorException("boom"), ErrorException("bang")]))
+
+  # Already across the taxonomy seam (what `fetch`'s catch sees).
+  @test CP._await_abandoned(PormG.StatementError("PostgreSQL", InterruptException()))
+  @test !CP._await_abandoned(PormG.StatementError("PostgreSQL", ErrorException("syntax error")))
+
+  # Ordinary failures are NOT abandonment — this is the guard against the fix over-firing.
+  @test !CP._await_abandoned(ErrorException("relation does not exist"))
+  @test !CP._await_abandoned(PormG.PoolTimeoutError("PostgreSQL", 1, 10, 1, 30.0))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The slot is NOT returned dirty (#315) — the headline assertion
+# The drain gate parks the recovery task mid-flight, so `available[1] === false` is observed
+# deterministically rather than raced. The raised error is pinned too: this fix deliberately does
+# NOT change what the caller sees.
+#
+# Reverted-fix signature: the old `finally` calls release_connection SYNCHRONOUSLY, so `available[1]`
+# is already `true` on the line after the throw. No timing involved.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an abandoned await leaves the slot leased, not released (#315)" begin
+  gate = Channel{Nothing}(1)
+  pool = MockPGPool315(drain_gate = gate)
+  old = pool.connections[1]
+
+  ft, err = _abandon_via_await_315(pool)
+
+  @test ft.abandoned === true                          # the await was classified as cancelled
+  @test pool.available[1] === false                    # ← the fix: slot still leased
+  @test pool.connections[1] === old                    # nothing swapped yet
+  # The caller-visible error is UNCHANGED by this fix: still the taxonomy wrapper, still carrying
+  # the interrupt as its cause. (Surfacing Ctrl-C as a StatementError is its own defect, tracked
+  # separately — pinning it here is what stops this PR from changing it by accident.)
+  @test err isa PormG.StatementError
+  @test err.cause isa InterruptException
+
+  put!(gate, nothing)                                  # let the recovery finish
+  @test _wait_until_315(() -> pool.available[1] === true)
+  close(gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ordering (#315): cancel first, drain only once the driver has let go
+# Draining while the driver still holds the connection is not merely wasteful — LibPQ's per-connection
+# lock is a plain Semaphore(1) held by the result task for the whole query, so the drain would block
+# for the runaway query's entire remaining life. PQcancel is the one call safe to issue in that window.
+#
+# Reverted-fix signature: `cancels` stays 0 forever, so the first _wait_until_315 returns false.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "recovery cancels before it touches the connection (#315)" begin
+  settle_gate = Channel{Nothing}(1)
+  pool = MockPGPool315()
+  conn = CP.acquire_connection(pool)
+  # A handle that is still in flight: it settles only when the test opens the gate.
+  handle = @async (take!(settle_gate); throw(InterruptException()))
+  ft = CP.FetchTask(handle, pool, conn, false)
+
+  CP._recover_abandoned_connection!(ft; settle_seconds = 5.0)
+
+  @test _wait_until_315(() -> pool.cancels[] == 1)      # cancel is issued immediately…
+  @test pool.drains[] == 0                             # …and nothing else is, while it is in flight
+  @test pool.available[1] === false                    # slot stays leased throughout
+
+  put!(settle_gate, nothing)                           # driver lets go
+  @test _wait_until_315(() -> pool.drains[] == 1)      # only now is the connection touched
+  @test _wait_until_315(() -> pool.available[1] === true)
+  close(settle_gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Clean drain (#315): the SAME handle goes back into the SAME slot
+# A connection that drained cleanly is healthy — renewing it would throw away a good session for
+# nothing. The pre-gate assertion pins the ORDER, so this cannot pass merely by reaching the right
+# end state eventually.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a clean drain releases the same handle (#315)" begin
+  gate = Channel{Nothing}(1)
+  pool = MockPGPool315(drain_clean = true, drain_gate = gate)
+  old = pool.connections[1]
+
+  _abandon_via_await_315(pool)
+  @test pool.available[1] === false                    # pre-gate: recovery has NOT released yet
+
+  put!(gate, nothing)
+  @test _wait_until_315(() -> pool.available[1] === true)
+  @test pool.connections[1] === old                    # same handle, same slot
+  @test old.closed === false                           # and it was not thrown away
+  @test pool.renewals[] == 0
+  @test pool.drains[] == 1
+  close(gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Failed drain (#315): renew the slot instead of releasing it
+# This is the branch that actually stops the reported bug when a cancel does not clear the socket:
+# the dirty handle is replaced in its slot and closed, so no borrower can ever reach it.
+#
+# Reverted-fix signature: `renewals` stays 0 and the dirty `old` is back in the pool, available.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a failed drain renews the slot and closes the dirty handle (#315)" begin
+  gate = Channel{Nothing}(1)
+  pool = MockPGPool315(drain_clean = false, drain_gate = gate)
+  old = pool.connections[1]
+
+  _abandon_via_await_315(pool)
+  @test pool.available[1] === false
+
+  put!(gate, nothing)
+  @test _wait_until_315(() -> pool.renewals[] == 1)
+  @test _wait_until_315(() -> pool.available[1] === true)
+  @test pool.connections[1] !== old                    # fresh handle in the slot
+  @test old.closed === true                            # dirty handle closed, not leaked
+  # (No `closed_while_busy` assertion here: this pool's driver never sets `busy`, so it would read
+  # `false` whatever the code did. The in-use close is proven where `busy` is really modelled —
+  # the never-settling testset below, and the SQLite one.)
+  close(gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A misbehaving backend must not cost the slot (#315)
+# `backend_drain_connection!` is documented to return Bool, and NOTHING enforces that — a downstream
+# backend override or a future driver could return something else. The recovery is the last code
+# holding this slot, so a TypeError there would leave it leased for the life of the process: #315
+# again, in a new place. Anything that is not a definite `true` must take the safe branch.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a non-Bool drain result renews the slot rather than losing it (#315)" begin
+  pool = MockPGPool315(drain_clean = nothing)          # violates the Bool contract
+  old = pool.connections[1]
+
+  _abandon_via_await_315(pool)
+
+  @test _wait_until_315(() -> pool.available[1] === true)   # the slot comes back at all…
+  @test pool.renewals[] == 1                           # ← …and via the SAFE branch, which is the point
+  # Distinguishes "renewed" from "the outer-catch fallback emptied the slot": the fallback leaves
+  # `nothing` behind, and on its own `available[1] === true` cannot tell the two apart.
+  @test pool.connections[1] !== nothing
+  @test pool.connections[1] !== old
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Never settles (#315): empty the slot WITHOUT closing the handle
+# Past the settle budget the connection is unrecoverable, but the driver may still be inside it —
+# on SQLite, inside sqlite3_step. So the slot leaves the pool immediately (nobody can borrow it) and
+# the handle is closed only once the driver finally lets go.
+#
+# Reverted-fix signature (of the `close_handle = false` kwarg specifically): `_discard_connection!`
+# closes straight away and `closed_while_busy` is true — a use-after-free in mock form.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a never-settling driver detaches the slot without closing the handle (#315)" begin
+  settle_gate = Channel{Nothing}(1)
+  pool = MockPGPool315()
+  conn = CP.acquire_connection(pool)
+  conn.busy[] = true                                   # the "driver" is on this handle
+  handle = @async (take!(settle_gate); throw(InterruptException()))
+  ft = CP.FetchTask(handle, pool, conn, false)
+
+  CP._recover_abandoned_connection!(ft; settle_seconds = 0.05, close_seconds = 5.0)
+
+  # Both facts in ONE predicate: `_discard_connection!` nils the slot and frees it inside a single
+  # `pool.lock` section, but this reader does not hold that lock, so polling them separately could
+  # observe the first write without the second.
+  @test _wait_until_315(() -> pool.connections[1] === nothing && pool.available[1] === true)
+  @test conn.closed === false                          # ← the handle is NOT closed while in use
+  @test pool.drains[] == 0                             # nothing tried to read it, either
+
+  conn.busy[] = false
+  put!(settle_gate, nothing)                           # driver finally lets go
+  @test _wait_until_315(() -> conn.closed === true)     # only now is it closed
+  @test conn.closed_while_busy === false
+  close(settle_gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SQLite (#315): the worker must be off the connection before anything touches it
+# Driven through the REAL global async worker, with a REAL interrupt thrown into the awaiting task
+# (shape (b)) — the only configuration in this file where the driver is genuinely still running when
+# `await_result` unwinds. That is the EXCEPTION_ACCESS_VIOLATION window, made observable.
+#
+# Reverted-fix signature: `available[1]` is already true while the worker is mid-backend_execute.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "SQLite: the worker is off the connection before it is reused (#315)" begin
+  work_gate = Channel{Nothing}(1)
+  pool = MockSQLitePool315(work_gate = work_gate)
+  old = pool.connections[1]
+
+  # Acquire the FetchTask FIRST, so a premature interrupt can only land inside `await_result`.
+  ft = CP.fetch_async(pool, "SELECT surname FROM drivers;")
+  me = current_task()
+  # `schedule(…; error = true)` is only safe on a task that is genuinely PARKED — on a runnable one
+  # it would enqueue a second time. What guarantees that here is not the sleep: `sqlite_execute_async`
+  # returns a `@async` task, which is STICKY to this thread, so `busy` can only become true after
+  # this task has already yielded — and between `fetch_async` and the assertions its only yield point
+  # is the park inside `await_result`'s `Base.fetch`. (Keep that in mind before rewriting this with
+  # `Threads.@spawn`, which would break the guarantee.) The sleep is slack, not the mechanism.
+  Threads.@spawn begin
+    # Bail out rather than fire blind: without this, a worker that never starts would deliver the
+    # interrupt at an unpredictable line instead of failing cleanly.
+    if _wait_until_315(() -> old.busy[])
+      sleep(0.05)
+      schedule(me, InterruptException(); error = true)
+    end
+  end
+
+  err = try; CP.await_result(ft); nothing; catch e; e; end
+
+  @test ft.abandoned === true
+  @test old.busy[] === true                            # the worker really is still on the handle…
+  @test pool.available[1] === false                    # …and the slot was NOT handed back
+  @test old.closed === false                           # nor was the handle closed under it
+  @test err isa PormG.StatementError && err.cause isa InterruptException
+
+  put!(work_gate, nothing)                             # let the worker finish
+  @test _wait_until_315(() -> pool.available[1] === true)
+  @test pool.connections[1] === old                    # SQLite has nothing to drain → plain release
+  @test old.closed === false                           # a clean handle is never thrown away…
+  @test old.closed_while_busy === false                # …and was never closed under the worker
+  @test pool.cancels[] == 1
+  close(work_gate)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression (#315): every NON-abandoned path releases exactly as it did before
+# The guard against the fix OVER-firing. A successful query and an ordinary database failure must
+# both still take the plain `release_connection` branch, on both backends — no cancel, no drain, no
+# renewal, and the same connection back in the same slot.
+# ─────────────────────────────────────────────────────────────────────────────
+mutable struct MockPGPlain315 <: PormG.PormGPostgres
+  connections::Vector{Any}
+  available::Vector{Bool}
+  connection_string::String
+  pool_size::Int
+  lock::ReentrantLock
+  fail::Bool
+  cancels::Threads.Atomic{Int}
+  drains::Threads.Atomic{Int}
+  renewals::Threads.Atomic{Int}
+end
+MockPGPlain315(; fail::Bool = false) =
+  MockPGPlain315(Any[FakeConn315(1)], [true], "mock://pg", 1, ReentrantLock(), fail,
+                 Threads.Atomic{Int}(0), Threads.Atomic{Int}(0), Threads.Atomic{Int}(0))
+PormG.backend_is_alive(::MockPGPlain315, conn) = conn isa FakeConn315 && !conn.closed
+PormG.backend_connect(pool::MockPGPlain315; kwargs...) = FakeConn315(99)
+PormG.backend_renew_connection(pool::MockPGPlain315, conn; kwargs...) =
+  (Threads.atomic_add!(pool.renewals, 1); FakeConn315(99))
+PormG.backend_cancel_query!(pool::MockPGPlain315, conn) =
+  (Threads.atomic_add!(pool.cancels, 1); nothing)
+PormG.backend_drain_connection!(pool::MockPGPlain315, conn) =
+  (Threads.atomic_add!(pool.drains, 1); true)
+PormG.backend_execute_async(pool::MockPGPlain315, conn, sql::String, params) =
+  @async (pool.fail && error("mock: relation \"drivers\" does not exist"); NamedTuple[])
+
+@testset "un-abandoned awaits release exactly as before (#315)" begin
+  @testset "PostgreSQL success" begin
+    pool = MockPGPlain315()
+    old = pool.connections[1]
+    ft = CP.fetch_async(pool, "SELECT surname FROM drivers;")
+
+    @test CP.await_result(ft) == NamedTuple[]
+    @test ft.abandoned === false
+    @test pool.available[1] === true                   # released synchronously, as always
+    @test pool.connections[1] === old
+    @test pool.cancels[] == 0 && pool.drains[] == 0 && pool.renewals[] == 0
+  end
+
+  @testset "PostgreSQL statement failure" begin
+    pool = MockPGPlain315(fail = true)
+    old = pool.connections[1]
+    ft = CP.fetch_async(pool, "SELECT surname FROM drivers;")
+
+    err = try; CP.await_result(ft); nothing; catch e; e; end
+    # Pin the CONCRETE type, mirroring the abandoned twin above: the umbrella `DatabaseError` would
+    # still pass if the mock's failure were reclassified, which is the thing worth noticing.
+    @test err isa PormG.StatementError
+    @test ft.abandoned === false                       # a refused statement is NOT abandonment
+    @test pool.available[1] === true
+    @test pool.connections[1] === old
+    @test pool.cancels[] == 0 && pool.drains[] == 0 && pool.renewals[] == 0
+  end
+
+  @testset "SQLite success through the real worker" begin
+    pool = MockSQLitePool315()                         # no work_gate → backend_execute returns at once
+    old = pool.connections[1]
+    ft = CP.fetch_async(pool, "SELECT surname FROM drivers;")
+
+    @test CP.await_result(ft) == NamedTuple[]
+    @test ft.abandoned === false
+    @test pool.available[1] === true
+    @test pool.connections[1] === old
+    @test pool.cancels[] == 0 && pool.drains[] == 0 && pool.renewals[] == 0
+  end
+end

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -101,8 +101,10 @@ using PormG
         # so precompiling the package would not catch it. This assertion would.
         for fn in (:backend_connect, :backend_renew_connection, :backend_is_alive,
                    :backend_execute, :backend_execute_async, :backend_is_connection_error,
-                   :backend_is_permanent_connect_error, :backend_num_affected_rows,
-                   :backend_num_rows, :backend_copy_in!, :backend_sqlite_version)
+                   :backend_is_permanent_connect_error,
+                   :backend_cancel_query!, :backend_drain_connection!,
+                   :backend_num_affected_rows, :backend_num_rows, :backend_copy_in!,
+                   :backend_sqlite_version)
             @test parentmodule(getfield(PormG, fn)) === PormG
         end
     end


### PR DESCRIPTION
Closes #315.

## The bug

`await_result` released the pooled connection in its `finally` regardless of *how* the await ended. That is correct when the await **ended** — rows came back, or the database refused the statement — because the driver is then done with the connection. It is wrong when a `Ctrl+C` **abandoned** it, and neither backend's state is visible to the pool:

- **PostgreSQL** — libpq has an unconsumed result queued on the socket. `backend_is_alive` is `PQstatus(conn) == CONNECTION_OK`, which stays **true** for exactly that connection, so neither `release_connection` nor the next `acquire_connection` can tell it apart from a healthy one. Every later query on that slot then failed with `another command is already in progress`, permanently.
- **SQLite** — the same defect, with a worse failure mode. The single global worker is still binding/stepping on that handle; handing it back lets a second borrower use it concurrently, and closing it (renew/discard) frees it under the worker — the use-after-free class behind the Windows `EXCEPTION_ACCESS_VIOLATION`.

## The fix

An abandoned await routes the connection to `_recover_abandoned_connection!` instead of `release_connection`: **cancel → bounded wait for the driver to let go → drain → release if clean, renew/discard if not.** If the driver never lets go, the slot leaves the pool *without* closing the handle, which is closed later once the driver is off it. The slot stays **leased** throughout — that is the point.

Two new backend generics carry the driver halves: `backend_cancel_query!` (PG `PQcancel`; SQLite `sqlite3_interrupt`) and `backend_drain_connection!` (PG reuses the existing COPY drain; SQLite has nothing to drain). The COPY primitive gains a `deadline` kwarg defaulting to `Inf`, so `backend_copy_in!` is byte-identical.

### Three design points that are load-bearing

- **Recovery runs detached**, matching Go's `pgxpool` (`Conn.Release` decides destroy-vs-return off the caller's goroutine). Three independent reasons: `Ctrl+C` must give the REPL back immediately; SQLite cannot have its handle touched *at all* until the worker is off it; and a second `Ctrl+C` would abort a synchronous cleanup half-way and re-poison the slot.
- **The bounded wait is not an optimization.** `LibPQ.lock(conn)` is `acquire(conn.semaphore)` on a `Base.Semaphore(1)` with no owner tracking, held by the result task for the whole query — so draining before it settles would block for the runaway query's entire remaining life. `PQcancel` builds its own `PGcancel` on its own socket, which is why it is the one call allowed to run before the wait.
- **`LibPQ.cancel(async_result)` is useless here** and is deliberately not used: it only sets a `should_cancel` flag read by the `_consume` loop *inside* the result task — which is the task the SIGINT killed.

## Verification

| | |
|---|---|
| Unit | **5442/5442** (on the rebased tree) |
| Integration `db_2` | **1963/1963** |
| Integration `db_sl` | **1930/1930** (1 pre-existing broken) |
| Mutation tests | 4, each caught |

A live-PostgreSQL script (scratch, deleted) ran both interrupt shapes on a `pool_size = 1` pool. It **reproduces the reported failure verbatim on unfixed code** — `OperationalError: ... another command is already in progress`, and permanently, so even an unrelated later query fails — and passes 14/14 on this branch. It waits for recovery before querying and asserts the pool never expanded, so the passing query provably runs on the slot that was poisoned rather than on a second slot the pool grew.

The new test file was mutation-tested: reverting the `finally` branch, removing `close_handle = false`, skipping the settle wait, and relaxing `clean === true` each produce failures.

## Deliberately NOT in this PR

- **`InterruptException` is still relabelled as `StatementError`.** It is a real defect — `_as_database_error`'s own docstring forbids it — but a separate caller-visible contract change. A test **pins** the current type so this PR cannot drift it.
- **The same hole exists at `with_transaction` (L1718) and at `_run_in_transaction_impl`'s `BEGIN` await.** Structurally identical. An interrupt in a transaction *body* self-heals (the ROLLBACK is refused → non-benign → renew/discard); one during `BEGIN` does not, because `tx_started` is still `false`. **Highest-value follow-up**; the one-line fix reuses this PR's helper: `!tx_started && _await_abandoned(e) && (rollback_error = e)`.
- `AdvisoryLock._exec_lock_query` can orphan a session-level `pg_advisory_lock` on a connection that returns to the pool.
- Classifying `another command is already in progress` as a connection error; exporting `close_pool!`; the pre-existing "re-await of a failed `FetchTask` returns `nothing`".

## Consequences worth naming

- An abandoned await on a **caller-pinned `conn=`** now renews-and-closes that handle rather than just releasing it. `FetchTask` carries no "caller pinned this" bit, and the alternative is handing back a connection we know is poisoned. No in-repo caller reaches it, and `conn` is not in either docstring's signature.
- Under `julia -t 1`, `PQcancel`/`PQreset` block the single worker thread while they run. Degraded responsiveness, not a hang; documented in `async.md` rather than claimed away.
- The recovery holds a lease for up to ~10s, so a `leak_detection_threshold` below that will warn after a `Ctrl+C`.
- **Unrelated pre-existing issue found:** `test/integration/test_bulk_copy.jl` run *standalone* depends on DB state left by earlier suite files — it fails on unmodified `main` too. In-suite it passes.

No `UPGRADING.md` entry and no `Project.toml` bump: this fixes something already broken, with no caller-visible contract change.

Reviewed independently by a fresh reader, twice (initial + delta). That review caught green theater in the first draft of the tests and a slot-leak the fix itself had introduced in its error path; both are fixed and now covered by assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
