### PR TITLE
fix(#331): bulk writes fill only absent columns; an explicit blank means NULL

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -40,6 +40,110 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.4.0`, dates
 
 ---
 
+## Bulk writes — a `default` / `auto_now` no longer overwrites a blank cell in a column the DataFrame carries (#331)
+
+- **Version**: Unreleased
+- **PormG ref**: #331; `src/querybuilder/execution_bulk.jl`
+- **Recorded**: 2026-08-08
+- **Severity**: **behavior change** — persisted values can differ, and a `null=false` column can now
+  raise where the write used to succeed. Part of the `0.4.x` wave.
+
+### What changed
+
+`create()` and the bulk paths disagreed about what an explicit "no value" meant on a field carrying a
+static `default`. `create()` honored it and stored `NULL`; `bulk_insert` / `bulk_copy` / `bulk_update`
+rewrote the cell with the default. There was no spelling of `NULL` that survived, so the two insert
+paths were not substitutable: swapping a `create()` loop for one `bulk_insert` silently changed what
+was stored.
+
+There is now one rule, shared by all three bulk operations:
+
+> **For a field the write touches, PormG supplies a value only when the `DataFrame` has no column
+> for it. A column that *is* present is caller-authored data, and PormG never rewrites its cells.**
+
+That covers every fill kind — a static `default`, `auto_now`, `auto_now_add`, and a UUID `auto_add` —
+on `:insert`, `:copy` and `:update` alike, nullable or not. Four consequences:
+
+- A blank cell (`missing`/`nothing`) in a present, **nullable** defaulted or auto column now persists
+  as SQL `NULL` instead of the fill value. On `bulk_update` that turns what used to be a silent no-op
+  — writing the default back over the live value — into an actual null-out.
+- A blank cell in a present **`null=false`** defaulted or auto column now raises `InvalidValueError`
+  (*"null values are not allowed"*) — PormG's own validation naming the field, not a database
+  constraint error, and nothing is persisted (the write is wrapped in a transaction, so a row that
+  fails part-way rolls back the chunks already sent). That is the same error `create()` has always
+  raised for an explicit `"field" => nothing`.
+- A blank cell in a `match_on` key column is no longer back-filled from that field's `default`. Match
+  keys are exempt from the per-row null check, so this changes **which rows are updated** rather than
+  raising: a row keyed on a blank no longer merges into the default-valued row by accident.
+- A `UUIDField(auto_add = true)` **primary key** carried in the frame with blank cells now raises
+  instead of being minted in place. The old behavior was not usable anyway — it reused a single UUID
+  for every row in the batch, so any multi-row insert violated the key. **Fill the column yourself**
+  — `df[!, :token] = [UUIDs.uuid4() for _ in 1:DataFrames.nrow(df)]` — which works precisely because
+  a present column is now honored verbatim. Do **not** drop the column instead: the absent path
+  currently mints one UUID for the whole batch (#334), so a multi-row insert collides on the key.
+  (The all-blank-means-absent rescue applies to `auto_increment` primary keys only; it does not
+  cover UUID ones.)
+
+**Absent columns are unchanged.** A defaulted or auto column the `DataFrame` does not carry is still
+injected exactly as before — including that `bulk_update(..., columns = [...])` does not synthesize a
+static `default`, and that an all-blank auto-increment primary key column still counts as absent.
+
+**A field you leave out of `columns=` is also unchanged.** It is out of scope by your own
+instruction, so its cells are not read from the frame even when the frame carries them; on
+`bulk_insert`/`bulk_copy` PormG still supplies its default, which is what keeps a partial `columns=`
+insert satisfying the model's `null=false` fields.
+
+### How to find the calls to migrate
+
+The `null=false` half announces itself: run the app or its tests and the new `InvalidValueError` names
+the model and the field. The nullable half is silent, so grep for it:
+
+```bash
+# 1. Which of your models declare a fill? Only these fields are affected.
+rg -n --glob '**/models*.jl' 'default\s*=|auto_now(_add)?\s*=\s*true|auto_add\s*=\s*true'
+
+# 2. Which files build a DataFrame for a bulk write AND can produce blanks?
+rg -l '\b(bulk_insert|bulk_copy|bulk_update)\s*\(' \
+  | xargs rg -n 'missing|nothing|CSV\.(File|read)|allowmissing'
+```
+
+Cross-check each hit's column list against the field names from step 1. A CSV import is the common
+case: an empty cell parses to `missing`, so a column that was silently receiving the model default now
+receives `NULL` — or raises, if the field is `null=false`.
+
+### Migrate your app
+
+```julia
+# Stint = Models.Model("stint",
+#     driver    = Models.CharField(),
+#     laps      = Models.IntegerField(default = 0),               # null = false
+#     note      = Models.CharField(default = "", null = true))
+
+df = DataFrames.DataFrame(
+    driver = ["Senna", "Prost"],
+    laps   = [missing, 71],      # ✗ before: stored 0 and 71
+    note   = [missing, "wet"],   # ✗ before: stored "" and "wet"
+)
+
+# ✗ before — the blanks silently became the model defaults
+bulk_insert(M.Stint.objects, df)
+
+# ✓ after, option A — you WANTED the default: write it yourself, explicitly.
+df[!, :laps] = coalesce.(df.laps, 0)
+df[!, :note] = coalesce.(df.note, "")
+bulk_insert(M.Stint.objects, df)
+
+# ✓ after, option B — you wanted PormG to supply it: drop the column.
+#   An ABSENT column is still filled from the model default, exactly as before.
+bulk_insert(M.Stint.objects, DataFrames.select(df, DataFrames.Not([:laps, :note])))
+
+# ✓ after, option C — you wanted NULL: change nothing. That is now what the nullable
+#   `note` stores, matching what create() always gave you. On the null=false `laps`
+#   it is now an InvalidValueError instead of a silent 0 — fix that one with A or B.
+```
+
+---
+
 ## The migration diff compares the physical column, not the Julia field type (#325)
 
 - **Version**: Unreleased

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -972,7 +972,7 @@ All field types support these common parameters:
 - `null::Bool = false`: Allow NULL values in database
 - `blank::Bool = false`: Allow empty values in forms  
 - `unique::Bool = false`: Enforce uniqueness constraint on this single column. For uniqueness spanning **two or more** columns, use a model-level `UniqueConstraint` — see [Composite Uniqueness](models.md#Composite-Uniqueness-(unique_together)).
-- `default`: Set default value for new records
+- `default`: Set default value for new records. PormG applies it only where the write supplies no value for the field; a field passed explicitly — including as `nothing`/`missing` — is honored as written. See [Defaults and Auto Values](write/bulk.md#Defaults-and-Auto-Values) for the `DataFrame` form of the same rule.
 
 ### Database Options
 - `db_index::Bool = false`: Create database index for faster queries

--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -11,11 +11,50 @@ All three operations accept `show_query=:sql`, `show_query=:dict`, `show_query=:
 ### The Mapping Adaptor Strategy ⭐
 
 All bulk operations in PormG use a **Mapping Adaptor** approach. This means:
-- **Never Mutates, Never Copies**: The pipeline works on a zero-copy wrapper of the input `DataFrame` (shared column vectors). Defaults, timestamps, and other ORM-side normalization happen on that internal frame only — your `DataFrame` is untouched, unconditionally, and no data is duplicated. There is no `copy=` knob because there is nothing to protect against.
+- **Never Mutates, Never Copies**: The pipeline works on a zero-copy wrapper of the input `DataFrame` (shared column vectors). Injected defaults and timestamps are added to that internal frame only — see [Defaults and Auto Values](#Defaults-and-Auto-Values) — so your `DataFrame` is untouched, unconditionally, and no data is duplicated. There is no `copy=` knob because there is nothing to protect against.
 - **Flexible Mapping**: Use `columns = ["df_col" => "model_field"]` to map any DataFrame column to any table field.
 - **Auto-Detection**: If you don't provide mappings, PormG automatically matches columns to fields by **exact, case-sensitive** name. A column differing only in case from a model field (e.g. `RaceId` vs `raceid`) raises an error instead of being silently folded — normalize first with `rename!(df, lowercase.(names(df)))` or map it explicitly.
 - **Centralized Validation**: Every row is automatically checked against the model's constraints (`max_length`, `nullability`, etc.) before reaching the database.
 - **Relation Value Semantics**: Foreign-key columns accept scalar key values (including `0` if present in the target table). Use `nothing` or `missing` when you want SQL `NULL` on nullable relation columns.
+
+### Defaults and Auto Values
+
+**For a field the write touches, PormG supplies a value only when your `DataFrame` has no column for it. A column that *is* present is your data, and PormG never rewrites its cells.**
+
+That is one rule covering every fill kind — a static `default`, `auto_now`, `auto_now_add`, and a UUID `auto_add` — across `bulk_insert()`, `bulk_copy()` and `bulk_update()` alike, whether or not the field is nullable.
+
+So a blank cell (`missing` or `nothing`) in a column you supplied means **`NULL`**, exactly as an explicit `"field" => nothing` does in [`create()`](create.md#Default-Values). On a `null=false` field that blank raises `InvalidValueError` — *"null values are not allowed"* — which is PormG's own validation reporting the field by name, not a database constraint error, and it is the same error `create()` raises for the same input. Nothing is persisted: the write is wrapped in a transaction, so a row that fails validation part-way through rolls back the chunks already sent.
+
+To have PormG supply the value, **leave the column out of the `DataFrame`**:
+
+```julia
+# Stint = Models.Model("stint",
+#     driver    = Models.CharField(),
+#     laps      = Models.IntegerField(default = 0, null = true),
+#     pit_stops = Models.IntegerField(default = 0))
+
+df = DataFrames.DataFrame(driver = ["Senna", "Prost"], laps = [missing, 71])
+
+bulk_insert(M.Stint.objects, df)
+# laps      → NULL, 71   (your column, your cells — the blank is honored)
+# pit_stops → 0, 0       (absent from the frame — PormG fills the default)
+
+bulk_insert(M.Stint.objects, DataFrames.select(df, DataFrames.Not(:laps)))
+# laps      → 0, 0       (now absent too, so the default applies)
+```
+
+Qualifications:
+
+- **A field you leave out of `columns=` is out of scope, not "your data".** If your frame carries a column for it, those cells are not written — you said not to write that field. On `bulk_insert()`/`bulk_copy()` PormG still supplies the field's default or timestamp, which is what lets a partial `columns=` insert satisfy the model's `null=false` columns.
+- `bulk_update(..., columns = [...])` does **not** synthesize a static `default` for an absent column — that would overwrite live rows merely because your frame lacks the column. `auto_now`/`auto_now_add` still inject, so timestamps stay current.
+- **`match_on` key columns are not null-checked.** They identify rows rather than being written, so a blank cell in one does not raise — it simply matches nothing, since `column = NULL` is never true. Before this rule changed, such a blank was quietly back-filled with the field's `default` and matched the default-valued row instead. (`filters=` fields are exempt from the check too, but they carry constants rather than `DataFrame` columns, so no cell can be blank there.)
+- An auto-increment primary key column whose values are **all** blank counts as absent, so the database allocates the ids. See [Auto-Generated Primary Keys](#Auto-Generated-Primary-Keys). This does **not** extend to a `UUIDField(auto_add = true)` primary key — carrying that column blank now raises. Fill it yourself, which works because a present column is honored verbatim:
+
+    ```julia
+    df[!, :token] = [UUIDs.uuid4() for _ in 1:DataFrames.nrow(df)]
+    ```
+
+    Dropping the column is *not* the fix: the absent path currently mints one UUID for the whole batch ([#334](https://github.com/PingoLee/PormG.jl/issues/334)), so a multi-row insert collides on the key.
 
 ---
 
@@ -443,7 +482,7 @@ WHERE "Tb"."id" = source."id"::bigint
 - **Handler filters are rebuilt**: `bulk_update()` clears any filters already attached to the query handler and rebuilds the `WHERE` clause from `match_on=` and `filters=`. Pass every predicate you need through those arguments rather than relying on prior `query.filter(...)` state.
 - **Dry-run support**: `show_query=:dict` and `show_query=:inspection` return metadata, `:sql` returns SQL text, `:params` returns the bound parameter list, and `:none` builds the statement and returns `nothing` without executing.
 - **Empty input is a no-op**: An empty `DataFrame` returns `nothing` after logging a warning.
-- **Nullable columns accept all-`missing` batches**: If a nullable update column is `missing` for every targeted row, PormG writes SQL `NULL` for every row in that column.
+- **Nullable columns accept all-`missing` batches**: If a nullable update column is `missing` for every targeted row, PormG writes SQL `NULL` for every row in that column — **including a column that carries a static `default`**, which is not written back over your blanks (see [Defaults and Auto Values](#Defaults-and-Auto-Values)).
 
 ### Migrating existing `bulk_update()` calls
 

--- a/docs/src/write/create.md
+++ b/docs/src/write/create.md
@@ -164,6 +164,12 @@ record = M.Status.objects.create("status" => "Finished")
 # created_at will be set automatically to the current timestamp
 ```
 
+A default is applied only to a field you **did not pass**. A key you pass is honored as written —
+including `"field" => nothing`, which stores SQL `NULL` on a nullable field and raises
+`InvalidValueError` on a `null=false` one. The bulk writers follow the identical rule, with
+*"a field you did not pass"* reading as *"a column your `DataFrame` does not contain"* — see
+[Defaults and Auto Values](bulk.md#Defaults-and-Auto-Values).
+
 **Generated SQL (PostgreSQL):**
 ```sql
 INSERT INTO "status" ("status") 

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -129,6 +129,12 @@ function _is_auto_generated_bulk_primary_key(field_meta)
     getfield(field_meta, :auto_increment)
 end
 
+# The single deliberate exception to the #331 rule ("a column the DataFrame carries is caller data;
+# PormG never rewrites its cells"): an auto-generated primary key column whose values are ALL blank
+# counts as ABSENT and is dropped from `mapping`/`fields_df` entirely, so the backend allocates the
+# ids. Note it REMOVES the column rather than rewriting cells, so the rule itself still holds — a
+# blank the caller wrote is never silently replaced by a different value. Mixed blank/explicit stays
+# a hard error. Documented for users in docs/src/write/bulk.md → Auto-Generated Primary Keys.
 function _drop_blank_auto_primary_keys!(df::DataFrames.DataFrame,
   model::PormGModel,
   fields_df::Vector{String},
@@ -411,7 +417,34 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   fields_df::Vector{String} = []
   mapping = Dict{String, String}() # model_field => df_column
 
-  function resolve_fill_value(f_meta, operation::Symbol, settings)
+  # What PormG fills into a column the DataFrame does NOT carry: a static `default`, an
+  # auto_now/auto_now_add timestamp, or a UUID `auto_add` value. Returns (should_fill, value).
+  #
+  # #331: this is consulted ONLY where the field has no mapped source column in the frame — both
+  # call sites below are guarded on exactly that (`!haskey(mapping, field)` in one arm, the
+  # not-in-`fields_df` arm in the other, where `mapping ⊆ fields_df` makes it equivalent). A column
+  # the field IS mapped to holds caller-authored data and is never rewritten, so there is nothing
+  # to ask about it — hence the name. The pre-#331 signature re-declared `operation`/`settings` as
+  # parameters that shadowed the enclosing ones with the same values, which read as if a caller
+  # could vary them; they come from the enclosing scope now.
+  #
+  # KNOWN HOLE (#335), pre-existing and NOT closed by #331: the injection sites write to
+  # `df[!, field]`, using the field's own name as the frame column. If an explicit `columns=` Pair
+  # maps some OTHER field to a source column that happens to be named `field`, that write lands on
+  # the column the other field reads from and destroys the caller's values. E.g.
+  # `columns = ["laps" => "pit_stops"]` on a model that also declares a defaulted `laps`:
+  # `pit_stops` binds `laps`'s default instead of the frame's numbers. Narrow (it needs the name
+  # collision) but silent. The guard belongs at the injection sites, not here.
+  #
+  # Second hole (#334): the UUID branch below calls `uuid4()` ONCE per field, and the injection
+  # sites broadcast that one value across the frame — so every row of an `auto_add` UUID column
+  # gets the same value, colliding immediately on a primary key. Correct for the temporal fills
+  # this idiom was written for (one `now()` per batch is intentional), wrong for UUIDs.
+  #
+  # The chain is deliberately EXCLUSIVE and default-first, mirroring `_prepare_row_insert!`
+  # (execution.jl:557-572): a field carrying BOTH a static `default` and `auto_now` takes the
+  # default, on the single-row and bulk paths alike.
+  function resolve_absent_column_fill(f_meta)
     if f_meta.default !== nothing
       return true, f_meta.default
     elseif f_meta.type == "TIMESTAMPTZ"
@@ -508,22 +541,49 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
     f_meta = model.fields[field]
     
     if in(field, fields_df)
-      if haskey(mapping, field)
-        # Field exists in mapping (and DF). Check if we should fill nulls with defaults.
-        col_name = mapping[field]
-        should_apply_default, fill_value = resolve_fill_value(f_meta, operation, settings)
-
-        if should_apply_default
-          # Mutate the column to replace missing/nothing with default
-          # We only do this if it's already there or if we really need it
-          df[!, col_name] = map(x -> x |> ismissing || x |> isnothing ? fill_value : x, df[!, col_name])
-        end
-      else
-        # Field is in fields_df (requested) but not in mapping (missing in DF)
-        # Check if we can auto-populate it
-        should_auto_populate, fill_value = resolve_fill_value(f_meta, operation, settings)
+      # ────────────────────────────────────────────────────────────────────────────────────────
+      # #331 — THE ONE RULE, for a field that TAKES PART in the write: PormG fills a value only
+      # when the DataFrame has no column for that field. A column that IS present is
+      # caller-authored data, and PormG never rewrites its cells — not for a static `default`,
+      # not for `auto_now`/`auto_now_add`, not for a UUID `auto_add`; on :insert, :copy and
+      # :update alike; nullable or not.
+      #
+      # "Takes part in the write" is what `in(field, fields_df)` above means: auto-detected from
+      # the frame, or named in an explicit `columns=`. A field `columns=` left out is out of
+      # scope by the caller's own instruction and is handled in the other arm — see the scope
+      # note there for why it is filled rather than read from the frame.
+      #
+      # So a blank cell (`missing`/`nothing`) in a present column means the caller asked for NULL,
+      # exactly as `create()` reads an explicit `"field" => nothing`: `_prepare_row_insert!`
+      # (execution.jl:557) fills only when `!haskey(real_obj.insert, field)`. On a NOT NULL field
+      # the blank then surfaces the ORM's own "null values are not allowed" from the per-row
+      # `validate_field_data` sweep every path already runs (:insert below, :copy and :update in
+      # their own loops) — the same error `create()` raises — instead of being silently papered
+      # over with the default.
+      #
+      # Pre-#331 a fourth fill site lived here, keyed on `haskey(mapping, field)`:
+      #     df[!, col_name] = map(x -> ismissing(x) || isnothing(x) ? fill_value : x, df[!, col_name])
+      # It carried no `is_explicit_update && is_static_default` guard (unlike the two absent-column
+      # sites below), so all three bulk ops disagreed with `create()` on the same input and turned
+      # an intentional NULL into the model default. Deleting it left this arm with a single
+      # branch, so the condition is inverted: what remains reads as "the DataFrame has no column
+      # for this field", which is the rule spelled by the control flow.
+      #
+      # Narrow known consequence: `bulk_update` exempts match keys and static-filter fields from
+      # the per-row null check, so a blank cell in a DEFAULTED match-key column is no longer
+      # back-filled — it now matches nothing rather than matching the default-valued row. That is
+      # the rule applied consistently, not an oversight.
+      # ────────────────────────────────────────────────────────────────────────────────────────
+      if !haskey(mapping, field)
+        # ABSENT column: the field was requested via `columns=` but the DataFrame has no column
+        # for it. The fill rule applies — inject one whole column of the fill value.
+        should_auto_populate, fill_value = resolve_absent_column_fill(f_meta)
 
         if should_auto_populate
+          # For an explicit-scope UPDATE (columns= was provided), a static `default` must NOT be
+          # synthesized: that would overwrite live rows merely because the DataFrame lacks the
+          # column. Temporal auto_now/auto_now_add injections are always allowed — an intentional
+          # ORM side-effect. Same guard as the never-requested branch below. Unchanged by #331.
           is_static_default = f_meta.default !== nothing
           is_explicit_update = operation == :update && !isempty(normalized_columns)
           if !(is_explicit_update && is_static_default)
@@ -545,8 +605,24 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
         push!(pk_field, field)
       end
     else
-      # Field not in fields_df. See if we should auto-populate it anyway (e.g. updated_at)
-      should_auto_populate, fill_value = resolve_fill_value(f_meta, operation, settings)
+      # Field not in fields_df — it takes no part in the write, either because the DataFrame has
+      # no column for it or because an explicit `columns=` left it out. See if we should
+      # auto-populate it anyway (e.g. updated_at).
+      #
+      # #331 scope note: this branch can fire for a field whose same-named column IS in the
+      # DataFrame, when `columns=` excluded it. That is NOT the rewrite #331 removed. `columns=`
+      # is the caller saying "do not write this field", so those cells were never going to be
+      # persisted; injecting the default here is what lets a partial `columns=` insert still
+      # satisfy the model's NOT NULL columns (pinned by test_bulk_update_column_scope.jl). The
+      # #331 rule governs the cells of a field that DOES take part in the write — see the comment
+      # in the other arm.
+      #
+      # Deferring to the frame here instead — reading the excluded column's values — was
+      # considered and rejected: it would make `columns=` stop deciding what gets written, which
+      # is a worse contract than the one above. (A *narrow* deferral, only when `field in
+      # names(df)`, would keep genuinely-absent columns injected and so would not break
+      # auto_now_add stamping — the objection is the contract, not a NOT NULL failure.)
+      should_auto_populate, fill_value = resolve_absent_column_fill(f_meta)
 
       if should_auto_populate
         # For an explicit-scope UPDATE (columns= was provided), a static `default`

--- a/test/integration/test_bulk_copy.jl
+++ b/test/integration/test_bulk_copy.jl
@@ -47,20 +47,22 @@ length(_bulk_copy_fk_rows) == 9 || error(
 _bulk_copy_fk_ids = [row[:resultid] for row in _bulk_copy_fk_rows]
 
 # One dependency this file cannot borrow its way out of: `test_result_set_default` is declared
-# `ForeignKey(Result, …, default = 1)`, and PormG writes a static default on every insert path —
-# `create()` fills it when the key is absent (execution.jl), and the bulk paths add a whole
-# column of it when the field is missing from the DataFrame (execution_bulk.jl). Supplying an
-# explicit `missing` does not help either: the bulk path rewrites missing/nothing back to the
-# default. So every row this file inserts into `just_a_test_deletion` carries
-# `test_result_set_default = 1` and needs `resultid = 1` to exist, whatever the other FK
-# columns say.
+# `ForeignKey(Result, …, default = 1)`, and PormG writes a static default whenever a write does
+# not mention the field — `create()` fills it when the key is absent (execution.jl), and the bulk
+# paths add a whole column of it when the DataFrame has no such column (execution_bulk.jl). Not one
+# of the writes below carries a `test_result_set_default` column, so every row this file inserts
+# into `just_a_test_deletion` gets `test_result_set_default = 1` and needs `resultid = 1` to exist,
+# whatever the other FK columns say.
 #
 # Assert it here rather than let it surface as a ForeignKeyViolation naming a constraint no
 # test mentions. Dodging it instead would mean threading a real id through three DataFrames
 # that have nothing to do with defaults (and adding a third entry to the column-mapping test),
-# which distorts what those tests read as. The asymmetry — `create()` honours an explicit
-# `nothing`, the bulk path overwrites it with the default — is a PormG-level quirk, not a
-# test-fixture one, and is tracked in #331 rather than worked around here.
+# which distorts what those tests read as.
+#
+# #331 does NOT lift this precondition, and that is not an oversight. It made an explicit blank
+# mean NULL — so a DataFrame *can* now opt out of the default — but opting out requires carrying
+# the column, which is exactly the distortion the paragraph above rejects. The fix is asserted
+# directly instead, in the "#331" testset below.
 M.Result.objects.filter("resultid" => 1).count() == 1 || error(
     "test_bulk_copy.jl requires `result.resultid = 1` to exist in \"$(PORMG_DB_FOLDER)\": " *
     "`Just_a_test_deletion.test_result_set_default` defaults to 1, and PormG writes that " *
@@ -187,6 +189,116 @@ M.Result.objects.filter("resultid" => 1).count() == 1 || error(
 
         unchanged = M.Just_a_test_deletion.objects.filter("name" => "update-target").list() |> first
         @test unchanged[:test_result] == _bulk_copy_fk_ids[1]
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Defaults and auto values (#331): a present column is caller data, an absent one is filled
+# PormG supplies a value only for a column the DataFrame does not contain. Before #331 the bulk
+# paths also rewrote blank cells of a column the caller DID supply, so `create("f" => nothing)`
+# stored NULL while `bulk_insert` of the same row stored the model default — a real referential
+# difference on `test_result_set_default`, which is a SET_DEFAULT foreign key onto `result`.
+#
+# Asserted against stored rows rather than generated SQL: the unit file
+# (test/unit/test_bulk_default_fill_scope.jl) already pins the bound parameters, and what this
+# issue is actually about is what ends up in the table.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "#331: defaults fill absent columns only, on every write path" begin
+    query = M.Just_a_test_deletion.objects
+    query.exists() && query.delete(allow_delete_all = true)
+
+    # Read one row's defaulted FK back by name. Returns `nothing` for SQL NULL so the two
+    # blank spellings (`missing` from the driver, `nothing`) compare equal across backends.
+    function stored_default_fk(name)
+        row = M.Just_a_test_deletion.objects.filter("name" => name).list() |> first
+        value = row[:test_result_set_default]
+        return (ismissing(value) || isnothing(value)) ? nothing : value
+    end
+
+    try
+        fk = _bulk_copy_fk_ids[1]
+
+        # Four writes covering both axes: create() vs bulk_insert × field absent vs explicitly blank.
+        query.create("name" => "i331-c-absent", "test_result" => fk)
+        query.create("name" => "i331-c-null", "test_result" => fk,
+                     "test_result_set_default" => nothing)
+        bulk_insert(query, DataFrames.DataFrame(
+            name = ["i331-b-absent"], test_result = [fk]))
+        bulk_insert(query, DataFrames.DataFrame(
+            name = ["i331-b-null"], test_result = [fk], test_result_set_default = [missing]))
+
+        # Absent → the default is written, on both paths. (Unchanged by #331, and the reason the
+        # `resultid = 1` precondition above still stands.)
+        @test stored_default_fk("i331-c-absent") == 1
+        @test stored_default_fk("i331-b-absent") == 1
+
+        # Explicitly blank → NULL, on both paths. The bulk arm stored 1 before #331.
+        @test stored_default_fk("i331-c-null") === nothing
+        @test stored_default_fk("i331-b-null") === nothing
+
+        # …and the two paths agree, which is the substitutability claim the issue is about.
+        # Stated separately from the absolutes above on purpose: an equality check alone would
+        # stay green if BOTH paths regressed to the default.
+        @test stored_default_fk("i331-c-null") == stored_default_fk("i331-b-null")
+        @test stored_default_fk("i331-c-absent") == stored_default_fk("i331-b-absent")
+
+        # bulk_update: clearing a defaulted column used to be a silent no-op — the default was
+        # written straight back, so the call reported success and changed nothing.
+        target_id = (M.Just_a_test_deletion.objects.filter("name" => "i331-b-absent") |> DataFrame).id
+        bulk_update(query, DataFrames.DataFrame(
+                        id = target_id, test_result_set_default = [missing]),
+                    columns = ["test_result_set_default"], match_on = ["id"])
+        @test stored_default_fk("i331-b-absent") === nothing
+    finally
+        query = M.Just_a_test_deletion.objects
+        query.exists() && query.delete(allow_delete_all = true)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #331 for auto_now_add / auto_now on a NOT NULL field
+# `test_result_set_default` covers the static-default fill kind but is nullable, so it cannot
+# show what a blank does when NULL is not a legal value. `Django_contract_scratch.created_at` is
+# `DateTimeField(auto_now_add = true)` — NOT NULL, no foreign key, no seeding — and covers both
+# gaps: the temporal fill kind, and the ORM-level error a blank must raise instead of being
+# quietly stamped with now().
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "#331: a blank in a present NOT NULL auto column raises, and absent still stamps" begin
+    query = M.Django_contract_scratch.objects
+    # Scoped to the "i331-" prefix so this cannot disturb test_django_contract.jl's rows.
+    # `filter` accumulates onto the handler, so build it once — calling it twice would AND the
+    # same predicate into the DELETE a second time.
+    purge = () -> begin
+        q = M.Django_contract_scratch.objects
+        q.filter("label__@startswith" => "i331-")
+        q.exists() && q.delete()
+    end
+    purge()
+
+    try
+        # Present + blank on a NOT NULL auto_now_add column: PormG's own typed error rather than a
+        # backend constraint violation, and nothing persisted — asserted below by the row count, so
+        # the rollback is proven rather than assumed. Pre-#331 this silently succeeded with now().
+        err = try
+            bulk_insert(query, DataFrames.DataFrame(
+                label = ["i331-notnull"], created_at = [missing]))
+            nothing
+        catch e
+            e
+        end
+        @test err isa PormG.InvalidValueError
+        @test occursin("created_at", string(err))
+        @test occursin("null values are not allowed", string(err))
+        @test M.Django_contract_scratch.objects.filter("label" => "i331-notnull").count() == 0
+
+        # Absent → still stamped. #331 narrows WHEN PormG supplies a value; it must not stop it
+        # supplying one, or a partial frame would no longer satisfy the NOT NULL columns.
+        bulk_insert(query, DataFrames.DataFrame(label = ["i331-stamped"]))
+        row = M.Django_contract_scratch.objects.filter("label" => "i331-stamped").list() |> first
+        @test !ismissing(row[:created_at]) && !isnothing(row[:created_at])
+        @test !ismissing(row[:updated_at]) && !isnothing(row[:updated_at])
+    finally
+        purge()
     end
 end
 
@@ -541,6 +653,69 @@ end
     @test err_type !== nothing
     @test occursin("test_result", string(err_type))
     @test occursin("expected Int64 or an integer string", string(err_type))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #331 on the COPY path — the third writer must agree with the other two
+# bulk_copy shares `_prepare_bulk_df!` with bulk_insert/bulk_update, so the rule is the same
+# code. What is NOT shared is where a blank becomes NULL: COPY writes an unquoted `\N` sentinel
+# into the CSV stream rather than binding a parameter, so agreement has to be observed rather
+# than assumed. This is also the ONLY layer at which bulk_copy's null validation is reachable —
+# under `show_query` it returns before its row loop, so the unit file cannot assert this half.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "#331: bulk_copy agrees with bulk_insert and create() on an explicit null" begin
+    query = M.Just_a_test_deletion.objects
+    query.exists() && query.delete(allow_delete_all = true)
+
+    function stored_default_fk(name)
+        row = M.Just_a_test_deletion.objects.filter("name" => name).list() |> first
+        value = row[:test_result_set_default]
+        return (ismissing(value) || isnothing(value)) ? nothing : value
+    end
+
+    try
+        fk = _bulk_copy_fk_ids[1]
+
+        bulk_copy(query, DataFrames.DataFrame(
+            name = ["i331-copy-absent"], test_result = [fk]))
+        bulk_copy(query, DataFrames.DataFrame(
+            name = ["i331-copy-null"], test_result = [fk], test_result_set_default = [missing]))
+        # The other two writers on the same table, so the three-way agreement is asserted from
+        # rows written in this same testset rather than inferred across testsets.
+        bulk_insert(query, DataFrames.DataFrame(
+            name = ["i331-copy-peer-bulk"], test_result = [fk],
+            test_result_set_default = [missing]))
+        query.create("name" => "i331-copy-peer-create", "test_result" => fk,
+                     "test_result_set_default" => nothing)
+
+        @test stored_default_fk("i331-copy-absent") == 1        # absent → default, as always
+        @test stored_default_fk("i331-copy-null") === nothing   # pre-#331: 1
+
+        # All three writers, same input, same stored value.
+        @test stored_default_fk("i331-copy-null") == stored_default_fk("i331-copy-peer-bulk")
+        @test stored_default_fk("i331-copy-null") == stored_default_fk("i331-copy-peer-create")
+
+        # NOT NULL + auto_now_add + a blank cell: refused before the COPY stream is opened, with
+        # the same diagnosis bulk_insert gives. Only provable here (see the header note).
+        err = try
+            bulk_copy(M.Django_contract_scratch.objects,
+                      DataFrames.DataFrame(label = ["i331-copy-notnull"], created_at = [missing]))
+            nothing
+        catch e
+            e
+        end
+        @test err isa PormG.InvalidValueError
+        @test occursin("bulk_copy", string(err))
+        @test occursin("created_at", string(err))
+        @test occursin("null values are not allowed", string(err))
+        @test M.Django_contract_scratch.objects.filter("label" => "i331-copy-notnull").count() == 0
+    finally
+        query = M.Just_a_test_deletion.objects
+        query.exists() && query.delete(allow_delete_all = true)
+        cleanup = M.Django_contract_scratch.objects
+        cleanup.filter("label" => "i331-copy-notnull")
+        cleanup.exists() && cleanup.delete()
+    end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,7 @@ end
     @testset "Reload Regressions" include("unit/test_reload.jl")
     @testset "Configuration API" include("unit/test_configuration_api.jl")
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
+    @testset "Bulk Default-Fill Scope (#331)" include("unit/test_bulk_default_fill_scope.jl")
     @testset "Bulk No-Mutation Contract (#132)" include("unit/test_bulk_no_mutation.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")

--- a/test/unit/test_bulk_default_fill_scope.jl
+++ b/test/unit/test_bulk_default_fill_scope.jl
@@ -1,0 +1,298 @@
+# ============================================================
+# test/unit/test_bulk_default_fill_scope.jl
+#
+# Regression suite for #331 — WHEN PormG supplies a value of its own on a
+# bulk write, and when it must not.
+#
+# THE ONE RULE:
+#   PormG fills a value only into a column the DataFrame does NOT contain.
+#   A column that IS present is caller-authored data, and PormG never
+#   rewrites its cells.
+#
+# It covers every fill kind (static `default`, `auto_now`, `auto_now_add`,
+# UUID `auto_add`), all three bulk operations, and both nullabilities.
+#
+# Before #331, `_prepare_bulk_df!` carried a fourth fill site that rewrote
+# `missing`/`nothing` cells of a PRESENT column with the fill value. That made
+# a DataFrame unable to express "I mean NULL here" on a defaulted field, and
+# split the two insert paths: `create("f" => nothing)` stored NULL while
+# `bulk_insert` of the identical row stored the default. Silent, and a real
+# referential difference on a SET_DEFAULT foreign key.
+#
+# Sibling files, deliberately not duplicated here:
+#   - test_bulk_update_column_scope.jl — the `columns=` scope contract, i.e.
+#     which ABSENT fields may be injected on an explicit-scope bulk_update.
+#   - test_bulk_no_mutation.jl — that none of these internal writes reaches
+#     the caller's DataFrame (#132).
+#
+# Deterministic and DB-free: a mock PostgreSQL connection with
+# `show_query = :dict`. bulk_insert and bulk_update both run their per-row
+# loop in dry-run mode, so `validate_field_data` — and therefore the NOT NULL
+# error asserted below — is genuinely exercised here. bulk_copy is the
+# exception: it returns before its row loop, so only its column list is
+# provable at this layer (see the bulk_copy testset).
+# ============================================================
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, IntegerField, CharField, DateTimeField, UUIDField
+using PormG.QueryBuilder: bulk_copy, bulk_insert, bulk_update
+using PormG: InvalidValueError, PormGError
+import DataFrames
+
+# Mock connection under a dedicated key so this file cannot contaminate (or be
+# contaminated by) other unit files sharing Main in runtests.jl.
+struct BulkFillScopeMockPg <: PormG.PormGPostgres end
+PormG.config["bdfs_mock"] = PormG.Configuration.Settings(
+    connections = BulkFillScopeMockPg(),
+    change_data = true,
+)
+
+# Every fill kind, at both nullabilities where it matters. F1-flavored: a pit-stop
+# stint sheet is exactly the shape of data that arrives from a CSV with holes in it.
+Bdfs_stint = Model("bdfs_stint",
+    id         = IDField(),
+    driver     = CharField(),
+    laps       = IntegerField(default = 0, null = true),        # static default, nullable
+    pit_stops  = IntegerField(default = 0),                     # static default, NOT NULL
+    checked_at = DateTimeField(auto_now_add = true, null = true),
+    updated_at = DateTimeField(auto_now = true, null = true),
+    token      = UUIDField(auto_add = true, null = true),
+)
+Bdfs_stint.connect_key = "bdfs_mock"
+
+# A second model with NO auto-generated fields. `auto_now`/`auto_now_add`/`auto_add` mint a
+# fresh value per call, so two calls can never produce equal parameter vectors — which would
+# make the create()-vs-bulk_insert parity assertion below impossible to state exactly. Every
+# column here is deterministic, so the two paths can be compared whole rather than slot by slot.
+Bdfs_pitlane = Model("bdfs_pitlane",
+    id        = IDField(),
+    driver    = CharField(),
+    laps      = IntegerField(default = 0, null = true),
+    pit_stops = IntegerField(default = 0),
+)
+Bdfs_pitlane.connect_key = "bdfs_mock"
+
+# ------------------------------------------------------------------
+# Read a bound value back BY COLUMN NAME rather than by a hard-coded index.
+#
+# An INSERT renders its column list in the same order it binds parameters, on the
+# create() path and the bulk path alike, so a column's position in that list is its
+# parameter index. Looking values up by name keeps these assertions readable and
+# immune to a future change in the order injected columns are appended — which is a
+# real risk here, since present columns come first and injected ones are appended.
+# ------------------------------------------------------------------
+function insert_columns(res)
+    m = match(r"INSERT INTO\s+\S+\s*\((.*?)\)\s*VALUES"s, res[:sql_text])
+    m === nothing && error("could not parse an INSERT column list from: $(res[:sql_text])")
+    return [strip(c, ['"', ' ', '\n', '\r', '\t']) for c in split(m.captures[1], ",")]
+end
+
+function param_for(res, col)
+    idx = findfirst(==(col), insert_columns(res))
+    idx === nothing && error("column $(col) is not in the INSERT: $(res[:sql_text])")
+    return res[:parameters][idx]
+end
+
+# The bulk_update VALUES source list plays the same role for an UPDATE.
+function source_param_for(res, col)
+    m = match(r"AS\s+source\s*\((.*?)\)"s, res[:sql_text])
+    m === nothing && error("could not parse a source column list from: $(res[:sql_text])")
+    cols = [strip(c, ['"', ' ', '\n', '\r', '\t']) for c in split(m.captures[1], ",")]
+    idx = findfirst(==(col), cols)
+    idx === nothing && error("column $(col) is not in the source list: $(res[:sql_text])")
+    return res[:parameters][idx]
+end
+
+@testset "#331: PormG fills only absent columns" begin
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Insert-path parity: create() and bulk_insert must store the SAME value
+    # This is the issue verbatim. `create("laps" => nothing)` has always stored NULL;
+    # `bulk_insert` of a DataFrame carrying `laps = [missing]` stored the model default
+    # instead, so switching a create() loop to one bulk_insert for speed silently changed
+    # what was persisted. Both arms are asserted absolutely as well as against each other:
+    # an equality check alone would stay green if BOTH paths regressed to the default.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "create() and bulk_insert agree on an explicit null" begin
+        c = Bdfs_pitlane.objects.create("driver" => "Senna", "laps" => nothing,
+                                        show_query = :dict)
+        b = bulk_insert(Bdfs_pitlane.objects,
+                        DataFrames.DataFrame(driver = ["Senna"], laps = [missing]),
+                        show_query = :dict)
+
+        # Same columns, same bound values — the two paths are substitutable.
+        @test insert_columns(c) == insert_columns(b)
+        @test isequal(c[:parameters], b[:parameters])
+
+        # …and independently, the value is actually NULL on each path (pre-fix the bulk
+        # arm bound 0 here, which is the whole bug).
+        @test ismissing(param_for(c, "laps"))
+        @test ismissing(param_for(b, "laps"))
+
+        # The same call still fills the ABSENT column: `pit_stops` is in neither the
+        # create() pairs nor the DataFrame, so both paths inject the default.
+        @test param_for(c, "pit_stops") == 0
+        @test param_for(b, "pit_stops") == 0
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # A present column is never rewritten — for ANY fill kind
+    # #331 is one rule, not a default-only carve-out. A blank cell in a column the
+    # caller supplied stays NULL whether the field carries a static `default`, an
+    # `auto_now_add`/`auto_now` timestamp, or a UUID `auto_add`. Pre-fix this row came
+    # out as (0, <now>, <now>, <fresh uuid>) — every one of them fabricated.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "present column + blank cells: every fill kind leaves them NULL" begin
+        res = bulk_insert(Bdfs_stint.objects, DataFrames.DataFrame(
+                driver     = ["Prost"],
+                laps       = [missing],
+                checked_at = [missing],
+                updated_at = [missing],
+                token      = [missing],
+            ), show_query = :dict)
+
+        @test ismissing(param_for(res, "laps"))
+        @test ismissing(param_for(res, "checked_at"))   # not stamped with now()
+        @test ismissing(param_for(res, "updated_at"))   # ditto
+        @test ismissing(param_for(res, "token"))        # no UUID minted
+
+        # `pit_stops` is the control: absent from the frame, so it IS still filled. Without
+        # it this testset would also pass against a fix that simply stopped filling anything.
+        @test param_for(res, "pit_stops") == 0
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # A present column with real values is left alone too
+    # Guards the mirror-image error: a fix that blanked every present column, or that
+    # re-derived auto_now from the clock while ignoring what the caller supplied.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "present column + concrete cells: values pass through verbatim" begin
+        res = bulk_insert(Bdfs_stint.objects, DataFrames.DataFrame(
+                driver = ["Piquet"],
+                laps   = [71],
+            ), show_query = :dict)
+
+        @test param_for(res, "laps") == 71              # not reset to the default 0
+        @test param_for(res, "pit_stops") == 0          # absent → injected, as always
+        @test !ismissing(param_for(res, "checked_at"))  # absent → stamped, as always
+        @test !ismissing(param_for(res, "token"))       # absent → minted, as always
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # NOT NULL + a default + a blank cell is an error, and the SAME error create() gives
+    # On a `null = false` field there is no NULL to mean, so the blank is a caller mistake.
+    # It must surface as PormG's own typed, actionable error — not as a raw backend constraint
+    # violation, and not silently papered over with the default (which is what happened pre-fix:
+    # the write succeeded, storing 0). That this testset runs against a mock with no database at
+    # all is itself the proof that the diagnosis is PormG's and not the backend's.
+    #
+    # Both arms assert the same two substrings. That is what makes "the same error create()
+    # raises" a tested claim rather than a comment in the source.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "NOT NULL field: a blank cell raises, matching create()" begin
+        bulk_err = try
+            bulk_insert(Bdfs_stint.objects,
+                        DataFrames.DataFrame(driver = ["Lauda"], pit_stops = [missing]),
+                        show_query = :dict)
+            nothing
+        catch e
+            e
+        end
+        create_err = try
+            Bdfs_stint.objects.create("driver" => "Lauda", "pit_stops" => nothing,
+                                      show_query = :dict)
+            nothing
+        catch e
+            e
+        end
+
+        for err in (bulk_err, create_err)
+            @test err isa InvalidValueError
+            @test err isa PormGError          # inside the taxonomy, so callers can catch broadly
+            msg = sprint(showerror, err)
+            @test occursin("pit_stops", msg)                    # names the offending field
+            @test occursin("null values are not allowed", msg)  # says why
+        end
+
+        # The operation is still named correctly in each message, so the two are
+        # distinguishable in a log even though the diagnosis is identical.
+        @test occursin("bulk_insert", sprint(showerror, bulk_err))
+        @test occursin("insert", sprint(showerror, create_err))
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # Absent-column injection is untouched — the other half of the rule
+    # #331 narrows WHEN PormG supplies a value; it must not stop it supplying one at all.
+    # A frame carrying only `driver` still gets all four fill kinds injected, which is what
+    # keeps a partial CSV loadable and NOT NULL columns satisfied.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "absent columns: all four fill kinds still inject" begin
+        res = bulk_insert(Bdfs_stint.objects,
+                          DataFrames.DataFrame(driver = ["Fittipaldi"]),
+                          show_query = :dict)
+
+        @test param_for(res, "laps") == 0
+        @test param_for(res, "pit_stops") == 0
+        @test !ismissing(param_for(res, "checked_at"))
+        @test !ismissing(param_for(res, "updated_at"))
+        @test !ismissing(param_for(res, "token"))
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_update: a blank cell nulls the column out instead of being a silent no-op
+    # This is the most damaging pre-fix case. Asking bulk_update to clear a defaulted
+    # column wrote the default straight back, so the call reported success and changed
+    # nothing the caller wanted changed. The auto_now injection must survive alongside.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_update: an explicit blank nulls the column" begin
+        res = bulk_update(Bdfs_stint.objects,
+                          DataFrames.DataFrame(id = [1], laps = [missing]),
+                          columns = ["laps"], match_on = ["id"], show_query = :dict)
+
+        @test ismissing(source_param_for(res, "laps"))      # pre-fix: 0
+        # auto_now still injects on an explicit-scope update — the intentional ORM
+        # side-effect, unchanged by #331.
+        @test occursin("\"updated_at\"", res[:sql_text])
+        @test !ismissing(source_param_for(res, "updated_at"))
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_update: an absent static default still must not leak into the SET
+    # The `columns=` scope guard predates #331 and is asserted in full in
+    # test_bulk_update_column_scope.jl. Restated as one line here so this file's
+    # statement of the rule is self-contained: absent + explicit scope + static default
+    # is the ONE case where an absent column is deliberately NOT filled.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_update: an absent static default stays out of an explicit scope" begin
+        res = bulk_update(Bdfs_stint.objects,
+                          DataFrames.DataFrame(id = [1], driver = ["Senna"]),
+                          columns = ["driver"], match_on = ["id"], show_query = :dict)
+        set_text = match(r"SET(.*?)FROM"s, res[:sql_text]).captures[1]
+
+        @test occursin("\"driver\"", set_text)
+        @test !occursin("laps", set_text)          # static default, absent → suppressed
+        @test !occursin("pit_stops", set_text)     # ditto
+        @test occursin("\"updated_at\"", set_text) # auto_now, absent → still injected
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_copy: the COPY column list obeys the same rule
+    # SCOPE LIMIT: bulk_copy returns its prepared statement before the row loop, so
+    # `validate_field_data` never runs under show_query and neither cell values nor the
+    # NOT NULL error are observable here. Both are covered against a live PostgreSQL in
+    # test/integration/test_bulk_copy.jl — this testset is the column list only. Do not
+    # read the gap as coverage.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_copy: present column participates, absent columns injected" begin
+        res = bulk_copy(Bdfs_stint.objects,
+                        DataFrames.DataFrame(driver = ["Regazzoni"], laps = [missing]),
+                        show_query = :dict)
+
+        @test occursin("COPY", res[:sql_text])
+        @test occursin("\"laps\"", res[:sql_text])       # present, kept (its cells stay NULL)
+        @test occursin("\"pit_stops\"", res[:sql_text])  # absent, injected
+        @test occursin("\"checked_at\"", res[:sql_text])
+        @test occursin("\"token\"", res[:sql_text])
+    end
+end

--- a/test/unit/test_bulk_no_mutation.jl
+++ b/test/unit/test_bulk_no_mutation.jl
@@ -2,12 +2,18 @@
 Unit coverage for the non-mutating bulk pipeline (#132).
 
 The bulk operations used to `deepcopy` the input DataFrame (`copy=true` default) because
-the pipeline mutates its working frame: `_prepare_bulk_df!` fills defaults in place
-(whole-column replacement) and injects auto-populated columns (`auto_now`, defaults).
+the pipeline mutates its working frame: `_prepare_bulk_df!` injects auto-populated columns
+(`auto_now`, static defaults) for every model field the DataFrame does not carry.
 #132 replaced the deepcopy with a zero-copy wrapper (`_bulk_working_frame`,
 `select(df_o, :; copycols=false)`): the wrapper shares the caller's column vectors, and
 because every internal write is a whole-column replacement/addition, nothing ever reaches
 the caller's frame — unconditionally, with no `copy=` knob.
+
+Since #331 the pipeline has exactly ONE mutation class: column INJECTION. It used to have a
+second — a whole-column default FILL that rewrote `missing`/`nothing` cells of a column the
+caller DID supply — and that site is gone: a present column is caller-authored data and is
+never rewritten. So this file's model carries `pit_stops` purely to keep an injection live,
+and `laps` (present, blank) to pin that the deleted fill site stays deleted.
 
 This file pins that contract for all three bulk ops, asserting three things after each
 call: the caller's column SET is unchanged (no injected `updated_at`/`laps`), the column
@@ -34,15 +40,19 @@ PormG.config["bnm_mock"] = PormG.Configuration.Settings(
     change_data = true,
 )
 
-# F1-flavored model exercising BOTH mutation classes of _prepare_bulk_df!:
-#   - laps has a static default  → present-with-missings triggers the default FILL
-#     (whole-column replacement on the working frame);
-#   - updated_at has auto_now    → absent from the df, triggers column INJECTION.
+# F1-flavored model exercising both injection kinds plus the #331 no-rewrite rule:
+#   - pit_stops has a static default → absent from every df, triggers column INJECTION;
+#   - updated_at has auto_now        → absent from every df, triggers column INJECTION;
+#   - laps has a static default and IS present in the df with blank cells → since #331 those
+#     cells are caller data and stay NULL, so it must be nullable (a NOT NULL field would now
+#     raise "null values are not allowed" here, which is the correct behavior but a different
+#     test — see test_bulk_default_fill_scope.jl).
 Bnm_result = Model("bnm_result",
     id         = IDField(),
     surname    = CharField(),
     points     = IntegerField(null = true),
-    laps       = IntegerField(default = 0),
+    laps       = IntegerField(default = 0, null = true),
+    pit_stops  = IntegerField(default = 0),
     updated_at = DateTimeField(auto_now = true),
 )
 Bnm_result.connect_key = "bnm_mock"
@@ -50,6 +60,19 @@ Bnm_result.connect_key = "bnm_mock"
 # Snapshot the caller-visible state of every column: names, vector identities, values.
 snapshot(df) = (names(df), Dict(c => df[!, c] for c in names(df)),
                 Dict(c => copy(df[!, c]) for c in names(df)))
+
+# Read a bound value back by COLUMN NAME. An INSERT binds parameters in the order it renders
+# its column list, so a column's position there is its parameter index — but that order is
+# "present columns first, then injected ones", which a model change can silently reshuffle.
+# Indexing by name fails loudly instead of asserting the wrong slot.
+function param_for(res, col)
+    m = match(r"INSERT INTO\s+\S+\s*\((.*?)\)\s*VALUES"s, res[:sql_text])
+    m === nothing && error("could not parse an INSERT column list from: $(res[:sql_text])")
+    cols = [strip(c, ['"', ' ', '\n', '\r', '\t']) for c in split(m.captures[1], ",")]
+    idx = findfirst(==(col), cols)
+    idx === nothing && error("column $(col) is not in the INSERT: $(res[:sql_text])")
+    return res[:parameters][idx]
+end
 
 # Assert the caller's frame is untouched: same column set, same vector objects (===),
 # same values (catches a write-through into a shared vector, which === alone misses).
@@ -64,21 +87,28 @@ end
 
 @testset "bulk ops never mutate the caller DataFrame (#132)" begin
 
-    @testset "bulk_insert: default fill + auto_now injection stay internal" begin
+    @testset "bulk_insert: default + auto_now injections stay internal" begin
         df = DataFrames.DataFrame(
             surname = ["Senna", "Prost"],
             points  = [25, 18],
-            laps    = [missing, missing],   # default=0 fills these — on the working frame only
+            laps    = [missing, missing],   # present + blank → #331: stays NULL, never filled
         )
         snap = snapshot(df)
         res = bulk_insert(Bnm_result.objects, df, show_query = :dict)
 
         assert_untouched(df, snap)
-        @test all(ismissing, df[!, "laps"])          # the fill never reached the caller
-        @test !("updated_at" in names(df))           # the injection never reached the caller
-        # …but both DID happen on the working frame: the prepared insert carries them.
-        @test occursin("\"laps\"", res[:sql_text])
+        @test all(ismissing, df[!, "laps"])          # unchanged, and now unchanged internally too
+        @test !("pit_stops" in names(df))            # the injection never reached the caller
+        @test !("updated_at" in names(df))           # ditto
+        # …but the injections DID happen on the working frame: the prepared insert carries them.
+        @test occursin("\"laps\"", res[:sql_text])   # present column still participates
+        @test occursin("\"pit_stops\"", res[:sql_text])
         @test occursin("\"updated_at\"", res[:sql_text])
+
+        # #331 — prove the values, not just the column list. This is the one assertion in this
+        # file that discriminates the #331 fix; the rest of the additions above are controls.
+        @test ismissing(param_for(res, "laps"))      # caller's blank survived as NULL
+        @test param_for(res, "pit_stops") == 0       # absent column, default injected
     end
 
     @testset "bulk_copy: same contract on the COPY path" begin
@@ -92,8 +122,10 @@ end
 
         assert_untouched(df, snap)
         @test all(ismissing, df[!, "laps"])
+        @test !("pit_stops" in names(df))
         @test !("updated_at" in names(df))
         @test occursin("COPY", res[:sql_text])
+        @test occursin("\"pit_stops\"", res[:sql_text])   # absent default still injected
     end
 
     @testset "bulk_update: auto_now injection stays internal" begin
@@ -110,6 +142,11 @@ end
         # auto_now must still inject into the UPDATE itself (the intentional ORM
         # side-effect the old copy=true existed to keep away from the caller).
         @test occursin("\"updated_at\"", res[:sql_text])
+        # …while a static default absent from an explicitly scoped update stays out, so it
+        # cannot overwrite live rows. Unchanged by #331; pinned in detail in
+        # test_bulk_update_column_scope.jl.
+        @test !occursin("\"laps\"", res[:sql_text])
+        @test !occursin("\"pit_stops\"", res[:sql_text])
     end
 
     @testset "allocate_primary_keys clone=true: independent copy, pk on the returned frame only" begin

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -27,6 +27,8 @@ Claims that genuinely need live data — the unprojected-FK read, `create()` val
 using Test
 using PormG
 using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, JSONField, UniqueConstraint
+using PormG.QueryBuilder: bulk_insert
+import DataFrames
 
 # Mock backends: dialect dispatch is by connection TYPE, so a bare subtype is enough to render
 # SQL and to fire the backend-capability guards. No DB, no pool.
@@ -63,6 +65,13 @@ end
 const DOCERR_STATUS_PG, DOCERR_DRIVER_PG, DOCERR_RESULT_PG = _docerr_models("docerr_pg")
 const DOCERR_STATUS_SL, DOCERR_DRIVER_SL, DOCERR_RESULT_SL = _docerr_models("docerr_sl")
 
+# #331 — a model of its own rather than a `default` bolted onto DOCERR_RESULT_*: a defaulted field
+# there would silently change what every other case's model injects on a write.
+const DOCERR_STINT_PG = let m = Model("docerr_stint_docerr_pg",
+        id = IDField(), driver = CharField(), laps = IntegerField(default = 0))
+    m.connect_key = "docerr_pg"; m._module = Main; m
+end
+
 # (docs claim this test pins, expected type, the call that must raise it).
 # Keep the doc reference exact — it is how a maintainer finds the sentence to update when a type
 # legitimately changes.
@@ -94,6 +103,27 @@ const DOCERR_CASES = [
         UnsafeMutationError,
         () -> DOCERR_RESULT_PG.objects.filter("resultid" => 1).limit(5).
             update("points" => 0, show_query = :dict),
+    ),
+    # #331 — `write/bulk.md` → Defaults and Auto Values promises that a blank cell in a PRESENT,
+    # `null=false` column raises "null values are not allowed" as *PormG's own validation, not a
+    # database constraint error*, and that it is the same error `create()` raises. Build-time:
+    # bulk_insert runs its per-row validation sweep even under show_query, so the mock is enough —
+    # which is also what makes the "not a database error" half of the claim demonstrable here.
+    (
+        "write/bulk.md — a blank cell in a present NOT NULL defaulted column is a null, not the default",
+        InvalidValueError,
+        () -> bulk_insert(DOCERR_STINT_PG.objects,
+                          DataFrames.DataFrame(driver = ["Senna"], laps = [missing]),
+                          show_query = :dict),
+    ),
+    # A control, not a regression: create() already behaved this way, and #331 aligned the bulk
+    # paths onto it. It is here so the two halves of the documented equivalence are pinned
+    # together — if create() ever drifts, the claim in write/bulk.md becomes false too.
+    (
+        "write/create.md — an explicit `nothing` on a NOT NULL defaulted field is a null, not the default",
+        InvalidValueError,
+        () -> DOCERR_STINT_PG.objects.create("driver" => "Senna", "laps" => nothing,
+                                             show_query = :dict),
     ),
     (
         "read/filters_and_aggregates.md — a JSON path key with spaces is not addressable",


### PR DESCRIPTION
Closes #331

`create()` and the bulk paths disagreed about what an explicit "no value" meant on a field carrying a static `default`. `create()` honoured it and stored `NULL`; `bulk_insert` / `bulk_copy` / `bulk_update` overwrote it with the default. Same model, same field, same caller intent, two different rows — and no way for a DataFrame to spell "I mean NULL here."

## The rule

> For a field the write touches, PormG supplies a value only when the DataFrame has no column for it. A column that **is** present is caller-authored data, and PormG never rewrites its cells.

Uniform across every fill kind (static `default`, `auto_now`, `auto_now_add`, UUID `auto_add`), all three bulk operations, nullable or not.

**Why this reading.** The frameworks split on it. Django (*"the default value is used … when a value isn't provided"*), Prisma, and raw SQL treat an omitted column and an explicit null as distinct. SQLAlchemy's ORM does the opposite — an explicit `None` is *"treated the same as though the value were never assigned"* — and pays for it with `null()` and `evaluates_none()` escape hatches, because the collapse is lossy. PormG's `create()` already implemented the Django reading, `docs/src/import_django.md` makes Django the reference, and a DataFrame column list is closer to SQLAlchemy Core (which emits NULL) than to its unit-of-work.

`docs/src/write/bulk.md` already promised this behaviour — *"Use `nothing` or `missing` when you want SQL `NULL` on nullable relation columns"* — which was false for a defaulted FK. The fix makes an existing doc claim true.

## The change

Deletes the present-column fill site in `_prepare_bulk_df!`, inverts the surviving condition so the branch reads as *"the DataFrame has no column for this field"*, and renames the nested closure to `resolve_absent_column_fill` (dropping two parameters that shadowed the enclosing scope with identical values). Five lines of behaviour; the rest is comments.

**Absent-column behaviour is unchanged**, including the `is_explicit_update && is_static_default` suppression for `bulk_update(..., columns=[...])` and the all-blank auto-increment pk rescue.

The NOT NULL half came free: `validate_field_data` already ran per row on all three bulk paths, so a blank now raises the same ORM-level *"null values are not allowed"* that `create()` raises — PormG's own diagnosis naming the field, not a backend constraint error.

## Verification

| | |
|---|---|
| `test/unit/test_bulk_default_fill_scope.jl` (new, 42 assertions) | **12 fail against unfixed `main`**, 0 on this branch; 3 control testsets green in both |
| `test_bulk_no_mutation.jl` | 45 pass; its one discriminating assertion fails pre-fix |
| Full unit suite | 5745 pass |
| Integration `db_sl` | 1982 pass, 1 pre-existing broken |
| Integration `db_2` | 2033 pass |

Every new assertion was mutation-tested against the pre-fix build rather than merely observed passing — including the integration testsets, checked by calling `_prepare_bulk_df!` directly on a pre-fix package.

## Behaviour changes (see the `UPGRADING.md` entry)

- A blank in a present, **nullable** defaulted/auto column persists as `NULL` instead of the fill value. On `bulk_update` that turns a silent no-op — writing the default back over the live value — into a real null-out.
- A blank in a present **`null=false`** column raises `InvalidValueError`.
- A blank in a `match_on` key column is no longer back-filled, so it matches nothing rather than merging into the default-valued row.
- A blank `UUIDField(auto_add = true)` **primary key** column raises instead of being minted in place.

## Deliberately not done

- **Two pre-existing defects found while probing this one are filed, not fixed here** — both cross-referenced from the code and the docs so they're navigable from where you'd hit them:
  - #334 — `bulk_insert` reuses one `auto_add` UUID for the whole batch where `create()` mints per row. This is why the `UPGRADING.md` guidance is *fill the column yourself* rather than *drop it*; if #334 lands first, that bullet wants rewording.
  - #335 — bulk default injection clobbers a `columns=` Pair's source column when its name matches another model field, silently destroying values the caller did supply.
- **`columns=`-excluded fields still get their default injected.** Considered and declined: deferring to the frame there would make `columns=` stop deciding what gets written, a worse contract than the status quo. The rule statement in code and docs is scoped so it no longer claims otherwise.
- **No `Project.toml` bump** — release trains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
