### PR TITLE
fix(#325): the migration diff compares the physical column, not the field type

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,87 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## The migration diff compares the physical column, not the Julia field type (#325)
+
+- **Version**: Unreleased
+- **PormG ref**: #325; `src/Dialect.jl`, `src/migrations/introspection.jl`,
+  `src/migrations/planner.jl`, `src/models/fields.jl`, `src/constants.jl`
+- **Recorded**: 2026-08-07
+- **Severity**: **behavior-visible (one-time migration plan against existing databases)** — no source
+  edit is required. Part of the `0.4.x` wave.
+
+### What changed
+
+The remainder of the churn [#318](#introspection-now-reads-single-column-unique-back-318) fixed for
+`unique`. A model declaring `URLField`, `SlugField`, `UUIDField`, `JSONField`, `ImageField`,
+`FileField` or a `varchar` longer than 255 never compared equal to its own live table, so
+`makemigrations` proposed the same alteration **on every run** — on SQLite the full
+`CREATE new → INSERT SELECT → DROP old → RENAME` table rebuild. The same held for **every**
+`db_index=true` field on both backends.
+
+The root cause is that introspection *cannot* reproduce the declared Julia type: several field types
+render the same column, so the information is not in the schema to read. PostgreSQL renders
+`CharField`, `URLField` and `SlugField` all as `varchar(n)` and `ImageField`/`FileField` as `text`;
+SQLite renders `UUIDField`, `JSONField`, `ImageField` and `TextField` all as bare `TEXT`. The diff
+now compares **what the database actually holds** — the rendered column type plus the bounds only a
+CHECK can express — and falls back to Julia struct identity only when the two structs match. Two
+fields that render the same column are the same column, and an ALTER between them was always a no-op.
+
+Six lossy reads are fixed alongside it:
+
+- **PostgreSQL `max_length`** — any `varchar(n > 255)` was retyped to `text` with no length, because
+  `CharField` refused a `max_length` above 255. That ceiling is gone (a MySQL-ism; PostgreSQL takes
+  up to 10,485,760 characters and SQLite ignores the length), so `varchar(n)` now round-trips as
+  `CharField(n)`, symmetric with `text` ⇒ `TextField`.
+- **SQLite `max_length`** — a bare `TEXT` column read back as `CharField`, whose constructor invents
+  `max_length = 250`. A lengthless textual column is now a `TextField`; only a declared `TEXT(n)`
+  (or a hand-written `VARCHAR(n)`/`CHAR(n)`, now recognized) is a `CharField`.
+- **`db_index`** — never read on either backend. PostgreSQL probed a `Dict{String,String}` with a
+  `Symbol` key, which never matches; SQLite did not look at indexes at all. Both now read the
+  single-column, non-unique, non-partial secondary indexes that `db_index=true` actually emits.
+- **`get_constraints_unique`** — returned the first row of an unordered result matching any
+  constraint the column merely belonged to, so a column in both `UNIQUE(a)` and `UNIQUE(a, b)` could
+  drop the composite one. It is now restricted to single-column constraints and ordered.
+- **`auto_now` / `auto_now_add`** — these emit **no DDL at all**: PormG stamps the timestamp in Julia
+  on write, it is not a column `DEFAULT` and not a trigger. So they can never be read back, and
+  `alter_field` had nothing to emit for them. Every `DateTimeField(auto_now_add=true)` was producing
+  an empty alteration on every run — a full table rebuild on SQLite. They are now recognized as
+  model-layer-only, like `blank` and `editable`.
+- **The introspection ignore list** (`postgres_ignore_table` / `sqlite_ignore_schema`) now matches a
+  **prefix** on both backends. PostgreSQL used `occursin`, so a user table merely *containing* an
+  entry — `oauth_tokens` contains `auth_`, `company_admin_log` contains `admin_` — vanished from the
+  live schema entirely. A table PormG cannot see does not read as "ignored" downstream, it reads as
+  "does not exist", so `makemigrations` proposed `CREATE TABLE` for it forever. (SQLite used `==`,
+  which could never match `sqlite_autoindex`, only ever a prefix.)
+
+An index difference is also no longer routed through a column `ALTER`: it emits `CREATE INDEX` /
+`DROP INDEX` alone. On SQLite that removes a full table rebuild that did nothing.
+
+### What you may see once
+
+Nothing to edit — but the **first** `makemigrations` after upgrading can propose a one-time plan:
+
+- A live secondary index on a field declaring `db_index=false` is now visible as drift, so PormG will
+  propose **dropping** it. Previously it was invisible. If the index should stay, add
+  `db_index=true` to the field before applying.
+- Conversely, a field declaring `db_index=true` whose index never actually got created (the create
+  path could be skipped while the attribute was unreadable) now gets one `CREATE INDEX`, once.
+- On SQLite, a **hand-written** lengthless `TEXT` column that your model declares as
+  `CharField(max_length=n)` now reads back as a `TextField`, so PormG will propose rebuilding it as
+  `TEXT(n)`. Tables PormG created are unaffected — it has always emitted the length.
+- On PostgreSQL, a table whose name merely *contained* a framework prefix — `oauth_tokens`,
+  `company_admin_log`, `my_social_graph` — used to be invisible, so `makemigrations` re-proposed
+  `CREATE TABLE` for it every run and any real drift on it was never reported. It is now
+  introspected normally, so the **first** run after upgrading may propose genuine changes that were
+  being hidden. Tables that actually *start* with a framework prefix (`django_*`, `auth_*`,
+  `celery_*`, …) are still skipped, exactly as before.
+
+Review that plan before applying it, as always. After it converges, `makemigrations` on an unchanged
+model set proposes **nothing** — which is the point: a clean baseline is what makes real drift
+visible.
+
+---
+
 ## Introspection now reads single-column `UNIQUE` back (#318)
 
 - **Version**: Unreleased

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -225,7 +225,7 @@ Part = Models.Model(
 ```
 
 **Key Parameters**:
-- `max_length::Int = 250`: Maximum characters (1-255)
+- `max_length::Int = 250`: Maximum characters (1 or greater; the backend sets the real ceiling)
 - `choices`: Tuple of (value, display_name) pairs
 - `unique::Bool = false`: Enforce uniqueness
 - `db_index::Bool = false`: Create database index

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -665,6 +665,63 @@ _byte_length_check_clause(col_name, max_length::Int, ::PormGPostgres)::String =
 _byte_length_check_clause(col_name, max_length::Int, ::PormGSQLite)::String =
   "CHECK (length(\"$(col_name)\") <= $(max_length))"
 
+# ── Physical-column identity (#325) ──────────────────────────────────────────────────────────────
+#
+# Several Julia field types materialize the SAME column. On PostgreSQL `CharField`, `URLField` and
+# `SlugField` all render `varchar(n)`, and `EmailField`/`PasswordField`/`ImageField`/`AutoField`/
+# `OneToOneField` all fall through `_get_column_type`'s `else` to `text`; on SQLite the collapse is
+# wider still — `UUIDField`, `JSONField`, `TextField` and `ImageField` are all bare `TEXT`.
+#
+# Introspection therefore CANNOT reproduce the declared Julia type: the information is not in the
+# schema to read. Making it reproducible would mean encoding the type into the DDL (extra CHECK
+# markers on PostgreSQL, non-standard declared types on SQLite — which also changes SQLite's column
+# affinity) and rebuilding every existing table. So the migration diff compares the PHYSICAL COLUMN
+# instead: if two fields render the same column, an ALTER between them is by construction a no-op,
+# and proposing one is the perpetual churn #325 is about.
+#
+# `_get_column_type` alone is not the whole column: two bounds are expressible only as a CHECK, and
+# a signature built from the type string alone would call `IntegerField` and `PositiveIntegerField`
+# the same column on PostgreSQL (both render `integer`).
+#
+# Case-folded because SQL type names are case-insensitive and PormG's own rendering is not
+# self-consistent about it: the `else` fallthrough shared by ImageField/FileField/EmailField/
+# PasswordField/AutoField/OneToOneField returns the literal `"TEXT"`, while `TextField` goes through
+# the map and returns `"text"` on PostgreSQL. Both produce the same `text` column — comparing the
+# strings verbatim would call them different and churn forever, which is the very bug being fixed.
+_column_signature(field::PormGField, conn::Union{PormGPostgres,PormGSQLite}) = (
+  lowercase(_get_column_type(field, conn)),
+  _requires_non_negative_check(field),
+  _requires_byte_length_check(field) ? getfield(field, :max_length) : nothing,
+)
+
+# A relational field's column type is only half of it — the FK constraint is planned separately, by
+# `_add_fk_constraint_in_alteration` / `_drop_fk_constraint_in_alteration`, which run AFTER the
+# planner's `isempty(colect_not_equal)` early-out. `sForeignKey` and `sBigIntegerField` both render
+# `bigint`, so calling them the same column would silently stop planning FK add/drop on an existing
+# column. Excluded here rather than at the call site so the predicate is safe wherever it is used.
+_is_relational_field(field::PormGField)::Bool = hasfield(typeof(field), :to)
+_declares_primary_key(field::PormGField)::Bool =
+  hasfield(typeof(field), :primary_key) && getfield(field, :primary_key)::Bool
+
+"""
+    describes_same_column(conn, a::PormGField, b::PormGField) -> Bool
+
+Whether `a` and `b` materialize the same physical column on `conn` — the same rendered column type
+*and* the same CHECK-expressed bounds (#325).
+
+Used by the migration planner for the cross-type case only: when two fields have the same Julia
+struct type the planner compares them attribute by attribute as before, so this predicate can only
+ever turn a spurious "changed" into "unchanged", never the reverse.
+
+Relational fields (anything with a `to`) and primary keys are always `false`: their identity is not
+carried by the column type alone.
+"""
+function describes_same_column(conn::Union{PormGPostgres,PormGSQLite}, a::PormGField, b::PormGField)::Bool
+  (_is_relational_field(a) || _is_relational_field(b)) && return false
+  (_declares_primary_key(a) || _declares_primary_key(b)) && return false
+  return _column_signature(a, conn) == _column_signature(b, conn)
+end
+
 function field_to_column(col_name::String, field::PormGField, conn::PormGPostgres; temporary_default::Any=nothing)::String
   # Resolve the physical column name (db_column when set, else the field name) — #50.
   col_name = field_db_column(field, col_name)
@@ -1054,10 +1111,14 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
     end
   end
 
-  # alert if any colect_not_equal are not checked
-  XXX::Vector{Symbol} = [:type, :max_length, :max_digits, :decimal_places, :null, :unique, :default, :primary_key, :generated, :generated_always, :blank, :auto_now, :auto_now_add]
-  if any(attr -> !(attr in XXX), colect_not_equal)
-    not_in = [attr for attr in colect_not_equal if !(attr in XXX)]
+  # Warn for any requested attribute this function emits no SQL for. Every entry below has a
+  # statement branch above it; `:blank`, `:auto_now` and `:auto_now_add` used to be listed here with
+  # none, which silenced the warning for three attributes that genuinely could not be applied. They
+  # are now filtered upstream by `planner._NON_SCHEMA_FIELD_ATTRS` — they alter no schema at all —
+  # so if one reaches this point it IS an unhandled request and deserves the warning (#325).
+  IMPLEMENTED::Vector{Symbol} = [:type, :max_length, :max_digits, :decimal_places, :null, :unique, :default, :primary_key, :generated, :generated_always]
+  if any(attr -> !(attr in IMPLEMENTED), colect_not_equal)
+    not_in = [attr for attr in colect_not_equal if !(attr in IMPLEMENTED)]
     @warn "The attributes $(not_in) are not implemented in alter_field function ($(table_name).$(field_name))"
   end
   return join(sql_statements, "\n")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -101,7 +101,14 @@ const sqlite_type_map = Dict{String, Symbol}(
   "INTEGER UNSIGNED" => :PositiveIntegerField,
   "SMALLINT" => :PositiveSmallIntegerField,
   "INT" => :BigIntegerField,
+  # PormG renders every VARCHAR-family field as `TEXT(n)` on SQLite (see `sqlite_type_map_reverse`),
+  # so a length suffix is what distinguishes a CharField from a TextField here — a BARE `TEXT` is
+  # resolved to `:TextField` in `convertSQLToModel(::PormGSQLite)` rather than to a CharField whose
+  # constructor would invent `max_length = 250` (#325). VARCHAR/CHAR are accepted for schemas PormG
+  # did not create, so a hand-written `VARCHAR(50)` keeps its length.
   "TEXT" => :CharField,
+  "VARCHAR" => :CharField,
+  "CHAR" => :CharField,
   "NUMERIC" => :FloatField,
   "REAL" => :FloatField,
   "DECIMAL" => :DecimalField,

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -263,14 +263,24 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
   # allows `DEFAULT (expr)`, e.g. `(datetime('now'))`, which `_strip_sqlite_default_wrapper` exists
   # to unwrap — one nesting level is enough for every form SQLite emits); then a bare token. The
   # bare-token branch must exclude `(` so it cannot run into a trailing CHECK.
-  column_matches = eachmatch(r"[^(]\"(\w+)\"\s+([A-Z]+(?: UNSIGNED)?)\s*(NOT NULL)?\s*(?:DEFAULT\s+('[^']*'|[Xx]'[0-9A-Fa-f]*'|\([^()]*(?:\([^()]*\)[^()]*)*\)|[^,()\s]+))?", sql)
+  #
+  # The single-integer length suffix (`TEXT(120)`) is captured because it is what distinguishes a
+  # CharField from a TextField on SQLite (#325) — see the note by `type_sym` below. A two-argument
+  # suffix (`DECIMAL(10,2)`) deliberately does not match: `\s*(NOT NULL)?` then matches empty and
+  # the match ends before it, exactly as it did before the group existed.
+  column_matches = eachmatch(r"[^(]\"(\w+)\"\s+([A-Z]+(?: UNSIGNED)?)(?:\(\s*(\d+)\s*\))?\s*(NOT NULL)?\s*(?:DEFAULT\s+('[^']*'|[Xx]'[0-9A-Fa-f]*'|\([^()]*(?:\([^()]*\)[^()]*)*\)|[^,()\s]+))?", sql)
   # Initialize fields dictionary
   fields_dict = Dict{Symbol, Any}()
   str_fields_dict = Dict{String, Any}()
   for match in column_matches
     # println(match.captures)
-    column_name, column_type, nullable, default_value = match.captures
+    column_name, column_type, declared_length, nullable, default_value = match.captures
     type_sym = get(type_map, column_type, :TextField)
+    # #325: keep this reader's CharField/TextField split identical to the PRAGMA reader's. A bare
+    # textual column has no length, and `CharField()` would invent `max_length = 250`.
+    if type_sym == :CharField && declared_length === nothing
+      type_sym = :TextField
+    end
     normalized_default = _normalize_sqlite_default(default_value, type_sym)
     # check if column_name is a primary key
     if haskey(pk_map, column_name)
@@ -290,6 +300,9 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
       # BLOB carries no length suffix, so a BinaryField's byte bound comes from its CHECK (#296).
       if type_sym == :BinaryField && haskey(byte_bounds, column_name)
         field_instance.max_length = byte_bounds[column_name]
+      elseif type_sym == :CharField && declared_length !== nothing
+        # #325: carry the declared length instead of letting CharField default it to 250.
+        field_instance.max_length = parse(Int, declared_length)
       end
     end
 
@@ -339,6 +352,9 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
   # #318: `PRAGMA table_info` above has no uniqueness column, so `unique` was never populated at all.
   # Read it once per table here; the per-column branches below test membership.
   unique_cols = _sqlite_single_column_unique_columns(db, table_name)
+  # #325: the same gap for `db_index` — PRAGMA table_info has no index column either. Column ⇒ index
+  # name, so the model can also carry `cache["index"]` for the planner's DROP INDEX path.
+  indexed_cols = _sqlite_single_column_indexed_columns(db, table_name)
 
   fields_dict = Dict{Symbol, Any}()
   fk_map = Dict{String, Any}()
@@ -382,6 +398,14 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
             default=_fk_default_or_warn(_normalize_sqlite_default(default_val, fk_type_sym), table_name, col_name))
     else
         type_sym = get(type_map, base_type, :TextField)
+        # #325: a BARE textual column carries no length, but `CharField()` INVENTS `max_length = 250`
+        # (models/fields.jl) — which then renders `TEXT(250)` and can never match the live `TEXT`.
+        # SQLite collapses UUIDField, JSONField, ImageField and TextField all onto bare `TEXT`, so
+        # every one of them read back as `CharField(250)` and churned forever. Only a declared `(n)`
+        # is a CharField here; a lengthless textual column is a TextField.
+        if type_sym == :CharField && !occursin("(", col_type)
+            type_sym = :TextField
+        end
         # Handle decimal precision if present
       field = getfield(Models, type_sym)(null=nullable, default=_normalize_sqlite_default(default_val, type_sym))
         if type_sym == :CharField && occursin("(", col_type)
@@ -405,11 +429,46 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
     if !is_pk && col_name in unique_cols && hasfield(typeof(field), :unique) && !field.unique
       field.unique = true
     end
+    # #325: same treatment for `db_index`, and for the same three reasons `!is_pk` is required —
+    # sIDField is immutable, it already defaults `db_index=true`, and only ever setting TRUE keeps a
+    # ForeignKey's constructor-forced `db_index` intact.
+    if !is_pk && haskey(indexed_cols, col_name) && hasfield(typeof(field), :db_index) && !field.db_index
+      field.db_index = true
+    end
     fields_dict[Symbol(col_name)] = field
   end
-  
-  return Models.Model(table_name, fields_dict)
+
+  model_resp = Models.Model(table_name, fields_dict)
+  # The planner reads `cache["index"]` to name the index it must DROP when a model stops declaring
+  # `db_index`. PostgreSQL's reader has always populated it; SQLite's never did, which was harmless
+  # only while `db_index` could not be true on this side (#325).
+  if !isempty(indexed_cols)
+    model_resp.cache = Dict("index" => indexed_cols)
+  end
+  return model_resp
 end
+
+"""
+    _is_ignored_table(table_name, ignore_table) -> Bool
+
+Whether `table_name` is skipped by the introspection ignore list — matched as a **prefix**, on both
+backends (#325).
+
+Every entry in `postgres_ignore_table` / `sqlite_ignore_schema` is a framework prefix
+(`"django_"`, `"auth_"`, `"celery_"`, `"sqlite_autoindex"`) or a whole table name
+(`"pormg_migrations"`), and a prefix test covers both. The two backends used to disagree, and both
+were wrong in different directions:
+
+  * PostgreSQL used `occursin`, so a user table merely *containing* an entry was silently dropped
+    from the live schema — `company_admin_log` matched `"admin_"`, `oauth_tokens` matched `"auth_"`.
+    A dropped table does not read as "ignored" downstream, it reads as "does not exist", so
+    `makemigrations` proposed `CREATE TABLE` for it on every single run.
+  * SQLite used `==`, so `"sqlite_autoindex"` — a prefix of `sqlite_autoindex_<table>_<n>`, never a
+    table name in its own right — could never match. Harmless only because the table query already
+    filters `name NOT LIKE 'sqlite_%'`.
+"""
+_is_ignored_table(table_name, ignore_table)::Bool =
+  any(ignored -> startswith(String(table_name), ignored), ignore_table)
 
 function convert_schema_to_models(db::PormGSQLite; ignore_table::Vector{String} = sqlite_ignore_schema, include_table::Union{Vector{String}, Nothing} = nothing)
   # Always skip consumer-registered framework tables (e.g. Nitro's), on top of the caller's list.
@@ -425,9 +484,8 @@ function convert_schema_to_models(db::PormGSQLite; ignore_table::Vector{String} 
     if include_table !== nothing
       !any(included -> table_name == included, include_table) && continue
     end
-    # check if each ignore_table value is contained in the table_name
-    any(ignored -> table_name == ignored, ignore_table) && continue
-    
+    _is_ignored_table(table_name, ignore_table) && continue
+
     push!(models_array, convertSQLToModel(db, table_name))
   end  
   return models_array
@@ -469,8 +527,7 @@ function convert_schema_to_models(db::PormGPostgres; ignore_table::Vector{String
     if include_table !== nothing
       !any(included -> schema.table_name == included, include_table) && continue
     end
-    # check if each ignore_table value is contained in the schema.table_name
-    any(ignored -> occursin(ignored, schema.table_name), ignore_table) && continue
+    _is_ignored_table(schema.table_name, ignore_table) && continue
     # println(typeof(schema), " ", convertSQLToModel(schema) |> println)
     
     push!(models_array, convertSQLToModel(schema))
@@ -548,15 +605,32 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
         WHERE con.contype = 'f'
         GROUP BY con.conrelid
     ),
+    -- Secondary indexes, filtered down to exactly what `field.db_index = true` emits: ONE
+    -- `CREATE INDEX` over ONE column (`planner._add_constrains` → `Dialect.create_index`). #325
+    -- made this feed `db_index` on read-back, which the three added predicates are what makes
+    -- safe — without them a model declaring only `unique=true` (or a composite `UniqueConstraint`,
+    -- #19) would read back as `db_index=true` and churn in the opposite direction:
+    --   * NOT indisunique — a UNIQUE constraint's backing index is `field.unique`, already read
+    --     from `pg_constraint` by the `unique_constraints` CTE above. Keeps the backends symmetric
+    --     with SQLite's `il."unique" = 0` filter.
+    --   * indpred IS NULL — a partial index constrains rows, not the column; PormG cannot declare
+    --     one, so reading it would be permanent churn.
+    --   * indnkeyatts = 1 — a composite index marks no single column, mirroring #318's
+    --     `HAVING COUNT(*) = 1` for composite UNIQUE.
+    -- An expression index joins no `pg_attribute` row (its `indkey` entry is 0) and so drops out
+    -- on its own.
     indexes AS (
         SELECT
             i.indrelid AS table_oid,
-            array_to_string(array_agg(quote_ident(a.attname)), ', ') AS index_columns,
+            array_to_string(array_agg(a.attname), ', ') AS index_columns,
             array_to_string(array_agg(quote_ident(c.relname)), ', ') AS index_names
         FROM pg_index i
         JOIN pg_class c ON c.oid = i.indexrelid
         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
         WHERE NOT i.indisprimary
+          AND NOT i.indisunique
+          AND i.indpred IS NULL
+          AND i.indnkeyatts = 1
         GROUP BY i.indrelid
     ),
     non_negative_checks AS (
@@ -798,6 +872,60 @@ function _sqlite_single_column_unique_columns(conn::PormGSQLite, table_name)::Se
 end
 
 """
+    _sqlite_single_column_indexed_columns(conn::PormGSQLite, table_name) -> Dict{String, String}
+
+Physical column ⇒ index name, for every SINGLE-column non-unique secondary index on `table_name` —
+exactly the set for which `field.db_index` must introspect back as `true` (#325).
+
+The `unique` sibling above and this one are the same shape for the same reason: `PRAGMA table_info`
+carries neither attribute, so `convertSQLToModel(::PormGSQLite)` never populated `db_index` at all.
+Every `db_index=true` field therefore compared unequal to its own live table, and — because
+`Dialect.alter_field` has no `db_index` branch — `makemigrations` proposed a rebuild that emitted no
+DDL for it, forever. `src/migrations/planner.jl` carried a workaround for one symptom of this
+(a duplicated `CREATE INDEX`); the cause is here.
+
+The three filters mirror the `unique` reader's, each excluding an index that is NOT `db_index`:
+
+  * `il."unique" = 0` — a UNIQUE index is `field.unique`, read by
+    [`_sqlite_single_column_unique_columns`](@ref). Marking it here would make a model declaring
+    only `unique=true` churn in the opposite direction. Symmetric with PostgreSQL's
+    `NOT i.indisunique`.
+  * `il.origin = 'c'` — only a `CREATE INDEX`, which is the one and only thing `db_index=true`
+    emits (`planner._add_constrains` → `Dialect.create_index`). Excludes `'u'` (a `UNIQUE` clause's
+    auto-index) and `'pk'`.
+  * `HAVING COUNT(*) = 1` — a composite index marks no single column, exactly as for composite
+    UNIQUE (#318). PormG only ever indexes one column per `db_index`.
+
+`il.partial = 0` IS load-bearing here, unlike in the `unique` reader: a partial index is created by
+`CREATE INDEX … WHERE` and so shares this reader's `origin = 'c'`. It constrains rows rather than
+the column, PormG cannot declare one, and reading it would be permanent churn.
+
+Returns the index NAME as well as the column because the planner needs it to drop an index the model
+no longer declares (`model.cache["index"]`); the PostgreSQL path builds the same mapping from its
+`indexes` CTE. ONE query per table; an unknown table yields an empty dict rather than throwing.
+"""
+function _sqlite_single_column_indexed_columns(conn::PormGSQLite, table_name)::Dict{String, String}
+  rows = fetch(conn, """
+    SELECT MIN(ii.name) AS col, il.name AS idx
+    FROM pragma_index_list(?) AS il
+    JOIN pragma_index_info(il.name) AS ii
+    WHERE il."unique" = 0 AND il.origin = 'c' AND il.partial = 0
+    GROUP BY il.name
+    HAVING COUNT(*) = 1
+    """, [string(table_name)]) |> DataFrame
+  # An empty frame's columns are eltype Missing, so guard before touching them.
+  nrow(rows) == 0 && return Dict{String, String}()
+  out = Dict{String, String}()
+  for r in eachrow(rows)
+    (r.col === missing || r.idx === missing) && continue
+    # First index wins if two single-column indexes cover the same column — the duplicate is
+    # redundant, and `db_index` is a boolean either way.
+    get!(out, string(r.col), string(r.idx))
+  end
+  return out
+end
+
+"""
     get_secondary_index_ddls(conn::PormGSQLite, table_name) -> Vector{String}
 
 Return the `CREATE INDEX` DDL for every *user-created* secondary index on `table_name`, verbatim from
@@ -884,17 +1012,40 @@ end
 
 # Returns `nothing` when no UNIQUE constraint matches — the annotation must admit it, or Julia
 # converts the `return nothing` below and raises instead of letting callers test it (#284).
+#
+# #325: the SINGLE-column UNIQUE on `field_name`, and nothing else. The caller is
+# `Dialect.alter_field`, dropping a constraint because the model stopped declaring `unique=true` —
+# and `field.unique` is only ever read back from a single-column constraint (#318), so a composite
+# one must never be droppable through this path. It was: the query matched every constraint the
+# column merely *belongs to* and returned `result[1, …]` from an unordered result, so a column in
+# both `UNIQUE(a)` and `UNIQUE(a, b)` dropped whichever row PostgreSQL happened to return first.
+#
+# Three changes make that deterministic:
+#   * `key_column_usage`, not `constraint_column_usage` — the former lists a constraint's OWN
+#     columns, which is what lets `COUNT(*) = 1` mean "single-column constraint". (The latter is
+#     equivalent for UNIQUE, but only by accident of PostgreSQL's implementation; the sibling
+#     `get_constraints_pk` above already uses `kcu`.)
+#   * `GROUP BY` + `HAVING COUNT(*) = 1` — the arity filter, mirroring the CTE #318 added.
+#   * `ORDER BY` — with the arity filter two matches are already pathological (two single-column
+#     UNIQUEs on the same column), but "whichever came first" is not an answer.
+#
+# Parameterized and search-path-restricted, like `get_constraints_byte_length_check` below; the
+# unparameterized siblings predate the rule and are left alone, but an edited query does not
+# inherit the exemption.
 function get_constraints_unique(conn::PormGPostgres, table_name::String, field_name::String)::Union{String, Nothing}
-  # `AND tc.table_schema = ccu.table_schema` for the same reason as get_constraints_pk above:
-  # constraint names are unique per schema, so a name-only join can cross schemas (#283 review).
   query = """
   SELECT tc.constraint_name
   FROM information_schema.table_constraints tc
-  JOIN information_schema.constraint_column_usage ccu
-    ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
-  WHERE tc.table_name = '$table_name' AND tc.constraint_type = 'UNIQUE' AND ccu.column_name = '$field_name';
+  JOIN information_schema.key_column_usage kcu
+    ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+  WHERE tc.table_name = \$1
+    AND tc.constraint_type = 'UNIQUE'
+    AND tc.table_schema = ANY(current_schemas(false))
+  GROUP BY tc.constraint_name, tc.table_schema
+  HAVING COUNT(*) = 1 AND bool_or(kcu.column_name = \$2)
+  ORDER BY tc.constraint_name, tc.table_schema;
   """
-  result = fetch(conn, query) |> DataFrame
+  result = fetch(conn, query, [table_name, field_name]) |> DataFrame
   if nrow(result) == 0
       return nothing
   end
@@ -1015,14 +1166,17 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
     end
   end
 
-  # Extract index information
+  # Extract index information — physical column ⇒ index name, for the single-column secondary
+  # indexes the `indexes` CTE keeps. Both halves are stored UNQUOTED (#325): the key has to match
+  # `fields_dict`, which is keyed by the de-quoted column name below, and the value is re-quoted by
+  # `_drop_index`. A mixed-case name (#57) arrived here wrapped in `"` and matched neither.
   index_map = Dict{String, String}()
   if !ismissing(row[:index_columns])
     indexes = split(row[:index_columns], ", ")
     index_names = split(row[:index_names], ", ")
     for (index, index_name) in zip(indexes, index_names)
-      index_map[index] = index_name
-    end      
+      index_map[replace(index, "\"" => "")] = replace(index_name, "\"" => "")
+    end
   end
    
   # Parse each column definition
@@ -1036,8 +1190,11 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       max_digits = nothing
       decimal_places = nothing
 
-      # Detect if the column is indexed
-      db_index = haskey(index_map, col_name |> Symbol)
+      # Detect if the column is indexed. #325: this probed a `Dict{String,String}` with a `Symbol`
+      # key, which `haskey` never matches — so `db_index` was a hard `false` for every plain
+      # PostgreSQL column, and every `db_index=true` field re-proposed its own CREATE INDEX on every
+      # `makemigrations`. `col_name` is de-quoted to match `index_map`'s keys.
+      db_index = haskey(index_map, replace(String(col_name), "\"" => ""))
 
       @pormg_debug false
 
@@ -1155,17 +1312,15 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # Only fields that actually carry these attributes get them. A primary-key column
       # is mapped to an IDField (above), which has no max_length/max_digits — guard the
       # assignments so such columns don't raise FieldError during introspection.
+      # #325: unconditional. This used to retype any `varchar(n > 255)` to TextField and DROP the
+      # length, because CharField refused a max_length above 255 — so a live `varchar(500)` read
+      # back as `text`, never matched the model that declared it, and `makemigrations` proposed the
+      # same widening on every run. CharField no longer carries that ceiling (models/fields.jl), so
+      # `varchar(n)` now always round-trips as `CharField(n)`, symmetric with `text` ⇒ `TextField`.
+      # (The sBinaryField branch that used to sidestep the ceiling for byte bounds, #296, is what
+      # this generalizes.)
       if max_length !== nothing && hasfield(typeof(field), :max_length)
-        if field isa Models.sBinaryField
-          # A BinaryField's bound is a BYTE count with no 255 ceiling — a 5 MB blob is ordinary, and
-          # the CharField fallback below would silently retype the column to TEXT (#296).
-          field.max_length = max_length
-        elseif max_length > 255
-          # CharField only supports max_length <= 255, use TextField for longer strings
-          field = Models.TextField(unique=unique, null=!not_null, default=default_value, db_index=db_index)
-        else
-          field.max_length = max_length
-        end
+        field.max_length = max_length
       end
 
       if max_digits !== nothing && hasfield(typeof(field), :max_digits)

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -8,6 +8,28 @@
 # Internal Helpers
 # ---
 
+# Field attributes a column ALTER can never express, so a difference in one must not enter
+# `colect_not_equal` — on SQLite that vector being non-empty means a full table rebuild.
+#
+#   * `blank`, `editable`, `verbose_name`, `related_name`, `how`, `formatter` are model-layer only.
+#   * `on_delete` and the FK identity are planned by `_add_fk_constraint_in_alteration` /
+#     `_drop_fk_constraint_in_alteration`.
+#   * `db_column` never alters the live schema by itself — the column identity is already proven
+#     equal by the matched (column-keyed) field, and the introspected side carries
+#     `db_column=nothing` (#50).
+#   * `db_index` is materialized by CREATE/DROP INDEX, planned separately in `_alter_table_fields`
+#     BEFORE the column diff. It was never in `Dialect.alter_field`'s implemented list either, so
+#     before #325 a `db_index` difference emitted the "attributes not implemented" warning plus a
+#     pointless ALTER (a full rebuild on SQLite).
+#   * `auto_now` / `auto_now_add` emit NO DDL anywhere — PormG stamps the timestamp in Julia on
+#     write, it is not a column DEFAULT and not a trigger. So introspection cannot read them back
+#     and `alter_field` has nothing to emit for them: every `DateTimeField(auto_now_add=true)`
+#     produced an empty alteration on every `makemigrations`, forever (#325). On SQLite that empty
+#     alteration was still a full table rebuild.
+const _NON_SCHEMA_FIELD_ATTRS = (:blank, :on_delete, :related_name, :verbose_name, :editable,
+                                 :how, :formatter, :db_column, :db_index,
+                                 :auto_now, :auto_now_add)
+
 function _hash_field_name(model_name::Symbol, field_name::Union{String, Symbol}; apend_number::Int64=5)::String
   _hash = randstring(8) 
   name = "$(model_name)_$field_name"
@@ -311,33 +333,63 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
     # Pass maps to resolve fields so original keys can be used for accessing model.fields
     _resolve_table_fields(conn, model_name, model, current_schema[model_name][:model], colect_deletion, colect_addition, migration_plan, settings, model_fields_map, current_fields_map, interactive=interactive)
       
+    # #325: index create/drop is DEFERRED to after the whole field loop, not emitted inline.
+    # `stripped_current_fields` is a `Set`, so field order is arbitrary — and on SQLite the table
+    # rebuild re-creates every live secondary index verbatim (#82). A `DROP INDEX` emitted before
+    # the rebuild is therefore undone by it, and whether that happened depended on which field the
+    # Set yielded first. Collecting the actions here and flushing them below puts them after any
+    # rebuild, deterministically. Each entry is `(:create | :drop, physical column, hashed name,
+    # live index name or nothing)`.
+    index_actions = Tuple{Symbol, String, String, Union{String, Nothing}}[]
+
     for field_name_stripped in stripped_current_fields
       original_code_key = current_fields_map[field_name_stripped]
       if haskey(model_fields_map, field_name_stripped)
         original_db_key = model_fields_map[field_name_stripped]
-        
+
         field = current_schema[model_name][:model].fields[original_code_key]
         old_field = model.fields[original_db_key]
 
+        # A ManyToManyField is not a physical column and `sManyToManyField` is the one field struct
+        # with no `db_index` at all, so the index blocks below would raise on it. It cannot normally
+        # be matched here (it is never a live column), but the guard is what makes that explicit —
+        # `_add_new_field` / `_add_constrains` both early-return on m2m for the same reason.
+        (Models.is_many_to_many_field(field) || Models.is_many_to_many_field(old_field)) && continue
+
+        name::String = _hash_field_name(model_name, field_name_stripped)
+
         # check if the field is diferent
         colect_not_equal::Vector{Symbol} = []
-        if old_field |> typeof == field |> typeof                          
-          # Check if all attributes are equal                
+        if old_field |> typeof == field |> typeof
+          # Check if all attributes are equal
           for attr in fieldnames(typeof(field))
             new_var = getfield(field, attr)
             old_var = getfield(old_field, attr)
-            if new_var != old_var                  
+            if new_var != old_var
               attr == :to && Models._compare_field_foreign_key(field, old_field) && continue
               # pk_field is compared by RESOLVED referenced column: a field-name pk_field on
               # the code side matches the introspected physical column when the parent pk is
               # renamed via db_column (#50). No-op when the referenced column isn't renamed.
               attr == :pk_field && Models.fk_target_column(field) == Models.fk_target_column(old_field) && continue
-              # :db_column never alters the live schema by itself — the column identity is
-              # already proven equal by the matched (column-keyed) field, and the introspected
-              # side carries db_column=nothing (#50).
-              attr in [:blank, :on_delete, :related_name, :verbose_name, :editable, :how, :formatter, :db_column] && continue
+              attr in _NON_SCHEMA_FIELD_ATTRS && continue
               push!(colect_not_equal, attr)
             end
+          end
+        elseif Dialect.describes_same_column(conn, field, old_field)
+          # #325: DIFFERENT Julia field types, SAME physical column. Introspection cannot reproduce
+          # the declared type — PostgreSQL renders CharField/URLField/SlugField all as `varchar(n)`,
+          # SQLite renders UUIDField/JSONField/ImageField/TextField all as bare `TEXT` — so demanding
+          # struct identity here proposed an ALTER whose SQL re-rendered the column unchanged, on
+          # every single `makemigrations`. Compare what the database can actually hold instead: the
+          # rendered column type (already proven equal) plus the attributes BOTH structs carry.
+          # `:type` is excluded because the signature supersedes it; the attributes only one side has
+          # (CharField's `choices`, UUIDField's `auto_add`) are Julia-side and never in the schema.
+          for attr in fieldnames(typeof(field))
+            hasfield(typeof(old_field), attr) || continue
+            attr == :type && continue
+            attr in _NON_SCHEMA_FIELD_ATTRS && continue
+            getfield(field, attr) == getfield(old_field, attr) && continue
+            push!(colect_not_equal, attr)
           end
         else
           # check is db_constraint is false in field
@@ -347,58 +399,77 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
             push!(colect_not_equal, :type)
           end
         end
-        
+
         # if field_name == "time"
         #   @pormg_debug
         # end
-        
-        isempty(colect_not_equal) && continue                       
 
-        # Check if is needed remove the foreign key
-        name::String = _hash_field_name(model_name, field_name_stripped)
-        
-        _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name_stripped, field, old_field)
-        
-        # For SQLite every field alteration requires a full table recreation. Use a
-        # single stable key ("Alter table: <model>") so repeated calls for the same
-        # table overwrite each other, producing exactly one recreation statement
-        # instead of one per changed field.
-        alter_key = conn isa PormGSQLite ? "Alter table: $model_name" : "Alter field: $field_name_stripped"
-        # #82: on SQLite this preserves the table's secondary indexes across the rebuild and gates on
-        # foreign_key_check (no-op on PostgreSQL). See _sqlite_rebuild_preserving_indexes.
-        alter_sql = _sqlite_rebuild_preserving_indexes(conn, model_table_name(model),
-          Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal);
-          surviving_columns = _model_physical_columns(current_schema[model_name][:model]))
-        _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, alter_sql)
+        # #325: the column ALTER is CONDITIONAL, but the index blocks below are not. `db_index` is
+        # in `_NON_SCHEMA_FIELD_ATTRS`, so an index-only difference leaves `colect_not_equal` empty —
+        # which is the point (on SQLite a non-empty vector means a FULL TABLE REBUILD, for something
+        # a CREATE/DROP INDEX expresses on its own). Before #325 this was an early `continue`, so an
+        # index-only difference would now be planned as nothing at all.
+        if !isempty(colect_not_equal)
+          # Check if is needed remove the foreign key
+          _drop_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name_stripped, field, old_field)
 
-        # Check if the field is a foreign key
-        _add_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name_stripped, field, old_field, name)
-        
+          # For SQLite every field alteration requires a full table recreation. Use a
+          # single stable key ("Alter table: <model>") so repeated calls for the same
+          # table overwrite each other, producing exactly one recreation statement
+          # instead of one per changed field.
+          alter_key = conn isa PormGSQLite ? "Alter table: $model_name" : "Alter field: $field_name_stripped"
+          # #82: on SQLite this preserves the table's secondary indexes across the rebuild and gates on
+          # foreign_key_check (no-op on PostgreSQL). See _sqlite_rebuild_preserving_indexes.
+          alter_sql = _sqlite_rebuild_preserving_indexes(conn, model_table_name(model),
+            Dialect.alter_field(conn, current_schema[model_name][:model], field_name_stripped, field, old_field, colect_not_equal);
+            surviving_columns = _model_physical_columns(current_schema[model_name][:model]))
+          _configure_order_dict_migration_plan(migration_plan, model_name, alter_key, alter_sql)
+
+          # Check if the field is a foreign key
+          _add_fk_constraint_in_alteration(conn, migration_plan, model_name, field_name_stripped, field, old_field, name)
+        end
+
+        # Index differences are RECORDED here and emitted after the loop — see `index_actions`.
+
         # Check if the field is also indexed
-        if !field.primary_key && field.db_index && !model.fields[original_db_key].db_index
+        if !field.primary_key && field.db_index && !old_field.db_index
           @pormg_debug false
-          # #82: SQLite introspection can't see db_index, so this branch always fires for an indexed
-          # field; and the table rebuild (alter_field) already re-emits every existing index. Skip the
-          # redundant CREATE INDEX when one already exists in the live DB, or it would duplicate the
-          # rebuilt index (random suffix defeats IF NOT EXISTS). Genuinely-new indexes still get created.
-          if !(conn isa PormGSQLite && get_constraints_index(conn, model_name, field_name_stripped) !== nothing)
-            index_name = "$(name)_idx"
-            _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name_stripped",
-            Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$field_name_stripped\""]))
-          end
+          push!(index_actions, (:create, field_name_stripped, name, nothing))
         end
 
         # Check if is need to remove the index
         if !field.primary_key && old_field.db_index && !field.db_index
           @pormg_debug
-          index_name = model.cache["index"][original_db_key]
-          _drop_index(conn, migration_plan, model_name, field_name_stripped, index_name=index_name)
-          # _configure_order_dict_migration_plan(migration_plan, model_name, "Remove index on $field_name_stripped", 
-          # Dialect.drop_index(conn, "\"$index_name\""))
+          # The live model's index cache maps physical column ⇒ index name. `db_index=true` on the
+          # live side means introspection saw exactly such an index, so the key is present; the
+          # `nothing` fallback routes `_drop_index` through `get_constraints_index` rather than
+          # raising a KeyError from inside makemigrations.
+          live_index_name = get(get(model.cache, "index", Dict{String,Any}()), original_db_key, nothing)
+          push!(index_actions, (:drop, field_name_stripped, name, live_index_name === nothing ? nothing : string(live_index_name)))
         end
       end
-    end    
-  end     
+    end
+
+    # Flush the deferred index actions — always after any "Alter table:"/"Alter field:" step the
+    # loop above registered, whichever field produced it.
+    for (kind, col, hashed, live_index_name) in index_actions
+      if kind === :create
+        # #82/#325: the SQLite rebuild already re-emits every existing index, so a CREATE INDEX
+        # alongside one would duplicate it (the random suffix defeats IF NOT EXISTS). Introspection
+        # now reads `db_index` back on both backends, so this branch no longer fires merely because
+        # SQLite could not see the index — but the probe stays: the rebuild is emitted from the
+        # DECLARED model, which can carry an index the live schema is only about to gain.
+        # Genuinely-new indexes still get created.
+        if !(conn isa PormGSQLite && get_constraints_index(conn, model_name, col) !== nothing)
+          index_name = "$(hashed)_idx"
+          _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $col",
+          Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$col\""]))
+        end
+      else
+        _drop_index(conn, migration_plan, model_name, col, index_name=live_index_name)
+      end
+    end
+  end
 end
 
 function _resolve_table_fields(

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -889,7 +889,7 @@ The `CharField` is the most commonly used field for storing textual data with a 
 
 # Keyword Arguments
 - `verbose_name::Union{String, Nothing} = nothing`: A human-readable name for the field
-- `max_length::Int = 250`: Maximum number of characters allowed (1-255)
+- `max_length::Int = 250`: Maximum number of characters allowed (1 or greater)
 - `unique::Bool = false`: Whether values in this field must be unique across all records
 - `blank::Bool = false`: Whether the field can be left blank in forms
 - `null::Bool = false`: Whether the database column can store NULL values
@@ -901,7 +901,8 @@ The `CharField` is the most commonly used field for storing textual data with a 
 
 # Length Constraints
 - **Minimum**: 1 character
-- **Maximum**: 255 characters
+- **Maximum**: bounded by the backend, not by PormG — PostgreSQL's `varchar` accepts up to
+  10,485,760 characters and SQLite ignores the declared length entirely
 - **Validation**: Automatically enforced at the field level
 - **Storage**: Efficient variable-length storage in PostgreSQL
 
@@ -994,7 +995,7 @@ Task = Models.Model(
 # CharField vs TextField
 | Feature | CharField | TextField |
 |---------|-----------|-----------|
-| **Length** | Limited (1-255) | Unlimited |
+| **Length** | Bounded (`max_length`) | Unlimited |
 | **Database Type** | VARCHAR | TEXT |
 | **Use Case** | Short strings | Long content |
 | **Indexing** | Efficient | Less efficient |
@@ -1028,7 +1029,11 @@ function CharField(; kwargs...)
 
   max_length isa AbstractString && (max_length = parse(Int, max_length))
   max_length isa Int || throw(_fielderr("The max_length must be an integer"))
-  max_length > 255 && throw(_fielderr("The max_length must be less than or equal to 255"))
+  # No upper bound (#325). The old 255 ceiling was a MySQL-ism — PostgreSQL's `varchar` takes up to
+  # 10,485,760 characters and SQLite ignores the declared length. Worse, it was LOSSY on read-back:
+  # introspecting a live `varchar(500)` had to retype the column to TextField and drop the length,
+  # so the declared model never matched its own table and `makemigrations` churned forever. A future
+  # MySQL backend enforces its own limit at render time (#60), not here.
   max_length < 1 && throw(_fielderr("The max_length must be greater than 1"))
   default isa Int && (default = string(default))
   if !(default isa Nothing) && !(default isa AbstractString) 

--- a/test/integration/common_migration_setup.jl
+++ b/test/integration/common_migration_setup.jl
@@ -224,6 +224,13 @@ end
 
 Smoke test: verifies the imported M module can reach the rebuilt schema.
 Call after reload_config_and_models!() and before fixture seeding.
+
+Also asserts the schema has **no drift**: every declared model compares equal to its own live
+table. That half was impossible until #325 — introspection lost each field's type, `max_length`
+and `db_index`, so `makemigrations` proposed the same no-op alteration forever and no point in the
+suite could be asserted schema-clean. Note that `st.pending` alone would NOT have caught it: it
+only tests whether a `pending_migrations.jl` file exists on disk, so it reports whatever some
+earlier call happened to leave behind and never re-diffs anything.
 """
 function assert_clean_state()
   settings = PormG.config[PORMG_DB_FOLDER]
@@ -231,6 +238,37 @@ function assert_clean_state()
   @assert st.has_history_table "Expected pormg_migrations table after bootstrap"
   @assert isempty(st.failed)   "Expected no failed migrations after bootstrap"
   @assert !st.pending          "Expected no pending migration file after bootstrap"
+  assert_no_schema_drift()
+  nothing
+end
+
+"""
+    assert_no_schema_drift()
+
+Re-diff the LIVE schema against the DECLARED models and assert the plan is empty (#325).
+
+In memory on purpose: `get_migration_plan` writes no `pending_migrations.jl`, so calling this
+never disturbs the `st.pending` check above or a later `makemigrations`. The failure message names
+every model that drifted and the plan steps proposed for it, because "the schema drifted" on its
+own is not enough to act on.
+
+This is the GLOBAL assertion #318 wanted and could not have: it was blocked on the type/length
+round-trip, which is why `test/integration/test_db_table_db.jl` carried a per-table workaround
+until #325 landed.
+"""
+function assert_no_schema_drift()
+  settings = PormG.config[PORMG_DB_FOLDER]
+  conn = settings.connections
+  live = PormG.Migrations.convert_schema_to_models(conn)
+  declared = PormG.Migrations.get_all_models(models)
+  plan = PormG.Migrations.get_migration_plan(live, declared, conn, settings; interactive = false)
+  if !isempty(plan)
+    lines = String[]
+    for (name, steps) in plan
+      push!(lines, string(name, ": ", join(collect(keys(steps)), "; ")))
+    end
+    error("Schema drift after bootstrap — makemigrations would propose:\n  " * join(lines, "\n  "))
+  end
   nothing
 end
 

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -199,7 +199,13 @@ Field_validation_scratch = Models.Model("field_validation_scratch",
 # Mirrors the column types Django generates for DateTimeField/DateField/DecimalField.
 # Used to validate PormG's wire-format compatibility with Django-managed PostgreSQL schemas
 # without requiring Python or Django as a test dependency.
-Django_contract_scratch = Models.Model("django_contract_scratch",
+#
+# The table is `contract_django_scratch`, NOT `django_contract_scratch` (#325): `django_` is a
+# framework prefix in `postgres_ignore_table`, so a table named that way is deliberately invisible
+# to introspection — which made `makemigrations` propose `CREATE TABLE` for it on every run and
+# blocked the global schema-clean assertion. Ignoring Django's own tables is correct behavior; the
+# fixture name was the mistake.
+Django_contract_scratch = Models.Model("contract_django_scratch",
   id          = Models.IDField(),
   label       = Models.CharField(max_length=100, unique=true),
   created_at  = Models.DateTimeField(auto_now_add=true),    # Django: DateTimeField(auto_now_add=True)

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -199,7 +199,13 @@ Field_validation_scratch = Models.Model("field_validation_scratch",
 # Mirrors the column types Django generates for DateTimeField/DateField/DecimalField.
 # Used to validate PormG's wire-format compatibility with Django-managed schemas
 # without requiring Python or Django as a test dependency.
-Django_contract_scratch = Models.Model("django_contract_scratch",
+#
+# The table is `contract_django_scratch`, NOT `django_contract_scratch` (#325): `django_` is a
+# framework prefix in `postgres_ignore_table`, so a table named that way is deliberately invisible
+# to introspection on PostgreSQL — which made `makemigrations` propose `CREATE TABLE` for it on
+# every run and blocked the global schema-clean assertion. Kept identical to the db_2 fixture so the
+# two backends stay comparable, even though `sqlite_ignore_schema` carries no `django_` entry.
+Django_contract_scratch = Models.Model("contract_django_scratch",
   id          = Models.IDField(),
   label       = Models.CharField(max_length=100, unique=true),
   created_at  = Models.DateTimeField(auto_now_add=true),    # Django: DateTimeField(auto_now_add=True)

--- a/test/integration/test_db_table_db.jl
+++ b/test/integration/test_db_table_db.jl
@@ -120,19 +120,27 @@ end
 # keyed on anything else, a db_table model would read as "a table to create" PLUS "a live table
 # nobody declared" — a CREATE and a DROP of a live table that did not change at all.
 #
-# The db_table fixtures were migrated by the same bootstrap as every other model here, so a re-diff
-# must propose NOTHING for them. Scoped to those tables on purpose: asserting global
-# `status().pending` would fold in unrelated drift from other fixtures in this shared database and
-# report a #59 regression that isn't one.
-@testset "db_table: a re-diff proposes nothing for the db_table-mapped tables" begin
+# GLOBAL since #325. This assertion used to be scoped to the db_table tables, because the whole
+# database carried standing drift from the type/`max_length`/`db_index` round-trip and a global
+# check would have reported a #59 regression that wasn't one. With that fixed, the plan must be
+# empty for EVERY fixture — which also catches the failure this test is really about (a db_table
+# model diffing as a CREATE plus a DROP) under any spelling, not only the five listed by hand.
+@testset "db_table: a re-diff proposes nothing (global, #325)" begin
     settings = PormG.config[PORMG_DB_FOLDER]
     conn = settings.connections
     live = PormG.Migrations.convert_schema_to_models(conn)
     declared = PormG.Migrations.get_all_models(M)
     plan = PormG.Migrations.get_migration_plan(live, declared, conn, settings; interactive = false)
 
-    # No plan entry under EITHER spelling: the physical name (a create/alter the planner thinks it
-    # needs) or the logical one (proof the two sides were keyed differently).
+    # Name the drifting models in the failure message — an `isempty` that just says `false` gives a
+    # reader nothing to act on.
+    @test isempty(plan) || error("Schema drift: " *
+        join([string(name, ": ", join(collect(keys(steps)), "; ")) for (name, steps) in plan], " | "))
+
+    # Kept explicitly on top of the global check: these are the two spellings #59 is about — the
+    # physical table name (a create/alter the planner thinks it needs) and the logical one (proof
+    # the two sides were keyed differently). A future change that legitimately relaxes the global
+    # assertion must still not relax these.
     for name in (:Db_Table_Scratch, :db_table_scratch, :Db_Table_Col_Scratch, :db_table_col_scratch,
                  :db_table_child_scratch)
         @test !haskey(plan, name)

--- a/test/integration/test_migration_bootstrap.jl
+++ b/test/integration/test_migration_bootstrap.jl
@@ -1859,6 +1859,157 @@ end
     @test !isfile(pending)
   end
 
+  # ── Phase 19: field type, max_length and db_index round-trip + no churn (#325) ────
+  # The rest of the same symptom #318 fixed for `unique`, with three more root causes:
+  #
+  #   * Several Julia field types render the SAME column, so introspection cannot reproduce the
+  #     declared type — the information is not in the schema to read. PostgreSQL renders
+  #     CharField/URLField/SlugField all as `varchar(n)` and ImageField as `text`; SQLite renders
+  #     UUIDField/JSONField/ImageField/TextField all as bare `TEXT`. The planner demanded Julia
+  #     struct identity, so it proposed an ALTER whose SQL re-rendered the column unchanged.
+  #   * `max_length` was lost on PostgreSQL (any `varchar(n > 255)` was retyped to `text`) and
+  #     INVENTED on SQLite (a bare `TEXT` read back as `CharField(250)`).
+  #   * `db_index` was never read on either backend — PostgreSQL probed a `Dict{String,String}`
+  #     with a `Symbol` key, SQLite never looked at indexes at all. Latent until the type fix
+  #     landed: SlugField defaults `db_index=true`, so the moment `slug` compared type-equal,
+  #     db_index became the NEW permanent churn.
+  #
+  # A fourth, found by the global drift assertion this issue restores: `auto_now`/`auto_now_add`
+  # emit NO DDL — PormG stamps the timestamp in Julia on write — so they can never be introspected
+  # and `alter_field` has nothing to emit for them. Every `DateTimeField(auto_now_add=true)` was
+  # producing an empty alteration on every run, which on SQLite is still a full table rebuild.
+  #
+  # `Rt325` declares one field per collapse so a regression in any single mapping shows up here.
+  # `Rtidx325` is the negative fixture: a declared-but-unindexed column and a composite
+  # UniqueConstraint whose members must NOT be marked `db_index`.
+  @testset "Phase 19: Type/Length/Index Round-trip + No Churn (#325)" begin
+    write_edge_models("""
+    Rt325 = Models.Model(
+        id = Models.IDField(),
+        canonical_url = Models.URLField(max_length=500),
+        slug = Models.SlugField(max_length=120, unique=true),
+        uuid_token = Models.UUIDField(),
+        payload = Models.JSONField(null=true),
+        photo = Models.ImageField(null=true),
+        body = Models.TextField(null=true),
+        created_at = Models.DateTimeField(auto_now_add=true),
+        updated_at = Models.DateTimeField(auto_now=true),
+        code = Models.CharField(max_length=40, db_index=true),
+        plain = Models.CharField(max_length=40)
+    )
+    Rtidx325 = Models.Model(
+        id = Models.IDField(),
+        season = Models.IntegerField(),
+        round = Models.IntegerField(),
+        constraints = [Models.UniqueConstraint(fields=("season", "round"), name="rtidx325_season_round_uniq")]
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # (a) The columns are physically REAL and hold what they claim to. A behavioral oracle, like
+    #     Phase 18's: a metadata query here would just re-implement the production reader.
+    #     `canonical_url` gets exactly 500 characters — the length PostgreSQL used to widen away, so
+    #     a regression that reverts to varchar(250) fails on the INSERT, not only on a diff.
+    long_url = "https://example.com/" * repeat("a", 480)
+    @test length(long_url) == 500
+    # `created_at`/`updated_at` are supplied explicitly: `auto_now`/`auto_now_add` are stamped by
+    # PormG in Julia on write and emit no column DEFAULT, so a raw INSERT must provide them.
+    PormG.ConnectionPool.fetch(pool, """INSERT INTO rt325 ("canonical_url","slug","uuid_token","code","plain","created_at","updated_at")
+      VALUES ('$(long_url)', 's1', '11111111-1111-4111-8111-111111111111', 'c1', 'p1',
+              '2026-01-01 00:00:00+00', '2026-01-01 00:00:00+00');""")
+    stored = PormG.ConnectionPool.fetch(pool, """SELECT "canonical_url" FROM rt325;""") |> DataFrame
+    @test nrow(stored) == 1
+    @test length(stored[1, :canonical_url]) == 500
+
+    # The SlugField's UNIQUE is still enforced — the type fix must not have relaxed it away.
+    _is_unique_violation(e) = occursin("unique", lowercase(sprint(showerror, e)))
+    dup_slug = try
+      PormG.ConnectionPool.fetch(pool, """INSERT INTO rt325 ("canonical_url","slug","uuid_token","code","plain","created_at","updated_at")
+        VALUES ('u2', 's1', '22222222-2222-4222-8222-222222222222', 'c2', 'p2',
+                '2026-01-01 00:00:00+00', '2026-01-01 00:00:00+00');"""); false
+    catch e; _is_unique_violation(e) end
+    @test dup_slug
+
+    # (b) INTROSPECTION reads the schema-visible attributes back — the unit of the fix, live.
+    intro = Dict(lowercase(string(m.name)) => m for m in PormG.Migrations.convert_schema_to_models(pool))
+    live = intro["rt325"]
+
+    # `max_length`: kept where the column carries one, absent where it does not. On PostgreSQL
+    # `canonical_url` used to come back as a TextField with no length at all; on SQLite `photo`,
+    # `payload` and `uuid_token` used to come back as CharField(250), a length nothing declared.
+    @test live.fields["canonical_url"].max_length == 500
+    @test live.fields["slug"].max_length == 120
+    @test !hasfield(typeof(live.fields["payload"]), :max_length)
+    @test !hasfield(typeof(live.fields["photo"]), :max_length)
+    @test !hasfield(typeof(live.fields["body"]), :max_length)
+
+    # `db_index`: read back on both backends now, and NOT over-marked. `slug` is the interesting
+    # one — SlugField defaults `db_index=true` AND declares `unique=true`, so PormG emits both a
+    # UNIQUE constraint and a separate CREATE INDEX; the reader must see the latter without
+    # mistaking the former for it.
+    @test live.fields["code"].db_index
+    @test live.fields["slug"].db_index
+    @test !live.fields["plain"].db_index          # …and it did not over-mark
+    @test !live.fields["canonical_url"].db_index
+    # A UNIQUE constraint's backing index is `field.unique`, never `db_index`; a composite
+    # UniqueConstraint (#19) marks neither of its members.
+    @test !intro["rtidx325"].fields["season"].db_index
+    @test !intro["rtidx325"].fields["round"].db_index
+    @test !intro["rtidx325"].fields["season"].unique
+    # `unique` itself still round-trips (#318) — this fix must not have regressed it.
+    @test live.fields["slug"].unique
+    @test !live.fields["plain"].unique
+
+    # (c) NO CHURN — the reason #325 exists. A re-diff against the SAME models proposes nothing,
+    #     even though every declared field type above reads back as a different Julia struct.
+    pending = joinpath(@__DIR__, edge_db_name, "migrations", "pending_migrations.jl")
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+
+    # (d) …and the diff is not merely inert: a REAL change to one of these fields is still planned.
+    #     Without this, a `describes_same_column` that returned `true` unconditionally would pass
+    #     every assertion above.
+    #
+    #     WIDENING (500 → 900), not shrinking: the row inserted in (a) holds 500 characters, and
+    #     PostgreSQL rejects `ALTER COLUMN TYPE varchar(300)` when a live value would not fit. 900
+    #     also keeps the column above the 255 mark this issue was about.
+    write_edge_models("""
+    Rt325 = Models.Model(
+        id = Models.IDField(),
+        canonical_url = Models.URLField(max_length=900),
+        slug = Models.SlugField(max_length=120, unique=true),
+        uuid_token = Models.UUIDField(),
+        payload = Models.JSONField(null=true),
+        photo = Models.ImageField(null=true),
+        body = Models.TextField(null=true),
+        created_at = Models.DateTimeField(auto_now_add=true),
+        updated_at = Models.DateTimeField(auto_now=true),
+        code = Models.CharField(max_length=40),
+        plain = Models.CharField(max_length=40)
+    )
+    Rtidx325 = Models.Model(
+        id = Models.IDField(),
+        season = Models.IntegerField(),
+        round = Models.IntegerField(),
+        constraints = [Models.UniqueConstraint(fields=("season", "round"), name="rtidx325_season_round_uniq")]
+    )
+    """)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test isfile(pending)   # 500 → 900 is a real column change; dropping db_index is a real DROP INDEX
+    migrate(joinpath(@__DIR__, edge_db_name), interactive=false, destructive=true)
+
+    # …and applying it converges: the widened column and the dropped index both land, and the
+    # NEXT diff is empty again.
+    intro2 = Dict(lowercase(string(m.name)) => m for m in PormG.Migrations.convert_schema_to_models(pool))
+    @test intro2["rt325"].fields["canonical_url"].max_length == 900
+    @test !intro2["rt325"].fields["code"].db_index
+    isfile(pending) && rm(pending)
+    makemigrations(joinpath(@__DIR__, edge_db_name), interactive=false)
+    @test !isfile(pending)
+  end
+
   # ── Cleanup ─────────────────────────────────────────────────────────
   PormG.Configuration.close_pool!(joinpath(@__DIR__, edge_db_name))
   delete!(PormG.config, joinpath(@__DIR__, edge_db_name))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ end
     @testset "Savepoint Naming (#26)" include("unit/test_savepoint_naming.jl")
     @testset "Sequence Sync (Postgres + SQLite)" include("unit/test_sequence_sync.jl")
     @testset "Introspection PK Guards" include("unit/test_introspection_guards.jl")
+    @testset "Physical-column Identity (#325)" include("unit/test_column_equivalence.jl")
     @testset "Self-Heal Key Inference" include("unit/test_self_heal_inference.jl")
     @testset "Ignore-Tables Registry" include("unit/test_ignore_tables_registry.jl")
     @testset "New Field Types (UUID, URL, Slug, JSON)" include("unit/test_new_field_types.jl")

--- a/test/unit/test_binary_field_bytes.jl
+++ b/test/unit/test_binary_field_bytes.jl
@@ -245,8 +245,11 @@ PormG.get_constraints_byte_length_check(::MockPGBinNamed, table_name::String, fi
 
     # The CHECK clause must not be mistaken for a column, and the neighbouring column's
     # own type must survive — the DEFAULT capture used to swallow the trailing CHECK.
+    # (#325: a lengthless `TEXT` now reads back as a TextField, not a CharField whose constructor
+    # would invent `max_length = 250`. What this assertion is here to prove — that `name` was
+    # parsed as a column at all — is unchanged.)
     @test !haskey(recovered.fields, "length")
-    @test recovered.fields["name"] isa Models.sCharField
+    @test recovered.fields["name"] isa Models.sTextField
   end
 
   @testset "an unbounded, defaultless BLOB column round-trips too" begin

--- a/test/unit/test_column_equivalence.jl
+++ b/test/unit/test_column_equivalence.jl
@@ -1,0 +1,140 @@
+"""
+Unit coverage for `Dialect.describes_same_column` — the physical-column identity predicate the
+migration planner uses in place of Julia struct identity (#325).
+
+Several field types materialize the SAME column, and introspection cannot tell them apart because
+the information is not in the schema to read: PostgreSQL renders `CharField`, `URLField` and
+`SlugField` all as `varchar(n)`, and SQLite collapses `UUIDField`, `JSONField`, `ImageField` and
+`TextField` all onto bare `TEXT`. Demanding struct identity therefore proposed an ALTER whose SQL
+re-rendered the column unchanged, on every single `makemigrations` — on SQLite as the full
+`CREATE new → INSERT SELECT → DROP old → RENAME` rebuild.
+
+Fully hermetic: `_get_column_type` dispatches on the abstract backend marker and never touches
+connection state, so a bare marker struct is a sufficient `conn`. The live-database half is
+test/integration/test_migration_bootstrap.jl.
+"""
+
+using Test
+using PormG
+using PormG.Models
+using PormG.Dialect: describes_same_column, _get_column_type
+
+# `PormGPostgres`/`PormGSQLite` are abstract backend markers (src/Kernel.jl); dialect rendering
+# dispatches on them alone. Same mock pattern as test/unit/test_alter_field_constraint_drops.jl.
+struct MockPg325 <: PormG.PormGPostgres end
+struct MockSQLite325 <: PormG.PormGSQLite end
+
+const PG325 = MockPg325()
+const SL325 = MockSQLite325()
+
+@testset "Physical-column identity (describes_same_column, #325)" begin
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The premise: the VARCHAR family really is one column on PostgreSQL
+  # If these rendering assertions ever stop holding, the equivalences below stop being safe rather
+  # than merely stop being useful — so they are pinned first, not assumed.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the rendered types this rests on" begin
+    @test _get_column_type(Models.CharField(max_length = 500), PG325) == "varchar(500)"
+    @test _get_column_type(Models.URLField(max_length = 500), PG325)  == "varchar(500)"
+    @test _get_column_type(Models.SlugField(max_length = 120), PG325) == "varchar(120)"
+    # SQLite has no varchar: the whole family renders TEXT(n), and the lengthless types bare TEXT.
+    @test _get_column_type(Models.CharField(max_length = 120), SL325) == "TEXT(120)"
+    @test _get_column_type(Models.UUIDField(), SL325)                 == "TEXT"
+    @test _get_column_type(Models.JSONField(), SL325)                 == "TEXT"
+    @test _get_column_type(Models.TextField(), SL325)                 == "TEXT"
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # PostgreSQL: the pairs that were churning
+  # `canonical_url = URLField(max_length=500)` introspects as `CharField(500)` — the same
+  # `varchar(500)` column. `photo = ImageField()` renders `text` (no `_get_column_type` branch) and
+  # introspects as `TextField`, also the same column.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "PostgreSQL: varchar and text families are each one column" begin
+    @test describes_same_column(PG325, Models.URLField(max_length = 500), Models.CharField(max_length = 500))
+    @test describes_same_column(PG325, Models.SlugField(max_length = 120), Models.CharField(max_length = 120))
+    @test describes_same_column(PG325, Models.ImageField(), Models.TextField())
+    @test describes_same_column(PG325, Models.FileField(), Models.TextField())
+
+    # A DIFFERENT length is a different column and must still be planned.
+    @test !describes_same_column(PG325, Models.URLField(max_length = 500), Models.CharField(max_length = 250))
+    # varchar is not text: PostgreSQL keeps them apart, so PormG must too.
+    @test !describes_same_column(PG325, Models.CharField(max_length = 250), Models.TextField())
+    # …and the types PostgreSQL DOES round-trip faithfully stay distinct.
+    @test !describes_same_column(PG325, Models.JSONField(), Models.TextField())    # jsonb vs text
+    @test !describes_same_column(PG325, Models.UUIDField(), Models.CharField())    # uuid vs varchar
+    @test !describes_same_column(PG325, Models.BinaryField(), Models.TextField())  # bytea vs text
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # SQLite: the collapse is wider, and that is CORRECT — the column really is identical
+  # A UUIDField and a JSONField are byte-for-byte the same SQLite column, so switching one for the
+  # other is genuinely a no-op schema change. What must NOT collapse is a length difference.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "SQLite: the lengthless textual types are one column" begin
+    @test describes_same_column(SL325, Models.UUIDField(), Models.TextField())
+    @test describes_same_column(SL325, Models.JSONField(), Models.TextField())
+    @test describes_same_column(SL325, Models.ImageField(), Models.TextField())
+    @test describes_same_column(SL325, Models.URLField(max_length = 500), Models.CharField(max_length = 500))
+
+    # A sized column is not a lengthless one — this is the pair the SQLite half of #325 was ABOUT.
+    # Before the introspection fix a bare `TEXT` read back as `CharField(250)`, i.e. `TEXT(250)`,
+    # and never matched the `TEXT` the model rendered.
+    @test !describes_same_column(SL325, Models.JSONField(), Models.CharField(max_length = 250))
+    @test !describes_same_column(SL325, Models.CharField(max_length = 120), Models.CharField(max_length = 250))
+    # BLOB is a real storage class on SQLite and stays distinct from TEXT.
+    @test !describes_same_column(SL325, Models.BinaryField(), Models.TextField())
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The CHECK-expressed bounds are part of the column, not decoration
+  # `_get_column_type` alone would call these pairs equal: PostgreSQL renders a PositiveIntegerField
+  # as plain `integer` (it has no unsigned type) and distinguishes it only by a `>= 0` CHECK, and a
+  # BinaryField's byte bound is a CHECK too because `bytea`/`BLOB` take no length parameter.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "CHECK-expressed bounds count as part of the column" begin
+    @test _get_column_type(Models.IntegerField(), PG325) == _get_column_type(Models.PositiveIntegerField(), PG325)
+    @test !describes_same_column(PG325, Models.IntegerField(), Models.PositiveIntegerField())
+
+    # Two BinaryFields with different byte bounds render identically but are not the same column.
+    # (Same struct type, so the planner would compare them attribute-wise anyway — this pins the
+    # predicate itself, which is what a future caller would rely on.)
+    @test !describes_same_column(SL325, Models.BinaryField(max_length = 8), Models.BinaryField())
+    @test !describes_same_column(PG325, Models.BinaryField(max_length = 8), Models.BinaryField(max_length = 16))
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # The relational / primary-key guard rail
+  # `sForeignKey` and `sBigIntegerField` both render `bigint`. Calling them the same column would
+  # silently stop planning FK add/drop on an existing column, because
+  # `_add_fk_constraint_in_alteration` runs only for a field the diff already flagged as changed.
+  # Same for a primary key, whose identity is not carried by the column type either.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "relational fields and primary keys are never 'the same column'" begin
+    @test _get_column_type(Models.ForeignKey("Races"), PG325) == _get_column_type(Models.BigIntegerField(), PG325)
+    @test !describes_same_column(PG325, Models.ForeignKey("Races"), Models.BigIntegerField())
+    @test !describes_same_column(PG325, Models.BigIntegerField(), Models.ForeignKey("Races"))
+    @test !describes_same_column(SL325, Models.ForeignKey("Races"), Models.IntegerField())
+
+    # IDField renders `bigint` on PostgreSQL exactly like BigIntegerField.
+    @test !describes_same_column(PG325, Models.IDField(), Models.BigIntegerField())
+    @test !describes_same_column(PG325, Models.CharField(max_length = 50, primary_key = true), Models.SlugField(max_length = 50))
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Symmetry and reflexivity
+  # The planner calls this with (declared, live); nothing should depend on that order.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "the predicate is symmetric and reflexive" begin
+    for conn in (PG325, SL325)
+      for (a, b) in ((Models.URLField(max_length = 500), Models.CharField(max_length = 500)),
+                     (Models.ImageField(), Models.TextField()),
+                     (Models.JSONField(), Models.TextField()),
+                     (Models.IntegerField(), Models.PositiveIntegerField()))
+        @test describes_same_column(conn, a, b) == describes_same_column(conn, b, a)
+      end
+      @test describes_same_column(conn, Models.TextField(), Models.TextField())
+    end
+  end
+end

--- a/test/unit/test_field_validation_and_operations.jl
+++ b/test/unit/test_field_validation_and_operations.jl
@@ -95,6 +95,24 @@ canon_utc(zdt) = Dates.format(astimezone(zdt, TimeZone("UTC")), Models.DATETIME_
 
         @test validate_field_data(mock_str_model, "email", "test@example.com", "insert") === true
 
+        # #325: CharField no longer caps `max_length` at 255. That ceiling was a MySQL-ism —
+        # PostgreSQL's `varchar` takes up to 10,485,760 characters and SQLite ignores the declared
+        # length — and it was LOSSY on read-back: introspecting a live `varchar(500)` had to retype
+        # the column to TextField and drop the length, so the model never matched its own table and
+        # `makemigrations` proposed the same widening forever. The constructor call goes red on main.
+        @test Models.CharField(max_length = 500).max_length == 500
+        @test Models.CharField(max_length = 10_000).max_length == 10_000
+        # The lower bound is untouched — a zero/negative length is still a declaration error.
+        @test_throws PormG.FieldValidationError Models.CharField(max_length = 0)
+        # …and length validation still fires at the declared bound, wherever it is.
+        mock_long_model = Models.Model_Type(
+            name = "long_char_test",
+            fields = Dict("url" => Models.CharField(max_length = 500)),
+            field_names = ["url"]
+        )
+        @test validate_field_data(mock_long_model, "url", "a"^500, "insert") === true
+        @test_throws PormGError validate_field_data(mock_long_model, "url", "a"^501, "insert")
+
         # Regression: a field whose `max_length` is `nothing` (the St_cruz.b1_n case) must SKIP
         # the length check, not compare `length(value) > nothing` (which threw
         # MethodError: isless(::Int, ::Nothing)).

--- a/test/unit/test_ignore_tables_registry.jl
+++ b/test/unit/test_ignore_tables_registry.jl
@@ -48,3 +48,51 @@ import PormG.Migrations: convert_schema_to_models
     PormG._EXTRA_IGNORE_TABLES[] = saved   # never leak registry state into other suites
   end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #325: the ignore list matches a PREFIX, and matches the same way on both backends
+#
+# Every entry is either a framework prefix (`"django_"`, `"auth_"`, `"sqlite_autoindex"`) or a whole
+# table name (`"pormg_migrations"`) — a prefix test covers both. The backends used to disagree, and
+# each was wrong in its own direction:
+#
+#   * PostgreSQL used `occursin`, so a user table merely CONTAINING an entry vanished from the live
+#     schema. A dropped table does not read as "ignored" downstream, it reads as "does not exist" —
+#     so `makemigrations` proposed `CREATE TABLE` for it on every single run, which is the same
+#     never-converging churn #325 is about. `company_admin_log` and `oauth_tokens` are the shapes
+#     that actually bite; both are ordinary user tables.
+#   * SQLite used `==`, so `"sqlite_autoindex"` — only ever a prefix of `sqlite_autoindex_<t>_<n>`,
+#     never a table name — could not match anything.
+#
+# Pure predicate, no database.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ignore-list matching is prefix-based on both backends (#325)" begin
+  import PormG.Migrations: _is_ignored_table
+
+  pg = PormG.postgres_ignore_table
+
+  # Genuine framework tables are still skipped — the whole point of the list.
+  @test _is_ignored_table("django_migrations", pg)
+  @test _is_ignored_table("django_content_type", pg)
+  @test _is_ignored_table("auth_user", pg)
+  @test _is_ignored_table("celery_taskmeta", pg)
+  @test _is_ignored_table("pormg_migrations", pg)
+
+  # THE mutation gate: user tables that merely CONTAIN an entry are no longer swallowed.
+  @test !_is_ignored_table("company_admin_log", pg)      # contains "admin_"
+  @test !_is_ignored_table("oauth_tokens", pg)           # contains "auth_"
+  @test !_is_ignored_table("contract_django_scratch", pg)  # contains "django_" — the #325 fixture
+  @test !_is_ignored_table("my_social_graph", pg)        # contains "social_"
+
+  # A table that genuinely starts with a framework prefix is STILL skipped, so the fix did not
+  # simply turn the list off. This is why the integration fixture had to be renamed rather than the
+  # list edited — ignoring `django_*` is correct behavior.
+  @test _is_ignored_table("django_contract_scratch", pg)
+
+  # SQLite side: `sqlite_autoindex` is a prefix and never a table name, so `==` could not match it.
+  sl = PormG.sqlite_ignore_schema
+  @test _is_ignored_table("sqlite_sequence", sl)
+  @test _is_ignored_table("sqlite_autoindex_drivers_1", sl)   # ← impossible under `==`
+  @test _is_ignored_table("pormg_migrations", sl)
+  @test !_is_ignored_table("drivers", sl)
+end

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -24,7 +24,8 @@ using PormG.Migrations: convertSQLToModel
 # `pg_constraint.confdeltype` codes, comma-joined in the same order as `foreign_keys` (#292).
 function _introspection_row(; table_name, columns, primary_keys,
                               foreign_keys = missing, foreign_tables = missing,
-                              referenced_primary_keys = missing, delete_rules = missing)
+                              referenced_primary_keys = missing, delete_rules = missing,
+                              index_columns = missing, index_names = missing)
   df = DataFrame(
     table_name              = [table_name],
     columns                 = [columns],
@@ -33,8 +34,8 @@ function _introspection_row(; table_name, columns, primary_keys,
     foreign_tables          = [foreign_tables],
     referenced_primary_keys = [referenced_primary_keys],
     delete_rules            = [delete_rules],
-    index_columns           = [missing],
-    index_names             = [missing],
+    index_columns           = [index_columns],
+    index_names             = [index_names],
   )
   return df[1, :]
 end
@@ -395,4 +396,66 @@ end
     primary_keys = "id"))
   @test !tricky.fields["UNIQUE_CODE"].unique
   @test !tricky.fields["label"].unique
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #325: a long VARCHAR must keep its length instead of being retyped to TEXT
+# The reader used to parse `character varying(500)`, then throw the result away — `CharField`
+# refused any `max_length > 255`, so the column was rebuilt as a `TextField` with no length at all.
+# The live column really was `varchar(500)`, so the declared model never matched its own table and
+# `makemigrations` proposed the same widening on every run. Both assertions go red on main.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PostgreSQL varchar(n > 255) keeps its length (#325)" begin
+  model = convertSQLToModel(_introspection_row(
+    table_name   = "long_varchar_guard",
+    columns      = "id bigint NOT NULL, canonical_url character varying(500) NOT NULL, " *
+                   "short character varying(120), body text",
+    primary_keys = "id"))
+
+  # THE mutation gate: on main this field is an `sTextField` and has no `max_length` at all.
+  @test model.fields["canonical_url"] isa PormG.Models.sCharField
+  @test model.fields["canonical_url"].max_length == 500
+
+  # The ≤ 255 case is the baseline — it passed before too. Kept so a fix that swings the other way
+  # (everything becomes a TextField) cannot go green here.
+  @test model.fields["short"] isa PormG.Models.sCharField
+  @test model.fields["short"].max_length == 120
+
+  # …and a genuine `text` column is still a TextField: `varchar` ⇒ CharField, `text` ⇒ TextField is
+  # now the whole rule, with no length-dependent crossover between them.
+  @test model.fields["body"] isa PormG.Models.sTextField
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #325: `db_index` is read back from the schema query's index columns
+# The reader computed `haskey(index_map, col_name |> Symbol)` against a `Dict{String,String}` — a
+# `Symbol` key never matches a `String` key, so `db_index` was a hard `false` for every plain
+# PostgreSQL column. Every `db_index=true` field therefore compared unequal to its own live table
+# forever, and `Dialect.alter_field` has no `db_index` branch, so the migration it triggered emitted
+# no DDL for it. The de-quoting half matters just as much: the CTE passes column names through
+# `quote_ident`, so a mixed-case column (#57) arrives wrapped in `"` and would miss even with the
+# key type fixed.
+#
+# The CTE's own filters (non-unique, non-partial, single-column) run against a live database in
+# test/integration/test_migration_bootstrap.jl — nothing here executes SQL.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "PostgreSQL db_index is read back off the index map (#325)" begin
+  model = convertSQLToModel(_introspection_row(
+    table_name    = "db_index_guard",
+    columns       = "id bigint NOT NULL, slug character varying(120), plain text, \"mixedCase\" text",
+    primary_keys  = "id",
+    # What the `indexes` CTE hands back: one entry per indexed column, `quote_ident`-ed, with the
+    # index names aligned positionally.
+    index_columns = "slug, \"mixedCase\"",
+    index_names   = "db_index_guard_slug_idx, db_index_guard_mixedcase_idx"))
+
+  # THE mutation gate — all three are `false` on main.
+  @test model.fields["slug"].db_index
+  @test model.fields["mixedCase"].db_index      # the de-quoting half (#57)
+  @test !model.fields["plain"].db_index         # …and it did not over-mark
+
+  # The index NAME is carried too, de-quoted, because the planner needs it to DROP the index when a
+  # model stops declaring `db_index`. `_drop_index` re-quotes, so a quoted value would double up.
+  @test model.cache["index"]["slug"] == "db_index_guard_slug_idx"
+  @test model.cache["index"]["mixedCase"] == "db_index_guard_mixedcase_idx"
 end

--- a/test/unit/test_sqlite_index_filter.jl
+++ b/test/unit/test_sqlite_index_filter.jl
@@ -24,7 +24,8 @@ using PormG
 using DataFrames
 import PormG.ConnectionPool: SQLiteConnectionPool, fetch, close_pool!
 import PormG.Migrations: get_secondary_index_ddls, _sqlite_column_is_unique,
-                         _sqlite_single_column_unique_columns, convertSQLToModel
+                         _sqlite_single_column_unique_columns,
+                         _sqlite_single_column_indexed_columns, convertSQLToModel
 
 @testset "get_secondary_index_ddls column filter (#116)" begin
   mktempdir() do dir
@@ -230,6 +231,95 @@ end
       @test c.fields["o2o"].unique        # …the uniqueness IS read, which is what #318 fixes
       @test c.fields["fk"]  isa PormG.Models.sForeignKey
       @test !c.fields["fk"].unique
+    finally
+      close_pool!(pool)
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #325: `_sqlite_single_column_indexed_columns` — the `db_index` twin of the #318 `unique` reader
+#
+# `PRAGMA table_info` carries neither attribute, so introspection never populated `db_index` on
+# SQLite at all. Every `db_index=true` field (SlugField defaults to it) therefore compared unequal
+# to its own live table forever — and since `Dialect.alter_field` has no `db_index` branch, the
+# rebuild it triggered emitted no DDL for it. `src/migrations/planner.jl` carried a workaround for
+# one symptom of that; this is the cause.
+#
+# The filters are the mirror image of the `unique` reader's, and each excludes an index that is NOT
+# `db_index`. Every assertion below names the filter it gates.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "_sqlite_single_column_indexed_columns (#325)" begin
+  mktempdir() do dir
+    pool = SQLiteConnectionPool(joinpath(dir, "indexedcols.sqlite"); pool_size = 1)
+    try
+      # One of every shape PRAGMA index_list reports, mirrored from the #318 fixture above:
+      #   ix     → plain CREATE INDEX        (origin 'c', unique 0, 1 col)  ← the ONLY db_index
+      #   uc     → column-level UNIQUE       (origin 'u')
+      #   plain  → CREATE UNIQUE INDEX       (origin 'c', unique 1)
+      #   a, b   → composite CREATE INDEX    (origin 'c', unique 0, 2 cols)
+      #   part   → partial CREATE INDEX      (origin 'c', unique 0, 1 col, partial 1)
+      fetch(pool, """CREATE TABLE t325 (
+        id INTEGER PRIMARY KEY, ix TEXT, uc TEXT UNIQUE, plain TEXT,
+        a TEXT, b TEXT, part TEXT);""")
+      fetch(pool, "CREATE INDEX ix_t325_ix ON t325(ix);")
+      fetch(pool, "CREATE UNIQUE INDEX ux_t325_plain ON t325(plain);")
+      fetch(pool, "CREATE INDEX ix_t325_ab ON t325(a, b);")
+      fetch(pool, "CREATE INDEX ix_t325_part ON t325(part) WHERE part IS NOT NULL;")
+
+      idx = _sqlite_single_column_indexed_columns(pool, :t325)
+      @test collect(keys(idx)) == ["ix"]
+      # The index NAME is carried too — the planner needs it to DROP the index when a model stops
+      # declaring `db_index`, and SQLite's reader never populated `cache["index"]` before.
+      @test idx["ix"] == "ix_t325_ix"
+
+      # Spelled out individually so a failure names the filter that broke:
+      @test haskey(idx, "ix")         # drop `origin = 'c'` and the UNIQUE auto-index leaks in
+      @test !haskey(idx, "uc")        # a column-level UNIQUE is `field.unique` (#318), not db_index
+      @test !haskey(idx, "plain")     # drop `il."unique" = 0` and CREATE UNIQUE INDEX leaks in —
+                                      #   that is how a single-field UniqueConstraint (#19) is
+                                      #   materialized, and marking it would churn the other way
+      @test !haskey(idx, "a")         # drop `HAVING COUNT(*) = 1` and composite members leak in;
+      @test !haskey(idx, "b")         #   PormG only ever indexes one column per db_index
+      @test !haskey(idx, "part")      # drop `il.partial = 0` and a partial index leaks in — it
+                                      #   constrains rows, not the column, and PormG cannot declare
+                                      #   one, so reading it would be permanent churn
+      @test !haskey(idx, "id")        # a PK is already an IDField (and sIDField is immutable)
+
+      # An unknown table yields an empty dict rather than throwing — convert_schema_to_models calls
+      # this per table and must survive a race with a concurrent DROP.
+      @test _sqlite_single_column_indexed_columns(pool, :nonexistent) == Dict{String, String}()
+
+      # END TO END: the dict is only useful if convertSQLToModel applies it. Without this the whole
+      # fix could be inert and every assertion above would still pass.
+      m = convertSQLToModel(pool, "t325")
+      @test m.fields["ix"].db_index
+      @test !m.fields["uc"].db_index
+      @test !m.fields["plain"].db_index
+      @test !m.fields["a"].db_index
+      @test !m.fields["part"].db_index
+      @test m.cache["index"]["ix"] == "ix_t325_ix"
+
+      # ── The other half of #325 on SQLite: a bare TEXT column must not invent a max_length ──
+      # SQLite renders CharField as `TEXT(n)` and UUIDField/JSONField/ImageField/TextField all as
+      # bare `TEXT`. Reading a lengthless `TEXT` back as `CharField` meant the constructor's default
+      # `max_length = 250` was invented from nothing — the model rendered `TEXT`, the "live" model
+      # rendered `TEXT(250)`, and the two never matched.
+      fetch(pool, """CREATE TABLE len325 (
+        id INTEGER PRIMARY KEY, bare TEXT, sized TEXT(120), vc VARCHAR(64));""")
+      lm = convertSQLToModel(pool, "len325")
+
+      @test lm.fields["bare"] isa PormG.Models.sTextField      # ← the mutation gate
+      @test !hasfield(typeof(lm.fields["bare"]), :max_length)  # nothing left to invent
+
+      # A declared length still means CharField, carrying that exact length — the fix must not
+      # swing the other way and turn every textual column into a TextField.
+      @test lm.fields["sized"] isa PormG.Models.sCharField
+      @test lm.fields["sized"].max_length == 120
+      # VARCHAR/CHAR are accepted for schemas PormG did not create; before #325 a hand-written
+      # `VARCHAR(64)` fell through to TextField and lost its length outright.
+      @test lm.fields["vc"] isa PormG.Models.sCharField
+      @test lm.fields["vc"].max_length == 64
     finally
       close_pool!(pool)
     end


### PR DESCRIPTION
Closes #325.

The remainder of the `makemigrations` churn that #318 fixed for `unique`.

## The contract this settles

#325's first task was to decide whether introspection should reproduce the declared field **type**, or whether the diff should treat type-compatible fields as equal. It has to be the second: introspection *cannot* reproduce the declared Julia type, because several types render the same column and the information is not in the schema to read.

- PostgreSQL — `CharField`, `URLField` and `SlugField` all render `varchar(n)`; `ImageField`/`FileField`/`EmailField`/`PasswordField` all fall through to `text`.
- SQLite — `UUIDField`, `JSONField`, `TextField` and `ImageField` are all bare `TEXT`.

Making it reproducible would mean encoding the Julia type into the DDL (marker CHECKs on PostgreSQL, non-standard declared types on SQLite — which also changes column affinity) and rebuilding every existing table.

So the diff now compares **what the database actually holds**: the rendered column type plus the bounds only a CHECK can express, falling back to Julia struct identity when the two structs match. If two fields render the same column, an ALTER between them was always a no-op.

`describes_same_column` excludes relational fields and primary keys on purpose — their identity is not carried by the column type alone, and `sForeignKey`/`sBigIntegerField` both render `bigint`, so conflating them would silently stop FK add/drop being planned (that runs *after* the planner's early-out).

## Six lossy reads fixed alongside it

| | |
|---|---|
| **PG `max_length`** | `CharField`'s 255 ceiling was a MySQL-ism, and it was lossy on read-back — a live `varchar(500)` had to retype to `TextField` and drop the length. Gone; `varchar(n)` round-trips as `CharField(n)`, symmetric with `text` ⇒ `TextField`. |
| **SQLite `max_length`** | A bare `TEXT` column read back as `CharField`, whose constructor *invents* `max_length = 250`. It is now a `TextField`; hand-written `VARCHAR(n)`/`CHAR(n)` are recognized and keep their length. |
| **`db_index`** | Never read on either backend — PostgreSQL probed a `Dict{String,String}` with a `Symbol` key (never matches); SQLite did not look at indexes at all. Both now read single-column, non-unique, non-partial secondary indexes. An index difference also no longer routes through a column ALTER: it emits `CREATE`/`DROP INDEX` alone, removing a full SQLite rebuild that did nothing. |
| **`get_constraints_unique`** | Returned the first row of an unordered result matching any constraint the column merely belonged to, so a column in both `UNIQUE(a)` and `UNIQUE(a, b)` could drop the composite one. Now restricted to single-column constraints, and ordered. |
| **`auto_now` / `auto_now_add`** *(not in the issue)* | These emit **no DDL at all** — PormG stamps the timestamp in Julia on write. So they can never be read back, and `alter_field` had nothing to emit. Every `DateTimeField(auto_now_add=true)` was producing an empty alteration on every run — a full table rebuild on SQLite. Now recognized as model-layer-only, like `blank`/`editable`. |
| **The ignore list** *(not in the issue)* | PostgreSQL used `occursin`, so a user table merely *containing* an entry — `oauth_tokens` contains `auth_` — vanished from the live schema. A table PormG cannot see does not read as "ignored" downstream, it reads as "does not exist", so `makemigrations` proposed `CREATE TABLE` for it forever, and real drift on it was never reported. Prefix-matched on both backends now. |

The `alter_field` warning list is also corrected: `:blank`, `:auto_now` and `:auto_now_add` were listed as implemented while emitting no SQL, which silenced the warning for three attributes that genuinely could not be applied.

## The assertion this unblocks

`assert_clean_state()` now calls `assert_no_schema_drift()`, which re-diffs the live schema against the declared models **in memory** (`get_migration_plan` writes no `pending_migrations.jl`, so it cannot disturb the `st.pending` check or a later `makemigrations`). Note `st.pending` alone never caught this — it only tests whether a file exists on disk.

That let the scoped workaround in `test/integration/test_db_table_db.jl` become the global assertion #318 wanted and could not have. The five #59 spellings are kept explicitly on top of it, so a future change that relaxes the global check still cannot relax those.

## Verification

- Unit — **5562/5562** pass, including the new `test/unit/test_column_equivalence.jl`.
- PostgreSQL (`db_2`) integration — **2002/2002** pass.
- SQLite (`db_sl`) — not run locally; relying on CI for this one.

## Docs

`UPGRADING.md` carries the `Unreleased` entry, including the one-time plan a user may see on first `makemigrations` (a previously-invisible live index now proposed for drop; a hand-written lengthless SQLite `TEXT` declared as `CharField(n)`; a PostgreSQL table whose name merely contained a framework prefix becoming visible). `docs/src/fields.md` and the `CharField` docstring drop the 1-255 claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
