### PR TITLE
fix(#342): resolve Django TextChoices instead of aborting the import

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -150,7 +150,7 @@ Django parameters are automatically converted to PormG equivalents:
 | `unique=True` | `unique=true` | Boolean conversion |
 | `default=value` | `default=value` | Value conversion |
 | `on_delete=CASCADE` | `on_delete=CASCADE` | Direct mapping |
-| `choices=[]` | `choices=()` | List to tuple conversion |
+| `choices=[…]` | `choices=(…)` | List to tuple; also resolves `TextChoices`/`IntegerChoices` — see [Choices](#Choices) |
 
 ### Meta Options
 
@@ -264,40 +264,85 @@ Relatorio = Models.Model("relatorio",
 Dropping the model instead would be the worse trade: a table that silently disappears is harder to
 notice than one that is present and annotated.
 
-### ⚠️ Important: CharField with Choices Syntax
+### Choices
 
-When using `CharField` with choices, PormG requires the choices to be defined **inline** for proper parsing. External variables are not supported.
+Both Django spellings are imported: an inline literal, and a `TextChoices` / `IntegerChoices`
+enumeration.
 
 ```python
-# ✅ CORRECT - Use this pattern:
-user_type = models.CharField(
-    default=3,
-    choices=((1,"Type 1"),(2,"Type 2"),(3,"Type 3"),(4,"Type 4"),(5,"Type 5")),
-    max_length=10
-)
+class ImportBatch(models.Model):
+    class Status(models.TextChoices):
+        DRAFT = "DRAFT", "Em processamento"
+        APPLIED = "APPLIED", "Aplicado"
+        IN_PROGRESS = "IN_PROGRESS"          # label derived: "In Progress"
 
-# ❌ INCORRECT - Don't use this pattern:
-user_type_data=((1,"Type 1"),(2,"Type 2"),(3,"Type 3"),(4,"Type 4"),(5,"Type 5"))
-user_type = models.CharField(
-    max_length=10,
-    choices=user_type_data
-)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
+    canal  = models.CharField(max_length=2, choices=(("UP", "Upload"), ("GS", "Sheets")))
 ```
 
-**Key Requirements:**
-- **Inline definition**: Define choices directly in the field, not as external variables
-- **Either outer bracket**: The choices *container* may be a list `[...]` or a tuple `(...)`. Before
-  the importer read Python source with a bracket-aware scanner, a list silently kept only its
-  *first* choice — the argument splitter counted parentheses only, so it split at the comma between
-  two bracketed pairs.
-- **Parenthesized pairs**: Each choice must be a `(value, display_name)` tuple. The *inner* bracket
-  is **not** free: `choices=[["A", "Alpha"]]` is valid Django but imports as an empty `choices=()`,
-  with no warning. Write `choices=[("A", "Alpha")]`.
-- **Parameter order**: Place `default` before `choices` for better parsing reliability
+imports as (fields are emitted in sorted order, so `canal` precedes `status`):
+
+```julia
+ImportBatch = Models.Model("importbatch",
+  id = Models.IDField(),
+  canal = Models.CharField(max_length=2, choices=(("UP", "Upload"), ("GS", "Sheets"))),
+  status = Models.CharField(max_length=20, default="DRAFT", choices=(("DRAFT", "Em processamento"), ("APPLIED", "Aplicado"), ("IN_PROGRESS", "In Progress"))))
+```
+
+**Enumerations.** An enum is found whether it is nested inside the model, declared at module level,
+or declared on an **abstract base** the model inherits. Lookup is scoped in that order, so two models
+may each nest a `Status` with different members and each resolves to its own. A nested enum can also
+be addressed through its owner (`ImportBatch.Status.choices`), as Django allows.
+
+| Reference | Result |
+|---|---|
+| `Status.choices` | the full `(value, label)` set |
+| `Status.MEMBER` | that member's value — typically what `default=` uses |
+| `Status.values` / `.labels` / `.names` | dropped and reported: a flat list, not `(value, label)` pairs |
+| a member the enum does not declare | dropped and reported |
+| an enum whose members are not literals (`CARRO = auto()`) | dropped and reported — the importer cannot know the value, and keeping `"auto()"` would give every member the same one |
+| a numeric member (`ALTO = 1_000`, `MEIO = 0x1F`) | imported as the value it **denotes** — `1000`, `31` — not as the source spelling, which would declare an enumeration no row can match |
+| a name this file does not define (`from .enums import Status`) | the option naming it is dropped and reported |
+
+That last row is per option, not per field: if `choices=Status.choices` resolves and only
+`default=Externo.ATIVO` does not, the field keeps its enumeration and loses just the default.
+Dropping the resolvable half as well would throw away what the source did give you. The reason
+neither is ever passed through as a literal is that `default="Externo.ATIVO"` against an empty
+`choices` is exactly what used to make `CharField` reject the field and abort the **entire** import.
+
+A member's own attributes work too: `Status.NOVO.value` resolves to the stored value, while
+`.label` and `.name` are display text and the member name rather than a value, so they are dropped
+and reported.
+
+The same rule catches a dotted name that is not an enum at all — a module constant such as
+`default=constants.MAX_QTD` — so the diagnostic says "this file does not define" rather than naming
+an enumeration it cannot verify. The test is the attribute's *shape*: `.choices`, `.values`,
+`.labels`, `.names`, `.value`, `.label`, `.name`, or a `SHOUTY_CASE` member. Any other dotted
+`default` (`uuid.uuid4`, `timezone.now`, an unconventionally-spelled `Externo.ativo`) is **kept
+verbatim as text**, exactly as before — and reported, because an expression landing in the schema as
+a literal default is not something to discover later.
+
+A `choices` naming a module-level constant (`choices=STATUS_CHOICES`) has nothing to read: the
+option is dropped and reported rather than becoming an empty enumeration.
+
+**`choices` needs a `CharField`.** It is the only PormG field type with a `choices` slot, so a Django
+`TextField(choices=…)` imports as a plain `TextField` with the option dropped and reported. The column
+is unaffected.
+
+!!! note "Values carry no quote characters"
+    An inline `("UP", "Upload")` imports as the value `UP`. Before this, it was stored as the
+    four-character string `"UP"` — the quote marks kept as part of the value. `choices` is Julia-side
+    metadata that never reaches DDL, so nothing downstream misbehaved, but regenerating an existing
+    import now produces the clean form.
+
+**Both containers, both pair styles.** `choices` may be a tuple or a list, and so may each pair —
+`[["A", "Alpha"]]` imports correctly. A comma inside a *label* (`("APPLIED", "Aplicado, com
+ressalvas")`) is content, not a separator. An entry that is not a `(value, label)` pair at all is
+dropped and reported, and the well-formed entries beside it survive.
 
 The field itself may be wrapped across several lines — that is what `black` produces, and it is read
-correctly. Note that a field whose declaration the importer cannot read is reported with a warning
-naming the field and its source line; it is never dropped silently.
+correctly. A field whose declaration the importer cannot read is reported with a warning naming the
+field and its source line; it is never dropped silently.
 
 ### Automatic Additions
 
@@ -319,8 +364,8 @@ naming the field and its source line; it is never dropped silently.
 
 | | |
 |---|---|
-| **Imported** | Fields (including definitions wrapped across lines), `ForeignKey` / `OneToOneField` / `ManyToManyField`, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints` (see the whitelist above), abstract-base inheritance, `AbstractUser` auth columns |
-| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import |
+| **Imported** | Fields (including definitions wrapped across lines), `ForeignKey` / `OneToOneField` / `ManyToManyField`, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints` (see the whitelist above), abstract-base inheritance, `AbstractUser` auth columns, `TextChoices` / `IntegerChoices` enumerations |
+| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them |
 | **Reported and skipped** | `Meta.indexes` and every other option with no PormG equivalent; a `UniqueConstraint` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`) |
 | **Not supported** | Field types PormG does not implement — these raise, naming the field and class, rather than importing something wrong. Model methods, managers, signals and validators are Python and have no PormG counterpart |
 
@@ -328,9 +373,6 @@ Nothing in the middle two rows is dropped in silence: each one produces a `@warn
 a `# PormG:` comment in the generated file. That is the contract this importer holds itself to — if
 something did not survive, the artifact says so.
 
-!!! note "`choices` as a list of lists"
-    `choices=[["A", "Alpha"]]` is valid Django but imports as an empty `choices=()`, with no warning.
-    Write the inner pair as a tuple: `choices=[("A", "Alpha")]`.
 
 ## API Naming Differences from Django
 

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -730,7 +730,7 @@ function import_models_from_django(
     has_primary_key = Ref(false)  # Flag to check if a primary key exists
 
     # Process fields separately
-    process_class_fields!(fields_dict, class_content, class_name, _inherits_auth_user(graph, class), has_primary_key, autofields_ignore, parameters_ignore, markers)
+    process_class_fields!(fields_dict, class_content, class_name, _inherits_auth_user(graph, class), has_primary_key, autofields_ignore, parameters_ignore, markers, graph.enums, _enum_scopes(graph, class))
 
     # Insert IDField if no primary key is defined
     if !has_primary_key[]
@@ -1079,7 +1079,246 @@ function _django_class_graph(model_py_string::AbstractString)
   for c in classes
     _classify_class!(info, index, visiting, c)
   end
-  return (classes = classes, index = index, info = info)
+  return (classes = classes, index = index, info = info, enums = _collect_enums(classes))
+end
+
+# ── Django `TextChoices` / `IntegerChoices` (#342) ───────────────────────────────────────────────
+# `choices=Status.choices` used to parse to the literal STRING "Status.choices", and
+# `default=Status.DRAFT` to "Status.DRAFT". CharField then validated the default against the choices
+# and threw FieldValidationError, which propagated out of `process_class_fields!` and killed the
+# ENTIRE import — every other model in the file lost, output a stack trace.
+#
+# The enum classes were already being parsed: #340 put a nested `class Status(models.TextChoices)`
+# into `PyClass.nested`, and `_lift_meta!` only ever removes `Meta`. This is the seam that consumes
+# them.
+
+# Bases that make a class a Django enumeration. Kept separate from `_NON_MODEL_BASES` — that list
+# says "not a table", this one says "a symbol table entry" — but every entry here is also on it, so
+# an enum is still never emitted as a model.
+const _CHOICES_BASES = ("models.TextChoices", "TextChoices",
+                        "models.IntegerChoices", "IntegerChoices",
+                        "models.Choices", "Choices")
+
+"""
+    _PyEnum
+
+One Django enumeration recovered from source: its `name` and its `members` as
+`(MEMBER, value, label)`.
+
+`value` is kept as the raw source text rather than parsed here, so the consumer can both test it
+(`_is_py_literal`) and convert it (`parse_value`) — an `IntegerChoices` member stays `1` until
+something asks for it. `label` is derived Django-style when omitted.
+
+Text and Integer enums are deliberately NOT distinguished: `parse_choices` stringifies either, and
+`CharField` coerces an `Int` default, so both land identically. A field recording which kind it was
+would be written and never read.
+"""
+struct _PyEnum
+  name::String
+  members::Vector{Tuple{String, String, String}}
+end
+
+# Django derives an omitted label from the member name: `IN_PROGRESS` -> "In Progress".
+_django_enum_label(member::AbstractString)::String = titlecase(replace(String(member), "_" => " "))
+
+# True when the text is a plain Python literal the importer can carry into PormG. Anything else —
+# `auto()`, `uuid.uuid4()`, a concatenation — is an expression whose VALUE this importer cannot know.
+# Keeping such a value verbatim is worse than dropping it: `CARRO = auto()` gives every member the
+# string "auto()", which is duplicate values that then PASS validation because the default is
+# literally in the set.
+function _is_py_literal(v::AbstractString)::Bool
+  t = strip(v)
+  isempty(t) && return false
+  t in ("None", "True", "False") && return true
+  _py_number(t) === nothing || return true
+  # A quoted string, with no unescaped quote of the same kind inside it.
+  return occursin(r"^\"(?:[^\"\\]|\\.)*\"$", t) || occursin(r"^'(?:[^'\\]|\\.)*'$", t)
+end
+
+"""
+    _py_number(t) -> Union{Int, Float64, Nothing}
+
+The NUMBER a Python numeric literal denotes, or `nothing` if `t` is not one.
+
+Denotes, not spells. Django stores what the literal means: `ALTO = 1_000` is the integer 1000 and
+`MEIO = 0x1F` is 31, so carrying the source text into `choices` and `default` declares an
+enumeration no row can ever match. Both halves are wrong identically, which is precisely why
+`CharField`'s default-in-choices validation passes and nothing is reported — a silent wrong value,
+the one outcome this importer exists to prevent.
+
+Handles Python's `_` digit separators, hex/octal/binary, exponents and a leading sign.
+"""
+function _py_number(t::AbstractString)::Union{Int, Float64, Nothing}
+  s = replace(String(strip(t)), "_" => "")
+  isempty(s) && return nothing
+  m = match(r"^([+-]?)0([xXoObB])([0-9a-fA-F]+)$", s)
+  if m !== nothing
+    c = lowercase(m.captures[2])
+    v = tryparse(Int, m.captures[3]; base = c == "x" ? 16 : c == "o" ? 8 : 2)
+    v === nothing && return nothing
+    return m.captures[1] == "-" ? -v : v
+  end
+  occursin(r"^[+-]?\d+$", s) && return tryparse(Int, s)
+  occursin(r"^[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?$", s) && return tryparse(Float64, s)
+  return nothing
+end
+
+# The text PormG should STORE for an enum member's value: a number in canonical form, or the
+# quote-stripped literal.
+function _py_scalar_text(v::AbstractString)::String
+  n = _py_number(v)
+  return n === nothing ? _strip_py_quotes(v) : string(n)
+end
+
+# `_("Azul")` / `gettext_lazy("Azul")` — the standard i18n spelling for a label. The wrapper carries
+# no schema meaning, so the string inside it is the label; leaving it wrapped put `_("Azul")` into
+# the generated file as the display text.
+const _GETTEXT_CALL_RE = r"^(?:_|gettext|gettext_lazy|ugettext|ugettext_lazy)\s*\(\s*(.*?)\s*,?\s*\)$"
+
+function _unwrap_gettext(s::AbstractString)::String
+  m = match(_GETTEXT_CALL_RE, strip(s))
+  return m === nothing ? String(strip(s)) : String(strip(m.captures[1]))
+end
+
+_is_enum_class(cls::PyClass)::Bool = any(b -> b in _CHOICES_BASES, _class_bases(cls))
+
+"""
+    _parse_enum(cls) -> _PyEnum
+
+Read an enum class body into members.
+
+Accepts all three Django spellings: `MEMBER = "VALUE", "Label"`, `MEMBER = "VALUE"` (label derived),
+and the integer form `MEMBER = 1, "Label"`. A `__dunder__` name is skipped — Django's `__empty__`
+declares the blank choice, which is not a member. Method bodies never reach here: `_py_classes`
+already excludes `def` frames.
+"""
+function _parse_enum(cls::PyClass)::_PyEnum
+  members = Tuple{String, String, String}[]
+  for s in cls.body
+    parts = _split_top_level_assign(s.text)
+    parts === nothing && continue
+    name, rhs = parts
+    Base.isidentifier(name) || continue
+    startswith(name, "__") && continue
+    toks = split_field_options(rhs)
+    isempty(toks) && continue
+    value = String(strip(toks[1]))
+    isempty(value) && continue
+    label = length(toks) >= 2 ? String(strip(toks[2])) : ""
+    # A label that is not a plain literal after unwrapping — `_("a") + _("b")`, an f-string, a
+    # conditional — cannot be read, so fall back to the name Django itself would derive rather than
+    # putting a fragment of Python into the generated file as display text. Only the LABEL degrades
+    # this way; a non-literal VALUE is reported and drops the option, because a value is schema.
+    unwrapped = isempty(label) ? "" : _unwrap_gettext(label)
+    label_text = if isempty(label) || !_is_py_literal(unwrapped)
+      _django_enum_label(name)
+    else
+      _strip_py_quotes(unwrapped)
+    end
+    push!(members, (String(name), value, label_text))
+  end
+  return _PyEnum(String(cls.name), members)
+end
+
+"""
+    _collect_enums(classes) -> Dict{String, Dict{String, _PyEnum}}
+
+Every enum in the file, keyed by OWNING class and then by enum name. `""` is the module-level scope.
+
+Scoped rather than flat on purpose: two models may each nest a `Status` with different members, and
+a flat table would silently give both the last one parsed.
+"""
+function _collect_enums(classes::Vector{PyClass})::Dict{String, Dict{String, _PyEnum}}
+  out = Dict{String, Dict{String, _PyEnum}}()
+  module_scope = Dict{String, _PyEnum}()
+  for c in classes
+    if _is_enum_class(c)
+      module_scope[c.name] = _parse_enum(c)
+      continue
+    end
+    nested = Dict{String, _PyEnum}()
+    # Recursive, not one level: `class Outer: class Inner: class Status(TextChoices)` is legal, and
+    # scanning only the roots' direct children reported such an enum as "not defined in this file"
+    # while it sat two lines away.
+    _collect_nested_enums!(nested, c)
+    isempty(nested) || (out[c.name] = nested)
+  end
+  isempty(module_scope) || (out[""] = module_scope)
+  return out
+end
+
+
+# Recursive, and each enum is registered under EXACTLY the name Python would bind it to: its path
+# relative to the model. A direct child is `Situacao`; one nested a level deeper is
+# `Grupo.Situacao`, and only that — because `Situacao` alone is not in the model body's namespace.
+#
+# Registering the bare name as well looked harmless and was not: a module-level `Situacao` is what
+# Python actually resolves in the model body, and an invented bare key for a deep enum SHADOWED it,
+# because `_lookup_enum` searches the class scope before the module scope. The field then imported
+# the wrong enumeration in complete silence, with a marker claiming the real member did not exist.
+function _collect_nested_enums!(into::Dict{String, _PyEnum}, cls::PyClass, prefix::AbstractString = "")
+  for n in cls.nested
+    if _is_enum_class(n)
+      into[string(prefix, n.name)] = _parse_enum(n)
+    else
+      _collect_nested_enums!(into, n, string(prefix, n.name, "."))
+    end
+  end
+  return into
+end
+
+"""
+    _enum_scopes(graph, cls) -> Vector{String}
+
+The scopes an enum reference inside `cls` may name, in precedence order: the class itself, then its
+ABSTRACT BASES (nearest first), then module level (`""`).
+
+The abstract-base step is not optional. `_inherited_statements` merges a base's field statements
+into the child and processes them under the CHILD's name, so a base declaring both
+`class Status(TextChoices)` and a field using it hands the child a reference that is nowhere in the
+child's own scope — which this importer then reported as "not defined in this file" while it sat
+three lines above. An abstract base with an enumerated status column is mainstream Django.
+"""
+function _enum_scopes(graph, cls::PyClass)::Vector{String}
+  out = String[cls.name]
+  seen = Set{String}()
+  function walk(name::AbstractString)
+    info = get(graph.info, String(name), nothing)
+    info === nothing && return
+    for b in info.parents
+      b in seen && continue
+      push!(seen, b)
+      push!(out, b)
+      walk(b)
+    end
+    return
+  end
+  walk(cls.name)
+  push!(out, "")
+  return out
+end
+
+"""
+    _lookup_enum(enums, scopes, ref) -> Union{_PyEnum, Nothing}
+
+Resolve an enum NAME against an ordered list of scopes. First match wins, so a nested enum shadows a
+module-level one of the same name — Python's own rule. A qualified `Owner.Status` is accepted last,
+since Django permits addressing a nested enum through its owner.
+"""
+function _lookup_enum(enums, scopes::Vector{String}, ref::AbstractString)::Union{_PyEnum, Nothing}
+  for s in scopes
+    scope = get(enums, s, nothing)
+    scope === nothing && continue
+    haskey(scope, ref) && return scope[ref]
+  end
+  idx = findlast('.', ref)
+  if idx !== nothing
+    owner = ref[firstindex(ref):prevind(ref, idx)]
+    inner = ref[nextind(ref, idx):end]
+    scope = get(enums, String(owner), nothing)
+    scope === nothing || (haskey(scope, inner) && return scope[inner])
+  end
+  return nothing
 end
 
 """
@@ -1317,7 +1556,7 @@ function _match_field_statement(text::AbstractString)
   return (name = lhs, type = String(m.captures[1]), args = args)
 end
 
-function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[])
+function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[], enums = Dict{String, Dict{String, _PyEnum}}(), enum_scopes::Vector{String} = String[String(class_name), ""])
   # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
   # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
   # class reaching `AbstractUser` through an abstract base both qualify — an equality test on the
@@ -1365,7 +1604,10 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     field_args_str = parsed.args
 
     # Parse field arguments
-    options, related_model = parse_field_args(field_args_str, field_type, parameters_ignore)
+    options, related_model = parse_field_args(field_args_str, field_type, parameters_ignore;
+                                              enums = enums, class_name = class_name,
+                                              enum_scopes = enum_scopes,
+                                              field_name = field_name, markers = markers)
 
     # Check for primary key
     if haskey(options, :primary_key) && options[:primary_key] == true
@@ -1390,6 +1632,57 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
       end
     catch e
       @pormg_debug
+      # #342's safety net. A choices/default disagreement is the ONE construction failure that used
+      # to abort the entire import — every other model in the file lost to one enum. Retry once
+      # without those two kwargs; the column survives, its enumeration does not, and the generated
+      # file says so.
+      #
+      # Not redundant with the drop rules in `parse_field_args`: this catches the case where both
+      # kwargs resolve perfectly well and the PAIR is invalid — `choices=Status.choices` with a
+      # `default` that is not one of the members.
+      #
+      # The retry SUCCEEDING is the whole safety property, and no inspection of the error is needed
+      # to get it. Removing exactly these two kwargs changes nothing else, so a construction that
+      # starts working without them failed because of them; one that still fails falls through to
+      # the normal path untouched. An unsupported field TYPE (#268) never reaches a different
+      # outcome for the same reason — the retry fails identically and rethrows.
+      #
+      # The `haskey` test below is an OPTIMIZATION, not a guard: with neither kwarg present the
+      # filter removes nothing and the retry would simply repeat the same failing call. Do not read
+      # it as load-bearing — `recovered` is what makes this safe.
+      if haskey(options, :choices) || haskey(options, :default)
+        retry_options = filter(kv -> !(kv.first in (:choices, :default)), options)
+        recovered = try
+          if field_type in ["ForeignKey", "OneToOneField"]
+            fields_dict[Symbol("$(field_name)_id")] = getfield(Models, Symbol(field_type))(related_model; retry_options...)
+          elseif field_type == "ManyToManyField"
+            fields_dict[Symbol(field_name)] = Models.ManyToManyField(related_model; retry_options...)
+          else
+            fields_dict[Symbol(field_name)] = getfield(Models, Symbol(field_type))(; retry_options...)
+          end
+          true
+        catch e2
+          # A control-flow exception is not a field-validation failure and must not be swallowed
+          # into `recovered = false` (#322's lesson: an interrupt in the wrong place leaves state
+          # nobody can reason about).
+          (e2 isa InterruptException || e2 isa StackOverflowError) && rethrow()
+          false
+        end
+        if recovered
+          reason = _one_line(sprint(showerror, e), 160)
+          # Name only what was actually there. The blanket "choices and default … the enumeration
+          # is not enforced" claimed an enumeration on fields that had none — an over-long `default`
+          # on a plain CharField recovers through this same path.
+          dropped = join(("`$(k)`" for k in (:choices, :default) if haskey(options, k)), " and ")
+          tail = haskey(options, :choices) ? " The column is real; the enumeration is not enforced." :
+                                             " The column is real, but its default is now unset here" *
+                                             " while Django still declares one."
+          @warn "import: field option rejected; field imported without it" class=class_name field=field_name dropped=dropped reason=reason
+          push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' — $(dropped) rejected " *
+                         "and dropped: $(reason).$(tail)")
+          continue
+        end
+      end
       # A FieldValidationError/InvalidValueError from field construction is already the right
       # type — stringifying it into an ErrorException would eject it from the taxonomy (audit).
       e isa PormGError && rethrow()
@@ -1405,20 +1698,29 @@ function django_field_type(field_type::AbstractString)::String
   return String(field_type)
 end
 
-function parse_field_args(args_str::AbstractString, field_type::AbstractString, parameters_ignore::Vector{String})
+function parse_field_args(args_str::AbstractString, field_type::AbstractString, parameters_ignore::Vector{String};
+                         enums = Dict{String, Dict{String, _PyEnum}}(),
+                         class_name::AbstractString = "",
+                         enum_scopes::Vector{String} = String[String(class_name), ""],
+                         field_name::AbstractString = "",
+                         markers::Vector{String} = String[])
   # This function parses field arguments handling nested parentheses and commas
   # and returns a dictionary of options.
   options = Dict{Symbol, Any}()
   options_list = split_field_options(args_str)
   # println(options_list)
   related_model = missing
+  # Enum references this file cannot resolve (`from .enums import Status`), as (option, enum) pairs.
+  # Each one is dropped where it is found — the literal must never reach the field constructor,
+  # since `default="Status.DRAFT"` against an empty `choices` is exactly the FieldValidationError
+  # that aborted the whole import. This list only drives the REPORT, so one field yields one marker
+  # naming every option it lost and why.
+  unresolved_enums = Tuple{String, String}[]
   for option_str in options_list
       key_value = split(option_str, "=", limit=2)
       if length(key_value) == 2
           key = strip(key_value[1])
           value = strip(key_value[2])
-          value_parsed = parse_value(value)
-          # println(value_parsed)
           field_type == "ManyToManyField" && key == "blank" && continue
           key in parameters_ignore && continue
           # Django callable datetime defaults (e.g. default=timezone.now) have no
@@ -1428,7 +1730,42 @@ function parse_field_args(args_str::AbstractString, field_type::AbstractString, 
               options[:auto_now_add] = true
               continue
           end
-          options[Symbol(key)] = value_parsed
+          # Resolve `Status.choices` / `Status.DRAFT` BEFORE parse_value (#342), which would
+          # otherwise hand the literal text through and let CharField reject the pair.
+          resolved = _resolve_enum_reference(value, enums, enum_scopes, class_name, field_name, key, markers, unresolved_enums)
+          # A DISTINCT sentinel, not `nothing`: `parse_value("None")` is `nothing`, so an enum
+          # member declared `NENHUM = None, "Nenhum"` resolved to `nothing` and was read here as
+          # "dropped" — the option vanished with no warn and no marker, which is the one thing this
+          # importer promises never to do.
+          resolved === _ENUM_DROP && continue       # dropped, and already reported
+          if resolved !== _ENUM_NOT_A_REFERENCE
+            options[Symbol(key)] = resolved
+          elseif key == "choices"
+            # Routed explicitly rather than through `parse_value`, whose bracket branch only takes
+            # `(...)`. A `[...]` container fell through to a raw String and was re-parsed much later
+            # by `Models.parse_choices`, which still keeps the quote characters — so one generated
+            # model carried both spellings, the very thing the normalization exists to prevent.
+            bad = String[]
+            parsed = parse_choices(value, bad)
+            for b in bad
+              # Two shapes share this channel and a reader must be able to tell them apart: the
+              # WHOLE option was unreadable (a bare name, nothing parsed), or ONE entry inside a
+              # readable container was malformed and its siblings survived.
+              whole = isempty(parsed) && length(bad) == 1 && b == _one_line(value)
+              @warn "import: choices could not be read; dropped" class=class_name field=field_name entry=_one_line(b) whole_option=whole
+              push!(markers, whole ?
+                "# PormG: field '$(field_name)' on '$(class_name)' has `choices=$(_one_line(b))`, " *
+                "which is a name rather than a literal — the whole option was dropped." :
+                "# PormG: field '$(field_name)' on '$(class_name)' has a choices entry that is not " *
+                "a (value, label) pair — that entry was dropped: $(_one_line(b))")
+            end
+            # Nothing readable means the option is DROPPED, not set to `()`. An empty tuple declares
+            # an enumeration with no members, which is a stranger claim than declaring none — and it
+            # round-trips into the generated file as a literal `choices=()`.
+            isempty(parsed) || (options[Symbol(key)] = parsed)
+          else
+            options[Symbol(key)] = parse_value(value)
+          end
       else
         if field_type in ["ForeignKey", "OneToOneField", "ManyToManyField"]
           related_model = replace(key_value[1], "\"" => "", "'" => "") |> string
@@ -1436,7 +1773,182 @@ function parse_field_args(args_str::AbstractString, field_type::AbstractString, 
         end
       end
   end
+
+  # One marker per FIELD, not per option: a `choices=X.choices, default=X.MEMBER` pair naming the
+  # same unknown enum is one problem, and saying it twice is noise. The options themselves were
+  # already dropped at the point each was read.
+  #
+  # Deliberately NOT a blanket "drop both": if `choices` resolves and only `default` does not, the
+  # field keeps its enumeration and loses just the default. Discarding the resolvable half would
+  # throw away information the source actually gave us.
+  if !isempty(unresolved_enums)
+    names = join(("`$(e)`" for e in unique(last.(unresolved_enums))), ", ")
+    opts = join(("`$(k)`" for k in unique(first.(unresolved_enums))), " and ")
+    # "does not define", not "enum": the same shape catches a module constant
+    # (`default=constants.MAX_QTD`), and calling that an enumeration in the artifact is a lie the
+    # reader has no way to check.
+    @warn "import: name is not defined in this file; option dropped" class=class_name field=field_name reference=unique(last.(unresolved_enums)) options=unique(first.(unresolved_enums))
+    push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' references $(names), which " *
+                   "this file does not define — $(opts) dropped. The column is real. If that is an " *
+                   "enumeration, import the module defining it alongside this one, or declare the " *
+                   "choices by hand.")
+  end
+
+  # `choices` only exists on CharField. Every other field type would take it to `_common_kwargs`,
+  # which warns anonymously ("Unexpected parameter for TextField") and drops it — true but useless
+  # for finding the field. Report it here, where the field, class and value are all known.
+  if haskey(options, :choices) && field_type != "CharField"
+    delete!(options, :choices)
+    @warn "import: this field type has no choices slot; the option was dropped" class=class_name field=field_name field_type=field_type
+    push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' declares choices, but " *
+                   "$(field_type) has no choices slot in PormG (only CharField does) — dropped. " *
+                   "The column is unaffected.")
+  end
+
   return options, related_model
+end
+
+# Sentinels. Two distinct ones, because `nothing` is a legitimate RESOLVED value: an enum member
+# declared `NENHUM = None, "Nenhum"` parses to `nothing`, and conflating that with "drop" made the
+# option disappear with no warn and no marker.
+const _ENUM_NOT_A_REFERENCE = :_enum_not_a_reference   # not a reference — parse it normally
+const _ENUM_DROP = :_enum_drop                         # drop this option; already reported
+
+# A dotted reference whose head could name an enum: `Status.choices`, `Status.DRAFT`,
+# `ImportBatch.Status.DRAFT`. Anything with a call, a bracket or a quote is not one.
+const _ENUM_REF_RE = r"^([A-Za-z_][\w.]*)\.([A-Za-z_]\w*)$"
+
+# Django enum attributes that are not a single value and have no PormG equivalent.
+const _ENUM_PLURAL_ATTRS = ("values", "labels", "names")
+
+# The attribute shapes worth claiming as an enumeration when the head is NOT a name this file
+# defines. `.choices` and its plural siblings are unambiguous, and a member of a Python `Enum` is
+# conventionally SHOUTY_CASE.
+#
+# Without this test, EVERY dotted `default=` was captured: `default=uuid.uuid4`,
+# `default=timezone.now` and `default=datetime.date.today` were all dropped and reported as
+# enumerations — an undocumented behavior change on fields that have nothing to do with enums, with
+# a diagnostic that named the wrong thing.
+_looks_like_enum_attr(attr::AbstractString)::Bool =
+  attr == "choices" || attr in _ENUM_PLURAL_ATTRS || attr in _ENUM_MEMBER_ATTRS ||
+  occursin(r"^[A-Z][A-Z0-9_]*$", attr)
+
+# Single-value attributes OF A MEMBER: `Status.NOVO.value`, `.label`, `.name`. Django's own
+# `TextChoices` exposes all three, and `.value` is an ordinary way to spell a default.
+const _ENUM_MEMBER_ATTRS = ("value", "label", "name")
+
+"""
+    _resolve_enum_reference(value, enums, class_name, field_name, key, markers, unresolved) -> Any
+
+Resolve a Django enum reference in a field option.
+
+Returns the resolved value, `_ENUM_NOT_A_REFERENCE` when `value` is not one, or `_ENUM_DROP` to mean
+"drop this option" (already warned and marked).
+"""
+function _resolve_enum_reference(value::AbstractString, enums, enum_scopes::Vector{String},
+                                 class_name::AbstractString,
+                                 field_name::AbstractString, key::AbstractString,
+                                 markers::Vector{String},
+                                 unresolved::Vector{Tuple{String, String}})
+  m = match(_ENUM_REF_RE, strip(value))
+  m === nothing && return _ENUM_NOT_A_REFERENCE
+  head = String(m.captures[1])
+  attr = String(m.captures[2])
+
+  # `Status.NOVO.value` — a single-value attribute OF A MEMBER. Peel it so the rest of this
+  # function sees the member reference it already knows how to resolve. `.label` and `.name` have
+  # no PormG equivalent as a column default, so they are reported like the plural attributes.
+  if attr in _ENUM_MEMBER_ATTRS
+    inner = findlast('.', head)
+    if inner !== nothing
+      enum_ref = head[firstindex(head):prevind(head, inner)]
+      member = head[nextind(head, inner):end]
+      if _lookup_enum(enums, enum_scopes, enum_ref) !== nothing
+        if attr != "value"
+          @warn "import: enum member attribute has no PormG equivalent; the option was dropped" class=class_name field=field_name attribute="$(head).$(attr)"
+          push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' uses " *
+                         "`$(head).$(attr)`, which is the member's $(attr) rather than its stored " *
+                         "value — PormG has no equivalent, so `$(key)` was dropped.")
+          return _ENUM_DROP
+        end
+        head = String(enum_ref)
+        attr = String(member)
+      end
+    end
+  end
+
+  enum = _lookup_enum(enums, enum_scopes, head)
+
+  if enum === nothing
+    # Only `choices`/`default` can carry an enum, and only an enum-SHAPED attribute is worth
+    # DROPPING — `on_delete=models.CASCADE` and `default=timezone.now` must keep flowing to
+    # `parse_value` exactly as before.
+    (key == "choices" || key == "default") || return _ENUM_NOT_A_REFERENCE
+    if !_looks_like_enum_attr(attr)
+      # Kept verbatim, as before this change — but REPORTED. `default=Externo.ativo` is an enum
+      # member spelled unconventionally, and it is indistinguishable from `default=uuid.uuid4` by
+      # syntax alone. Guessing either way is wrong for the other, so the value is left untouched
+      # and the reader is told a dotted expression landed in the schema as a literal.
+      key == "default" || return _ENUM_NOT_A_REFERENCE
+      @warn "import: dotted default kept verbatim; the importer cannot evaluate it" class=class_name field=field_name value=_one_line(value)
+      push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' has " *
+                     "`default=$(_one_line(value))`, an expression the importer cannot evaluate — " *
+                     "kept verbatim as text. Check it: if it names an enum member or a constant, " *
+                     "the stored default is the expression, not its value.")
+      return _ENUM_NOT_A_REFERENCE
+    end
+    push!(unresolved, (String(key), head))
+    return _ENUM_DROP
+  end
+
+  if attr == "choices"
+    bad = [n for (n, v, _) in enum.members if !_is_py_literal(v)]
+    if !isempty(bad)
+      # `CARRO = auto()` is a documented Django idiom, and importing it verbatim gives every member
+      # the value "auto()" — duplicates that then PASS validation, because the default is literally
+      # in the set. Wrong metadata kept in silence is the mirror of a silent drop.
+      @warn "import: enum has members whose values are not literals; choices dropped" class=class_name field=field_name enum=head members=bad
+      push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' uses `$(head).choices`, but " *
+                     "$(join(("`$(head).$(b)`" for b in bad), ", ")) " *
+                     "$(length(bad) == 1 ? "has a value" : "have values") the importer cannot read " *
+                     "(a call or an expression, not a literal) — `$(key)` was dropped.")
+      return _ENUM_DROP
+    end
+    if isempty(enum.members)
+      @warn "import: enum declares no members; choices dropped" class=class_name field=field_name enum=head
+      push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' uses `$(head).choices`, " *
+                     "but `$(head)` declares no members — `$(key)` was dropped.")
+      return _ENUM_DROP
+    end
+    return Tuple((_py_scalar_text(v), l) for (_, v, l) in enum.members)
+  elseif attr in _ENUM_PLURAL_ATTRS
+    @warn "import: enum attribute has no PormG equivalent; the option was dropped" class=class_name field=field_name attribute="$(head).$(attr)"
+    push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' uses `$(head).$(attr)`, " *
+                   "which is a list of $(attr) rather than (value, label) pairs — PormG has no " *
+                   "equivalent, so `$(key)` was dropped.")
+    return _ENUM_DROP
+  end
+
+  idx = findfirst(t -> t[1] == attr, enum.members)
+  if idx === nothing
+    @warn "import: enum has no such member; the option was dropped" class=class_name field=field_name reference="$(head).$(attr)"
+    push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' references " *
+                   "`$(head).$(attr)`, which is not a member of `$(head)` — `$(key)` was dropped.")
+    return _ENUM_DROP
+  end
+  member_value = enum.members[idx][2]
+  if !_is_py_literal(member_value)
+    @warn "import: enum member value is not a literal; the option was dropped" class=class_name field=field_name reference="$(head).$(attr)" value=_one_line(member_value)
+    push!(markers, "# PormG: field '$(field_name)' on '$(class_name)' references " *
+                   "`$(head).$(attr)`, whose value is `$(_one_line(member_value))` — a call or an " *
+                   "expression the importer cannot read, not a literal. `$(key)` was dropped.")
+    return _ENUM_DROP
+  end
+  # The member's VALUE, canonicalized the same way the `choices` tuple is — otherwise a `1_000`
+  # default and a `"1_000"` choice agree with each other and with nothing in the database.
+  # `parse_value` handles the non-numeric literals (quoted strings, `None`, booleans).
+  n = _py_number(member_value)
+  return n === nothing ? parse_value(member_value) : n
 end
 
 # Django field types that map to PormG date/time fields carrying auto_now_add.
@@ -1517,20 +2029,76 @@ function parse_value(value::AbstractString)
   end
 end
 
-function parse_choices(choices_str::AbstractString)
-  # Parse a string into a tuple of tuples
+"""
+    _strip_py_quotes(s) -> String
+
+Strip one layer of matching Python quotes, if present. `"UP"` -> `UP`; `UP` -> `UP`.
+
+Not folded into `parse_value`: this is for text that is already known to be a bare literal, where
+`parse_value`'s type inference (`True`, `None`, integers, nested tuples) would be wrong.
+"""
+function _strip_py_quotes(s::AbstractString)::String
+  t = strip(s)
+  if length(t) >= 2 &&
+     ((startswith(t, '"') && endswith(t, '"')) || (startswith(t, '\'') && endswith(t, '\'')))
+    return String(t[nextind(t, firstindex(t)):prevind(t, lastindex(t))])
+  end
+  return String(t)
+end
+
+"""
+    parse_choices(choices_str, skipped = String[]) -> NTuple{N, Tuple{String, String}}
+
+Django `choices=((value, label), …)` -> PormG's choices tuple. Both `(...)` and `[...]` containers,
+and both bracket styles for the inner pairs.
+
+Rebased on the shared scanner (#342), which fixes an abort of exactly the kind this issue exists to
+remove. The old body found pairs with `r"\\(([^()]+)\\)"` and split them on EVERY comma, so an
+ordinary human label — `("APPLIED", "Aplicado, com ressalvas")` — produced three fragments and threw
+`InvalidMigrationError` from *outside* the field-construction `try`. Nothing caught it, no file was
+written, and every model in the file was lost. `split_field_options` does not split inside a string,
+so that label now parses correctly.
+
+A genuinely malformed element (a bare value where a pair belongs, or a 3-tuple) is appended to
+`skipped` rather than thrown, so the caller can report it and keep going. That also makes
+`choices=[["A", "Alpha"]]` — a list of *lists*, valid Django — import correctly, where it used to
+yield an empty `choices=()` with no warning.
+
+Quotes are STRIPPED from both halves. They used to be kept as part of the value, so a Django
+`("UP", "Upload")` imported as the four-character string `"UP"` — quote marks included. Nothing
+downstream broke, because `choices` is Julia-side metadata that never reaches DDL and
+`return_just_strings` strips quotes again before validating a default; but it is the wrong value, and
+enum resolution produces the clean form, so one generated model would otherwise have carried two
+spellings of the same concept.
+"""
+function parse_choices(choices_str::AbstractString, skipped::Vector{String} = String[])
+  inner = _balanced_group(choices_str)
+  if inner === nothing
+    # `choices=STATUS_CHOICES` — a module-level constant, not a literal. There is nothing to read,
+    # and returning an empty tuple in silence is how a field lost its entire enumeration with no
+    # trace. The old docs called this out as the one shape to avoid; the code never did.
+    push!(skipped, String(strip(choices_str)))
+    return ()
+  end
   choices = ()
-  pattern = r"\(([^()]+)\)"
-  for m in eachmatch(pattern, choices_str)
-      inner = m.captures[1]
-      values = split(inner, ",")
-      if length(values) == 2
-          key = strip(values[1])
-          value = strip(values[2])
-          choices = (choices..., (key, value))
-      else
-          throw(InvalidMigrationError("Invalid choices format"))
-      end
+  for element in split_field_options(inner)
+    el = String(strip(element))
+    isempty(el) && continue
+    if !(startswith(el, '(') || startswith(el, '['))
+      push!(skipped, el)          # a bare value where a (value, label) pair belongs
+      continue
+    end
+    pair = _balanced_group(el)
+    if pair === nothing
+      push!(skipped, el)
+      continue
+    end
+    parts = split_field_options(pair)
+    if length(parts) != 2
+      push!(skipped, el)
+      continue
+    end
+    choices = (choices..., (_strip_py_quotes(parts[1]), _strip_py_quotes(parts[2])))
   end
   return choices
 end

--- a/test/unit/fixtures/django_models_choices_forms.txt
+++ b/test/unit/fixtures/django_models_choices_forms.txt
@@ -1,0 +1,233 @@
+from django.db import models
+
+# An enum living in another module. Nothing here defines it, so a single-file import cannot resolve
+# `Externo.ATIVO` — and passing the literal through is exactly the abort #342 exists to remove.
+from .enums import Externo
+
+
+class Prioridade(models.IntegerChoices):
+    """A MODULE-LEVEL enum, used by a model below. Django allows both placements and real projects
+    use both, so both must reach the symbol table."""
+
+    BAIXA = 1, "Baixa"
+    ALTA = 2, "Alta"
+
+
+class ImportBatch(models.Model):
+    class Status(models.TextChoices):
+        """A NESTED enum. `_lift_meta!` removes only `Meta`, so this has been sitting in
+        `PyClass.nested` unused since #340 — it is the seam #342 consumes."""
+
+        DRAFT = "DRAFT", "Em processamento"
+        APPLIED = "APPLIED", "Aplicado"
+        # Label omitted: Django derives it from the member name, IN_PROGRESS -> "In Progress".
+        IN_PROGRESS = "IN_PROGRESS"
+        # Django's blank-choice idiom. Not a member; must be skipped.
+        __empty__ = "(Desconhecido)"
+
+    filename = models.CharField(max_length=255)
+    # The shape from the issue: both kwargs resolve through the enum. Before #342 this threw
+    # FieldValidationError and killed the whole import.
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
+
+
+class ImportRow(models.Model):
+    class Status(models.TextChoices):
+        """A DIFFERENT enum under the SAME name. Resolution is class-scoped, so this must not
+        collide with ImportBatch.Status — a flat table would silently give both the last one
+        parsed."""
+
+        OK = "OK", "Validada"
+        REJECTED = "REJECTED", "Rejeitada"
+
+    # Scoped resolution: this default is "OK", never "DRAFT".
+    situacao = models.CharField(max_length=20, choices=Status.choices, default=Status.OK)
+    # A module-level IntegerChoices on a CharField: parse_choices stringifies and CharField coerces
+    # an Int default, so both enum kinds land correctly here.
+    prioridade = models.CharField(max_length=2, choices=Prioridade.choices, default=Prioridade.BAIXA)
+    # Qualified through the owning class — Django permits it.
+    espelho = models.CharField(max_length=20, choices=ImportBatch.Status.choices)
+
+
+class Relatorio(models.Model):
+    """Every degrade path. This model must still import, and every other model in the file must
+    survive it — one bad enum costing a whole file is the bug."""
+
+    titulo = models.CharField(max_length=80)
+    # An enum this file cannot see: choices AND default are dropped TOGETHER. Dropping only one
+    # reproduces the abort, because the survivor still carries the unresolvable literal.
+    origem = models.CharField(max_length=10, choices=Externo.choices, default=Externo.ATIVO)
+    # Only the DEFAULT is unresolvable; `choices` resolves fine. The field must keep its
+    # enumeration and lose only the default — a blanket "drop both" would throw away what the
+    # source actually gave us.
+    parcial = models.CharField(max_length=10, choices=Prioridade.choices, default=Externo.BAIXA)
+    # `.values` is a list of values, not (value, label) pairs — no PormG equivalent.
+    listagem = models.CharField(max_length=10, choices=Prioridade.values)
+    # A member that does not exist on the enum.
+    fantasma = models.CharField(max_length=10, default=Prioridade.INEXISTENTE)
+    # Only CharField has a choices slot; TextField does not, so the option is dropped and named.
+    corpo = models.TextField(choices=Prioridade.choices)
+    # Both kwargs resolve, but the PAIR is invalid: "NOPE" is not one of the members. Nothing in
+    # parse_field_args can catch this — it is the case the construction-time safety net exists for.
+    combinado = models.CharField(max_length=10, choices=Prioridade.choices, default="NOPE")
+    # An INLINE literal, to pin the quote normalization: the stored values must be UP and Upload,
+    # not "UP" and "Upload" with the quote characters kept as part of the string.
+    canal = models.CharField(max_length=2, choices=(("UP", "Upload"), ("GS", "Sheets")), default="UP")
+
+
+class Auditavel(models.Model):
+    """An ABSTRACT base declaring both an enum and a field that uses it. Inherited statements are
+    processed under the CHILD's name, so unless the lookup walks the abstract chain the child sees a
+    reference that is nowhere in its own scope — and the marker then says 'not defined in this file'
+    about an enum three lines above it."""
+
+    class Estado(models.TextChoices):
+        ON = "ON", "Ligado"
+        OFF = "OFF", "Desligado"
+
+    estado = models.CharField(max_length=3, choices=Estado.choices, default=Estado.ON)
+
+    class Meta:
+        abstract = True
+
+
+class Equipamento(Auditavel):
+    nome = models.CharField(max_length=10)
+
+
+class Rotulo(models.Model):
+    """Every shape that used to be read wrongly rather than reported."""
+
+    # A comma inside a LABEL. The old splitter cut on every comma, produced three fragments, and
+    # threw from OUTSIDE the field-construction try — no file written, whole import lost.
+    virgula = models.CharField(max_length=3, choices=(("a", "Alpha, primeiro"),), default="a")
+    # A list container. It used to bypass the importer's parse_choices entirely and be re-parsed
+    # much later by the field layer, which keeps the quote characters — so one generated model
+    # carried both spellings of the same concept.
+    lista = models.CharField(max_length=2, choices=[("UP", "Upload"), ("GS", "Sheets")], default="UP")
+    # A list of LISTS. Valid Django; used to import as an empty choices=() with no warning at all.
+    listas = models.CharField(max_length=2, choices=[["A", "Alpha"], ["B", "Beta"]], default="A")
+    # A genuinely malformed entry beside a good one: reported, and the good one survives.
+    torto = models.CharField(max_length=2, choices=(("A", "Alpha"), ("B", "Beta", "extra")), default="A")
+
+
+class NaoEnum(models.Model):
+    """Dotted defaults that are NOT enums. Capturing these was an undocumented behavior change on
+    fields with nothing to do with enumerations, reported with a diagnostic naming the wrong thing."""
+
+    ident = models.CharField(max_length=36, default=uuid.uuid4)
+    criado = models.DateTimeField(default=timezone.now)
+
+
+class ValorEstranho(models.Model):
+    """Enum member values the importer cannot read. `auto()` is a documented Django idiom, and
+    keeping it verbatim gives every member the value "auto()" — duplicates that then PASS validation
+    because the default is literally in the set. Wrong metadata kept in silence."""
+
+    class Tipo(models.IntegerChoices):
+        CARRO = auto()
+        CAMINHAO = auto()
+
+    class Cor(models.TextChoices):
+        # gettext-wrapped labels are the standard i18n spelling; the wrapper is not the label.
+        AZUL = "AZUL", _("Azul")
+        VERDE = "VERDE", _("Verde")
+        # A COMPOUND label. Unwrapping it naively yields the fragment `a") + _("b`, which would go
+        # into the generated file as display text; the derived label is used instead. Only the
+        # LABEL degrades this way — a non-literal VALUE drops the option, because a value is schema.
+        MISTO = "MISTO", _("a") + _("b")
+
+    class Vazia(models.TextChoices):
+        """No members at all."""
+
+    tipo = models.CharField(max_length=10, choices=Tipo.choices)
+    cor = models.CharField(max_length=10, choices=Cor.choices, default=Cor.AZUL)
+    vazia = models.CharField(max_length=5, choices=Vazia.choices)
+
+
+class NoneMembro(models.Model):
+    """A member whose value is `None`. `parse_value("None")` is `nothing`, which the caller used to
+    read as "dropped" — the option vanished with no warn and no marker."""
+
+    class E(models.TextChoices):
+        NENHUM = None, "Nenhum"
+        A = "a", "Aa"
+
+    x = models.CharField(max_length=3, choices=E.choices, default=E.NENHUM, null=True)
+
+
+class Agrupado(models.Model):
+    """A doubly-nested enum. Python resolves it as `Grupo.Situacao`, so collecting it under the bare
+    name `Situacao` puts it behind a key the real reference can never reach — the enum is found and
+    still reported as undefined."""
+
+    class Grupo:
+        class Situacao(models.TextChoices):
+            A = "a", "Aa"
+            B = "b", "Bb"
+
+    campo = models.CharField(max_length=2, choices=Grupo.Situacao.choices, default=Grupo.Situacao.A)
+
+
+SITUACAO_CONSTANTE = (("A", "Ativo"), ("I", "Inativo"))
+
+
+class Prioridade2(models.IntegerChoices):
+    """A module-level enum whose name a DEEPLY nested one also uses. Python binds the module-level
+    one inside a model body — a nested enum two levels down is not in that namespace — so an
+    invented bare-name key for the deep one silently imports the wrong enumeration."""
+
+    # Django stores what the literal MEANS, not how it is spelled: 1_000 is 1000 and 0x1F is 31.
+    # Importing the source text gives an enumeration no row can ever match — and since the default
+    # is wrong the same way, validation passes and nothing is reported.
+    MIL = 1_000, "Mil"
+    MEIO = 0x1F, "Meio"
+    UM = 1, "Um"
+
+
+class Sombreado(models.Model):
+    class Interno(models.Model):
+        class Prioridade2(models.TextChoices):
+            FUNDO = "F", "Fundo"
+
+    # Resolves to the MODULE-LEVEL Prioridade2, exactly as Python does. The default is deliberately
+    # the NON-CANONICAL member: `1_000` must reach the field as 1000, or the default and the
+    # choices agree with each other and with nothing in the database.
+    nivel = models.CharField(max_length=5, choices=Prioridade2.choices, default=Prioridade2.MIL)
+
+
+class Atributos(models.Model):
+    class Status(models.TextChoices):
+        NOVO = "NOVO", "Novo"
+        VELHO = "VELHO", "Velho"
+
+    # `.value` is an ordinary way to spell a default and resolves to the member's value.
+    com_value = models.CharField(max_length=10, choices=Status.choices, default=Status.NOVO.value)
+    # `.label`/`.name` are the display text and the member name, not the stored value.
+    com_label = models.CharField(max_length=10, choices=Status.choices, default=Status.NOVO.label)
+
+
+class Constante(models.Model):
+    """`choices` naming a module-level constant. There is nothing to read, and returning an empty
+    tuple in silence is how a field lost its whole enumeration without a trace."""
+
+    s = models.CharField(max_length=3, choices=SITUACAO_CONSTANTE)
+
+
+class MinusculoMembro(models.Model):
+    """An enum member spelled unconventionally. It is indistinguishable from `uuid.uuid4` by syntax
+    alone, so the value is kept verbatim — but reported, because an expression landing in the schema
+    as literal text is exactly what must never happen quietly."""
+
+    a = models.CharField(max_length=40, default=Externo.ativo)
+    # `.value` on an UNRESOLVABLE enum. The member-attribute peel cannot fire (the enum is unknown),
+    # so the only thing that stops the literal reaching the schema is `.value` counting as an
+    # enum-shaped attribute — drop and report, rather than keep verbatim.
+    b = models.CharField(max_length=40, default=Externo.ATIVO.value)
+
+
+class Posterior(models.Model):
+    """Declared AFTER every degrade above. Its presence is what proves a bad enum costs one field's
+    metadata rather than the rest of the file."""
+
+    nome = models.CharField(max_length=30)

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -1292,3 +1292,505 @@ end
         cleanup_import_test!(config_key, db_dir_existed)
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: TextChoices / IntegerChoices resolve (#342)
+# `choices=Status.choices` used to parse to the literal string "Status.choices"
+# and `default=Status.DRAFT` to "Status.DRAFT"; CharField then rejected the pair
+# and the FieldValidationError killed the ENTIRE import — every other model in
+# the file lost to one enum. The enum classes were already parsed into
+# `PyClass.nested` by #340; this is the seam that consumes them.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer resolves nested TextChoices" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_nested_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # Both kwargs resolve through the enum — the exact shape from the issue.
+        @test occursin(
+            "status = Models.CharField(max_length=20, default=\"DRAFT\", " *
+            "choices=((\"DRAFT\", \"Em processamento\"), (\"APPLIED\", \"Aplicado\"), " *
+            "(\"IN_PROGRESS\", \"In Progress\")))",
+            generated,
+        )
+        # Neither literal survives anywhere: those are what CharField choked on.
+        @test !occursin("Status.choices", generated)
+        @test !occursin("Status.DRAFT", generated)
+
+        # An omitted label is derived Django-style: IN_PROGRESS -> "In Progress".
+        @test occursin("(\"IN_PROGRESS\", \"In Progress\")", generated)
+        # `__empty__` declares Django's blank choice; it is not a member.
+        @test !occursin("Desconhecido", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: enum resolution is class-scoped (#342)
+# Two models may each nest a `Status` with different members. A flat symbol
+# table silently gives both the last one parsed, and the failure is invisible —
+# the field still imports, with the wrong enumeration.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer scopes enum lookup to the declaring class" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_scope_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # ImportRow.Status, not ImportBatch.Status — the whole point.
+        @test occursin(
+            "situacao = Models.CharField(max_length=20, default=\"OK\", " *
+            "choices=((\"OK\", \"Validada\"), (\"REJECTED\", \"Rejeitada\")))",
+            generated,
+        )
+        # A module-level enum reaches a model that nests one of its own...
+        @test occursin(
+            "prioridade = Models.CharField(max_length=2, default=\"1\", " *
+            "choices=((\"1\", \"Baixa\"), (\"2\", \"Alta\")))",
+            generated,
+        )
+        # ...and a nested enum can be addressed through its owner, as Django allows. This resolves
+        # to ImportBatch's members from inside ImportRow, which a class-scoped-only lookup misses.
+        @test occursin(
+            "espelho = Models.CharField(max_length=20, " *
+            "choices=((\"DRAFT\", \"Em processamento\"), (\"APPLIED\", \"Aplicado\"), " *
+            "(\"IN_PROGRESS\", \"In Progress\")))",
+            generated,
+        )
+
+        # A DOUBLY-nested enum. Python resolves it as `Grupo.Situacao`, so it has to be registered
+        # under that dotted path — collecting it under the bare `Situacao` finds the enum and then
+        # reports it as undefined, because the reference the source actually contains never matches.
+        @test occursin(
+            "campo = Models.CharField(max_length=2, default=\"a\", " *
+            "choices=((\"a\", \"Aa\"), (\"b\", \"Bb\")))",
+            generated,
+        )
+        @test !occursin("`Grupo.Situacao`, which this file does not define", generated)
+
+        # ...and the dotted key is the ONLY one a deep enum gets. Registering the bare name too
+        # shadows the module scope, because lookup searches the class before `""` — `Sombreado`
+        # would then silently import `Interno.Prioridade2` where Python binds the module-level one.
+        #
+        # The numeric members pin the other half: Django stores what a literal MEANS, so `1_000` is
+        # 1000 and `0x1F` is 31. Carrying the source spelling declares an enumeration no row can
+        # match — and because the default would be wrong identically, validation passes and nothing
+        # is reported. A silent wrong value is worse than the reported drop it replaced.
+        # The DEFAULT is the non-canonical member on purpose: normalizing only the choices leaves
+        # `default="1_000"` agreeing with nothing, and both halves have to go through the same path.
+        @test occursin(
+            "nivel = Models.CharField(max_length=5, default=\"1000\", " *
+            "choices=((\"1000\", \"Mil\"), (\"31\", \"Meio\"), (\"1\", \"Um\")))",
+            generated,
+        )
+        @test !occursin("1_000", generated)
+        @test !occursin("0x1F", generated)
+        @test !occursin("(\"F\", \"Fundo\")", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: every choices degrade is reported, and costs one field (#342)
+# The bug is not that some enums cannot be resolved — it is that one of them
+# used to cost the whole file. Each degrade names itself in the generated file,
+# and a model declared after all of them must still be there.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer degrades unresolvable choices without losing the file" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_degrade_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # An enum defined in another module: choices AND default drop together. Dropping only one
+        # leaves the survivor carrying the unresolvable literal — which is the original abort.
+        # "which this file does not define", not "enum": the same shape catches a module constant
+        # (`default=constants.MAX`), and calling that an enumeration in the artifact is a claim the
+        # reader has no way to check.
+        @test occursin("references `Externo`, which this file does not define", generated)
+        @test occursin("origem = Models.CharField(max_length=10)", generated)
+        # The literal must never reach the field as a VALUE. Both names do appear in the file now —
+        # inside markers naming what was dropped — so the assertion is on the declaration form,
+        # which is what it always meant.
+        @test !occursin("default=\"Externo.ATIVO\"", generated)
+        @test !occursin("\"Externo.choices\"", generated)
+
+        # When only the DEFAULT is unresolvable, the resolvable `choices` stays. A blanket
+        # "drop both" is tidier to write and throws away what the source did give us — this is the
+        # assertion that keeps it honest.
+        @test occursin(
+            "parcial = Models.CharField(max_length=10, " *
+            "choices=((\"1\", \"Baixa\"), (\"2\", \"Alta\")))",
+            generated,
+        )
+        @test occursin("`default` dropped", generated)
+
+        # `.values` is a list of values, not (value, label) pairs.
+        @test occursin("uses `Prioridade.values`", generated)
+        @test occursin("listagem = Models.CharField(max_length=10)", generated)
+
+        # A member that does not exist on the enum.
+        @test occursin("`Prioridade.INEXISTENTE`, which is not a member", generated)
+        @test occursin("fantasma = Models.CharField(max_length=10)", generated)
+
+        # Only CharField has a choices slot. `_common_kwargs` would warn anonymously
+        # ("Unexpected parameter for TextField"); this names the field and class.
+        @test occursin("TextField has no choices slot in PormG", generated)
+        @test occursin("corpo = Models.TextField()", generated)
+
+        # ...and the model declared AFTER all of them is still here. This is the assertion that
+        # actually pins the issue: one bad enum must cost one field's metadata, not the file.
+        @test occursin("Posterior = Models.Model(\"posterior\"", generated)
+        # Every model in the fixture reaches the file. A count rather than nine `occursin`s, so a
+        # regression that loses one anywhere in the middle fails here.
+        # Bump this when the fixture gains a model — that maintenance is the price of catching a
+        # model that silently disappears from the middle of the file.
+        @test count("Models.Model(", generated) == 14
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: the construction-time safety net (#342)
+# `choices=Prioridade.choices, default="NOPE"` — both kwargs resolve perfectly
+# well and the PAIR is invalid. Nothing in parse_field_args can see that; only
+# CharField's own validation can, and before #342 it aborted the whole import.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer recovers from a rejected choices/default pair" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_safetynet_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The field survives without its enumeration...
+        @test occursin("combinado = Models.CharField(max_length=10)", generated)
+        # ...and says why, naming ONLY the kwargs that were actually present and quoting the
+        # validation that rejected them. The blanket wording claimed "the enumeration is not
+        # enforced" on fields that had no enumeration — an over-long `default` on a plain CharField
+        # recovers through this same path.
+        @test occursin("`choices` and `default` rejected and dropped", generated)
+        @test occursin("The default value must be one of the choices", generated)
+        # The bad default never reaches the output.
+        @test !occursin("\"NOPE\"", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: inline choice values carry no quote characters (#342)
+# `parse_value` stored a Django ("UP", "Upload") as the four-character string
+# `"UP"` — quote marks kept as part of the value. Metadata-only, so nothing
+# downstream broke, but enum resolution produces the clean form and one model
+# would otherwise have carried two spellings of the same concept.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer strips quotes from inline choice values" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_quotes_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        @test occursin(
+            "canal = Models.CharField(max_length=2, default=\"UP\", " *
+            "choices=((\"UP\", \"Upload\"), (\"GS\", \"Sheets\")))",
+            generated,
+        )
+        # The old shape, spelled out so the assertion cannot pass by accident: the value used to be
+        # the four-character string including its quote marks.
+        @test !occursin("\\\"UP\\\"", generated)
+
+        # ...and a LIST container gets the same treatment. It used to bypass the importer's
+        # parse_choices entirely (which only handled `(...)`) and be re-parsed much later by the
+        # field layer, which still keeps the quotes — so one generated model carried both spellings
+        # of the same concept, the very thing the normalization exists to prevent.
+        @test occursin(
+            "lista = Models.CharField(max_length=2, default=\"UP\", " *
+            "choices=((\"UP\", \"Upload\"), (\"GS\", \"Sheets\")))",
+            generated,
+        )
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a choices literal is read with the shared scanner (#342)
+# `parse_choices` split on EVERY comma and threw InvalidMigrationError from
+# OUTSIDE the field-construction try. A comma inside a human-readable label —
+# "Aplicado, com ressalvas" — therefore aborted the whole import: no file
+# written, every model lost. That is verbatim the failure this issue exists to
+# remove, in the function the issue asks to rewrite.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer reads choices literals with the bracket-aware scanner" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_scanner_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # A comma inside a label is content, not a separator.
+        @test occursin(
+            "virgula = Models.CharField(max_length=3, default=\"a\", " *
+            "choices=((\"a\", \"Alpha, primeiro\"),))",
+            generated,
+        )
+
+        # A list of LISTS is valid Django. It used to import as an empty `choices=()` with no
+        # warning at all — a documented limitation that the scanner rebase removes.
+        @test occursin(
+            "listas = Models.CharField(max_length=2, default=\"A\", " *
+            "choices=((\"A\", \"Alpha\"), (\"B\", \"Beta\")))",
+            generated,
+        )
+
+        # A genuinely malformed entry is reported and skipped; the good one beside it survives, so
+        # the leniency is per entry rather than a blanket bail-out.
+        @test occursin("has a choices entry that is not a (value, label) pair", generated)
+        @test occursin(
+            "torto = Models.CharField(max_length=2, default=\"A\", choices=((\"A\", \"Alpha\"),))",
+            generated,
+        )
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: an abstract base's enum resolves from its children (#342)
+# Inherited statements are merged into the child and processed under the CHILD's
+# name, so a base declaring both the enum and a field using it hands the child a
+# reference that is nowhere in its own scope. The importer then reported it as
+# "not defined in this file" about an enum three lines above — a marker stating
+# something the reader can see is false.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer resolves an enum declared on an abstract base" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_abstract_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        @test occursin(
+            "estado = Models.CharField(max_length=3, default=\"ON\", " *
+            "choices=((\"ON\", \"Ligado\"), (\"OFF\", \"Desligado\")))",
+            generated,
+        )
+        # ...and no marker claims the base's enum is missing.
+        @test !occursin("`Estado`, which this file does not define", generated)
+        # The abstract base itself emits no table.
+        @test !occursin("Auditavel = Models.Model(", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a dotted default that is not an enum is left alone (#342)
+# Enum resolution runs on EVERY option value. Capturing any dotted `default=`
+# made `default=uuid.uuid4` and `default=timezone.now` disappear from fields
+# that have nothing to do with enumerations — an undocumented behavior change,
+# reported with a diagnostic that named the wrong thing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer does not treat every dotted default as an enum" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_dotted_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # Kept exactly as before this change.
+        @test occursin("ident = Models.CharField(max_length=36, default=\"uuid.uuid4\")", generated)
+        # ...and the datetime-callable mapping still wins for `timezone.now`.
+        @test occursin("criado = Models.DateTimeField(auto_now_add=true)", generated)
+        # Neither is reported as an enumeration.
+        @test !occursin("`uuid`, which this file does not define", generated)
+        @test !occursin("`timezone`, which this file does not define", generated)
+
+        # But a dotted default that IS kept verbatim is still reported. `Externo.ativo` is an enum
+        # member spelled unconventionally and is indistinguishable from `uuid.uuid4` by syntax
+        # alone — so the value is left untouched and the reader is told an expression landed in the
+        # schema as literal text. Keeping it AND saying nothing is the silent gain the contract
+        # forbids.
+        @test occursin("a = Models.CharField(max_length=40, default=\"Externo.ativo\")", generated)
+        @test occursin("an expression the importer cannot evaluate — kept verbatim as text", generated)
+
+        # `.value` on an UNRESOLVABLE enum. The member-attribute peel cannot fire, so `.value`
+        # counting as an enum-shaped attribute is the only thing keeping the literal out of the
+        # schema — dropped and reported, not kept verbatim like `Externo.ativo` above.
+        @test occursin("b = Models.CharField(max_length=40)", generated)
+        @test !occursin("\"Externo.ATIVO.value\"", generated)
+
+        # `.value` resolves to the member's stored value — it is an ordinary way to spell a default,
+        # and rejecting it cost the resolvable `choices` as well via the safety net.
+        @test occursin(
+            "com_value = Models.CharField(max_length=10, default=\"NOVO\", " *
+            "choices=((\"NOVO\", \"Novo\"), (\"VELHO\", \"Velho\")))",
+            generated,
+        )
+        # `.label` is display text, not a stored value: dropped and named, choices kept.
+        @test occursin("which is the member's label rather than its stored value", generated)
+        @test occursin(
+            "com_label = Models.CharField(max_length=10, " *
+            "choices=((\"NOVO\", \"Novo\"), (\"VELHO\", \"Velho\")))",
+            generated,
+        )
+
+        # `choices` naming a module-level constant: nothing to read, and an empty tuple in silence
+        # is how a field lost its whole enumeration without a trace. The marker must say the WHOLE
+        # option went — the per-entry phrasing shares this channel and would leave a reader thinking
+        # the rest survived.
+        @test occursin("s = Models.CharField(max_length=3)", generated)
+        @test occursin(
+            "has `choices=SITUACAO_CONSTANTE`, which is a name rather than a literal — the whole " *
+            "option was dropped.",
+            generated,
+        )
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: enum member values the importer cannot read (#342)
+# `CARRO = auto()` is a documented Django idiom. Imported verbatim it gives
+# every member the value "auto()" — duplicates that then PASS validation,
+# because the default is literally in the set. Wrong metadata kept in silence is
+# the mirror of a silent drop, and this importer's contract forbids both.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer reports enum members whose values are not literals" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_nonliteral_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # `auto()` never reaches the output as a value...
+        @test !occursin("auto()\"", generated)
+        @test occursin("have values the importer cannot read", generated)
+        @test occursin("tipo = Models.CharField(max_length=10)", generated)
+
+        # An enum with no members cannot supply choices.
+        @test occursin("`Vazia` declares no members", generated)
+        @test occursin("vazia = Models.CharField(max_length=5)", generated)
+
+        # A gettext-wrapped label is unwrapped: the wrapper is i18n plumbing, not the display text.
+        @test occursin(
+            "cor = Models.CharField(max_length=10, default=\"AZUL\", " *
+            "choices=((\"AZUL\", \"Azul\"), (\"VERDE\", \"Verde\"), (\"MISTO\", \"Misto\")))",
+            generated,
+        )
+        @test !occursin("_(\\\"Azul\\\")", generated)
+
+        # A COMPOUND label unwraps to the fragment `a") + _("b`. Falling back to Django's derived
+        # label keeps that fragment out of the generated file as display text. Only the LABEL
+        # degrades this way; a non-literal VALUE drops the option, because a value is schema.
+        @test occursin("(\"MISTO\", \"Misto\")", generated)
+        @test !occursin("+ _(", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: a resolved `None` member is not mistaken for a drop (#342)
+# `parse_value("None")` is `nothing`, and `nothing` was also the "drop this
+# option" signal. A member declared `NENHUM = None, "Nenhum"` therefore made the
+# option vanish with no warn and no marker — the one thing this importer
+# promises never to do. The two now use distinct sentinels.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer distinguishes a None member value from a dropped option" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = "django_choices_none_unit.jl",
+    )
+
+    try
+        generated = read(generated_path, String)
+
+        # The field imports with its choices...
+        @test occursin("x = Models.CharField(max_length=3, null=true, choices=(", generated)
+        # ...and nothing about it is reported, because nothing about it was dropped. A silent drop
+        # would look identical in the declaration, so the absence of a marker is the assertion.
+        @test !occursin("on 'NoneMembro'", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer: the choices output is loadable Julia (#342)
+# Everything above is downstream of this. The whole issue is an import that ends
+# as a stack trace and no file at all, so the file existing, parsing, evaluating
+# and carrying the right choices on the right field is the real assertion.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer emits a choices-carrying module that evaluates" begin
+    fixture = joinpath(@__DIR__, "fixtures", "django_models_choices_forms.txt")
+    output_file = "django_choices_evaluates_unit.jl"
+    config_key, db_dir_existed, generated_path = import_fixture_to_temp(
+        fixture;
+        output_file = output_file,
+    )
+
+    try
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(read(generated_path, String)))
+        # Read back through `Core.eval`: the module was defined during this call, so its bindings
+        # are newer than this frame's world age and a direct `getfield` raises UndefVarError.
+        modelof(sym) = Core.eval(sandbox, :(django_choices_evaluates_unit.$sym))
+
+        batch = modelof(:ImportBatch)
+        @test batch.fields["status"].choices ==
+              (("DRAFT", "Em processamento"), ("APPLIED", "Aplicado"), ("IN_PROGRESS", "In Progress"))
+        @test batch.fields["status"].default == "DRAFT"
+
+        # An IntegerChoices on a CharField: parse_choices stringifies the values and CharField
+        # coerces the Int default, so both enum kinds land correctly.
+        row = modelof(:ImportRow)
+        @test row.fields["prioridade"].choices == (("1", "Baixa"), ("2", "Alta"))
+        @test row.fields["prioridade"].default == "1"
+
+        # A degraded field keeps its column and loses only the enumeration.
+        rel = modelof(:Relatorio)
+        @test rel.fields["origem"].choices === nothing
+        @test rel.fields["origem"].default === nothing
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+end


### PR DESCRIPTION
Closes #342.

Third of the arc that ends in multi-app Django import (#346), on top of #340's statement-aware scanner and #341's resolved class graph. This is the last chunk before the naming work (#343/#344/#345) and the multi-app method itself.

## The bug

`TextChoices` is the modern Django idiom for an enumerated column, and the importer had no notion of it. `choices=Status.choices` parsed to the literal **string** `"Status.choices"` and `default=Status.DRAFT` to `"Status.DRAFT"`; `CharField` then rejected the pair and the `FieldValidationError` propagated out of `process_class_fields!`, **killing the entire import** — every other model in the file lost, the only output a stack trace.

```python
class ImportBatch(models.Model):
    class Status(models.TextChoices):
        DRAFT = "DRAFT", "Em processamento"
        APPLIED = "APPLIED", "Aplicado"

    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
```

The enum classes were already being parsed — #340 put a nested `class Status(TextChoices)` into `PyClass.nested`, and `_lift_meta!` only ever removes `Meta`. This consumes that seam.

## The change

```julia
status = Models.CharField(max_length=20, default="DRAFT",
  choices=(("DRAFT", "Em processamento"), ("APPLIED", "Aplicado"), ("IN_PROGRESS", "In Progress")))
```

An enum is found **nested** in the model, at **module level**, or on an **abstract base** the model inherits, and lookup is scoped in that order — so two models may each nest a `Status` with different members and each resolves to its own. A missing label is derived as Django does (`IN_PROGRESS` → `In Progress`).

**Nothing is dropped in silence, and nothing wrong is kept in silence either.** Every degrade emits a `@warn` *and* a `# PormG:` comment in the generated file: `.values`/`.labels`/`.names`, a member the enum does not declare, an enum whose members are not literals, an empty enum, a `choices` naming a module constant, and a `choices` on any field type but `CharField` — the only one with a slot for it.

A name this file does not define drops the option that names it, **per option**: if `choices` resolves and only `default` does not, the field keeps its enumeration. The reason neither is ever passed through as a literal is that `default="Externo.ATIVO"` against an empty `choices` is the original abort.

Enum references are claimed by **attribute shape** — `.choices`, the plural attributes, `.value`/`.label`/`.name`, or a `SHOUTY_CASE` member. Any other dotted default (`uuid.uuid4`, `timezone.now`) is kept verbatim exactly as before, and reported.

## Also in scope, because the change reached them

- **`parse_choices` is rebased on #340's shared scanner.** It split on **every** comma and threw from *outside* the field-construction `try`, so an ordinary label — `("APPLIED", "Aplicado, com ressalvas")` — aborted the whole import exactly as the enum did. It no longer throws at all: a malformed entry is reported and its well-formed siblings survive. `choices=[["A","Alpha"]]` (a list of *lists*) now imports correctly, where it used to yield an empty `choices=()` silently.
- **Choice values carry no quote characters.** `("UP","Upload")` was stored as the four-character string `"UP"`, quote marks included.
- **A numeric member imports as the value it denotes** — `1_000` is 1000, `0x1F` is 31. The source spelling declares an enumeration no row can match, and since the default would be wrong identically, validation passes and nothing is reported.
- **gettext labels are unwrapped**; a compound one falls back to Django's derived label rather than emitting a fragment of Python as display text.

## Verification

- 39 importer testsets (21 pre-existing, all still passing, + 18 new); full unit suite **6142/6142**; docs build clean.
- **Mutation-tested: 33 mutations** across three rounds, each reverting one behavior, all killed by the assertion written for it. Three separate survivors were coverage gaps I closed by adding the input that reaches them; one survivor made me *delete* code rather than test it.
- **Three independent review rounds, 15 findings (10 → 4 → 1), all resolved.** Every round found defects in the previous round's fixes. The ones worth naming:
  - A comma in a choice label still aborted the entire import — the exact bug this issue exists to close, in the function it asks to rewrite.
  - An enum lookup that **silently imported the wrong enumeration** by shadowing the module scope with a key Python never binds.
  - A numeric widening I made to close a *low-severity* nit, which traded a reported degrade for a **silent wrong value**.

## Deliberately not done

- **No `UPGRADING.md` entry.** Nothing that worked before stops working; existing generated files keep loading; regeneration is opt-in. The quote and numeric normalizations are metadata that never reaches DDL, and both fix values that were already wrong.
- **A sibling's deeply-nested enum, fully qualified** (`Dono.Grupo.Situacao.choices`) does not resolve — the qualified fallback splits on the last dot only. It drops **with** a marker and the column survives, so the contract holds. Worth a backlog line.
- **`parse_value`'s own `parse_choices` call discards its `skipped` list.** Reachable only for a non-`choices` kwarg whose value is a `(...)` literal; PormG drops those kwargs anyway, and the pre-PR code *threw* there. Strictly better, but the invariant is not global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
