### PR TITLE
fix(#341): resolve a Django base list instead of string-matching it

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -154,14 +154,38 @@ Django parameters are automatically converted to PormG equivalents:
 
 ### Meta Options
 
-The importer reads one `class Meta:` option:
+| Django `Meta` option | Outcome | Notes |
+|----------------------|---------|-------|
+| `db_table = "x"` | **imported** as `db_table = "x"` | The physical table. Absolute, as in Django: it overrides the derived name *and* a configured `django_prefix`. The positional slot keeps the derived logical name (`"matricula"`, or `"dash_matricula"` under a prefix). |
+| `unique_together = ('a', 'b')` | **imported** as `constraints = [Models.UniqueConstraint(fields = ("a", "b"))]` | A tuple-of-tuples (several composite keys) becomes one `UniqueConstraint` per group. |
+| `constraints = [UniqueConstraint(fields=…, name=…)]` | **imported** | The modern spelling. See the acceptance rule below — it is narrower than Django's. |
+| `constraints = [CheckConstraint(…)]` | **rejected**, reported | No PormG equivalent. |
+| `abstract = True` | **no table** | The class becomes a base: its fields merge into every child. See [Model inheritance](#Model-inheritance). |
+| `proxy = True` | **no table** | A proxy shares its parent's table; emitting one would declare that table twice. |
+| `indexes`, `index_together` | **dropped**, reported | PormG has no composite-index primitive — only per-field `db_index`. |
+| `ordering`, `get_latest_by` | **dropped**, reported | PormG orders per query, not per model. |
+| `managed`, `verbose_name*`, `permissions`, `default_related_name`, `app_label`, … | **dropped**, reported | No PormG equivalent. |
+| anything unrecognised | **dropped**, reported | A typo or a Django option this importer has not met. Neither is safe to pass over quietly. |
 
-| Django `Meta` option | PormG equivalent | Notes |
-|----------------------|------------------|-------|
-| `unique_together = ('a', 'b')` | `constraints=[Models.UniqueConstraint(fields=("a", "b"))]` | Composite uniqueness. A tuple-of-tuples (multiple composite keys) becomes one `UniqueConstraint` per group. |
+"Reported" means two things at once: a `@warn` at import time **and** a `# PormG:` comment on the
+line above the model in the generated file. The console warning scrolls away; the comment is still
+there when someone reads the file six months later.
+
+!!! warning "`Meta.constraints` acceptance is a whitelist"
+    A `UniqueConstraint` is imported only when its arguments are within
+    `fields`, `name`, `violation_error_message`, `violation_error_code`. Anything else — `condition`,
+    `expressions`, `nulls_distinct`, `deferrable`, or a positional expression such as
+    `UniqueConstraint(Lower("name"), …)` — causes **that one constraint** to be dropped and reported;
+    its siblings on the same model are unaffected.
+
+    The direction is deliberate. `Models.UniqueConstraint` is exactly `(fields, name)`, so a Django
+    *partial* index (`condition=Q(active=True)`) imported as an unconditional one would start
+    silently rejecting rows the live database accepts. Refusing an option is recoverable;
+    reinterpreting one is not.
 
 Because foreign-key fields are imported with an `_id` suffix (`item` → `item_id`), the importer
-resolves each `unique_together` member to its imported field name automatically:
+resolves each declared member — in both `unique_together` and `constraints` — to its imported field
+name automatically:
 
 ```python
 class Dim_item_fabricante(models.Model):
@@ -184,8 +208,61 @@ Dim_item_fabricante = Models.Model("dim_item_fabricante",
 ```
 
 See [Composite Uniqueness](models.md#Composite-Uniqueness-(unique_together)) for how the
-constraint is materialized. Django's newer `Meta.constraints = [UniqueConstraint(...)]` form is
-not parsed yet — declare it directly in PormG.
+constraint is materialized.
+
+### Model inheritance
+
+A class becomes a table when its base list **resolves** to one — not when it matches a fixed
+spelling. `class Pedido(TimeStampedModel):` is imported; so is `class User(AbstractUser, SomeMixin)`.
+
+| Shape | Outcome |
+|---|---|
+| `class Base(models.Model)` with `Meta.abstract = True` | No table. Its fields merge into every child, and a child that **redeclares** a field wins. |
+| `class Child(Base)` where `Base` is abstract | One table carrying `Base`'s fields plus its own. |
+| `class Child(Base)` where `Base` is **concrete** | **Not imported.** See below. |
+| `class Child(models.Model, PlainMixin)` | One table. Django collects fields only from bases that are themselves models, so a plain mixin contributes none — and PormG matches that. |
+| `class Child(Base)` where `Base` is in another file | Imported **with its own fields only**, plus a marker naming the missing base — provided the body declares at least one field (see the row below). |
+| `class X(models.QuerySet / models.Manager / models.TextChoices / object)` | Skipped, silently — these are not tables. A class **this file defines** always wins over that list, so your own model named `Manager` is imported normally. |
+| any class declaring `Meta.model = X` | Skipped, silently. That is the signature of a `ModelForm`, serializer or `FilterSet`; Django's own `ModelBase` rejects the attribute on a real model. |
+| any other unrecognised base | Imported only if the body declares at least one **database** field — see the namespace rule below. A class with only methods and a `Meta` declares none, so it stays out. |
+
+A field counts toward that last rule when it is called through a *model* namespace: `models.CharField(...)`, `db.models.CharField(...)`, the fully qualified `django.db.models.CharField(...)`, or a directly-imported bare `CharField(...)`. A `forms.CharField(...)` or `serializers.CharField(...)` does not.
+
+That distinction is the whole guard for a plain `forms.Form` or DRF `serializers.Serializer` — neither declares `Meta.model`, and their members are field-shaped, so without it both import as `id`-only tables that reach `makemigrations` as real `CREATE TABLE`s. Silent junk in the schema is the mirror of silent loss, and the worse of the two. One consequence worth knowing: an **aliased** import (`from django.db import models as db_models`) is not recognised, so `db_models.CharField(...)` does not count as a field for this rule — it only matters for a class that *also* has an unresolvable base and no plainly-spelled field.
+
+**Meta inheritance follows Django's rule, minus one footgun.** A child that declares no `Meta` block
+at all inherits its abstract base's whole `Meta`. Two keys are withheld: `abstract` (Django resets it
+too), and `db_table` — Django *does* inherit that one, and the result is every child of the base
+pointing at a single table, so PormG refuses it and says so on each affected child.
+
+**Multi-table inheritance is refused, not approximated.** For `class Pedido(Venda)` with a concrete
+`Venda`, Django creates a child table whose primary key is a `venda_ptr_id` one-to-one to the parent.
+PormG cannot express that. Merging the parent's fields would duplicate its columns; omitting them
+would lose the primary key. Both put a schema on disk that contradicts the live database, so the
+child is skipped and the generated file records why (markers are one line each; wrapped here to fit):
+
+```julia
+# PormG: model 'Pedido' inherits the concrete model 'Venda' (Django multi-table inheritance) —
+#   not imported. Django keys the child table on a 'venda_ptr_id' one-to-one to the parent, which
+#   PormG cannot express.
+```
+
+**A base in another app degrades, it does not delete.** One `models.py` cannot see
+`from core.models import TimeStampedModel`, so the child is imported without that base's columns and
+says so. The walk covers abstract ancestors too — a base that is itself missing a base loses columns
+the same way, and it emits nothing of its own to carry the marker:
+
+```julia
+# PormG: model 'Relatorio' inherits 'TimeStampedModel', not defined in this file — any fields
+#   declared there are MISSING below. Add them by hand, or import the app that defines them
+#   together with this one.
+Relatorio = Models.Model("relatorio",
+  id = Models.IDField(),
+  titulo = Models.CharField(max_length=80))
+```
+
+Dropping the model instead would be the worse trade: a table that silently disappears is harder to
+notice than one that is present and annotated.
 
 ### ⚠️ Important: CharField with Choices Syntax
 
@@ -238,13 +315,22 @@ naming the field and its source line; it is never dropped silently.
 
 ## Limitations and Considerations
 
-### Current Limitations
+### What survives the import
 
-1. **Field Types**: Not all Django field types are supported
-2. **Complex Relationships**: ManyToManyField is not yet supported
-3. **Custom Fields**: Custom Django fields require manual conversion
-4. **Metaclass Options**: Model Meta options are not converted
-5. **Methods**: Model methods are not converted (only fields)
+| | |
+|---|---|
+| **Imported** | Fields (including definitions wrapped across lines), `ForeignKey` / `OneToOneField` / `ManyToManyField`, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints` (see the whitelist above), abstract-base inheritance, `AbstractUser` auth columns |
+| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import |
+| **Reported and skipped** | `Meta.indexes` and every other option with no PormG equivalent; a `UniqueConstraint` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`) |
+| **Not supported** | Field types PormG does not implement — these raise, naming the field and class, rather than importing something wrong. Model methods, managers, signals and validators are Python and have no PormG counterpart |
+
+Nothing in the middle two rows is dropped in silence: each one produces a `@warn` at import time and
+a `# PormG:` comment in the generated file. That is the contract this importer holds itself to — if
+something did not survive, the artifact says so.
+
+!!! note "`choices` as a list of lists"
+    `choices=[["A", "Alpha"]]` is valid Django but imports as an empty `choices=()`, with no warning.
+    Write the inner pair as a tuple: `choices=[("A", "Alpha")]`.
 
 ## API Naming Differences from Django
 

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -620,29 +620,117 @@ function import_models_from_django(
     model_py_string = django_to_string(model_py_string)
   end
 
-  # Recover the importable classes as structured blocks (#340). The parser itself is the validity
-  # test: the regex that used to guard this required the class header to sit on ONE physical line,
-  # so once the parser learned to read a wrapped header it was rejecting files it could handle.
-  class_colector = parse_class(model_py_string)
+  # Recover and classify every module-level class (#340 parses them, #341 resolves their bases).
+  # The parser itself is the validity test: the regex that used to guard this required the class
+  # header to sit on ONE physical line, so once the parser learned to read a wrapped header it was
+  # rejecting files it could handle.
+  graph = _django_class_graph(model_py_string)
 
   # check if model_py_string is a model.py file content and not a path
-  if isempty(class_colector)
+  if !any(c -> _is_emitted(graph.info[c.name]), graph.classes)
     @warn("The string does not contain a valid model.py content")
     return
   end
 
   Instructions = Vector{Any}()
-  for class in class_colector
+  # A class name defined twice at module level is pathological Python, but it used to emit TWO
+  # `X = Models.Model(...)` assignments into one module: the file loads, the second silently wins,
+  # and the first model is gone. `graph.index` already keeps the first definition for base
+  # resolution; this keeps emission agreeing with it.
+  seen_names = Set{String}()
+
+  for class in graph.classes
     class_name = class.name
-    base_class = class.bases          # "models.Model" or "AbstractUser"
-    class_content = class.body        # this class's OWN statements; nested bodies excluded
+    ci = graph.info[class_name]
+
+    # A class name declared twice at module level used to emit TWO `X = Models.Model(...)`
+    # assignments into one module: the file loads, the second silently wins, and the first model is
+    # gone. `graph.info` is memoized by NAME from the first definition, so the duplicate is never
+    # classified on its own — which is why the test below is on the DUPLICATE'S OWN shape.
+    #
+    # Reporting is conditional on purpose. Two `class Foo(models.QuerySet)` blocks lose nothing that
+    # reaches the schema, and a comment about a QuerySet in a module that never mentions it is
+    # noise. But helper-first / model-second — a `QuerySet` and then the real model under one name —
+    # loses a table, and the memoized kind says `:not_a_model`, so only the duplicate's own field
+    # declarations reveal it.
+    if class_name in seen_names
+      if _is_emitted(ci) || _declares_fields(class)
+        @warn "import: class name is declared more than once at module level; only the first declaration is used" class=class_name
+        push!(Instructions, "# PormG: '$(class_name)' is declared more than once in this " *
+                            "models.py — only the FIRST declaration is used here. Python binds the " *
+                            "last one, so this may not be the class you expect.")
+      end
+      continue
+    end
+    push!(seen_names, class_name)
+
+    # ── Classes that produce no table ──────────────────────────────────────────────────────────
+    # A skipped model has no declaration for a marker to sit above, so the marker becomes a
+    # standalone comment in the generated module. That is the #70 convention applied one level up:
+    # the artifact itself shows what is missing, instead of the gap living only in a console warning
+    # the reader of the file will never see.
+    if ci.kind === :not_a_model || ci.kind === :abstract
+      continue                       # a QuerySet/Manager/Form/enum/helper, or a base — silent
+    end
+
+    if ci.proxy
+      @warn "import: proxy model shares its parent's table; not imported" class=class_name
+      push!(Instructions, "# PormG: model '$(class_name)' is a Django proxy (Meta.proxy = True) — " *
+                          "not imported, because it has no table of its own.")
+      continue
+    elseif ci.kind === :mti
+      @warn "import: Django multi-table inheritance has no PormG equivalent; model not imported" class=class_name parent=ci.mti_parent
+      push!(Instructions, "# PormG: model '$(class_name)' inherits the concrete model " *
+                          "'$(ci.mti_parent)' (Django multi-table inheritance) — not imported. " *
+                          "Django keys the child table on a '$(lowercase(String(ci.mti_parent)))_ptr_id' " *
+                          "one-to-one to the parent, which PormG cannot express.")
+      continue
+    end
+
+    # `# PormG:` lines to emit directly above this model's declaration.
+    markers = String[]
+
+    # An abstract base declared elsewhere (`from core.models import TimeStampedModel`) cannot be
+    # merged, so the model is imported WITHOUT its columns. Skipping instead would re-create the
+    # vanishing-model bug this issue exists to close; importing with a loud marker keeps the table
+    # and names exactly what is absent. Importing the defining app alongside this one (#346)
+    # resolves it.
+    # Walked over the ABSTRACT ANCESTORS too, not just this class's own base list: an abstract base
+    # with an unresolvable base of its own loses columns identically, and it emits nothing to hang a
+    # marker on, so its gap would otherwise reach the file unannounced.
+    unresolved_bases = _inherited_unresolved(graph, class)
+    if !isempty(unresolved_bases)
+      for b in unresolved_bases
+        @warn "import: base class is not defined in this file; any fields it declares are missing from the imported model" class=class_name base=b
+      end
+      push!(markers, "# PormG: model '$(class_name)' inherits " *
+                     join(("'$(b)'" for b in unresolved_bases), ", ") *
+                     ", not defined in this file — any fields declared there are MISSING below. " *
+                     "Add them by hand, or import the app that defines them together with this one.")
+    end
+
+    # Django would hand this model its abstract base's `db_table`, giving every child of that base
+    # the same physical table. Refused deliberately (see `_effective_meta`) — and reported, because
+    # a silently different table name is the defect this issue is about.
+    db_table_base = _abstract_db_table_base(graph, class)
+    if db_table_base !== nothing
+      @warn "import: db_table on an abstract base is not inherited; the child keeps its own derived table name" class=class_name base=db_table_base
+      push!(markers, "# PormG: abstract base '$(db_table_base)' declares Meta.db_table — NOT " *
+                     "inherited by '$(class_name)', because that would point every child of " *
+                     "'$(db_table_base)' at one table. Declare db_table on this model if it really " *
+                     "shares that table.")
+    end
+
+    # Abstract bases merge by CONCATENATION, ancestors first: process_class_fields! writes into a
+    # Dict, so the last write wins and the child overrides its parents for free.
+    class_content = vcat(_inherited_statements(graph, class), class.body)
 
     # Initialize fields_dict
     fields_dict = Dict{Symbol, Any}()
     has_primary_key = Ref(false)  # Flag to check if a primary key exists
 
     # Process fields separately
-    process_class_fields!(fields_dict, class_content, class_name, base_class, has_primary_key, autofields_ignore, parameters_ignore)
+    process_class_fields!(fields_dict, class_content, class_name, _inherits_auth_user(graph, class), has_primary_key, autofields_ignore, parameters_ignore, markers)
 
     # Insert IDField if no primary key is defined
     if !has_primary_key[]
@@ -653,18 +741,64 @@ function import_models_from_django(
     # Collect all create instructions
     if !isempty(fields_dict)
         model = Models.Model(class_name, fields_dict)
-        # Recover Django `Meta.unique_together` → composite UniqueConstraints (#19). Lenient:
-        # BOTH parsing and validation are wrapped — a malformed `unique_together` (e.g. duplicate
-        # fields) is warned and skipped, never aborting the whole multi-class import.
-        try
-          # `class.meta`, not the whole body (#340): the Meta block is now isolated, so the word
-          # `unique_together` appearing in a docstring or a sibling nested class no longer matches.
-          constraints = parse_meta_unique_together(class.meta, fields_dict, class_name)
-          isempty(constraints) || Models._apply_unique_constraints!(model, constraints)
-        catch e
-          @warn "import: could not parse/apply unique_together; skipping" class=class_name exception=e
+        meta_options = _effective_meta(graph, class)
+
+        # `Meta.db_table` is ABSOLUTE in Django — it overrides the derived name, and it overrides a
+        # configured `django_prefix` too. `Model_to_str` renders both: the positional slot stays the
+        # logical handle, `db_table=` carries the physical table (#59).
+        if haskey(meta_options, "db_table")
+          dt = _meta_string_literal(meta_options["db_table"])
+          if dt === nothing || isempty(dt)
+            @warn "import: Meta.db_table is not a non-empty string literal; ignored" class=class_name value=meta_options["db_table"]
+            push!(markers, "# PormG: Meta.db_table on '$(class_name)' is not a string literal — " *
+                           "ignored; the table name below is derived from the class name.")
+          else
+            Models._apply_db_table!(model, dt)
+          end
         end
-        push!(Instructions, Models.Model_to_str(model, render_settings))
+
+        # Composite uniqueness from BOTH Django spellings (#19, #341). Each constraint is validated
+        # on its own so one bad entry cannot take the others with it — which is what the coarse
+        # try/catch around the whole apply used to do.
+        constraints = Models.UniqueConstraint[]
+        if haskey(meta_options, "unique_together")
+          try
+            append!(constraints, parse_meta_unique_together(meta_options["unique_together"], fields_dict, class_name, markers))
+          catch e
+            @warn "import: could not parse unique_together; skipping" class=class_name exception=e
+            push!(markers, "# PormG: Meta.unique_together on '$(class_name)' could not be read — dropped.")
+          end
+        end
+        if haskey(meta_options, "constraints")
+          append!(constraints, _parse_meta_constraints(meta_options["constraints"], fields_dict, class_name, markers))
+        end
+        for c in constraints
+          try
+            Models._apply_unique_constraints!(model, vcat(_existing_unique_constraints(model), [c]))
+          catch e
+            @warn "import: could not apply a unique constraint; skipping it" class=class_name fields=c.fields exception=e
+            push!(markers, "# PormG: a constraint over ($(join(c.fields, ", "))) on '$(class_name)' " *
+                           "was dropped — $(replace(sprint(showerror, e), "\n" => " "))")
+          end
+        end
+
+        # Every remaining Meta option is REPORTED. An unrecognised key is a typo or a Django option
+        # this importer has not met, and neither is safe to pass over quietly. Sorted so the
+        # generated file is byte-stable across runs.
+        for k in sort(collect(keys(meta_options)))
+          k in _META_OPTIONS_CONSUMED && continue
+          reason = get(_META_OPTION_REASONS, k, nothing)
+          if reason === nothing
+            @warn "import: unrecognised Meta option; dropped" option=k class=class_name
+            push!(markers, "# PormG: Meta.$(k) on '$(class_name)' is not recognised — dropped.")
+          else
+            @warn "import: Meta option has no PormG equivalent; dropped" option=k class=class_name reason=reason
+            push!(markers, "# PormG: Meta.$(k) on '$(class_name)' — dropped: $(reason).")
+          end
+        end
+
+        rendered = Models.Model_to_str(model, render_settings)
+        push!(Instructions, isempty(markers) ? rendered : join(markers, "\n") * "\n" * rendered)
     end
 
   end
@@ -672,24 +806,441 @@ function import_models_from_django(
   generate_models_from_db(file, Instructions, render_settings, path=model_path)
 end
 
-# Base lists the importer recognises as "this class becomes a table". Deliberately unchanged from the
-# regex it replaces (`\((models\.Model|AbstractUser)\)`) — widening it to arbitrary/abstract bases is
-# #341, and doing it here would silently change which classes get imported.
-const _MODEL_BASES = ("models.Model", "AbstractUser")
+# The UniqueConstraints already stashed on a model by `_apply_unique_constraints!`. Applying
+# constraints one at a time (so a rejection is per-constraint) means each call must carry the ones
+# that already passed — the setter REPLACES the cache entry rather than appending to it.
+function _existing_unique_constraints(model)::Vector{Models.UniqueConstraint}
+  haskey(model.cache, "unique_constraints") || return Models.UniqueConstraint[]
+  return get(model.cache["unique_constraints"], "constraints", Models.UniqueConstraint[])
+end
+
+# ── Class classification and inheritance (#341) ─────────────────────────────────────────────────
+# Until #341 a class became a table iff its ENTIRE base list was one of two literals
+# (`\((models\.Model|AbstractUser)\)`). That is a silent-loss shape, and the worst one in this file:
+# `class Pedido(TimeStampedModel):` matched neither literal, so the model was not imported and
+# NOTHING said so — the same failure #340 exists to remove, one level up.
+#
+# Widening it to "any base list" is not safe either. A real models.py is full of QuerySet, Manager,
+# ModelForm and serializer subclasses that are emphatically not tables, and importing those is the
+# mirror-image defect. So the base list is RESOLVED against the file instead of string-matched, and
+# the residual guess — a base this file does not define — is gated on whether the class actually
+# declares columns.
+
+# Bases that make a class a table root on their own.
+const _MODEL_ROOT_BASES = ("models.Model", "Model", "db.models.Model", "django.db.models.Model")
+
+# Roots that ALSO carry Django's auth columns (see `process_class_fields!`). `AbstractBaseUser` is
+# deliberately absent: its field set is a strict subset of `AbstractUser`'s — no `username`,
+# `email`, `is_staff`, `date_joined` — so treating the two as one root emits a user table missing
+# real columns. It falls through to the unresolved path instead, which imports the model and states
+# what is missing rather than inventing it.
+const _AUTH_USER_BASES = ("AbstractUser", "models.AbstractUser", "auth_models.AbstractUser")
+
+# Bases that are definitively NOT tables. Skipped in silence — a warning here is pure noise, and
+# noise is what buried the one real finding in #340.
+#
+# Load-bearing, not belt-and-braces: the field gate below cannot replace this list, because a
+# non-model class may still declare field-shaped members. `class PlainHelper(object)` with a
+# `models.CharField(...)` in its body is exactly that case, and it is already a test.
+const _NON_MODEL_BASES = (
+  "object",
+  "models.TextChoices", "models.IntegerChoices", "models.Choices",
+  "TextChoices", "IntegerChoices", "Choices",
+  "models.Manager", "models.QuerySet", "Manager", "QuerySet",
+  "Enum", "IntEnum", "StrEnum", "ABC", "Exception",
+)
+
+"""
+    _ClassInfo
+
+What the importer decided about one `class` in the source.
+
+`kind` is one of:
+
+- `:concrete` — becomes a table.
+- `:abstract` — `Meta.abstract = True`: a base only. Emits nothing; its fields merge into children.
+- `:mti` — Django *multi-table inheritance*, i.e. a base that itself becomes a table. Refused, and
+  deliberately so: Django gives the child its own table keyed by a `<parent>_ptr_id` one-to-one to
+  the parent, which PormG cannot express. Emitting the child with merged fields would duplicate the
+  parent's columns; emitting it without them would lack the primary key Django actually created.
+  Both put a schema on disk that does not match the database, so neither is emitted.
+- `:not_a_model` — a QuerySet, Manager, Form, enum or plain helper. Skipped silently.
+
+`unresolved` holds bases that name nothing in this file (`from core.models import TimeStampedModel`).
+The class is still imported — dropping it would re-create the vanishing-model bug — but it carries a
+marker saying whose fields are missing. Importing several apps together (#346) resolves these.
+"""
+struct _ClassInfo
+  kind::Symbol
+  bases::Vector{String}
+  parents::Vector{String}              # in-file ABSTRACT bases whose fields this class inherits
+  unresolved::Vector{String}           # bases this file does not define
+  mti_parent::Union{String, Nothing}
+  meta::Dict{String, String}
+  is_auth_user::Bool
+  proxy::Bool
+end
+
+# A class this importer emits a `Models.Model(...)` for. A proxy is `:concrete` in every other
+# respect but shares its parent's table, so emitting it would declare that table twice.
+_is_emitted(ci::_ClassInfo)::Bool = ci.kind === :concrete && !ci.proxy
+
+"""
+    _class_bases(cls) -> Vector{String}
+
+The base list of a class header, split on its top-level commas. A token carrying a top-level `=`
+(`class Foo(Base, metaclass=abc.ABCMeta)`) is a class keyword, not a base, and is dropped.
+"""
+function _class_bases(cls::PyClass)::Vector{String}
+  out = String[]
+  isempty(strip(cls.bases)) && return out
+  for t in split_field_options(cls.bases)
+    tt = strip(t)
+    isempty(tt) && continue
+    _split_top_level_assign(tt) === nothing || continue
+    push!(out, String(tt))
+  end
+  return out
+end
+
+# Namespaces a *database* field can be called through. `""` is the bare form
+# (`from django.db.models import CharField` → `titulo = CharField(...)`), which is ordinary Django
+# and also how third-party fields arrive (`ArrayField`, django-mptt's `TreeForeignKey`).
+const _MODEL_FIELD_NAMESPACES = ("", "models", "db.models", "django.db.models")
+
+# The dotted prefix of a call's target: `forms.CharField(` → "forms", `CharField(` → "", and
+# `a.b.Thing(` → "a.b". `nothing` when `rhs` is not a call at all.
+const _CALL_NAMESPACE_RE = r"^((?:[A-Za-z_]\w*\s*\.\s*)*)([A-Za-z_]\w*)\s*\("
+
+function _field_call_namespace(rhs::AbstractString)::Union{String, Nothing}
+  m = match(_CALL_NAMESPACE_RE, rhs)
+  m === nothing && return nothing
+  return String(strip(replace(rstrip(strip(m.captures[1]), '.'), r"\s+" => "")))
+end
+
+# True when the class's OWN body declares at least one DATABASE column. This is the gate that lets an
+# unrecognised base list be treated as a model without a blacklist that has to be exhaustive.
+#
+# `models.X(...)` is not the only spelling — `from django.db.models import CharField` then
+# `titulo = CharField(...)` is ordinary Django, and #340 already added `_looks_like_a_field_call` to
+# recognise it. Matching only the dotted form made the gate and that reporter disagree, and the gate
+# won: such a model was dropped in silence.
+#
+# But accepting *any* field-shaped call is the mirror defect, and a worse one — it puts junk in the
+# schema instead of leaving it out. A plain `forms.Form` and a DRF `serializers.Serializer` have no
+# `Meta.model` to exclude them and their members are `forms.CharField(...)` /
+# `serializers.CharField(...)`, which `_looks_like_a_field_call` accepts because `_CALL_TARGET_RE`
+# discards the namespace and tests only the suffix. Both imported as `id`-only tables that reach
+# `makemigrations` as real `CREATE TABLE`s.
+#
+# So the namespace is the discriminator, and it is the one piece of information already in the
+# source: `models.CharField` and `forms.CharField` differ by nothing else.
+function _declares_fields(cls::PyClass)::Bool
+  for s in cls.body
+    p = _match_field_statement(s.text)
+    p === nothing && continue
+    p.type === nothing || return true           # `models.X(...)`, matched by _FIELD_CALL_RE
+    _looks_like_a_field_call(p.args) || continue
+    ns = _field_call_namespace(p.args)
+    if ns !== nothing && ns in _MODEL_FIELD_NAMESPACES
+      return true
+    end
+  end
+  return false
+end
+
+# `abstract = True` / `proxy = True`, read off the raw right-hand side.
+_meta_is_true(raw::AbstractString)::Bool = parse_value(raw) === true
+
+function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, PyClass},
+                          visiting::Set{String}, cls::PyClass)::_ClassInfo
+  haskey(info, cls.name) && return info[cls.name]
+
+  meta = _parse_meta_options(cls.meta)
+  bases = _class_bases(cls)
+  abstract = _meta_is_true(get(meta, "abstract", ""))
+  proxy = _meta_is_true(get(meta, "proxy", ""))
+  is_auth = any(b -> b in _AUTH_USER_BASES, bases)
+
+  # An inheritance CYCLE is malformed Python. Refuse the class rather than recurse forever; not
+  # memoized, because the in-progress outer call owns the entry for this name.
+  if cls.name in visiting
+    return _ClassInfo(:not_a_model, bases, String[], String[], nothing, meta, is_auth, proxy)
+  end
+
+  is_root = is_auth || any(b -> b in _MODEL_ROOT_BASES, bases)
+  # `Meta.model = X` is the definitive signature of a class that DESCRIBES a model rather than being
+  # one — ModelForm, ModelSerializer, FilterSet. Django's own `ModelBase` rejects the attribute
+  # ("class Meta got invalid attribute(s): model"), so a real model can never carry it. This is an
+  # absolute exclusion, unlike the base-list blacklist below.
+  describes_a_model = haskey(meta, "model")
+  # Only consulted once nothing better is known — see the `kind` selection, where a model root, an
+  # abstract parent and a concrete parent all outrank it. Filtering out bases this file defines
+  # would be redundant here for exactly that reason; the in-file lookup that matters happens in the
+  # resolution loop below.
+  non_model = any(b -> b in _NON_MODEL_BASES, bases)
+
+  parents = String[]
+  unresolved = String[]
+  mti_parent::Union{String, Nothing} = nothing
+  poisoned = false
+
+  # Bases are resolved even when one of them is blacklisted, because a blacklisted base no longer
+  # decides the outcome on its own — see the `kind` selection below.
+  #
+  # `haskey(index, b)` is tested BEFORE `_NON_MODEL_BASES`, and that ordering is the whole fix for a
+  # real silent loss: `Manager`, `Choices` and `Enum` are perfectly good model names — a Manager in
+  # an HR schema is a person — and dismissing such a base by NAME made the class invisible as an
+  # ancestor. Its children then resolved no parent, fell through to `non_model`, and were dropped
+  # without a word, taking the base's columns with them. A definition in this file always outranks
+  # a name on a list.
+  push!(visiting, cls.name)
+  try
+    for b in bases
+      (b in _MODEL_ROOT_BASES || b in _AUTH_USER_BASES) && continue
+      if haskey(index, b)
+        pk = _classify_class!(info, index, visiting, index[b]).kind
+        if pk === :abstract
+          push!(parents, b)
+        elseif pk === :concrete || pk === :mti
+          # Inheriting anything that becomes a table IS multi-table inheritance. A `:mti` parent
+          # is already refused above us, and refusing here too keeps the chain from emitting a
+          # child whose parent never existed.
+          mti_parent === nothing && (mti_parent = b)
+        else  # :not_a_model — a Manager/QuerySet/helper base makes this one a helper too
+          poisoned = true
+        end
+      elseif b in _NON_MODEL_BASES
+        # A known non-model NAME that this file does not define. Already reflected in `non_model`;
+        # it is not an unresolved ancestor, so it must not be marked as one.
+        continue
+      else
+        push!(unresolved, b)
+      end
+    end
+  finally
+    delete!(visiting, cls.name)
+  end
+
+  kind = if describes_a_model || isempty(bases)
+    :not_a_model
+  elseif proxy
+    # A proxy subclasses a CONCRETE model, which is otherwise the multi-table-inheritance shape —
+    # but `proxy = True` is Django saying "no new table", not "a second table keyed to the parent".
+    # Classified as a model so the caller reports it as a proxy; `_is_emitted` still refuses it.
+    :concrete
+  elseif mti_parent !== nothing
+    :mti
+  elseif is_root || !isempty(parents)
+    # A recognised model root WINS over EVERY non-model base — both the blacklist (`non_model`) and
+    # an in-file helper (`poisoned`). `class Servidor(models.Model, ExportMixin)` is ordinary
+    # Django, and so is `class Servidor(models.Model, object)`, which is the only legal ordering
+    # since `object` must come last. Testing either flag first dropped the whole model in SILENCE —
+    # the shape this issue exists to close.
+    #
+    # Such a base contributes no columns either way: Django collects fields only from bases that
+    # carry `_meta`, so a plain mixin's attributes are inherited as Python, never as schema.
+    abstract ? :abstract : :concrete
+  elseif non_model || poisoned
+    # No model root and no abstract parent, and a base that is definitively not a model — a
+    # `class PlainHelper(object)` or `class Foo(SomeQuerySet)`. A helper deriving from a helper.
+    :not_a_model
+  elseif !isempty(unresolved) && _declares_fields(cls)
+    # Nothing in the base list is recognisable, but the body declares real columns — so this is a
+    # model whose ancestry we cannot see, not a helper. Import it; the caller marks what is missing.
+    abstract ? :abstract : :concrete
+  else
+    :not_a_model
+  end
+
+  ci = _ClassInfo(kind, bases, parents, unresolved, mti_parent, meta, is_auth, proxy)
+  info[cls.name] = ci
+  return ci
+end
+
+"""
+    _django_class_graph(src) -> (classes, index, info)
+
+Every module-level class in `src`, indexed by name and classified. `classes` keeps source order so
+generated output is stable; `info[name]` is the [`_ClassInfo`](@ref).
+
+Deliberately silent: classification emits no warnings, so `parse_class` can be called from a test
+without side effects. The importer reads `info` and does the reporting.
+"""
+function _django_class_graph(model_py_string::AbstractString)
+  classes = _py_classes(_py_logical_lines(model_py_string))
+  index = Dict{String, PyClass}()
+  for c in classes
+    # First definition wins; a name redefined at module level is pathological Python.
+    haskey(index, c.name) || (index[c.name] = c)
+  end
+  info = Dict{String, _ClassInfo}()
+  visiting = Set{String}()
+  for c in classes
+    _classify_class!(info, index, visiting, c)
+  end
+  return (classes = classes, index = index, info = info)
+end
+
+"""
+    _inherited_statements(graph, cls) -> Vector{PyStmt}
+
+The field statements `cls` inherits from its abstract bases, ancestors first. Concatenating these
+before the class's own body is the whole merge: `process_class_fields!` writes into a `Dict`, so
+**last write wins** gives child-overrides-parent for free.
+
+Bases are walked in **reverse** declaration order, because Python resolves `class C(A, B)` left to
+right — A must win, so A's statements have to be written last.
+"""
+function _inherited_statements(graph, cls::PyClass)::Vector{PyStmt}
+  out = PyStmt[]
+  seen = Set{String}()
+  function walk(c::PyClass)
+    ci = get(graph.info, c.name, nothing)
+    ci === nothing && return
+    for b in Iterators.reverse(ci.parents)
+      b in seen && continue
+      push!(seen, b)
+      p = get(graph.index, b, nothing)
+      p === nothing && continue
+      walk(p)
+      append!(out, p.body)
+    end
+    return
+  end
+  walk(cls)
+  return out
+end
+
+# Django's `AbstractUser` columns reach a class through an abstract base too:
+# `class BaseUser(AbstractUser): class Meta: abstract = True` then `class User(BaseUser)`.
+function _inherits_auth_user(graph, cls::PyClass)::Bool
+  ci = get(graph.info, cls.name, nothing)
+  ci === nothing && return false
+  ci.is_auth_user && return true
+  for b in ci.parents
+    p = get(graph.index, b, nothing)
+    p === nothing && continue
+    _inherits_auth_user(graph, p) && return true
+  end
+  return false
+end
+
+"""
+    _effective_meta(graph, cls) -> Dict{String, String}
+
+The `Meta` options that apply to `cls`.
+
+Django installs an abstract base's **whole** `Meta` on a child that declares none of its own,
+resetting `abstract` as it does. Two keys are withheld:
+
+- `abstract`, because Django resets it — inheriting it would emit no table for the child either.
+- `db_table`, because inheriting it points every child of one base at a single table. Django does
+  inherit it; that is a documented Django footgun rather than something to reproduce, so the caller
+  warns instead.
+
+Everything else carries through, including options with no PormG equivalent — otherwise an
+`indexes` declared on the base would be dropped without the report the child's own `indexes` gets.
+"""
+const _META_KEYS_NOT_INHERITED = ("abstract", "db_table")
+
+function _effective_meta(graph, cls::PyClass)::Dict{String, String}
+  b = _inherited_meta_base(graph, cls)
+  b === nothing && return graph.info[cls.name].meta
+  pm = graph.info[b].meta
+  return Dict{String, String}(k => v for (k, v) in pm if !(k in _META_KEYS_NOT_INHERITED))
+end
+
+"""
+    _inherited_meta_base(graph, cls) -> Union{String, Nothing}
+
+The abstract base whose `Meta` Django installs on `cls`: the nearest ancestor declaring a `Meta`
+block at all. `nothing` when `cls` declares its own, or when no ancestor has one.
+
+One walk, used by BOTH consumers — `_effective_meta` and the withheld-`db_table` report. They used
+to walk separately and disagree: the reporter climbed the whole chain while `_effective_meta`
+stopped at the first match, so a grandparent's `db_table` was reported as withheld from a child that
+would never have inherited it (Django resolves `Meta` to one class, not a merge of the chain).
+
+Gated on whether a Meta BLOCK was declared, not on whether it yielded options: `class Meta:`
+carrying only a docstring is still a declaration, and Django does not inherit past one.
+"""
+function _inherited_meta_base(graph, cls::PyClass)::Union{String, Nothing}
+  isempty(cls.meta) || return nothing
+  seen = Set{String}()
+  function walk(c::PyClass)::Union{String, Nothing}
+    ci = get(graph.info, c.name, nothing)
+    ci === nothing && return nothing
+    for b in ci.parents
+      b in seen && continue
+      push!(seen, b)
+      p = get(graph.index, b, nothing)
+      p === nothing && continue
+      isempty(p.meta) || return b
+      r = walk(p)
+      r === nothing || return r
+    end
+    return nothing
+  end
+  return walk(cls)
+end
+
+"""
+    _inherited_unresolved(graph, cls) -> Vector{String}
+
+Bases that neither `cls` nor any of its abstract ancestors could resolve.
+
+An abstract base with its own unresolvable base (`class Auditavel(TimeStampedModel)` with
+`abstract = True`) loses columns exactly as the child would, but the base emits nothing — so without
+walking the chain its gap reaches the generated file with no marker at all.
+"""
+function _inherited_unresolved(graph, cls::PyClass)::Vector{String}
+  out = String[]
+  seen = Set{String}()
+  function walk(c::PyClass)
+    ci = get(graph.info, c.name, nothing)
+    ci === nothing && return
+    for b in ci.unresolved
+      b in out || push!(out, b)
+    end
+    for b in ci.parents
+      b in seen && continue
+      push!(seen, b)
+      p = get(graph.index, b, nothing)
+      p === nothing || walk(p)
+    end
+    return
+  end
+  walk(cls)
+  return out
+end
+
+# An abstract base declaring `db_table` is a Django footgun the importer refuses to reproduce (see
+# `_effective_meta`). Reported on each child that would have inherited it — which is exactly the one
+# base `_inherited_meta_base` picks, not every ancestor in the chain.
+function _abstract_db_table_base(graph, cls::PyClass)::Union{String, Nothing}
+  b = _inherited_meta_base(graph, cls)
+  b === nothing && return nothing
+  return haskey(graph.info[b].meta, "db_table") ? b : nothing
+end
 
 """
     parse_class(model_py_string) -> Vector{PyClass}
 
-Recover the importable model classes from Django source.
+Recover the model classes this importer emits a table for.
 
 Statement- and indentation-driven (#340): a field spanning several physical lines arrives intact,
 a nested `class Status(models.TextChoices)` stays in `nested` instead of leaking into the parent's
 fields, `class Meta:` is isolated in `meta`, and module-level code after the last class is ignored
 rather than appended to it.
+
+Base lists are **resolved**, not string-matched (#341): an abstract base contributes its fields to
+its children and emits nothing itself, a proxy emits nothing, and a class whose bases this file does
+not define is still imported (its missing ancestry is reported by the caller).
 """
 function parse_class(model_py_string::String)::Vector{PyClass}
-  classes = _py_classes(_py_logical_lines(model_py_string))
-  return filter(c -> strip(c.bases) in _MODEL_BASES, classes)
+  graph = _django_class_graph(model_py_string)
+  return filter(c -> _is_emitted(graph.info[c.name]), graph.classes)
 end
 
 # Split `text` on its first TOP-LEVEL `=` — not inside a string or bracket, and not part of a
@@ -766,9 +1317,12 @@ function _match_field_statement(text::AbstractString)
   return (name = lhs, type = String(m.captures[1]), args = args)
 end
 
-function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, base_class::AbstractString, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String})
-  # Initialize fields for AbstractUser
-  if base_class == "AbstractUser"
+function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[])
+  # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
+  # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
+  # class reaching `AbstractUser` through an abstract base both qualify — an equality test on the
+  # whole base list matched neither.
+  if is_auth_user
       has_primary_key[] = true
       fields_dict[:id] = Models.IDField()
       fields_dict[:password] = Models.CharField()
@@ -797,6 +1351,11 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
       # stay quiet: see `_looks_like_a_field_call` for why the test is deliberately narrow.
       if _looks_like_a_field_call(parsed.args)
         @warn "import: field-shaped call the importer cannot read; not imported — declare it in PormG by hand" field=parsed.name class=class_name line=stmt.lineno
+        # ...and a marker in the generated file, not the warning alone (#341). A console warning
+        # scrolls away; whoever opens the generated file months later needs to see the gap there.
+        push!(markers, "# PormG: field '$(parsed.name)' on '$(class_name)' (models.py line " *
+                       "$(stmt.lineno)) is a field-shaped call the importer cannot read — NOT " *
+                       "imported. Declare it in PormG by hand.")
       end
       continue
     end
@@ -1012,11 +1571,225 @@ function split_field_options(field_options::AbstractString)
   return tokens
 end
 
-# ── Django `Meta.unique_together` → PormG `UniqueConstraint` (#19) ────────────────────────
+# ── Django `class Meta:` options (#19, #341) ──────────────────────────────────────────────────────
 # `class Meta:` options are not field declarations, so they never reach `fields_dict`. These helpers
-# recover `unique_together` from the isolated Meta block (`PyClass.meta`) and map it to PormG's
-# composite-uniqueness declaration. Django `Meta.constraints=[UniqueConstraint(...)]` (the newer
-# named form) is not parsed here yet — `unique_together` is the concrete #19 need.
+# read the isolated Meta block (`PyClass.meta`, #340) into an option table and map the three options
+# that carry schema meaning — `db_table`, `constraints` and the legacy `unique_together` — onto
+# PormG. Everything else is reported, never dropped in silence.
+
+"""
+    _parse_meta_options(meta) -> Dict{String, String}
+
+Read a `class Meta:` block into `option => raw right-hand side`.
+
+One pass over statements the block parser already isolated, rather than an `occursin` over the
+class's whole text — which is what `parse_meta_unique_together` used to do, and why the word
+`unique_together` appearing inside a docstring attached a constraint the model never declared.
+
+A statement with no top-level `=` (the block's own docstring) is not an option and is skipped.
+"""
+function _parse_meta_options(meta::Vector{PyStmt})::Dict{String, String}
+  out = Dict{String, String}()
+  for s in meta
+    parts = _split_top_level_assign(s.text)
+    parts === nothing && continue
+    lhs, rhs = parts
+    Base.isidentifier(lhs) || continue
+    out[lhs] = rhs
+  end
+  return out
+end
+
+"""
+    _meta_string_literal(raw) -> Union{String, Nothing}
+
+The value of a Meta option that must be a **literal** string, or `nothing`.
+
+The literal check is not decoration. `parse_value` returns anything it cannot classify verbatim, so
+a computed `db_table = f"{prefix}_matricula"` would otherwise be applied as the *text*
+`f"{prefix}_matricula"` — a declaration pointing at a table whose name contains a brace.
+"""
+function _meta_string_literal(raw::AbstractString)::Union{String, Nothing}
+  s = strip(raw)
+  isempty(s) && return nothing
+  (startswith(s, '"') || startswith(s, '\'')) || return nothing
+  v = parse_value(s)
+  v isa AbstractString || return nothing
+  # A residual quote or a newline means the text was not a well-formed single-line literal, whatever
+  # produced it. The case this actually catches is the TRIPLE-quoted one: `parse_value` strips
+  # exactly one character per side, so `\"\"\"arq_legado\"\"\"` comes back as `\"\"arq_legado\"\"` —
+  # a value that passes a naive starts-with-a-quote test and names a table no database has.
+  (occursin('\n', v) || occursin('"', v) || occursin('\'', v)) && return nothing
+  return String(v)
+end
+
+# Meta options with no PormG equivalent, each with the reason stated once so the warning and the
+# generated file's marker say the same thing.
+const _META_OPTION_REASONS = Dict{String, String}(
+  "indexes"               => "PormG has no composite-index primitive (only per-field db_index)",
+  "index_together"        => "PormG has no composite-index primitive (only per-field db_index)",
+  "ordering"              => "PormG orders per query, not per model",
+  "managed"               => "PormG migrations have no per-model opt-out",
+  "verbose_name"          => "PormG models carry no display metadata",
+  "verbose_name_plural"   => "PormG models carry no display metadata",
+  "permissions"           => "PormG has no permission framework",
+  "default_permissions"   => "PormG has no permission framework",
+  "default_related_name"  => "PormG names reverse accessors per relation, not per model",
+  "get_latest_by"         => "PormG orders per query, not per model",
+  "base_manager_name"     => "PormG has no manager layer",
+  "order_with_respect_to" => "PormG has no ordered-relation support",
+  "app_label"             => "PormG resolves models per connection, not per app",
+  "required_db_features"  => "PormG has no per-model backend gate",
+  "select_on_save"        => "PormG has no per-model save strategy",
+)
+
+# Options this importer consumes itself, so they are never reported as dropped.
+const _META_OPTIONS_CONSUMED = ("abstract", "proxy", "db_table", "constraints", "unique_together")
+
+# Django's `UniqueConstraint` arguments that PormG can honour. `violation_error_message` /
+# `violation_error_code` only change Django's Python-side error text and have no effect on the
+# index, so accepting and ignoring them is faithful.
+const _UNIQUE_CONSTRAINT_KWARGS = ("fields", "name", "violation_error_message", "violation_error_code")
+
+const _CONSTRAINT_CTOR_RE = r"^(?:[A-Za-z_]\w*\s*\.\s*)*([A-Za-z_]\w*)\s*\("
+
+"""
+    _one_line(s, limit = 120) -> String
+
+Collapse whitespace and truncate, for text interpolated into a `# PormG:` marker.
+
+A marker is a `#` comment in generated Julia, so it must be ONE line. Statement text is already
+newline-folded by `_py_logical_lines`, but a *value* pulled out of one is not: a field name inside a
+triple-quoted string keeps its newline, and a marker that spans two lines breaks the whole module.
+Every site that interpolates source text into a marker goes through this — a file that will not
+parse is a catastrophic outcome for a guard this cheap.
+"""
+_one_line(s::AbstractString, limit::Int = 120)::String =
+  String(first(strip(replace(s, r"\s+" => " ")), limit))
+
+function _drop_constraint!(markers::Vector{String}, class_name::AbstractString,
+                           element::AbstractString, reason::AbstractString)
+  short = _one_line(element)
+  reason = _one_line(reason, 200)
+  @warn "import: Meta.constraints entry dropped" class=class_name reason=reason constraint=short
+  push!(markers, "# PormG: a constraint on '$(class_name)' was dropped — $(reason): $(short)")
+  return markers
+end
+
+"""
+    _parse_meta_constraints(raw, fields_dict, class_name, markers) -> Vector{UniqueConstraint}
+
+Django `Meta.constraints = [...]` → PormG composite uniqueness.
+
+Argument acceptance is a **whitelist**, and that is the point of this function rather than an
+incidental detail. `Models.UniqueConstraint` is exactly `(fields, name)`, so a Django
+`UniqueConstraint(fields=…, condition=Q(active=True))` — a *partial* unique index — imported as an
+unconditional one would start silently rejecting rows the live database accepts. The same holds for
+`expressions=`, `nulls_distinct=` and `deferrable=`. Rejecting anything outside the whitelist means
+a Django option this importer has never met is refused rather than quietly reinterpreted, which is
+the only direction that fails safe.
+
+Each entry is judged on its own: one rejected constraint never takes its siblings with it.
+"""
+function _parse_meta_constraints(raw::AbstractString, fields_dict::Dict{Symbol, Any},
+                                 class_name::AbstractString, markers::Vector{String})
+  out = Models.UniqueConstraint[]
+  inner = _balanced_group(raw)
+  if inner === nothing
+    @warn "import: Meta.constraints is not a list or tuple literal; dropped" class=class_name
+    push!(markers, "# PormG: Meta.constraints on '$(class_name)' could not be read — dropped.")
+    return out
+  end
+
+  for element in split_field_options(inner)
+    el = String(strip(element))
+    isempty(el) && continue
+
+    m = match(_CONSTRAINT_CTOR_RE, el)
+    ctor = m === nothing ? "" : String(m.captures[1])
+    if ctor != "UniqueConstraint"
+      _drop_constraint!(markers, class_name, el,
+        isempty(ctor) ? "it is not a constraint constructor" : "$(ctor) has no PormG equivalent")
+      continue
+    end
+
+    args = _balanced_group(el)
+    if args === nothing
+      _drop_constraint!(markers, class_name, el, "its argument list could not be read")
+      continue
+    end
+
+    kwargs = Dict{String, String}()
+    reason::Union{String, Nothing} = nothing
+    for tok in split_field_options(args)
+      t = String(strip(tok))
+      isempty(t) && continue
+      kv = _split_top_level_assign(t)
+      if kv === nothing
+        # `UniqueConstraint(Lower("name"), name="x")` — an EXPRESSION constraint. Django indexes a
+        # function of the column; PormG would index the column itself, which is a different index.
+        reason = "it takes a positional expression (`$(t)`)"
+        break
+      end
+      k, v = kv
+      if !(k in _UNIQUE_CONSTRAINT_KWARGS)
+        reason = "`$(k)=` changes what the index means and PormG cannot express it"
+        break
+      end
+      kwargs[k] = v
+    end
+    if reason !== nothing
+      _drop_constraint!(markers, class_name, el, reason)
+      continue
+    end
+
+    if !haskey(kwargs, "fields")
+      _drop_constraint!(markers, class_name, el, "it declares no `fields=`")
+      continue
+    end
+    fields_inner = _balanced_group(kwargs["fields"])
+    if fields_inner === nothing
+      _drop_constraint!(markers, class_name, el, "its `fields=` is not a list or tuple literal")
+      continue
+    end
+
+    declared = _clean_constraint_field_names(split_field_options(fields_inner))
+    if isempty(declared)
+      _drop_constraint!(markers, class_name, el, "its `fields=` is empty")
+      continue
+    end
+    resolved = String[]
+    unknown = nothing
+    for name in declared
+      r = _resolve_django_constraint_field(name, fields_dict)
+      if r === nothing
+        unknown = name
+        break
+      end
+      push!(resolved, r)
+    end
+    if unknown !== nothing
+      _drop_constraint!(markers, class_name, el, "field '$(unknown)' matches no imported field")
+      continue
+    end
+
+    # Django requires `name=`; a computed one (an f-string, a call) is not a literal we can carry,
+    # so the constraint is imported with an auto-derived name rather than dropped — the index is
+    # what matters, its identifier is not.
+    cname = haskey(kwargs, "name") ? _meta_string_literal(kwargs["name"]) : nothing
+    if haskey(kwargs, "name") && cname === nothing
+      @warn "import: UniqueConstraint name is not a string literal; importing with a derived name" class=class_name value=kwargs["name"]
+    end
+    try
+      push!(out, Models.UniqueConstraint(fields = resolved, name = cname))
+    catch e
+      # A duplicate-field or empty-name rejection from the constructor: report THIS constraint and
+      # keep the rest, rather than losing every constraint on the model to one bad entry.
+      _drop_constraint!(markers, class_name, el, replace(sprint(showerror, e), "\n" => " "))
+    end
+  end
+  return out
+end
 
 # Return the text inside the FIRST balanced (...) or [...] group in `s` (Django allows tuples
 # or lists), or nothing. Quote-aware so a paren inside a string literal is ignored.
@@ -1061,18 +1834,28 @@ end
 
 # Split the inner text of a `unique_together` value into column groups. Handles both a flat
 # single group `('a','b')` and a tuple/list of groups `(('a','b'),('c','d'))`.
-function _parse_unique_together_groups(inner::AbstractString)::Vector{Vector{String}}
+#
+# `skipped` collects any token in a grouped list that is not itself a group — Django's
+# `(("a","b"), "c")` is malformed, and a bare `"c"` used to be `continue`d without a word.
+function _parse_unique_together_groups(inner::AbstractString,
+                                       skipped::Vector{String} = String[])::Vector{Vector{String}}
   tokens = split_field_options(inner)
   isempty(tokens) && return Vector{String}[]
   if any(t -> (st = strip(t); startswith(st, "(") || startswith(st, "[")), tokens)
     groups = Vector{String}[]
     for t in tokens
       st = strip(t)
-      (startswith(st, "(") || startswith(st, "[")) || continue
+      if !(startswith(st, "(") || startswith(st, "["))
+        isempty(st) || push!(skipped, String(st))
+        continue
+      end
       innerg = _balanced_group(st)
-      innerg === nothing && continue
+      if innerg === nothing
+        push!(skipped, String(st))
+        continue
+      end
       names = _clean_constraint_field_names(split_field_options(innerg))
-      isempty(names) || push!(groups, names)
+      isempty(names) ? push!(skipped, String(st)) : push!(groups, names)
     end
     return groups
   else
@@ -1092,29 +1875,50 @@ end
 # Build PormG UniqueConstraints from a class's `Meta.unique_together`, resolving each declared
 # Django field to its imported PormG field name. Unresolvable groups are warned and skipped
 # (lenient, matching the importer's philosophy) rather than aborting the whole import.
-function parse_meta_unique_together(meta_content, fields_dict::Dict{Symbol, Any}, class_name::AbstractString)
-  content = join((s isa PyStmt ? s.text : string(s) for s in meta_content), "\n")
-  occursin("unique_together", content) || return Models.UniqueConstraint[]
-  # `\b` anchors to a word boundary so a longer identifier ending in `unique_together`
-  # (e.g. `not_unique_together = ...`) is not mis-parsed as the Meta option.
-  m = match(r"\bunique_together\s*=\s*(.*)"s, content)
-  m === nothing && return Models.UniqueConstraint[]
-  inner = _balanced_group(m.captures[1])
-  inner === nothing && return Models.UniqueConstraint[]
+#
+# `raw` is the option's right-hand side, taken straight from `_parse_meta_options` (#341). It used
+# to be the Meta block's joined text, matched with `\bunique_together\s*=\s*(.*)`s — a regex whose
+# `\b` anchor was there only because there was no real parse to lean on.
+function parse_meta_unique_together(raw::AbstractString, fields_dict::Dict{Symbol, Any},
+                                    class_name::AbstractString,
+                                    markers::Vector{String} = String[])
+  inner = _balanced_group(raw)
+  if inner === nothing
+    # `unique_together = CHAVE_EXTERNA` — a name, not a literal. This used to return an empty vector
+    # and the composite key vanished without a word, while the SAME shape on `Meta.constraints` was
+    # reported. Same loss, same report.
+    @warn "import: Meta.unique_together is not a tuple or list literal; dropped" class=class_name value=_one_line(raw)
+    push!(markers, "# PormG: Meta.unique_together on '$(class_name)' is not a tuple or list " *
+                   "literal — dropped.")
+    return Models.UniqueConstraint[]
+  end
   constraints = Models.UniqueConstraint[]
-  for group in _parse_unique_together_groups(inner)
+  skipped = String[]
+  for group in _parse_unique_together_groups(inner, skipped)
     resolved = String[]
     ok = true
     for name in group
       r = _resolve_django_constraint_field(name, fields_dict)
       if r === nothing
         @warn "import: unique_together field matches no imported field; skipping constraint" field=name class=class_name
+        # Whitespace collapsed before interpolation, like every other marker: a field name can
+        # carry a real newline (a triple-quoted string survives `_py_logical_lines` intact), and a
+        # marker that spans two lines breaks the generated module outright. Verified: without this,
+        # `unique_together = ("""nao\nexiste""", "a")` produces a file that will not parse.
+        push!(markers, "# PormG: a unique_together group on '$(class_name)' was dropped — field " *
+                       "'$(_one_line(name))' matches no imported field: " *
+                       "($(_one_line(join(group, ", "))))")
         ok = false
         break
       end
       push!(resolved, r)
     end
     ok && !isempty(resolved) && push!(constraints, Models.UniqueConstraint(fields = resolved))
+  end
+  for s in skipped
+    @warn "import: unique_together entry is not a field group; dropped" class=class_name entry=s
+    push!(markers, "# PormG: a unique_together entry on '$(class_name)' is not a field group — " *
+                   "dropped: $(_one_line(s))")
   end
   return constraints
 end

--- a/test/unit/fixtures/django_models_meta_forms.txt
+++ b/test/unit/fixtures/django_models_meta_forms.txt
@@ -1,0 +1,352 @@
+from django import forms
+from django.db import models
+from django.db.models import CharField, Q, UniqueConstraint
+from django.db.models.functions import Lower
+from rest_framework import serializers
+
+# An abstract base living in ANOTHER app. Nothing in this file defines it, so `Relatorio` below
+# cannot merge its columns.
+from core.models import TimeStampedModel
+
+TABELA_LEGADO = "legado_" + "codigos"
+CHAVE_RESERVA = ("hospede",)
+
+
+class Source(models.TextChoices):
+    """A module-level enum. Not a table, and it must be skipped in SILENCE — a warning for every
+    QuerySet/Manager/enum in a real models.py buries the one finding that matters."""
+
+    UPLOAD = "UPLOAD", "Upload manual"
+    GSHEETS = "GSHEETS", "Google Sheets API"
+
+
+class Auditavel(models.Model):
+    """An abstract base: emits NO table of its own, and its two columns merge into every child.
+
+    Its `Meta` carries `unique_together`, which Django installs on a child that declares no Meta
+    at all — and only on such a child. Both halves are asserted below.
+    """
+
+    criado_em = models.DateTimeField(auto_now_add=True)
+    origem = models.CharField(max_length=8, default="base")
+
+    class Meta:
+        abstract = True
+        unique_together = ("criado_em", "origem")
+        # Django DOES inherit db_table onto a child that declares no Meta — which would point every
+        # child of this base at one table. Refused deliberately, and reported. Present here so the
+        # "not inherited" assertion has something that could fail.
+        db_table = "aud_base"
+
+
+class Matricula(Auditavel):
+    """Concrete child. `origem` is REDECLARED here, so the child's max_length=32 must win over the
+    base's max_length=8 — that is what proves the merge order rather than merely the merge.
+
+    It declares its own `Meta`, so Django does NOT install `Auditavel`'s: this model must come out
+    with no `unique_together` constraint at all.
+    """
+
+    numero = models.CharField(max_length=20)
+    origem = models.CharField(max_length=32, default="matricula")
+
+    class Meta:
+        db_table = "rh_matricula_legado"
+        ordering = ["numero"]
+
+
+class Ocorrencia(Auditavel):
+    """Concrete child with NO Meta of its own — so Django installs the abstract base's, and
+    `unique_together` reaches this table while it does not reach Matricula's."""
+
+    descricao = models.CharField(max_length=100)
+
+
+class Setor(models.Model):
+    nome = models.CharField(max_length=40)
+
+
+class Servidor(models.Model):
+    cpf = models.CharField(max_length=11)
+    lotacao = models.ForeignKey(Setor, on_delete=models.CASCADE)
+    ativo = models.BooleanField(default=True)
+    apelido = models.CharField(max_length=30)
+
+    class Meta:
+        constraints = [
+            # IMPORTED. `lotacao` resolves to the imported `lotacao_id` column.
+            models.UniqueConstraint(fields=["cpf", "lotacao"], name="uniq_servidor_cpf_lotacao"),
+            # REJECTED — a PARTIAL unique index. Imported unconditionally it would start rejecting
+            # rows the live database accepts, which is silent data loss on write.
+            models.UniqueConstraint(
+                fields=["apelido"], condition=Q(ativo=True), name="uniq_apelido_ativo"
+            ),
+            # REJECTED — an expression constraint. Django indexes lower(apelido); PormG would index
+            # apelido, which is a different index wearing the same name.
+            models.UniqueConstraint(Lower("apelido"), name="uniq_apelido_lower"),
+            # REJECTED — no PormG equivalent at all.
+            models.CheckConstraint(check=Q(cpf__regex=r"^\d{11}$"), name="chk_cpf_digitos"),
+        ]
+        indexes = [models.Index(fields=["apelido"])]
+
+
+class Venda(models.Model):
+    valor = models.IntegerField()
+
+
+class Pedido(Venda):
+    """Django multi-table inheritance. Django gives this its own table keyed by a `venda_ptr_id`
+    one-to-one to Venda; PormG cannot express that, so nothing is emitted. Venda itself still is."""
+
+    desconto = models.IntegerField()
+
+
+class ServidorAtivo(Servidor):
+    """A proxy: no table of its own. Its base is concrete, which is also the MTI shape — so this
+    doubles as the check that `proxy = True` is read BEFORE the inheritance kind is decided."""
+
+    class Meta:
+        proxy = True
+        ordering = ["cpf"]
+
+
+class Relatorio(TimeStampedModel):
+    """The base is imported from another app, so its columns cannot be merged. The model is still
+    emitted — dropping it is the vanishing-model bug — with a marker naming what is absent."""
+
+    titulo = models.CharField(max_length=80)
+
+
+class RelatorioForm(forms.ModelForm):
+    """An unresolvable base AND no `models.X(...)` in the body. That second half is what keeps
+    every form, serializer and manager subclass in a real models.py out of the schema."""
+
+    class Meta:
+        model = Relatorio
+        fields = ["titulo"]
+
+
+class ServidorSerializer(serializers.ModelSerializer):
+    """Unlike `RelatorioForm` above, a serializer DOES declare field-shaped members — so the field
+    gate alone would import it as a table. `Meta.model` is what keeps it out: it is the signature
+    of a class that describes a model, and Django's own ModelBase rejects the attribute on a real
+    model ("class Meta got invalid attribute(s): model")."""
+
+    apelido = serializers.CharField(max_length=30)
+
+    class Meta:
+        model = Servidor
+        fields = ["apelido"]
+
+
+class ServidorAdminForm(forms.ModelForm):
+    """A form carrying a genuine `models.` field — a copy-paste slip that happens in real code. The
+    namespace rule cannot help here, because the member really is a model field; `Meta.model` is the
+    only thing keeping this out of the schema. The two guards are not redundant."""
+
+    observacao = models.CharField(max_length=50)
+
+    class Meta:
+        model = Servidor
+        fields = ["observacao"]
+
+
+class ContatoForm(forms.Form):
+    """A PLAIN form — no `Meta.model` to exclude it, and its members are field-shaped. What keeps
+    it out is the NAMESPACE: `forms.CharField` differs from `models.CharField` by nothing else, and
+    accepting any field-shaped call put junk `id`-only tables into the schema."""
+
+    nome = forms.CharField(max_length=50)
+    email = forms.EmailField()
+
+
+class RelatorioSerializer(serializers.Serializer):
+    """A plain serializer — same shape as the plain form, different namespace."""
+
+    titulo = serializers.CharField(max_length=80)
+
+
+class Ausencia(models.Model, object):
+    """`object` must come LAST in a Python base list, so this is the only legal ordering — and it is
+    what a Python-2-era codebase writes. A recognised model root has to outrank the non-model base
+    list, or this whole model vanishes without a word."""
+
+    motivo = models.CharField(max_length=30)
+
+
+class Rastreavel(TimeStampedModel):
+    """An abstract base whose OWN base lives in another app. It emits nothing itself, so unless the
+    unresolved-base walk climbs the abstract chain, the columns missing from every child reach the
+    generated file with no marker anywhere."""
+
+    rastreio = models.CharField(max_length=20)
+
+    class Meta:
+        abstract = True
+
+
+class Encomenda(Rastreavel):
+    peso = models.IntegerField()
+
+
+class Duplicada(models.QuerySet):
+    """Helper first, real model second, under ONE name. Classification is memoized by name from the
+    first definition, so the second is never classified on its own — only its own field
+    declarations reveal that a table was lost here. Two helpers under one name lose nothing and
+    must stay silent; this shape must not."""
+
+    def ativos(self):
+        return self
+
+
+class Duplicada(models.Model):
+    ativo = models.BooleanField(default=True)
+
+
+class SoRuido(models.QuerySet):
+    def a(self):
+        return self
+
+
+class SoRuido(models.QuerySet):
+    """Two helpers under one name. Nothing reaches the schema either way, so a comment about a
+    QuerySet in a module that never mentions it would be pure noise."""
+
+    def b(self):
+        return self
+
+
+class SoDocstring(Auditavel):
+    """A child whose `Meta` block carries ONLY a docstring. It DECLARED a Meta, so Django does not
+    inherit the base's — which means no `unique_together` here, and no withheld-db_table marker.
+    Gating on the parsed options instead of on the block would inherit both."""
+
+    nota = models.CharField(max_length=10)
+
+    class Meta:
+        """Intentionally empty of options."""
+
+
+class Manager(models.Model):
+    """A user model whose NAME collides with the non-model base list. A Manager in an HR schema is
+    a person. Matching that list against the raw base list made this class invisible as a base, so
+    its children resolved no parent and were dropped in silence."""
+
+    nome = models.CharField(max_length=40)
+
+
+class SeniorManager(Manager):
+    bonus = models.IntegerField()
+
+
+class RaizConfig(models.Model):
+    """Three-level abstract chain. Django installs the NEAREST ancestor's Meta class, not a merge of
+    the chain — so only that one's withheld db_table concerns the child. Walking the whole chain
+    reported this grandparent's on a child that would never have inherited it."""
+
+    codigo = models.CharField(max_length=8)
+
+    class Meta:
+        abstract = True
+        db_table = "raiz_config"
+
+
+class MeioConfig(RaizConfig):
+    extra = models.CharField(max_length=8)
+
+    class Meta:
+        abstract = True
+        ordering = ["extra"]
+
+
+class FimConfig(MeioConfig):
+    valor = models.IntegerField()
+
+
+class ChaveQuebrada(models.Model):
+    """A field name carrying a REAL newline: a triple-quoted string survives statement folding
+    intact. Interpolated raw into a marker it yields a `#` comment spanning two lines and the
+    generated module stops parsing — so the "evaluates" testset is this class's guard."""
+
+    a = models.IntegerField()
+
+    class Meta:
+        unique_together = ("""nao
+existe""", "a")
+
+
+class ExportMixin:
+    """A plain (non-model) mixin — ordinary Django. It is not a table itself, and Django collects
+    fields only from bases that ARE models, so it contributes no columns either."""
+
+    def to_csv(self):
+        return ""
+
+
+class Lotacao(models.Model, ExportMixin):
+    """A recognised model root beside a base that is definitively not a model. Testing the
+    not-a-model base first dropped this whole model in SILENCE — the shape #341 exists to close."""
+
+    setor = models.CharField(max_length=40)
+
+
+class Frequencia(TimeStampedModel):
+    """Fields declared with a DIRECTLY IMPORTED type (`from django.db.models import CharField`),
+    under a base this file cannot resolve. Gating the model on the dotted `models.X(...)` spelling
+    alone made this vanish without a word, while #340's own warning path already recognises the
+    bare form."""
+
+    competencia = CharField(max_length=7)
+
+
+class Quarto(models.Model):
+    """The two `unique_together` shapes that used to be dropped without a word, kept asymmetric
+    with the `Meta.constraints` path that always reported them."""
+
+    andar = models.IntegerField()
+    numero = models.IntegerField()
+
+    class Meta:
+        unique_together = (("andar", "numero"), "nao_e_um_grupo")
+
+
+class Reserva(models.Model):
+    """`unique_together` as a NAME rather than a literal. The composite key cannot be recovered, and
+    it used to vanish without a word — while the very same shape on `Meta.constraints` was
+    reported. Same loss, same report."""
+
+    hospede = models.CharField(max_length=40)
+
+    class Meta:
+        unique_together = CHAVE_RESERVA
+
+
+class Diaria(models.Model):
+    """A `unique_together` member matching no imported field: warned before, but the generated file
+    said nothing, so a reader of the artifact saw a model with no composite key and no reason."""
+
+    valor = models.IntegerField()
+
+    class Meta:
+        unique_together = ("valor", "nao_existe_esse_campo")
+
+
+class Legado(models.Model):
+    """`db_table` computed rather than literal: applying it verbatim would point the declaration at
+    a table named after the expression's source text. Ignored, reported, model still imported."""
+
+    codigo = models.CharField(max_length=10)
+
+    class Meta:
+        db_table = TABELA_LEGADO
+        nao_existe_essa_opcao = True
+
+
+class Arquivado(models.Model):
+    """A TRIPLE-quoted db_table. It starts with a quote, so a naive literal check accepts it — and
+    the value comes back carrying two stray quote characters, naming a table no database has."""
+
+    ref = models.CharField(max_length=10)
+
+    class Meta:
+        db_table = """arq_legado"""

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -780,8 +780,514 @@ end
 
         # The import completed despite the warning.
         generated = read(joinpath(config_key, output_file), String)
-        @test !occursin("tags", generated)
+        # `tags` must not become a COLUMN. Since #341 the word does appear in the file — in a
+        # `# PormG:` marker naming the field — which is the point: the gap is recorded in the
+        # artifact, not only in a console warning that scrolls away. So assert the absence of the
+        # DECLARATION, which is what this test always meant, rather than the absence of the word.
+        @test !occursin("tags = Models.", generated)
+        @test occursin("# PormG: field 'tags' on 'ImportBatch'", generated)
         @test occursin("ImportBatch = Models.Model(", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: Meta.db_table pins the physical table (#341)
+# The importer read exactly ONE Meta option before this. A model declaring
+# `db_table` therefore generated a declaration addressing a table that does not
+# exist — the schema was wrong, and nothing said so.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer reads Meta.db_table" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_db_table_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The positional slot stays the LOGICAL name while `db_table` carries the physical one —
+        # the #59 split. Asserted as ONE string so a regression emitting only half fails here.
+        @test occursin(
+            "Matricula = Models.Model(\"matricula\", db_table = \"rh_matricula_legado\"",
+            generated,
+        )
+
+        # A model that declares no db_table must not acquire one.
+        @test !occursin("Setor = Models.Model(\"setor\", db_table", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a computed Meta.db_table is refused, not applied (#341)
+# `parse_value` returns anything it cannot classify verbatim, so applying the
+# option without a literal check would pin the table name to the expression's
+# own source text (`TABELA_LEGADO`). The model still imports.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer refuses a non-literal Meta.db_table" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_db_table_computed_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The expression's source text must never reach a `db_table=` kwarg, quoted or bare.
+        @test !occursin("db_table = \"TABELA_LEGADO\"", generated)
+        @test !occursin("db_table = TABELA_LEGADO", generated)
+
+        # ...and the model is still imported, under its derived name, with the reason stated.
+        @test occursin("Legado = Models.Model(\"legado\"", generated)
+        @test occursin("# PormG: Meta.db_table on 'Legado' is not a string literal", generated)
+
+        # A TRIPLE-quoted literal is the case a naive "starts with a quote" test lets through:
+        # `parse_value` strips one character per side, so the value keeps two stray quotes.
+        @test !occursin("arq_legado", generated)
+        @test occursin("# PormG: Meta.db_table on 'Arquivado' is not a string literal", generated)
+        @test occursin("Arquivado = Models.Model(\"arquivado\"", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: Meta.constraints, accepted by whitelist (#341)
+# The modern Django spelling of composite uniqueness. Argument acceptance is a
+# whitelist rather than a blacklist because the failure direction is asymmetric:
+# a `condition=` partial index imported as an unconditional one starts silently
+# rejecting rows the live database accepts.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer converts Meta.constraints and rejects what it cannot express" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_constraints_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The plain constraint is imported with its Django name, and `lotacao` is resolved to the
+        # imported `lotacao_id` column — FK fields gain that suffix at import.
+        @test occursin(
+            "constraints = [Models.UniqueConstraint(fields = (\"cpf\", \"lotacao_id\",), " *
+            "name = \"uniq_servidor_cpf_lotacao\")]",
+            generated,
+        )
+
+        # The rejected forms never become constraints. `apelido` is the column all three of them
+        # cover, so a single-field UniqueConstraint over it is the signature of any leaking through.
+        @test !occursin("Models.UniqueConstraint(fields = (\"apelido\",)", generated)
+
+        # ...and each rejection says which argument it could not express.
+        @test occursin("`condition=` changes what the index means", generated)
+        @test occursin("it takes a positional expression", generated)
+        @test occursin("CheckConstraint has no PormG equivalent", generated)
+
+        # Rejection is PER CONSTRAINT. Three dropped and the fourth kept, on one model — the
+        # assertion above proves the survivor, this one proves the other three did not take it with
+        # them, which is exactly what the coarse try/catch this replaces used to do.
+        # Scoped to Servidor's own markers: other models in the fixture report dropped
+        # `unique_together` groups with the same wording, and a file-wide count would silently
+        # stop measuring this model the moment one of those changed.
+        @test count("a constraint on 'Servidor' was dropped", generated) == 3
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: abstract bases merge into their children (#341)
+# `class Matricula(Auditavel):` matched neither literal base list before this, so
+# the model was not imported at all and nothing said so. The base itself must
+# emit no table — Django never created one for it.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer merges abstract base fields into concrete children" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_abstract_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The abstract base emits no TABLE. It is named in the file — in the marker explaining that
+        # its `db_table` is not inherited — so the assertion is on the declaration, not the word.
+        @test !occursin("Auditavel = Models.Model(", generated)
+        @test !occursin("Models.Model(\"auditavel\"", generated)
+
+        # Its columns reach EVERY child — Matricula, Ocorrencia and SoDocstring. A count rather than
+        # three `occursin`s, so a merge that fires for only some of them fails here.
+        @test count("criado_em = Models.DateTimeField(auto_now_add=true)", generated) == 3
+
+        # The CHILD's redeclaration wins. This pair proves merge ORDER, not merely that a merge
+        # happened: Matricula redeclares `origem` at max_length=32 over the base's 8, Ocorrencia
+        # does not redeclare it and keeps 8. Reversing the concatenation order flips both.
+        @test occursin("origem = Models.CharField(max_length=32, default=\"matricula\")", generated)
+        @test occursin("origem = Models.CharField(max_length=8, default=\"base\")", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: an abstract base's Meta reaches only a child with no Meta
+# Django installs an abstract base's Meta on a child that declares none of its
+# own. Both halves matter, so the fixture pairs a child that declares Meta with
+# one that does not, and the same `unique_together` must reach exactly one.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer inherits an abstract base's Meta only when the child declares none" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_inherit_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # Ocorrencia declares no Meta, so the base's unique_together applies to it...
+        @test occursin(
+            "constraints = [Models.UniqueConstraint(fields = (\"criado_em\", \"origem\",))]",
+            generated,
+        )
+        # ...exactly once. Matricula declares its own Meta, so Django does NOT install the base's.
+        # The count is what discriminates "inherited by the right child" from "inherited by all".
+        @test count("UniqueConstraint(fields = (\"criado_em\", \"origem\",))", generated) == 1
+
+        # `db_table` is deliberately NOT inherited even though Django inherits it: otherwise every
+        # child of one abstract base would point at a single table. `Auditavel` declares
+        # `db_table = "aud_base"` precisely so this assertion has something that could fail —
+        # without it on the base, no implementation could ever put one on the child.
+        @test !occursin("Ocorrencia = Models.Model(\"ocorrencia\", db_table", generated)
+        @test !occursin("aud_base", generated)
+        # ...and the refusal is REPORTED, not silent — otherwise a reader sees a model addressing a
+        # different table from the one Django would have given it, with nothing to explain why.
+        @test occursin("abstract base 'Auditavel' declares Meta.db_table — NOT inherited", generated)
+
+        # ...and it is reported for exactly the base Django would have inherited from, not for every
+        # ancestor. In the three-level chain RaizConfig -> MeioConfig -> FimConfig, `FimConfig`
+        # inherits `MeioConfig`'s Meta (the nearest with a Meta block), which declares no db_table —
+        # so `RaizConfig`'s must NOT be reported against it, and `MeioConfig`'s ordering must be.
+        @test !occursin("abstract base 'RaizConfig' declares Meta.db_table", generated)
+        @test occursin("Meta.ordering on 'FimConfig'", generated)
+        @test occursin("FimConfig = Models.Model(\"fimconfig\"", generated)
+
+        # A `class Meta:` carrying ONLY a docstring is still a declaration, so Django inherits
+        # nothing past it. Gating on the parsed OPTIONS instead of on the block would hand
+        # `SoDocstring` the base's unique_together and the withheld-db_table marker; gating on the
+        # block — which is what the code does — gives it neither.
+        # The `== 1` count above already covers the constraint half: SoDocstring is a third child of
+        # Auditavel, so inheriting past its docstring-only Meta would make it 2.
+        @test occursin("SoDocstring = Models.Model(\"sodocstring\"", generated)
+        @test !occursin("abstract base 'Auditavel' declares Meta.db_table — NOT inherited by 'SoDocstring'", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: multi-table inheritance and proxies emit no table (#341)
+# Django gives an MTI child its own table keyed by a `<parent>_ptr_id` one-to-one;
+# a proxy gets no table at all. PormG can express neither, and any table emitted
+# for them would contradict the live schema — so the omission is recorded in the
+# generated file rather than left to a console warning nobody re-reads.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer refuses multi-table inheritance and proxy models" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_mti_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # Neither child is declared...
+        @test !occursin("Pedido = Models.Model(", generated)
+        @test !occursin("ServidorAtivo = Models.Model(", generated)
+        # ...nor do the MTI child's own fields leak into any other model.
+        @test !occursin("desconto", generated)
+
+        # The parents still import — refusing the child must not cost the parent.
+        @test occursin("Venda = Models.Model(\"venda\"", generated)
+        @test occursin("Servidor = Models.Model(\"servidor\"", generated)
+
+        # The generated file states each omission and its reason. ServidorAtivo doubles as the
+        # check that `proxy = True` is read BEFORE the inheritance kind is decided: its base is
+        # concrete, which is otherwise exactly the multi-table-inheritance shape.
+        @test occursin("# PormG: model 'Pedido' inherits the concrete model 'Venda'", generated)
+        @test occursin("# PormG: model 'ServidorAtivo' is a Django proxy", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: an unresolvable base degrades, it does not delete (#341)
+# A base living in another app cannot be merged from one file. Skipping the model
+# would re-create the exact bug this issue closes, so it is imported with its own
+# fields and a marker naming what is absent. #346 resolves these by importing the
+# defining app alongside this one.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer imports a model whose base is defined in another file" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_unresolved_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        @test occursin("Relatorio = Models.Model(\"relatorio\"", generated)
+        @test occursin("titulo = Models.CharField(max_length=80)", generated)
+        @test occursin("# PormG: model 'Relatorio' inherits 'TimeStampedModel'", generated)
+
+        # The other half of the rule: an unresolvable base with NO field declarations in the body
+        # is a form/serializer/manager, not a model. Without that gate every such class in a real
+        # models.py would import as a table.
+        @test !occursin("RelatorioForm", generated)
+
+        # A ModelSerializer does declare field-shaped members, so the field gate alone lets it
+        # through. `Meta.model` is what keeps it out — the signature of a class that describes a
+        # model, which Django's ModelBase rejects on a real one.
+        @test !occursin("ServidorSerializer", generated)
+
+        # A PLAIN form and a PLAIN serializer have no `Meta.model` at all, so that rule cannot help
+        # here — the NAMESPACE does. `forms.CharField` and `models.CharField` differ by nothing
+        # else, and accepting any field-shaped call turned both of these into `id`-only tables that
+        # would reach makemigrations as real CREATE TABLEs. Silent junk in the schema is the mirror
+        # of silent loss, and the worse of the two.
+        @test !occursin("ContatoForm", generated)
+        @test !occursin("RelatorioSerializer", generated)
+
+        # ...and the two guards are not redundant. `ServidorAdminForm` carries a genuine
+        # `models.CharField(...)`, so the namespace rule sees a real model field and cannot help —
+        # `Meta.model` is the only thing keeping the form out of the schema.
+        @test !occursin("ServidorAdminForm", generated)
+
+        # The unresolved-base walk climbs the ABSTRACT chain. `Encomenda` inherits the abstract
+        # `Rastreavel`, whose own base is the one missing — and `Rastreavel` emits nothing, so
+        # without the walk its gap would reach the file with no marker anywhere.
+        @test occursin("Encomenda = Models.Model(\"encomenda\"", generated)
+        @test occursin("rastreio = Models.CharField(max_length=20)", generated)
+        @test occursin("# PormG: model 'Encomenda' inherits 'TimeStampedModel'", generated)
+
+        # A module-level enum is skipped in silence. Note this is carried by the field gate above,
+        # not by `_NON_MODEL_BASES` — a TextChoices declares no field-shaped members either way.
+        # The blacklist's own coverage comes from `PlainHelper(object)`, which DOES declare a field.
+        @test !occursin("Source = Models.Model(", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a plain mixin beside a model root does not delete the model
+# `class Servidor(models.Model, ExportMixin)` is ordinary Django. Classifying on
+# the non-model base first dropped the whole model in SILENCE — the very shape
+# #341 exists to close, and one the code's own comments claimed to support.
+# Django collects fields only from bases that are themselves models, so the
+# mixin correctly contributes no columns.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer keeps a model that mixes a model root with a plain mixin" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_mixin_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        @test occursin("Lotacao = Models.Model(\"lotacao\"", generated)
+        @test occursin("setor = Models.CharField(max_length=40)", generated)
+
+        # ...and the same for a BLACKLISTED base rather than an in-file helper. `object` must come
+        # last in a Python base list, so `class Ausencia(models.Model, object)` is the only legal
+        # ordering — and it is asserted separately because the two exclusions are separate flags:
+        # fixing one and leaving the other still deletes the model in silence.
+        @test occursin("Ausencia = Models.Model(\"ausencia\"", generated)
+        @test occursin("motivo = Models.CharField(max_length=30)", generated)
+
+        # The mixin itself is not a table, and contributes nothing — matching Django, which only
+        # collects fields from bases that carry `_meta`.
+        @test !occursin("ExportMixin = Models.Model(", generated)
+        @test !occursin("to_csv", generated)
+
+        # A class this file DEFINES outranks the non-model name list. `Manager` is a perfectly good
+        # model name — in an HR schema a manager is a person — and matching that list against the
+        # raw base list made the class invisible as a base, so `SeniorManager` resolved no parent
+        # and was dropped in silence. It is multi-table inheritance, and must be reported as such.
+        @test occursin("Manager = Models.Model(\"manager\"", generated)
+        @test occursin("# PormG: model 'SeniorManager' inherits the concrete model 'Manager'", generated)
+
+        # A duplicated class name is pathological Python, and reporting it is conditional on what is
+        # actually at stake. Helper-first / model-second loses a TABLE — and classification is
+        # memoized by name from the first definition, so only the duplicate's own field declarations
+        # reveal it.
+        @test occursin("# PormG: 'Duplicada' is declared more than once", generated)
+        # ...while two helpers under one name lose nothing that reaches the schema, so a comment
+        # about a QuerySet in a module that never mentions it would be pure noise.
+        @test !occursin("SoRuido", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a directly-imported field type still counts as a field (#341)
+# `from django.db.models import CharField` then `titulo = CharField(...)` is
+# ordinary Django. Gating "is this a model?" on the dotted `models.X(...)`
+# spelling alone made such a class vanish with no warning — while #340's own
+# reporter already recognised the bare form. The gate and the reporter must
+# agree, or the gate wins and the model disappears.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer recognises a directly-imported field type" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_bare_field_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The model survives...
+        @test occursin("Frequencia = Models.Model(\"frequencia\"", generated)
+        # ...and the field it could not read is named in the file, not merely warned about.
+        @test occursin("field 'competencia' on 'Frequencia'", generated)
+        @test occursin("is a field-shaped call the importer cannot read", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: unique_together loses nothing in silence (#341)
+# Three paths used to drop a composite key with neither a warn nor a marker,
+# while the SAME shapes on `Meta.constraints` were always reported. The
+# asymmetry is the bug: a reader of the generated file could not tell a model
+# with no composite key from one whose key was thrown away.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer reports every unique_together it cannot recover" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_meta_ut_reported_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # (a) the value is a NAME, not a literal — nothing to parse.
+        @test occursin("Meta.unique_together on 'Reserva' is not a tuple or list literal", generated)
+        # (b) a member matches no imported field.
+        @test occursin("field 'nao_existe_esse_campo' matches no imported field", generated)
+        # (c) an entry in a grouped list is not itself a group...
+        @test occursin("a unique_together entry on 'Quarto' is not a field group", generated)
+        # ...and the well-formed group beside it still survives, so (c) is a targeted drop rather
+        # than the whole option being abandoned.
+        @test occursin("Models.UniqueConstraint(fields = (\"andar\", \"numero\",))", generated)
+
+        # All three models are still imported — reporting is not refusing.
+        @test occursin("Reserva = Models.Model(\"reserva\"", generated)
+        @test occursin("Diaria = Models.Model(\"diaria\"", generated)
+        @test occursin("Quarto = Models.Model(\"quarto\"", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: Meta options with no PormG equivalent are reported (#341)
+# Every option the importer cannot honor is named in the generated file with its
+# reason. A dropped option that only ever appeared in a console warning is the
+# silent loss this issue exists to remove — one level up from #340's fields.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer reports Meta options it cannot honor" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    config_key, db_dir_existed = temp_import_config!()
+    output_file = "django_meta_dropped_options_unit.jl"
+
+    try
+        # The option name is STRUCTURED metadata on the warning, not text inside the message, so a
+        # message-only matcher would silently stop discriminating.
+        logs, _ = Test.collect_test_logs() do
+            import_models_from_django(
+                fixture; db = config_key, file = output_file, force_replace = true,
+            )
+        end
+        dropped = [get(Dict(r.kwargs), :option, nothing) for r in logs
+                   if r.level == Logging.Warn && occursin("Meta option", string(r.message))]
+
+        @test "indexes" in dropped
+        @test "ordering" in dropped
+        # An UNRECOGNISED key is reported too: it is a typo or a Django option this importer has
+        # not met, and passing over either quietly is how a real option gets lost.
+        @test "nao_existe_essa_opcao" in dropped
+
+        # Options the importer consumes itself are never reported as dropped. Asserted one by one
+        # because a blanket "report everything" regression passes the three assertions above.
+        @test !("db_table" in dropped)
+        @test !("abstract" in dropped)
+        @test !("constraints" in dropped)
+        @test !("unique_together" in dropped)
+        @test !("proxy" in dropped)
+
+        generated = read(joinpath(config_key, output_file), String)
+        @test occursin("# PormG: Meta.indexes on 'Servidor' — dropped: PormG has no composite-index", generated)
+        @test occursin("# PormG: Meta.nao_existe_essa_opcao on 'Legado' is not recognised", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: the generated Meta output is loadable Julia (#341)
+# Everything above is downstream of this. `db_table=` and `constraints=` are
+# emitted as kwargs on Models.Model, and `_apply_unique_constraints!` rejects a
+# constraint naming a field the model does not carry — so a file that renders but
+# does not evaluate is the failure that actually reaches a user.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer emits a Meta-carrying module that evaluates" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_meta_forms.txt")
+    output_file = "django_meta_evaluates_unit.jl"
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = output_file,
+    )
+
+    try
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(read(generated_path, String)))
+        # Each binding is read back through `Core.eval` rather than `getfield`: the module was
+        # defined during this call, so its bindings are newer than this frame's world age and a
+        # direct `getfield` raises UndefVarError.
+        modelof(sym) = Core.eval(sandbox, :(django_meta_evaluates_unit.$sym))
+
+        # `db_table` survives the round trip as the PHYSICAL table while the logical name stays
+        # lowercase. Reloading is where a wrong kwarg actually bites — rendering it is not enough.
+        matricula = modelof(:Matricula)
+        @test PormG.model_table_name(matricula) == "rh_matricula_legado"
+        @test matricula.name == "matricula"
+
+        # ...and so do the constraints, including the FK `_id` resolution and the Django name.
+        rc = modelof(:Servidor).cache["unique_constraints"]["constraints"]
+        @test length(rc) == 1
+        @test rc[1].fields == ["cpf", "lotacao_id"]
+        @test rc[1].name == "uniq_servidor_cpf_lotacao"
+
+        # A model declaring no db_table must not have acquired one on the way through.
+        @test !PormG.model_has_db_table(modelof(:Setor))
     finally
         cleanup_import_test!(config_key, db_dir_existed)
     end


### PR DESCRIPTION
Closes #341.

Second of the arc that ends in multi-app Django import (#346), on top of #340's statement-aware scanner. #342 (TextChoices) needs the `Meta` and inheritance structure this adds.

## The bug

The importer read exactly **one** `class Meta:` option — the legacy `unique_together` — and decided whether a class became a table by comparing its **entire base list** against two literals. Three silent losses:

```python
class Matricula(models.Model):
    class Meta:
        db_table = "rh_matricula_legado"   # ignored → the generated model addressed a
                                           #   table that does not exist

class Pedido(TimeStampedModel):            # matched neither literal → the whole model
    ...                                    #   was not imported, with no warning
```

...and `Meta.constraints`, the modern spelling of composite uniqueness, was dropped outright. A class with `abstract = True` still got a table Django never created.

## The change

Base lists are **resolved against the file** rather than string-matched. An abstract base contributes its fields to its children and emits nothing itself; a proxy emits nothing; multi-table inheritance is refused; and a base this file does not define still imports the model, with a marker naming what is missing. `class Meta:` is read into an option table, so `db_table` and `constraints` are honored and every option that is not is **reported**.

**Nothing is dropped in silence.** Each skip, degrade and unsupported option emits a `@warn` **and** a `# PormG:` comment in the generated file — the #70 convention, because a console warning scrolls away and the file is what someone reads six months later.

```julia
# PormG: Meta.indexes on 'Servidor' — dropped: PormG has no composite-index primitive.
# PormG: a constraint on 'Servidor' was dropped — `condition=` changes what the index means
#   and PormG cannot express it: models.UniqueConstraint(fields=["apelido"], condition=…)
Servidor = Models.Model("servidor", db_table = "rh_servidor",
  …
  constraints = [Models.UniqueConstraint(fields = ("cpf", "lotacao_id",), name = "uniq_servidor_cpf_lotacao")])
```

## Decisions worth stating

**`Meta.constraints` acceptance is a whitelist** (`fields`, `name`, `violation_error_*`). `Models.UniqueConstraint` is exactly `(fields, name)`, so a Django *partial* index (`condition=Q(active=True)`) imported as an unconditional one would start silently rejecting rows the live database accepts. Rejecting an option is recoverable; reinterpreting one is not. Each constraint is judged on its own, so one rejected entry never takes its siblings with it.

**Multi-table inheritance is refused, not approximated.** Django keys the child table on a `<parent>_ptr_id` one-to-one. Merging the parent's fields duplicates its columns; omitting them loses the primary key. Both put a schema on disk that contradicts the database, so the child is skipped and the file records why. The parent still imports.

**An unresolvable base degrades, it does not delete.** A base in another app can't be merged from one file, so the model is imported with its own fields and a marker. Dropping it would be the vanishing-model bug this issue exists to close. #346 resolves these by importing the defining app alongside.

**Deciding "is this a model?" needs two guards that cannot be collapsed into one:**

- A class declaring `Meta.model` is never a model — Django's own `ModelBase` raises on the attribute, and it is the ModelForm/ModelSerializer/FilterSet signature.
- A field counts only when called through a **model namespace**: `models.CharField`, `django.db.models.CharField`, or a bare imported `CharField`. `forms.CharField` and `serializers.CharField` do not. Without this, a plain `forms.Form` and a DRF `serializers.Serializer` imported as `id`-only tables that would reach `makemigrations` as real `CREATE TABLE`s.

**A definition in the file always outranks the non-model name list.** `Manager` and `Choices` are perfectly good model names — in an HR schema a manager is a person — and dismissing such a base by *name* made the class invisible as an ancestor, so its children were dropped with its columns.

## Also in scope, because the change reached them

- **Meta inheritance** follows Django's rule minus one footgun: a child declaring no `Meta` block inherits its abstract base's whole `Meta`, except `abstract` (Django resets it) and `db_table` — Django inherits that one, and the result is every child of a base pointing at a single table. The refusal is reported per child.
- **`unique_together` no longer loses a composite key in silence.** A non-literal value, an unresolvable member and a non-group entry are each reported — matching what the `constraints` path always did. The asymmetry was the bug.
- **A field-shaped call the importer cannot read** now emits a marker as well as a warn, so the gap is visible in the artifact rather than only in the console.
- **Text interpolated into a marker is collapsed to one line.** A field name inside a triple-quoted string keeps its newline, and a two-line `#` comment breaks the entire generated module.
- **A class name declared twice** reports only when a table is actually at stake — helper-then-model loses one, helper-then-helper loses nothing.

## Verification

- 31 importer testsets (21 pre-existing, all still passing, + 10 new); full unit suite **6070/6070**; docs build clean.
- **Mutation-tested: 37 mutations**, each reverting one behavior individually, all killed by the assertion written for it or shown equivalent. This found a real defect the green suite walked past — a duplicated, unreachable `elseif ci.proxy` branch — and twice caught me shipping two guards for one outcome, where one is untestable by construction.
- **Four independent review rounds, 23 findings (10 → 7 → 5 → 1), all resolved.** Rounds 2 and 3 found that earlier fixes had introduced new defects, including one input that produced a generated file which would not parse, and two that deleted models silently — the same failure mode this issue exists to close. Every confirmed finding was reproduced before being fixed.

## Deliberately not done

- **No `UPGRADING.md` entry.** Nothing that worked before stops working, existing generated files are untouched, and regeneration is opt-in — a fix to something already broken is additive by the rule in `UPGRADING.md` itself.
- **`titulo = CharField(...)` imports the model but reports the field** rather than converting it. Widening `_FIELD_CALL_RE` past `models.X(` risks matching `serializers.CharField`; that belongs in its own issue.
- **An aliased import** (`from django.db import models as db_models`) is not recognised by the namespace rule. Documented; it only bites a class that *also* has an unresolvable base and no plainly-spelled field.
- **`TextChoices` / `IntegerChoices`** — #342. `PyClass.nested` is still the seam that consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
