### PR TITLE
fix(#318): introspection reads single-column UNIQUE back on both backends

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,60 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Introspection now reads single-column `UNIQUE` back (#318)
+
+- **Version**: Unreleased
+- **PormG ref**: #318; `src/migrations/introspection.jl`, `src/migrations/planner.jl`
+- **Recorded**: 2026-08-07
+- **Severity**: **behavior-visible (one-time migration plan against existing databases)** — no source
+  edit is required. Part of the `0.4.x` wave.
+
+### What changed
+
+Neither backend read a column's `UNIQUE` constraint back, so a model declaring `unique=true` never
+compared equal to its own live table. `makemigrations` proposed the same alteration **on every run**
+— on SQLite that alteration is the full `CREATE new → INSERT SELECT → DROP old → RENAME` table
+rebuild. It also masked genuine drift: with a permanently-dirty baseline, a real schema change was
+indistinguishable from the standing false positive.
+
+Two independent root causes, both fixed:
+
+- **SQLite** — `PRAGMA table_info` has no uniqueness column, so `unique` was never populated at all.
+  Introspection now reads it from `PRAGMA index_list`/`index_info`.
+- **PostgreSQL** — the `unique_constraints` CTE grouped by *table*, merging every unique constraint's
+  columns into one array; the consumer then required that array to have length 1. So a table with
+  **two separate single-column `UNIQUE`s** reported **neither** as unique. The single-column test now
+  applies per *constraint*.
+
+Composite uniqueness is deliberately **not** read as a per-field `unique`: PormG models it as a
+model-level `UniqueConstraint` (#19), and marking a member column would churn in the other direction.
+For the same reason a bare `CREATE UNIQUE INDEX` (including a single-field `UniqueConstraint`) is not
+read back — that keeps both backends symmetric, since PostgreSQL reads `pg_constraint`, which cannot
+see an index either.
+
+### What you may see once
+
+Nothing to edit — but the **first** `makemigrations` after upgrading can propose a one-time plan:
+
+- A live single-column `UNIQUE` your model does **not** declare is now visible as drift, so PormG will
+  propose removing it (on SQLite, via the table rebuild). Previously it was silently ignored. Review
+  that plan before applying it: if the constraint should stay, add `unique=true` to the field.
+- On PostgreSQL this newly affects every table carrying **two or more** unique constraints — those
+  columns previously introspected as `unique=false` regardless of what the model said.
+
+After that one plan, re-running `makemigrations` is clean, which is the point of the fix.
+
+### How to find the calls to migrate
+
+```bash
+# Models declaring column-level uniqueness — the ones whose diff behavior changes.
+rg -n 'unique\s*=\s*true' --glob '*.jl'
+```
+
+Then run `makemigrations` and **read the plan** before `migrate`.
+
+---
+
 ## Model-level `db_table`, and DDL now quotes the table identifier (#59)
 
 - **Version**: Unreleased

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -205,7 +205,12 @@ Converts a SQL CREATE TABLE statement into a model definition in PormGModel.
 - `PormGModel`: The model definition.
 
 # Example"""
-function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_type_map)   
+function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_type_map)
+  # NOTE (#318): this DDL-regex reader does NOT populate `field.unique`, unlike the PRAGMA reader
+  # (`convertSQLToModel(::PormGSQLite, …)`) that #318 fixed. Deliberate: `convert_schema_to_models`
+  # reaches the PRAGMA method, so this one is off the production introspection path. Reading it here
+  # would mean regex-parsing inline and table-level UNIQUE clauses out of the DDL text — strictly
+  # worse than the pragma. If this path is ever put back on the live route, close that gap first.
 
   # Extract table name
   table_name_match = match(r"CREATE TABLE \"(.+?)\"", sql)
@@ -331,6 +336,10 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
   _bounds_rows = fetch(db, "SELECT sql FROM sqlite_master WHERE type='table' AND name = ?", [table_name]) |> DataFrame
   byte_bounds = _sqlite_byte_length_bounds(nrow(_bounds_rows) == 0 || ismissing(_bounds_rows[1, :sql]) ? nothing : _bounds_rows[1, :sql])
 
+  # #318: `PRAGMA table_info` above has no uniqueness column, so `unique` was never populated at all.
+  # Read it once per table here; the per-column branches below test membership.
+  unique_cols = _sqlite_single_column_unique_columns(db, table_name)
+
   fields_dict = Dict{Symbol, Any}()
   fk_map = Dict{String, Any}()
   if !isempty(fks)
@@ -359,6 +368,15 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
         # `convert_schema_to_models(::PormGSQLite)` actually reaches. The FK column's declared type
         # drives normalization the same way a non-FK column's does.
         fk_type_sym = get(type_map, base_type, :TextField)
+        # A UNIQUE foreign key is conceptually a one-to-one, and PostgreSQL introspection returns
+        # `OneToOneField` for it — but SQLite deliberately does NOT follow suit here (#318). PormG
+        # cannot currently materialize a OneToOneField: `Dialect._get_column_type` has no branch for
+        # it, so it renders `TEXT` rather than the referenced key's type, and (on SQLite) the inline
+        # `FOREIGN KEY … REFERENCES` clause is gated on `isa sForeignKey`, so no constraint is emitted
+        # at all. Returning O2O here would therefore make the inspectdb round trip strictly WORSE:
+        # with the `unique` flag below, a live `INTEGER UNIQUE REFERENCES parent(id)` now regenerates
+        # LOSSLESSLY as `INTEGER UNIQUE` + the foreign key, where an O2O would regenerate as `TEXT`
+        # with no foreign key. The flag is what #318 is actually about; the field type is not.
         field = Models.ForeignKey(uppercasefirst(fk_info.table); pk_field=fk_info.to,
             on_delete=_normalize_introspected_on_delete(fk_info.on_delete), null=nullable,
             default=_fk_default_or_warn(_normalize_sqlite_default(default_val, fk_type_sym), table_name, col_name))
@@ -376,6 +394,16 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
             # cannot come from `col_type` the way CharField's does (#296).
             field.max_length = byte_bounds[col_name]
         end
+    end
+    # #318: set post-construction, matching the `field.max_length = …` mutations just above — that
+    # avoids threading a kwarg through three different constructors.
+    #
+    # `!is_pk` is required, not defensive, on two independent counts: `sIDField` is the ONE immutable
+    # field struct (models/fields.jl), so `setfield!` would throw; and it already defaults
+    # `unique=true`, which must survive an `INTEGER PRIMARY KEY` rowid alias that has no backing index
+    # at all. Hence the rule everywhere here: only ever set TRUE, never clear it.
+    if !is_pk && col_name in unique_cols && hasfield(typeof(field), :unique) && !field.unique
+      field.unique = true
     end
     fields_dict[Symbol(col_name)] = field
   end
@@ -481,6 +509,21 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
         FROM pg_constraint con
         JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
         WHERE con.contype = 'u'
+          -- #318: the single-column test belongs HERE, per CONSTRAINT — not on the aggregate below.
+          -- This CTE groups by TABLE, so it merged every unique constraint's columns into ONE array:
+          -- a table with two SEPARATE single-column UNIQUEs produced {slug, uuid_token}, and the
+          -- consumer's `array_length(...) = 1` guard then rejected BOTH. Every such column
+          -- introspected as `unique=false`, never matched its own declaration, and makemigrations
+          -- proposed the same alteration forever.
+          --
+          -- Multi-column constraints stay excluded on purpose: PormG models composite uniqueness as
+          -- a model-level UniqueConstraint (#19), never as a per-field `unique`, so marking a member
+          -- column would churn in the opposite direction. `CREATE UNIQUE INDEX` — how #19 is
+          -- materialized — has no pg_constraint row at all and is excluded for free.
+          --
+          -- Grouping by `con.oid` instead would be wrong: the CTE must stay ONE ROW PER TABLE, or the
+          -- LEFT JOIN below fans out and every table yields N duplicate models.
+          AND array_length(con.conkey, 1) = 1
         GROUP BY con.conrelid
     ),
     foreign_keys AS (
@@ -568,11 +611,12 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
             || CASE WHEN a.attnotnull THEN ' NOT NULL' ELSE '' END
             || CASE WHEN ad.adbin IS NOT NULL THEN ' DEFAULT ' || pg_get_expr(ad.adbin, ad.adrelid) ELSE '' END
             $(identity_case)
-            || CASE
-                WHEN array_length(u.unique_cols, 1) = 1
-                     AND a.attname = ANY(u.unique_cols) THEN ' UNIQUE'
-                ELSE ''
-               END
+            -- #318: plain membership now. `unique_cols` already holds ONLY single-column constraints
+            -- (filtered per-constraint in the CTE above), so the old `array_length(...) = 1` guard
+            -- here was testing the wrong thing — the merged per-table array — and rejected every
+            -- column on any table with more than one unique constraint. `unique_cols` is NULL when a
+            -- table has none (LEFT JOIN) and `x = ANY(NULL)` is NULL, so this still falls through.
+            || CASE WHEN a.attname = ANY(u.unique_cols) THEN ' UNIQUE' ELSE '' END
             || CASE
                 WHEN nn.check_cols IS NOT NULL
                      AND a.attname = ANY(nn.check_cols) THEN ' NON_NEGATIVE_CHECK'
@@ -687,11 +731,14 @@ function get_constraints_index(conn::PormGSQLite, table_name::Symbol, field_name
   return nothing
 end
 
-# #151: SQLite introspection does not populate `field.unique` (see convertSQLToModel(::PormGSQLite)), so the
-# deletion path can't trust the old field's attribute — probe the live schema for a UNIQUE index covering
-# `field_name`. That covers the column-level UNIQUE auto-index (`sqlite_autoindex_…`, which `DROP INDEX`
-# can't remove) as well as any `CREATE UNIQUE INDEX`. Such a column is refused by `ALTER TABLE DROP COLUMN`,
+# #151: probe the live schema for a UNIQUE index of ANY arity covering `field_name`. That covers the
+# column-level UNIQUE auto-index (`sqlite_autoindex_…`, which `DROP INDEX` can't remove), a table-level
+# `UNIQUE (a, b)`, and any `CREATE UNIQUE INDEX`. Such a column is refused by `ALTER TABLE DROP COLUMN`,
 # so its deletion must route through a table rebuild (same remedy #116 uses for FK columns).
+#
+# STILL REQUIRED after #318 gave introspection a `unique` flag, and deliberately BROADER than it: this
+# answers "would SQLite refuse to drop this column?", which is true for a composite-unique member and
+# for a `CREATE UNIQUE INDEX` column — neither of which sets `field.unique`. Do not collapse the two.
 function _sqlite_column_is_unique(conn::PormGSQLite, table_name, field_name::String)::Bool
   idx_list = fetch(conn, "PRAGMA index_list(\"$(string(table_name))\")") |> DataFrame
   isempty(idx_list) && return false
@@ -701,6 +748,53 @@ function _sqlite_column_is_unique(conn::PormGSQLite, table_name, field_name::Str
     (!isempty(idx_info) && field_name in idx_info.name) && return true
   end
   return false
+end
+
+"""
+    _sqlite_single_column_unique_columns(conn::PormGSQLite, table_name) -> Set{String}
+
+Physical columns of `table_name` carrying a SINGLE-column `UNIQUE` **constraint** — exactly the set for
+which `field.unique` must introspect back as `true` (#318).
+
+`PRAGMA table_info` has no uniqueness column at all, so `convertSQLToModel(::PormGSQLite)` never
+populated `unique`: every `unique=true` field compared unequal to its own live table and
+`makemigrations` proposed the same rebuild forever.
+
+Deliberately NARROWER than [`_sqlite_column_is_unique`](@ref) above, which answers the different
+question `ALTER TABLE DROP COLUMN` asks. Two filters make the difference, and both are load-bearing:
+
+  * `origin = 'u'` keeps only the auto-index SQLite creates for a `UNIQUE` clause inside
+    `CREATE TABLE` — the one and only thing `field.unique` emits (`Dialect.field_to_column`). It
+    excludes `origin = 'c'` (`CREATE UNIQUE INDEX`), which is how a model-level `UniqueConstraint`
+    (#19) is materialized, and `origin = 'pk'` (a primary key is already an IDField). Arity alone is
+    NOT enough here: a `UniqueConstraint` may name a single field, and marking that column would
+    churn in the opposite direction. This also keeps the backends symmetric — PostgreSQL reads
+    `pg_constraint` (`contype='u'`), which likewise cannot see a bare `CREATE UNIQUE INDEX`.
+  * `HAVING COUNT(*) = 1` drops a table-level `UNIQUE (a, b)`, whose origin is also `'u'`.
+
+`partial = 0` is belt-and-braces rather than load-bearing: SQLite only produces a partial index via
+`CREATE INDEX … WHERE`, which is always `origin = 'c'` and therefore already excluded. Kept so the
+predicate stays correct if that ever changes.
+
+Known, accepted gap: a hand-written `CREATE UNIQUE INDEX` in a foreign schema introspects as
+`unique=false`. Reading it would restore inspectdb fidelity at the cost of permanent churn for
+single-field `UniqueConstraint` — the exact bug class #318 fixes.
+
+ONE query per table (the table-valued-pragma idiom `get_secondary_index_ddls` also uses), not one probe
+per column: callers test membership. An unknown table yields an empty set rather than throwing.
+"""
+function _sqlite_single_column_unique_columns(conn::PormGSQLite, table_name)::Set{String}
+  rows = fetch(conn, """
+    SELECT ii.name AS col
+    FROM pragma_index_list(?) AS il
+    JOIN pragma_index_info(il.name) AS ii
+    WHERE il."unique" = 1 AND il.origin = 'u' AND il.partial = 0
+    GROUP BY il.name
+    HAVING COUNT(*) = 1
+    """, [string(table_name)]) |> DataFrame
+  # An empty frame's column is eltype Missing, so guard before touching `rows.col`.
+  nrow(rows) == 0 && return Set{String}()
+  return Set{String}(string(c) for c in rows.col if c !== missing)
 end
 
 """
@@ -990,7 +1084,11 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       
       # Determine field constraints
       primary_key::Bool = col_name in pk_set
-      unique::Bool = occursin("UNIQUE", col)
+      # #318: token match, not a substring test. `col` is the whole rendered column string, so
+      # `occursin` also fired on a column *named* `UNIQUE_CODE` (mixed-case names are supported, #57)
+      # or a `DEFAULT 'UNIQUE'` literal — inventing uniqueness that would then be diffed forever.
+      # The CTE appends ' UNIQUE' as its own space-separated token, so membership is exact.
+      unique::Bool = "UNIQUE" in col_parts
       not_null::Bool = occursin("NOT NULL", col)
       default_value = nothing
       if occursin("DEFAULT", col)

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -522,8 +522,11 @@ function _resolve_table_fields(
     # deleted field forces a rebuild, route the WHOLE table's deletions through it and skip the per-column
     # DROP COLUMNs (emitting both would race: the rebuild removes the column, then a stray `DROP COLUMN` for a
     # sibling deletion fails "no such column"). Ordinary indexed columns still take the cheap DROP COLUMN path
-    # below (their plain index is pre-dropped). `unique` is probed live — SQLite introspection doesn't set
-    # `old_field.unique` (see _sqlite_column_is_unique) — while `primary_key` IS populated by introspection.
+    # below (their plain index is pre-dropped). `unique` is probed live, and STILL must be after #318 gave
+    # SQLite introspection a `unique` flag: that flag is deliberately narrow (single-column UNIQUE constraints
+    # only), whereas SQLite refuses DROP COLUMN for a column in ANY unique index — a composite-unique member
+    # or a `CREATE UNIQUE INDEX` column included. `_sqlite_column_is_unique` answers that broader question;
+    # `old_field.unique` does not. `primary_key` IS populated by introspection.
     rebuild_delete_idx = nothing
     if conn isa PormGSQLite
       rebuild_delete_idx = findfirst(colect_deletion) do fsym

--- a/test/integration/test_importers_introspection.jl
+++ b/test/integration/test_importers_introspection.jl
@@ -32,7 +32,8 @@
   # Child before parent: since #276 SQLite enforces foreign keys, so dropping the parent while the
   # child still references it raises instead of silently succeeding.
   fixtures = ("pormg_it_fk_child", "pormg_it_fk_parent",
-              "pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored")
+              "pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored",
+              "pormg_it_uniq")
   drop_fixtures() = for t in fixtures
     try; ddl("DROP TABLE IF EXISTS \"$(t)\""); catch; end
   end
@@ -77,12 +78,27 @@
          fk_o2o        INTEGER UNIQUE REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE
        )"""
 
+  # #318: TWO separate single-column UNIQUEs on one table plus a composite. This is the ONLY place
+  # PostgreSQL's `unique_constraints` CTE actually runs, and the two-uniques shape is precisely what
+  # it got wrong (it merged both constraints' columns into one per-table array, then rejected both
+  # for being length 2). The composite pins the must-NOT-mark half on both backends.
+  uniq_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_uniq" (
+         id BIGINT PRIMARY KEY, slug VARCHAR(60) UNIQUE, token VARCHAR(60) UNIQUE,
+         a INT, b INT, plain TEXT, UNIQUE (a, b)
+       )""" :
+    """CREATE TABLE "pormg_it_uniq" (
+         id INTEGER PRIMARY KEY, slug TEXT UNIQUE, token TEXT UNIQUE,
+         a INTEGER, b INTEGER, plain TEXT, UNIQUE (a, b)
+       )"""
+
   drop_fixtures()                      # clean slate if a prior run aborted mid-test
   ddl(natural_pk_ddl)
   ddl(numeric_pk_ddl)
   ddl(ignored_ddl)
   ddl(fk_parent_ddl)
   ddl(fk_child_ddl)
+  ddl(uniq_ddl)
 
   saved_ignore = copy(PormG._EXTRA_IGNORE_TABLES[])
   try
@@ -140,13 +156,37 @@
     # self-consistent enough to register.
     @test child.fields["fk_setdefault"].default == 1
 
-    # OneToOneField had the identical omission and is fixed with ForeignKey. PostgreSQL-only: the
-    # SQLite PRAGMA path does not read UNIQUE, so `fk_o2o` stays a plain ForeignKey there — a
-    # pre-existing divergence this issue does not change.
+    # OneToOneField had the identical omission and is fixed with ForeignKey. PostgreSQL-only, and
+    # deliberately so as of #318: SQLite introspection now reads single-column UNIQUE, but it still
+    # returns a ForeignKey for a UNIQUE foreign key rather than a OneToOneField. PormG cannot
+    # materialize an O2O — `Dialect._get_column_type` has no branch for it and the FK clause is gated
+    # on `isa sForeignKey` — so returning one would regenerate `TEXT` with no foreign key where a
+    # plain ForeignKey regenerates `INTEGER` + the constraint. See the note in convertSQLToModel.
     if is_pg
       @test child.fields["fk_o2o"] isa PormG.Models.sOneToOneField
       @test child.fields["fk_o2o"].on_delete === PormG.Models.CASCADE
     end
+    # Both backends DO read the uniqueness itself, which is what #318 fixes.
+    @test child.fields["fk_o2o"].unique
+
+    # ── 3b. Single-column UNIQUE round-trips; composite does not (#318) ──────
+    # Introspection never read UNIQUE back, so every `unique=true` field diffed as changed on every
+    # makemigrations — forever. This is the ONLY coverage that executes PostgreSQL's
+    # `unique_constraints` CTE, which is where the PG half of the bug lived: it grouped by TABLE, so
+    # `pormg_it_uniq`'s two separate single-column UNIQUEs merged into one length-2 array and the
+    # consumer's `array_length(...) = 1` guard rejected BOTH.
+    uniq_models = PormG.Migrations.convert_schema_to_models(pool)
+    uniq = Dict(lowercase(string(m.name)) => m for m in uniq_models)["pormg_it_uniq"]
+
+    @test uniq.fields["slug"].unique
+    @test uniq.fields["token"].unique     # the mutation gate for the per-table-array bug
+    @test !uniq.fields["plain"].unique    # no over-marking
+
+    # Composite uniqueness is a model-level UniqueConstraint (#19), never a per-field attribute —
+    # marking a member would churn in the opposite direction. Excluded on both backends: PostgreSQL
+    # by `array_length(conkey,1) = 1`, SQLite by `HAVING COUNT(*) = 1`.
+    @test !uniq.fields["a"].unique
+    @test !uniq.fields["b"].unique
 
     # ── 4. The regenerated module registers via set_models (#287/#291) ───────
     # THE regression assertion. Before #292 this threw ModelDefinitionError ("declares on_delete

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1792,6 +1792,73 @@ end
     @test accepted
   end
 
+  # ── Phase 18: single-column UNIQUE round-trips + no churn (#318) ────
+  # Introspection never read a column's UNIQUE back, so a `unique=true` field never compared equal to
+  # its own live table: are_model_fields_equal said "changed" and makemigrations proposed the same
+  # alteration on EVERY run — on SQLite a real CREATE/INSERT-SELECT/DROP/RENAME table rebuild.
+  #
+  # Two root causes, one per backend, and `Uniq318` reproduces the harder one:
+  #   * SQLite — `PRAGMA table_info` has no uniqueness column at all, so `unique` was never populated.
+  #   * PostgreSQL — the `unique_constraints` CTE grouped by TABLE, merging every unique constraint's
+  #     columns into ONE array; a table with TWO separate single-column UNIQUEs produced length 2 and
+  #     the consumer's `array_length(...) = 1` guard then rejected BOTH.
+  # Hence two uniques on one table, not one.
+  @testset "Phase 18: UNIQUE Round-trip + No Churn (#318)" begin
+    write_edge_models("""
+    Uniq318 = Models.Model(
+        id = Models.IDField(),
+        slug = Models.CharField(unique=true),
+        token = Models.CharField(unique=true),
+        plain = Models.CharField(null=true)
+    )
+    Uniqcomp318 = Models.Model(
+        id = Models.IDField(),
+        season = Models.IntegerField(),
+        round = Models.IntegerField(),
+        constraints = [Models.UniqueConstraint(fields=("season", "round"), name="uniqcomp318_season_round_uniq")]
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # (a) The constraints are physically REAL, asserted behaviorally (the same oracle Phase 17 uses):
+    #     a metadata query here would just re-implement the production predicate and could not catch
+    #     it being wrong.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO uniq318 ("slug","token","plain") VALUES ('s1','t1','p');""")
+    # Match the UNIQUE-violation message rather than catching everything: a bare `catch` would read a
+    # typo'd table name or a pool error as "constraint enforced" and pass for the wrong reason.
+    _is_unique_violation(e) = occursin("unique", lowercase(sprint(showerror, e)))
+    dup_slug = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO uniq318 ("slug","token") VALUES ('s1','t2');"""); false
+    catch e; _is_unique_violation(e) end
+    dup_token = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO uniq318 ("slug","token") VALUES ('s2','t1');"""); false
+    catch e; _is_unique_violation(e) end
+    ok_both = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO uniq318 ("slug","token") VALUES ('s3','t3');"""); true
+    catch; false end
+    @test dup_slug     # both single-column uniques are enforced…
+    @test dup_token
+    @test ok_both      # …and independently, not as a composite
+
+    # (b) INTROSPECTION reads them back — the unit of the fix, against a live database.
+    intro = Dict(lowercase(string(m.name)) => m for m in PormG.Migrations.convert_schema_to_models(pool))
+    @test intro["uniq318"].fields["slug"].unique
+    @test intro["uniq318"].fields["token"].unique    # mutation gate for the PG per-table-array bug
+    @test !intro["uniq318"].fields["plain"].unique   # …and it did not over-mark
+
+    # Composite uniqueness is model-level (#19), never a per-field attribute. Marking a member column
+    # would churn in the OPPOSITE direction on every subsequent makemigrations.
+    @test !intro["uniqcomp318"].fields["season"].unique
+    @test !intro["uniqcomp318"].fields["round"].unique
+
+    # (c) NO CHURN — the reason #318 exists.
+    pending = joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl")
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+  end
+
   # ── Cleanup ─────────────────────────────────────────────────────────
   PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
   delete!(PormG.config, joinpath(@__DIR__, edge_db_name))

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -357,3 +357,42 @@ using PormG.Migrations: _pg_confdeltype_to_on_delete, _normalize_introspected_on
   end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #318: the PostgreSQL reader takes uniqueness from a ' UNIQUE' token the schema query appends to
+# each column string. This pins that CONTRACT hermetically — a future edit to the CTE that renames or
+# drops the token fails here, without a database.
+#
+# It does NOT test the CTE itself (no SQL runs here); that query is covered in
+# test/integration/test_importers_introspection.jl. What it DOES test is the half that silently
+# over-matched: the read used `occursin("UNIQUE", col)` against the WHOLE column string, so a column
+# *named* `UNIQUE_CODE` (mixed-case names are supported, #57) or a `DEFAULT 'UNIQUE'` literal
+# introspected as unique and then churned forever.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PostgreSQL UNIQUE marker is a token, not a substring (#318)" begin
+  row = _introspection_row(
+    table_name   = "uniq_guard",
+    columns      = "id bigint NOT NULL, slug character varying(120) NOT NULL UNIQUE, " *
+                   "token uuid NOT NULL UNIQUE, plain text",
+    primary_keys = "id")
+  model = convertSQLToModel(row)
+
+  # Baseline, NOT a mutation gate: these three pass on main too, because this file feeds
+  # `convertSQLToModel` a pre-rendered `columns` string and never runs the CTE. They pin the marker
+  # CONTRACT — if a future CTE edit renames or drops the ' UNIQUE' token, the reader stops seeing it
+  # and these fail. The CTE bug itself (a per-table array that rejected both columns of a two-unique
+  # table) is gated in test/integration/test_importers_introspection.jl, where the SQL actually runs.
+  @test model.fields["slug"].unique
+  @test model.fields["token"].unique
+  @test !model.fields["plain"].unique
+
+  # THE mutation gate for this testset: a column whose NAME contains the substring, and a DEFAULT
+  # literal that does. Both returned `true` under the old `occursin("UNIQUE", col)` and `false` under
+  # the token match — so these two assertions, unlike the three above, go red on main.
+  tricky = convertSQLToModel(_introspection_row(
+    table_name   = "uniq_guard_tricky",
+    columns      = "id bigint NOT NULL, UNIQUE_CODE text, label text DEFAULT 'UNIQUE'",
+    primary_keys = "id"))
+  @test !tricky.fields["UNIQUE_CODE"].unique
+  @test !tricky.fields["label"].unique
+end

--- a/test/unit/test_sqlite_index_filter.jl
+++ b/test/unit/test_sqlite_index_filter.jl
@@ -23,7 +23,8 @@ using Test
 using PormG
 using DataFrames
 import PormG.ConnectionPool: SQLiteConnectionPool, fetch, close_pool!
-import PormG.Migrations: get_secondary_index_ddls, _sqlite_column_is_unique
+import PormG.Migrations: get_secondary_index_ddls, _sqlite_column_is_unique,
+                         _sqlite_single_column_unique_columns, convertSQLToModel
 
 @testset "get_secondary_index_ddls column filter (#116)" begin
   mktempdir() do dir
@@ -122,10 +123,12 @@ end
 # needs a table rebuild.
 #
 # SQLite refuses `ALTER TABLE DROP COLUMN` for a UNIQUE column, and its backing `sqlite_autoindex_…` can't
-# be pre-dropped with `DROP INDEX` — so such a deletion must route through a rebuild. SQLite introspection
-# does NOT populate `field.unique`, so the deletion path can't trust the old field's attribute; it probes
-# the live schema instead. This probe must fire for a column-level `UNIQUE` (auto-index) but NOT for an
-# ordinary secondary index (whose column CAN take DROP COLUMN once the plain index is pre-dropped).
+# be pre-dropped with `DROP INDEX` — so such a deletion must route through a rebuild. The deletion path
+# probes the live schema rather than reading `old_field.unique`, and STILL must after #318 gave
+# introspection a `unique` flag: that flag is narrow by design (single-column UNIQUE *constraints*), while
+# this probe must answer the broader "is the column in ANY unique index?" — composite members and
+# `CREATE UNIQUE INDEX` columns included. This probe must fire for a column-level `UNIQUE` (auto-index) but
+# NOT for an ordinary secondary index (whose column CAN take DROP COLUMN once the plain index is pre-dropped).
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "_sqlite_column_is_unique (#151)" begin
   mktempdir() do dir
@@ -144,6 +147,89 @@ end
       fetch(pool, "CREATE UNIQUE INDEX ux_plain ON t(plain);")
       @test _sqlite_column_is_unique(pool, :t, "plain") == true
       # Mutation gate: without the `row.unique == 1` filter, `ic` (plain index) would return true.
+    finally
+      close_pool!(pool)
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #318: `_sqlite_single_column_unique_columns` — the NARROW sibling of the probe above, and the one
+# introspection uses to populate `field.unique`.
+#
+# `PRAGMA table_info` has no uniqueness column at all, so introspection never set `unique`: a model
+# declaring `unique=true` never compared equal to its own live table and `makemigrations` proposed the
+# same rebuild forever. This function answers a deliberately DIFFERENT question from the #151 probe —
+# "does this column carry a single-column UNIQUE *constraint*?", i.e. exactly what `field.unique`
+# emits — so the two must not be collapsed into one.
+#
+# Each filter has a distinct mutation gate, spelled out per assertion below.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_sqlite_single_column_unique_columns (#318)" begin
+  mktempdir() do dir
+    pool = SQLiteConnectionPool(joinpath(dir, "uniquecols.sqlite"); pool_size = 1)
+    try
+      # One of every shape that PRAGMA index_list can report:
+      #   uc     → column-level UNIQUE      (origin 'u', 1 col)  ← the ONLY one that is field.unique
+      #   a, b   → table-level UNIQUE(a,b)  (origin 'u', 2 cols)
+      #   plain  → CREATE UNIQUE INDEX      (origin 'c')
+      #   ic     → plain CREATE INDEX       (not unique)
+      #   id     → INTEGER PRIMARY KEY      (origin 'pk', or no index at all for a rowid alias)
+      fetch(pool, "CREATE TABLE t (id INTEGER PRIMARY KEY, uc TEXT UNIQUE, ic INTEGER, plain TEXT, a TEXT, b TEXT, UNIQUE(a,b));")
+      fetch(pool, "CREATE INDEX ix_ic ON t(ic);")
+      fetch(pool, "CREATE UNIQUE INDEX ux_plain ON t(plain);")
+
+      cols = _sqlite_single_column_unique_columns(pool, :t)
+      @test cols == Set(["uc"])
+
+      # Spelled out individually so a failure names the filter that broke:
+      @test "uc" in cols        # drop `il."unique" = 1` and `ic` leaks in
+      @test !("a" in cols)      # drop `HAVING COUNT(*) = 1` and composite members leak in — they are
+      @test !("b" in cols)      #   model-level UniqueConstraint (#19), never a per-field attribute
+      @test !("plain" in cols)  # drop `origin = 'u'` and CREATE UNIQUE INDEX leaks in — that is how a
+                                #   single-field UniqueConstraint is materialized, and marking it would
+                                #   churn in the opposite direction (and diverge from PostgreSQL, whose
+                                #   pg_constraint read cannot see a bare index either)
+      @test !("ic" in cols)
+      @test !("id" in cols)     # a PK is already an IDField; introspection must never touch it (and
+                                #   sIDField is immutable, so setting `unique` on it would throw)
+
+      # An unknown table yields an empty set rather than throwing — convert_schema_to_models calls this
+      # per table and must not blow up on a race with a concurrent DROP.
+      @test _sqlite_single_column_unique_columns(pool, :nonexistent) == Set{String}()
+
+      # The #151 probe's BROAD semantics are untouched by all of the above — this is the assertion that
+      # proves the two functions were not accidentally merged.
+      @test _sqlite_column_is_unique(pool, :t, "uc") == true
+      @test _sqlite_column_is_unique(pool, :t, "plain") == true   # CREATE UNIQUE INDEX
+      @test _sqlite_column_is_unique(pool, :t, "a") == true       # composite member
+      @test _sqlite_column_is_unique(pool, :t, "ic") == false
+
+      # END TO END: the set above is only useful if convertSQLToModel actually applies it. Without
+      # this, the whole fix could be inert and every assertion above would still pass.
+      m = convertSQLToModel(pool, "t")
+      @test m.fields["uc"].unique
+      @test !m.fields["plain"].unique
+      @test !m.fields["a"].unique
+      @test !m.fields["ic"].unique
+      @test m.fields["id"] isa PormG.Models.sIDField   # PK branch untouched (and immutable)
+
+      # A UNIQUE foreign key gets the `unique` flag like any other column, but STAYS a ForeignKey —
+      # SQLite deliberately does not mirror PostgreSQL's OneToOneField here (#318). PormG cannot
+      # materialize an O2O (`Dialect._get_column_type` has no branch for it, and the FK clause is
+      # gated on `isa sForeignKey`), so returning one would make the inspectdb round trip strictly
+      # worse: `INTEGER` + a foreign key becomes `TEXT` + no foreign key. Pinned so a future
+      # "let's mirror PG" change has to confront that first.
+      fetch(pool, "CREATE TABLE parent318 (id INTEGER PRIMARY KEY, nome TEXT);")
+      fetch(pool, """CREATE TABLE child318 (
+        id INTEGER PRIMARY KEY,
+        o2o INTEGER UNIQUE REFERENCES parent318(id),
+        fk  INTEGER REFERENCES parent318(id));""")
+      c = convertSQLToModel(pool, "child318")
+      @test c.fields["o2o"] isa PormG.Models.sForeignKey
+      @test c.fields["o2o"].unique        # …the uniqueness IS read, which is what #318 fixes
+      @test c.fields["fk"]  isa PormG.Models.sForeignKey
+      @test !c.fields["fk"].unique
     finally
       close_pool!(pool)
     end


### PR DESCRIPTION
Closes #318.

## The bug

Neither backend read a column's `UNIQUE` constraint back, so a model declaring `unique=true` never compared equal to its own live table. `are_model_fields_equal` returned false → `makemigrations` proposed the same alteration → **on every run, forever**. On SQLite that alteration is the full `CREATE new → INSERT SELECT → DROP old → RENAME` table rebuild, so it is destructive-shaped churn rather than mere noise. It also masked genuine drift: with a permanently-dirty baseline, a real schema change is indistinguishable from the standing false positive.

## Scope correction

**I filed #318 as SQLite-only. That was wrong**, and measuring both databases proved it — PostgreSQL drifts too, with an *independent* root cause. The issue body has been corrected. Measured before the fix:

```
db_sl (SQLite):     case_preserve_parent_scratch.driverRef.unique   declared=true live=false
                    django_contract_scratch.label.unique            declared=true live=false
db_2 (PostgreSQL):  field_validation_scratch.slug.unique            declared=true live=false
                    field_validation_scratch.uuid_token.unique      declared=true live=false
```

## Two root causes

**SQLite** — `convertSQLToModel(::PormGSQLite)` reads columns via `PRAGMA table_info`, which has no uniqueness column at all. `unique` was never populated; not set wrongly, simply never touched. New `_sqlite_single_column_unique_columns` reads it from `pragma_index_list`/`pragma_index_info` — one query per table, callers test membership.

**PostgreSQL** — the `unique_constraints` CTE grouped by `con.conrelid` (**the table**), merging every unique constraint's columns into one array; the consumer then required `array_length(unique_cols, 1) = 1`. So a table with **two separate single-column `UNIQUE`s** produced a length-2 array and **neither** column was marked. The single-column test now applies per *constraint*, in the CTE's `WHERE`. The CTE deliberately still emits one row per table — grouping by `con.oid` would fan out through the outer `LEFT JOIN` and yield duplicate models.

## Why composite uniqueness is excluded, on both backends

PormG models composite uniqueness as a model-level `UniqueConstraint` (#19), never as a per-field `unique`. Marking a member column would churn in the *opposite* direction. The discriminators:

| SQLite `PRAGMA index_list` | source | marked? |
| :--- | :--- | :--- |
| `origin='u'`, 1 column | inline `UNIQUE` in `CREATE TABLE` — what `field.unique` emits | **yes** |
| `origin='u'`, ≥2 columns | table-level `UNIQUE (a, b)` | no (arity) |
| `origin='c'` | `CREATE UNIQUE INDEX` — how `UniqueConstraint` is materialized | no (origin) |
| `origin='pk'` | primary key | no (origin) |

`origin` is load-bearing, not arity alone: a *single-field* `UniqueConstraint` is legal and materializes as `CREATE UNIQUE INDEX`. Excluding it also keeps the backends symmetric, since PostgreSQL reads `pg_constraint`, which cannot see a bare index either.

**Accepted gap, documented in the helper docstring:** a hand-written `CREATE UNIQUE INDEX` in a foreign schema introspects as `unique=false`. Reading it would restore inspectdb fidelity at the cost of permanent churn for single-field `UniqueConstraint` — the exact bug class this fixes.

## Also included

**Marker read hardened from substring to token.** `occursin("UNIQUE", col)` matched a column *named* `UNIQUE_CODE` (mixed-case names are supported, #57) or a `DEFAULT 'UNIQUE'` literal, inventing uniqueness that then churned forever. Now `"UNIQUE" in col_parts`.

**SQLite deliberately does NOT mirror PostgreSQL's `OneToOneField`** for a UNIQUE foreign key. I originally included that parity and was wrong to: `sOneToOneField` has no branch in `Dialect._get_column_type` and the inline FK clause is gated on `isa sForeignKey`, so PormG cannot materialize one. Returning it would regenerate `TEXT` with **no foreign key**, where a `ForeignKey` now regenerates `INTEGER UNIQUE` + the constraint — **losslessly**, which is an improvement this PR delivers. The PG/SQLite divergence is left in place and explained at the call site; the underlying "O2O is unmaterializable" bug is filed separately.

## Independent review — two rounds

**Round 1 (7 findings).** The headline caught the `OneToOneField` parity above: my stated justification ("it closes the O2O churn") was false, and the change made the inspectdb round trip strictly worse. Reverted. Also: a missing `UPGRADING.md` entry (added), three new PG assertions that were green-theater with a comment claiming otherwise (relabelled honestly — that file feeds a pre-rendered string and never runs the CTE), a dead `partial = 0` filter (kept, documented as belt-and-braces), a missing note on the DDL-regex reader, and a bare `catch` in the new integration phase (now matches the UNIQUE-violation message).

**Round 2** caught that the branch was two commits behind `main`, so `git diff origin/main` read as a **revert of #315** and the reported green numbers predated it. Fast-forwarded and everything re-run. It also found a stale parenthetical claiming the round trip "loses only the UNIQUE" — it is now lossless.

## Tests

- `test/unit/test_sqlite_index_filter.jl` — new `_sqlite_single_column_unique_columns (#318)` testset. Every filter has a named mutation gate (drop `HAVING COUNT(*) = 1` → composite members leak; drop `origin='u'` → `CREATE UNIQUE INDEX` leaks; drop `unique = 1` → plain indexes leak), plus an **end-to-end** `convertSQLToModel` block — without it the whole fix could be inert and the set assertions would still pass. Also pins that the #151 probe's *broad* semantics are unchanged, since that one must stay broader (SQLite refuses `DROP COLUMN` for a column in **any** unique index).
- `test/unit/test_introspection_guards.jl` — pins the PG `' UNIQUE'` marker contract hermetically. Explicitly labelled: three assertions are a baseline that passes on `main`, and the `UNIQUE_CODE` / `DEFAULT 'UNIQUE'` pair is the actual mutation gate.
- `test/integration/test_migration_bootstrap.jl` — new **Phase 18**, mirroring the Phase 14/15 "no churn" pattern, covering two single-column uniques on one table (the PG failure shape), a composite `UniqueConstraint` (must-not-mark), and a negative control. Uniqueness is asserted **behaviorally** via rejected duplicate inserts rather than a metadata query that would re-implement the production predicate.
- `test/integration/test_importers_introspection.jl` — new `pormg_it_uniq` fixture. This is the **only** place PostgreSQL's rewritten CTE actually executes.

## Verification

| | |
| :--- | :--- |
| Full unit suite | **5468 / 5468** |
| PostgreSQL integration (`db_2`) | **1978 / 1978** |
| SQLite integration (`db_sl`) | **1945 / 1946** (1 pre-existing broken) |
| `unique` drift, SQLite | **2 → 0** |
| `unique` drift, PostgreSQL | **2 → 0** |

All measured on the merged tree. The drift re-measurement is the assertion that matters: **zero** `unique` mismatches remain on either backend.

The highest-risk regression the plan flagged is clear: Phase 5→6 of the bootstrap drops a `unique=true` on re-declaration, which now enters `colect_not_equal` for the first time and exercises PostgreSQL's `ALTER TABLE … DROP CONSTRAINT` path — previously unreached by that suite.

## What is NOT fixed — deliberately

Type/length round-trip drift remains, and is a different root cause:

```
db_2:  photo BLOB→TEXT · canonical_url VARCHAR(500)→TEXT (max_length lost)
db_sl: photo BLOB→VARCHAR · payload JSONB→VARCHAR · uuid_token UUID→VARCHAR (+ invented max_length=250)
```

So the **global** `assert_clean_state()` / `status().pending` assertion still cannot be restored, and #59's scoped workaround in `test/integration/test_db_table_db.jl` stays. Filed separately, along with two latent bugs this work surfaced: `db_index` is never read back on either backend (the PG path tests a `Symbol` against a `Dict{String,String}`, so it is always `false`), and `get_constraints_unique` returns `result[1, :constraint_name]` — row-order dependent when a column belongs to both a single-column and a composite unique constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
