### PR TITLE
docs(#315): drop an unresolvable @ref from the FetchTask docstring

### DIFF
--- a/src/ConnectionPool.jl
+++ b/src/ConnectionPool.jl
@@ -1441,8 +1441,11 @@ Use `await_result(task)` to get the result and properly release the connection.
 - `result_cache::Union{Nothing, Any}`: Cached result for multiple `await_result` calls
 - `in_transaction::Bool`: Whether this task is part of a transaction (don't release connection)
 - `abandoned::Bool`: Whether the await was cut short by a cancellation rather than a database
-  failure (#315). Set by `await_result`; it routes the connection to
-  [`_recover_abandoned_connection!`](@ref) instead of a plain release.
+  failure (#315). Set by `await_result`; it sends the connection through the abandoned-await
+  recovery — cancel, wait for the driver, drain, then release or renew — instead of a plain
+  release. (Plain backticks, not an `@ref`: this struct is exported, so `@autodocs` publishes this
+  docstring to `api.md`, and a cross-reference from there to an internal helper cannot resolve —
+  `Private = false` means the target is never rendered. That broke the docs build once.)
 """
 mutable struct FetchTask
   async_result::Any  # LibPQ.AsyncResult (PG) or Task (SQLite)


### PR DESCRIPTION
Fixes the red **Documentation** build on `main` ([run 31182586780](https://github.com/PingoLee/PormG.jl/actions/runs/31182586780), introduced by #320).

## What broke

`FetchTask` is exported, so `api.md`'s `@autodocs` block publishes its docstring. The `abandoned` field description added in #320 linked `@ref` to `_recover_abandoned_connection!` — which is **private**, and that block sets `Private = false`, so the target is never rendered and Documenter cannot resolve the reference. It terminates the build before rendering:

```
┌ Error: Cannot resolve @ref for md"[`_recover_abandoned_connection!`](@ref)" in docs/src/api.md.
│ - No docstring found in doc for binding `PormG.ConnectionPool._recover_abandoned_connection!`.
ERROR: LoadError: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

The unit and integration suites cannot see this — only `docs/make.jl` can.

## The fix

Plain backticks instead of the cross-reference, with the constraint recorded inline so the next edit to this docstring does not rediscover it: an exported struct's docstring is published, and a link from there into `Private = false` territory has no target.

I audited the rest rather than patching only the one that fired. Every other `@ref` to an underscore-private name in `src/` sits inside a **private function's own** docstring, which `Private = false` never expands, so none of them reach the cross-reference resolver. `FetchTask` was the only exported carrier.

## Verification

| Check | Result |
|---|---|
| `julia --project=docs -e 'include("docs/make.jl")'` | reproduced the failure **before** this change; **exit 0** after |
| Unit suite | **5442/5442** |
| `test_docstring_coverage`, `test_docs_error_types`, `test_public_exports`, `test_docs_error_type_drift` | pass |

Docstring text only — no behaviour change, no `UPGRADING.md` entry, no `Project.toml` bump.

## Process note

#320 shipped without a docs build. `general.instructions.md` lists `docs/make.jl` under *Verification* and warns that local green is not CI green; I ran the unit and integration suites but not the docs build, and did not check the PR's CI before merge. The docs build belongs in the pre-merge ladder for any change that touches a docstring on an exported name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
