### PR TITLE
fix(#343): store the reverse relation's binding instead of respelling it

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -80,7 +80,7 @@ registration has `connect_key === nothing` and no reverse relations.
 | `name` | `Model(...)`, or `set_models` from the Julia binding | The table name. For a model you *declare* it is always lowercase — a positional name is rejected unless already lowercase (#300), a binding-derived one is lowercased as it is filled in. A model built by `inspectdb` introspection or the Django importer instead keeps the name read from its source, mixed case and all |
 | `fields` | `Model(...)` | Declared field name → `PormGField`, including many-to-many fields |
 | `field_names` | `Model(...)` | The subset that owns a real column — many-to-many fields are excluded |
-| `related_objects` | `set_models` | Reverse accessors installed by foreign keys pointing *at* this model |
+| `related_objects` | `set_models` | Reverse accessors installed by relations pointing *at* this model: accessor name → a `ReverseRelation` (a foreign key on another model) or a `ManyToManyRelation` (a many-to-many, reversed). Each carries the resolved child model, so a reverse join never re-derives a Julia binding from a name (#343) |
 | `_module` / `connect_key` | `set_models` | The defining module and the connection key it registered under |
 | `cache` | `set_models`, `Model(constraints = …)` | Derived metadata: many-to-many relations, declared unique constraints |
 
@@ -122,6 +122,56 @@ end
   owner_model_resolved::Union{PormGModel, Nothing} = nothing
   related_model_resolved::Union{PormGModel, Nothing} = nothing
 end
+
+# What `related_objects` stores for a REVERSE FOREIGN KEY accessor — the sibling of
+# `ManyToManyRelation` above, and the other half of that Dict's value domain.
+#
+# It replaces a bare 4-tuple (#343). The tuple's third slot was the child's LOGICAL name, written
+# through `get_model_name`, which lowercases unconditionally — so every consumer had to guess the
+# Julia binding back with `uppercasefirst`, and that spelling can only ever be `Xxxxx`. A binding
+# with an internal capital (`Dim_CNES`, `CustomUser`, `Cust_adminHOD`) was therefore unreachable in
+# reverse, by ANY string function: since #300 the positional name is validated lowercase, so the
+# information was not merely folded, it was never stored. Ten of 668 models across the consuming
+# apps were affected, including a central dimension table.
+#
+# `model_resolved` is the fix: the child model is RECORDED at registration, where `set_models`
+# already holds it as the loop variable, and READ at query time. It is deliberately NOT nullable —
+# there is exactly one producer and it always has the model, so a nullable slot would only invite a
+# `=== nothing` fallback back into the consumers, which is the bug wearing a hat.
+#
+# `binding` has no reader in `src/` today, and that is a deliberate exception to the rule that killed
+# the old 4th slot below. The difference is recoverability: `child_pk` is derivable from the model at
+# any time, whereas the binding is derivable from NOTHING once registration ends — that is the whole
+# content of #343. It is the reverse-side counterpart to `ManyToManyRelation`'s
+# `owner_binding`/`related_binding`, and it is the spelling a diagnostic or a code generator has to
+# print for a user to be able to type it (`M.Dim_CNES`). Dropping it would re-create the hole.
+#
+# The old tuple's 4th slot (the child's own pk) is gone: nothing in `src/` ever read it, and it is
+# now derivable as `get_model_pk_field(rel.model_resolved)`. Storing a derived value nothing reads is
+# how the 3rd slot rotted in the first place.
+@kwdef struct ReverseRelation
+  fk_field::Symbol            # the FK column on the CHILD model
+  target_pk::Symbol           # the column on the PARENT (this Dict's owner) that the FK references
+  model_name::Symbol          # the CHILD's LOGICAL name: django_prefix-stripped and lowercased
+  binding::Symbol             # the CHILD's Julia binding in `_module` — the #343 fix
+  model_resolved::PormGModel  # the CHILD model itself
+end
+
+# Single constructor for the three `set_models` branches (>=2 FKs to one target, 1 FK with an
+# implicit accessor, 1 FK with an explicit `related_name`). They differ only in the Dict KEY they
+# store under; the relation itself is identical, and before #343 that identity was three copies of
+# one tuple literal. `Symbol(field.pk_field)` reproduces the old `field.pk_field |> Symbol` exactly,
+# including the `:nothing` degenerate for a pk_field `resolve_fk_target!` could not default.
+_reverse_relation(child::PormGModel, model_name::Symbol, binding::Symbol,
+                  fk_field_name::AbstractString, field::PormGField) =
+  ReverseRelation(
+    fk_field       = Symbol(fk_field_name),
+    target_pk      = Symbol(field.pk_field),
+    model_name     = model_name,
+    binding        = binding,
+    model_resolved = child,
+  )
+
 # A Model_Type is resolved schema state — its `fields`, `_module`, and `related_objects` are built once
 # by `set_models` and treated as an immutable, SHARED reference everywhere (the query builder copies query
 # state but shares the model verbatim: `SQLObjectQuery` deepcopy sets `model=obj.model`). Deep-copying a
@@ -129,36 +179,16 @@ end
 # `.to` (another Model_Type) it descends into `_module::Module` → "deepcopy of Modules not supported".
 # Override the recursion hook to SHARE — return the same model, registered in `stackdict` so its identity
 # is stable across the surrounding copy. So `deepcopy(model) === model`, and any container/field that
-# holds a model shares it rather than cloning the schema graph. Mirrors the `ManyToManyRelation` override
-# below (#65) and resolves the module-traversal throw (#157).
+# holds a model shares it rather than cloning the schema graph. Resolves the module-traversal throw (#157).
+#
+# This one hook is also what makes BOTH relation structs above deep-copy correctly, with no override
+# of their own: they are immutable, every other field is a Symbol/String/Bool, and their resolved-model
+# slots land here and are shared. So Base's default rebuilds a relation whose every field is `===` the
+# original's — and `===` on an immutable is field-wise egality, hence `deepcopy(rel) === rel`.
+# #65 shipped a hand-written `deepcopy_internal(::ManyToManyRelation, …)` that did this by hand; #157
+# added the hook below, which superseded it, and #343 removed it. Do not reintroduce one for a new
+# relation struct without first checking whether the default already does the job.
 Base.deepcopy_internal(m::Model_Type, stackdict::IdDict) = get!(stackdict, m, m)
-
-# #65: a ManyToManyRelation now carries resolved model objects (owner/related). Those are shared,
-# derived state — `set_models` repopulates them — so deep-copying them would needlessly clone the
-# whole related-model graph (a Model_Type's `related_objects` holds these relations). Copy the
-# value-type String/Bool fields; SHARE the two resolved-model references — consistent with the
-# `Model_Type` share hook above (#157) and the targeted override for SQLiteParameterizedQuery.
-function Base.deepcopy_internal(r::ManyToManyRelation, stackdict::IdDict)
-  haskey(stackdict, r) && return stackdict[r]
-  new = ManyToManyRelation(
-    field_name=r.field_name,
-    through_model=r.through_model,
-    owner_model=r.owner_model,
-    owner_binding=r.owner_binding,
-    owner_pk=r.owner_pk,
-    owner_column=r.owner_column,
-    related_model=r.related_model,
-    related_binding=r.related_binding,
-    related_pk=r.related_pk,
-    related_column=r.related_column,
-    inverse_accessor=r.inverse_accessor,
-    reverse=r.reverse,
-    owner_model_resolved=r.owner_model_resolved,
-    related_model_resolved=r.related_model_resolved,
-  )
-  stackdict[r] = new
-  return new
-end
 
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Management/Reflection
@@ -197,12 +227,41 @@ function get_all_models(modules::Module; symbol::Bool=false)::Vector{Union{Symbo
   return model_names
 end
 
-function capitalize_symbol(s::Symbol)
-  str = string(s)
-  if isempty(str)
-    return s
+# One walk, two outputs: the model vector `set_models` iterates, and the model → binding map it
+# records into `ReverseRelation.binding` (#343).
+#
+# Split from `get_all_models` rather than folded into its `symbol` kwarg, which returns the Symbol
+# XOR the model and so can never express the PAIRING. Kept separate from `_find_model_binding_name`
+# too, deliberately: that helper is an O(N) identity scan, and calling it once per foreign key across
+# a real app's ~670 models is ~450k `invokelatest` calls per `set_models`. Here the binding is simply
+# not thrown away in the first place.
+#
+# Airtight by construction: both outputs come from the SAME iteration, so every model in `models` is
+# a key of `bindings`, no fallback spelling is needed — and none is offered, because a fallback
+# spelling is exactly what #343 was.
+#
+# `get!` keeps the FIRST binding when one model object is bound under several names, matching
+# `_find_model_binding_name`; `names` returns sorted symbols, so that choice is deterministic.
+function _collect_models_and_bindings(modules::Module)
+  models = PormGModel[]
+  bindings = IdDict{PormGModel, Symbol}()
+  for name in names(modules; all=true, imported=true)
+    # Use invokelatest to avoid World Age issues in Julia 1.12+
+    attr = try
+        Base.invokelatest(getfield, modules, name)
+    catch
+        nothing
+    end
+    isa(attr, PormGModel) || continue
+    # Same binding-derived name fill as `get_all_models` — load-bearing for `Model(; fields...)`,
+    # which leaves `name` empty and relies on registration to derive it from the binding.
+    if attr.name == ""
+      attr.name = name |> format_model_name
+    end
+    push!(models, attr)
+    get!(bindings, attr, name)
   end
-  return Symbol(uppercase(str[1]) * str[2:end])
+  return models, bindings
 end
 
 function get_model_pk_field(model::PormGModel)::Union{Symbol, Nothing}
@@ -411,7 +470,9 @@ See also [`Model`](@ref), `PormG.@import_models`, `PormG.@models_module`.
 """
 function set_models(_module::Module, path::String)::Nothing
   @pormg_debug false
-  models = get_all_models(_module)  
+  # #343: one walk yields the models AND their Julia bindings. The binding cannot be recovered later
+  # from a model — `name` is validated lowercase (#300) — so it is captured here or it is lost.
+  models, bindings = _collect_models_and_bindings(_module)
 
   # Register for lazy loading / self-healing
   REGISTERED_MODULES[_module] = path
@@ -463,7 +524,12 @@ function set_models(_module::Module, path::String)::Nothing
     dict_tables_c = Dict{String, Int}()
     dict_tables_fiels = Dict{String, Vector{String}}()
     model.connect_key = connect_key
-    # @pormg_debug model.name == "dash_tab_cvat" 
+    # Hoisted: both describe the CHILD (`model`) and are identical for every FK it declares. The
+    # logical name was recomputed per field before #343, inconsistently — sometimes inline, sometimes
+    # into a local of the same name.
+    model_name = get_model_name(model, settings)::Symbol
+    model_binding = bindings[model]
+    # @pormg_debug model.name == "dash_tab_cvat"
     # println(model.name)
     for (field_name, field) in pairs(model.fields)
       if field isa sForeignKey || field isa sOneToOneField
@@ -487,28 +553,27 @@ function set_models(_module::Module, path::String)::Nothing
         end
         if dict_tables_c[field_to.name] > 1
           @pormg_debug false
-          if field.related_name === nothing 
-            field.related_name = string(get_model_name(model, settings), "_", field_name) |> lowercase
+          if field.related_name === nothing
+            field.related_name = string(model_name, "_", field_name) |> lowercase
             @info("The field $field_name in the model $(model.name) is a ForeignKey and the related_name is not defined, so the related_name was set to $(field.related_name)")
           end
           if haskey(field_to.related_objects, field.related_name)
             throw(ModelDefinitionError("The related_name $(field.related_name) in the model $(model.name) is already defined"))
           else
-            field_to.related_objects[field.related_name] = (field_name |> Symbol, field.pk_field |> Symbol, get_model_name(model, settings), get_model_pk_field(model) |> Symbol)
+            field_to.related_objects[field.related_name] = _reverse_relation(model, model_name, model_binding, field_name, field)
           end
         elseif dict_tables_c[field_to.name] == 1
           @pormg_debug false
-          model_name = get_model_name(model, settings)
-          if field.related_name === nothing            
-            field_to.related_objects[model_name |> string] = (field_name |> Symbol, field.pk_field |> Symbol, model_name |> Symbol, get_model_pk_field(model) |> Symbol)
+          if field.related_name === nothing
+            field_to.related_objects[model_name |> string] = _reverse_relation(model, model_name, model_binding, field_name, field)
           else
             if haskey(field_to.related_objects, field.related_name)
               throw(ModelDefinitionError("The related_name $(field.related_name) in the model $(model.name) is already defined"))
             else
-              field_to.related_objects[field.related_name] = (field_name |> Symbol, field.pk_field |> Symbol, model_name, get_model_pk_field(model) |> Symbol)
+              field_to.related_objects[field.related_name] = _reverse_relation(model, model_name, model_binding, field_name, field)
             end
           end
-        end        
+        end
         
         # check on_delete — a schema that contradicts itself is rejected at registration (#287).
         # These were `@error` logs until #287: they named the problem and then let the broken model
@@ -957,7 +1022,7 @@ end
 # Resolve a field-name string to its physical column within `model` (db_column when
 # the named field carries one), verbatim when the name is not a field of `model`. For
 # call sites that hold only a model + a field-name string — e.g. reverse-relation join
-# keys assembled from `related_objects` tuples (#50). A strict no-op without db_column.
+# keys read off a `ReverseRelation` (#50). A strict no-op without db_column.
 function model_column(model::PormGModel, name::AbstractString)::String
   haskey(model.fields, name) ? field_db_column(model.fields[name], name) : String(name)
 end
@@ -2181,6 +2246,41 @@ function _same_model_reference(a::Union{String, PormGModel}, b::PormGModel)::Boo
   return format_model_name(_model_reference_name(a)) == format_model_name(b.name)
 end
 
+# Recover a model's Julia binding by identity. Used by the many-to-many registration path, which
+# stores the two bindings on the relation; the reverse-FK path gets its binding straight from
+# `_collect_models_and_bindings` instead, which is a great deal cheaper than one scan per relation.
+#
+# The `uppercasefirst` fallback is lossy in exactly the way #343 is about — it can only ever spell
+# `Xxxxx` — and #343 tried to replace it with a throw. DO NOT: it is load-bearing, for a reason the
+# scan above cannot see. `names(_module; all=true, imported=true)` does NOT list bindings introduced
+# by `using` (only explicitly `import`ed ones), while `isdefined`/`getfield` DO reach them. So for a
+# model declared in one module and pulled into the registering module with `using`, the scan misses,
+# yet `_resolve_m2m_side_model`'s binding branch (`build_joins.jl`, which tests `isdefined`) resolves
+# the guessed `Xxxxx` spelling successfully. Throwing here broke that working layout — and broke it
+# quietly, because both `set_models` callers that matter (the injected `__init__` in `Utils.jl` and
+# the Revise callback) swallow the exception, so the symptom is "no models registered", not an error.
+#
+# Pinned by `test_many_to_many.jl` → "using-scoped M2M target keeps the binding fallback". A comment
+# did not stop this deletion the first time, so the guard is a test.
+#
+# What the fallback does NOT rescue, so nobody reads more into it than is there: it works only where
+# the binding happens to equal `uppercasefirst(name)`. A `using`-scoped model whose binding carries
+# an internal capital (`Dim_CNES`) still fails here and on `main` alike — `isdefined(mod, :Dim_cnes)`
+# is false, and `_resolve_m2m_side_model`'s name-scan fallback misses for the same `names()` reason,
+# so it raises `QueryBuildError`. That intersection is what `ReverseRelation` fixes for reverse
+# foreign keys and cannot fix for many-to-many, because the M2M path still re-resolves by binding
+# instead of reading `related_model_resolved` (#68/#41).
+#
+# The reverse-FK path depends on none of this: `set_models` records its binding directly from
+# `_collect_models_and_bindings`. This helper is many-to-many-only.
+#
+# The real repair is making `using`-scoped models visible to registration at all, and it is NOT the
+# one-word change it looks like. `names(...; usings=true)` exists on the 1.12 floor, but `using Base`
+# is implicit in every module, so it returns ~1112 names where `imported=true` returns 3 (measured on
+# 1.12.6). Both this scan and `_collect_models_and_bindings` do a `getfield` per name, so a straight
+# substitution turns registration into a ~1100-name sweep per module on a 670-model app, and drags in
+# any `PormGModel` an unrelated package re-exported. It needs a filter — `usings=true` on the miss
+# path only, or screening by `parentmodule`/`Base.binding_module`. Tracked in #354.
 function _find_model_binding_name(_module::Module, model::PormGModel)::String
   for name in names(_module; all=true, imported=true)
     attr = try
@@ -2411,10 +2511,22 @@ function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dic
 
   for (model_name, model_info) in current_schema
     source_model = model_info[:model]
-    # Derive from the model's LOGICAL name, symmetric with `related_binding` below — not from the
-    # dict key, which is the resolved PHYSICAL table name (#59) and so would carry a `db_table`
-    # spelling into a Julia-side binding label. Identical output for every model without `db_table`,
-    # since the key is that same logical name lowercased.
+    # These two labels are NOT real Julia bindings, and nothing here reads them as such: on this
+    # lifecycle the relation is a transient carrier for the through-table SHAPE only — the five slots
+    # consumed below are `through_model`, `owner_column`, `related_column`, `owner_pk`, `related_pk`,
+    # and the relation is then discarded rather than stored on a model. So `_resolve_m2m_side_model`
+    # never sees these, and their spelling cannot reach a `getfield`.
+    #
+    # #343 note, so the next reader does not "fix" this into the trap in reverse: the identity scan
+    # `_find_model_binding_name` uses is UNAVAILABLE here. `_load_current_models` (planner.jl) builds
+    # the schema by `Base.include`ing the model file into a throwaway module and deliberately never
+    # runs `set_models`, so `source_model._module` is `nothing` on the makemigrations path. Deriving
+    # from the model's LOGICAL name is therefore the only option — and it is a harmless one, because
+    # these slots are write-only here. Retiring them properly is #68/#41.
+    #
+    # Derive from the LOGICAL name, not the dict key: the key is the resolved PHYSICAL table name
+    # (#59) and would carry a `db_table` spelling into a Julia-side label. Identical output for every
+    # model without `db_table`, since the key is that same logical name lowercased.
     owner_binding = uppercasefirst(format_model_name(source_model.name))
     for (field_name, field) in source_model.fields
       is_many_to_many_field(field) || continue

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -7,7 +7,7 @@ import DataFrames, Tables, JSON, CSV, OrderedCollections
 import DataFrames: DataFrame
 using Dates, TimeZones, Decimals, UUIDs
 
-import PormG.Models: CharField, IntegerField, get_model_pk_field, capitalize_symbol, sForeignKey, sManyToManyField, sBinaryField
+import PormG.Models: CharField, IntegerField, get_model_pk_field, sForeignKey, sManyToManyField, sBinaryField
 import PormG: Dialect, Models
 import PormG: config
 import PormG: SQLType, PormGSettings, PormGSQLite, PormGPostgres, PormGSQLiteParam, PormGPostgresParam, AbstractPormGParam, SQLInstruction, SQLTypeF, SQLTypeFunction, SQLTypeOper, SQLTypeQ, SQLTypeQor, SQLObjectHandler, SQLObject, SQLTableAlias, SQLTypeText, SQLTypeOrder, SQLTypeField, SQLTypeArrays, PormGModel, PormGField, PormGTypeField

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -391,28 +391,35 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       m2m_inserted = true
     else
     # @pormg_debug false
-    s_model = Symbol(uppercasefirst(string(instruct.object.model.related_objects[vector[1]][3])))
-    reverse_model = getfield(foreing_table_module, s_model)
+    # #343: the child model is READ off the relation, never rebuilt from its name. The old
+    # `Symbol(uppercasefirst(lowercased_name))` could only ever spell `Xxxxx`, so a binding with an
+    # internal capital (Dim_CNES, CustomUser) raised UndefVarError instead of joining.
+    rel = related_object::Models.ReverseRelation
+    reverse_model = rel.model_resolved
     length(vector) == 1 && throw(QueryBuildError("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
     # !(vector[2] in reverse_model.field_names) && throw("Error in _build_row_join, the column $(vector[2]) not found in $(reverse_model.name)")
     row_join["a"] = Models.model_table_name(instruct.object.model)
     row_join["alias_a"] = instruct.alias
-    join_field = reverse_model.fields[instruct.object.model.related_objects[vector[1]][1] |> String]
+    join_field = reverse_model.fields[String(rel.fk_field)]
     row_join["how"] = _determine_join_type(join_field, second_fild_name= vector[2])
     size(vector, 1) == 2 && (last_field = reverse_model.fields[vector[2]])
-    # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
-    # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
-    foreign_table_name = instruct.object.model.related_objects[vector[1]][3] |> String
-    row_join["b"] = _reverse_join_table(reverse_model, foreign_table_name, instruct.django)
+    # The LOGICAL name goes straight into the table fallback, which is the only thing that ever
+    # wanted it — before #343 it was assigned to `foreign_table_name` and then overwritten below.
+    row_join["b"] = _reverse_join_table(reverse_model, String(rel.model_name), instruct.django)
 
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
     # Reverse join: key_a is the parent's referenced column, key_b the child's FK
     # column; both honor db_column (resolved in their own model, no-op without it) (#50).
-    row_join["key_a"] = Models.model_column(instruct.object.model, instruct.object.model.related_objects[vector[1]][2] |> String)
-    row_join["key_b"] = Models.model_column(reverse_model, instruct.object.model.related_objects[vector[1]][1] |> String)
+    row_join["key_a"] = Models.model_column(instruct.object.model, String(rel.target_pk))
+    row_join["key_b"] = Models.model_column(reverse_model, String(rel.fk_field))
     # #74: a reverse foreign key (one-to-many) makes the child table the many-side.
     row_join["to_many"] = "1"
-    foreign_table_name = s_model |> string
+    # Carry the RESOLVED model forward, matching the CTE and M2M branches. `foreign_table_name` is
+    # already declared `Union{String, PormGModel, Nothing}`, and both cross-branch readers accept a
+    # model: the next-hop lookup branches on `isa PormGModel`, and the terminal column resolver
+    # dispatches to `_solve_field(::String, ::Module, ::PormGModel, …)`. That terminal site was a
+    # FIFTH broken reconstruction, reached only if the join above had not already thrown.
+    foreign_table_name = reverse_model
     @pormg_debug false
     end
   else
@@ -498,28 +505,27 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
         foreign_table_name = foreign_model
         _m2m_inserted = true
       else
-      s_model = Symbol(uppercasefirst(string(new_object.related_objects[vector[1]][3])))
-      reverse_model = getfield(foreing_table_module, s_model)
+      # #343: read the resolved child — see the first-hop branch above for why respelling the
+      # binding from the logical name cannot work.
+      rel = related_object::Models.ReverseRelation
+      reverse_model = rel.model_resolved
       length(vector) == 1 && throw(QueryBuildError("Invalid field path: $(vector[1]) is a reverse field, you must inform the column to be selected. Example: ...filter(\"$(vector[1])__column\")"))
       !(vector[2] in reverse_model.field_names) && throw(UnknownFieldError("Invalid field path: the column $(vector[2]) not found in $(reverse_model.name)"))
       row_join["a"] = prev_b
       row_join["alias_a"] = tb_alias
-      join_field = reverse_model.fields[new_object.related_objects[vector[1]][1] |> String]
+      join_field = reverse_model.fields[String(rel.fk_field)]
       row_join["how"] = _determine_join_type(join_field, previus_how=prev_how, second_fild_name= vector[2])
       size(vector, 1) == 2 && (last_field = reverse_model.fields[vector[2]])
-      # After `|> String`, foreign_table_name is always a String — the old `=== nothing` and
-      # `isa PormGModel` arms were type-impossible dead code (removed in the #197 review pass).
-      foreign_table_name = new_object.related_objects[vector[1]][3] |> String
-      row_join["b"] = _reverse_join_table(reverse_model, foreign_table_name, instruct.django)
+      row_join["b"] = _reverse_join_table(reverse_model, String(rel.model_name), instruct.django)
 
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
       # Reverse join: key_a is the parent's referenced column, key_b the child's FK
       # column; both honor db_column (resolved in their own model, no-op without it) (#50).
-      row_join["key_a"] = Models.model_column(new_object, new_object.related_objects[vector[1]][2] |> String)
-      row_join["key_b"] = Models.model_column(reverse_model, new_object.related_objects[vector[1]][1] |> String)
+      row_join["key_a"] = Models.model_column(new_object, String(rel.target_pk))
+      row_join["key_b"] = Models.model_column(reverse_model, String(rel.fk_field))
       # #74: a reverse foreign key (one-to-many) makes the child table the many-side.
       row_join["to_many"] = "1"
-      foreign_table_name = s_model |> string
+      foreign_table_name = reverse_model
       vector = vector[2:end]
       _reverse_advanced = true
       end

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -191,8 +191,10 @@ function _resolve_join_target_model(q::SQLObject, join_path::String)
         # query builder when emitting joins.
         current_model = getfield(current_module, Symbol(related_value.related_binding))
       else
-        reverse_model = Symbol(uppercasefirst(string(related_value[3])))
-        current_model = getfield(current_module, reverse_model)
+        # #343: hop to the resolved child. This arm used to respell the binding as
+        # `uppercasefirst(lowercased_name)` — the mirror of the M2M arm above, except that one reads
+        # a STORED binding and therefore worked, while this one could not reach `Dim_CNES`.
+        current_model = (related_value::Models.ReverseRelation).model_resolved
       end
     else
       throw(QueryBuildError("Join path '$(join_path)' is invalid. The segment '$(part)' is not a relation on model '$(current_model.name)'."))

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -350,16 +350,20 @@ end
 function find_related_objects!(collector::DeletionCollector, model::PormGModel, dict::Vector{Dict{Symbol, Union{String, SQLObjectHandler}}})
   # For each foreign key in the model (model has FK -> related_model)
   @pormg_debug false
-  _django = collector.settings.django_prefix === nothing ? false : true
-    
+
   # For models with foreign keys pointing to this model (related_model has FK -> model)
   for (related_name, related_value) in model.related_objects
     # Skip many-to-many reverse accessors — these are handled by the through
     # table's own CASCADE FK on the owner side, not by this loop.
     related_value isa Models.ManyToManyRelation && continue
-    field_name, pk_field, related_model_name, pk_model = related_value
-    _django && (related_model_name = replace(string(related_model_name), collector.settings.django_prefix * "_" => "") |> Symbol)
-    related_model = getfield(model._module, related_model_name |> capitalize_symbol);
+    # #343: read the resolved child. This used to respell the binding with `capitalize_symbol`,
+    # which cannot produce an internal capital, so a cascade through `Dim_CNES` threw UndefVarError.
+    # Its django-prefix strip went with it: `get_model_name` strips the prefix at REGISTRATION, so
+    # the stored name never carried one and the strip was a guaranteed no-op. The tuple's `pk_field`
+    # and `pk_model` slots were destructured here and never read — both are gone with the tuple.
+    rel = related_value::Models.ReverseRelation
+    field_name = rel.fk_field
+    related_model = rel.model_resolved
 
     _query = related_model |> object;
     if size(dict, 1) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,7 @@ end
     @testset "Model_to_str Identifier Sanitizing (#317)" include("unit/test_model_to_str_identifiers.jl")
     @testset "Field-name Case Preservation (#57)" include("unit/test_field_name_case.jl")
     @testset "Model-name Case (#300)" include("unit/test_model_name_case.jl")
+    @testset "Mixed-case Model Binding in Reverse Joins (#343)" include("unit/test_reverse_join_mixed_case_binding.jl")
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "db_table Authoritative (#59)" include("unit/test_db_table.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -2155,11 +2155,21 @@ end
     # model name of Just_a_nested_roll_back.
     @test haskey(M.Just_a_test_deletion.related_objects, "just_a_nested_roll_back")
 
-    # Verify the tuple structure: (field_name, pk_field, related_model_name, pk_model)
+    # Verify the relation structure. This was a bare 4-tuple until #343; the 4th slot (the child's
+    # own PK) is gone with it, unread by anything, and two slots were ADDED that no string function
+    # could have reconstructed from the other three.
     entry = M.Just_a_test_deletion.related_objects["just_a_nested_roll_back"]
-    @test entry isa Tuple{Symbol, Symbol, Any, Symbol}
-    @test entry[1] == :test  # FK field name in Just_a_nested_roll_back
-    @test entry[2] == :id    # pk_field referenced in the FK definition
+    @test entry isa PormG.Models.ReverseRelation
+    @test entry.fk_field == :test                     # FK field name in Just_a_nested_roll_back
+    @test entry.target_pk == :id                      # pk_field referenced in the FK definition
+    @test entry.model_name == :just_a_nested_roll_back # child's LOGICAL name — lowercase by #300
+
+    # #343: the binding and the resolved model. Here the binding happens to equal
+    # `uppercasefirst(model_name)`, which is exactly why the old reconstruction survived this long —
+    # every model in this fixture is spelled that way. See test_reverse_join_mixed_case_binding.jl
+    # for the shape that is NOT recoverable by respelling.
+    @test entry.binding === :Just_a_nested_roll_back
+    @test entry.model_resolved === M.Just_a_nested_roll_back
 end
 
 @testset "Related Objects - Duplicate related_name rejection" begin

--- a/test/unit/test_db_table.jl
+++ b/test/unit/test_db_table.jl
@@ -315,10 +315,12 @@ DbtPlain.connect_key = "db_table_mock"
       m.connect_key = "db_table_mock"
       Base.eval(rmod, :(const $bind = $m))
     end
-    # The reverse-accessor tuple `set_models` would install: (child FK field, parent's referenced
-    # field, child model's LOGICAL name, child PK). Note the third slot is the logical name — which
-    # is precisely why the reverse renderer must consult the resolved model for a db_table.
-    rparent.related_objects["kids"] = (:parentid, :id, :dbtr_child_scratch, :id)
+    # The reverse accessor `set_models` would install. `model_name` is the child's LOGICAL name —
+    # which is precisely why the reverse renderer must consult `model_resolved` for a db_table, and
+    # (since #343) why `binding` is stored rather than respelled from that name.
+    rparent.related_objects["kids"] = PormG.Models.ReverseRelation(
+      fk_field = :parentid, target_pk = :id, model_name = :dbtr_child_scratch,
+      binding = :Dbtr_child_scratch, model_resolved = rchild)
 
     rev = inspect_query(rparent.objects.values("nome", "kids__note"))[:sql_text]
     @test occursin("\"Dbtr_Child_Legacy\"", rev)

--- a/test/unit/test_docstring_coverage.jl
+++ b/test/unit/test_docstring_coverage.jl
@@ -273,7 +273,7 @@ end
         # from closure branches) must be excluded: the rule cannot ask anyone to rename
         # `Base.deepcopy`. But a helper defined in a SIBLING PormG module and imported here is
         # renameable and must stay in scope — a `QueryBuilder`-only test passes a branch routing to,
-        # say, `PormG.Models.capitalize_symbol`, and if that branch were ChainCaller-backed
+        # say, `PormG.Models.get_model_pk_field`, and if that branch were ChainCaller-backed
         # `_fluent_name` would leak the internal spelling, which is the whole regression this guards.
         pormg_owned(mod) = mod === PormG || startswith(string(mod), "PormG.")
         idents = unique(m.match for m in eachmatch(r"[A-Za-z_][A-Za-z0-9_]*!?", code))

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -296,6 +296,75 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# `_find_model_binding_name`'s `uppercasefirst` fallback is load-bearing (#343).
+#
+# The fallback looks like dead defensive code — an identity scan that already walked the module,
+# followed by a guess. #343 deleted it for a throw on exactly that reading, and the whole 6118-test
+# suite stayed green, because nothing exercised the shape that needs it. This is that test.
+#
+# The shape: a model declared in one module and pulled into the REGISTERING module with `using`.
+# `names(mod; all=true, imported=true)` does not list `using`-brought bindings (only explicitly
+# `import`ed ones), so the identity scan misses — but `isdefined`/`getfield` do reach them, and
+# `_resolve_m2m_side_model` tests `isdefined`. So the guessed spelling resolves and the layout works.
+#
+# Deleting the fallback breaks it QUIETLY: the injected `__init__` in `Utils.jl` and the Revise
+# callback both swallow a `set_models` throw, so the symptom is "no models registered at all", not an
+# error anyone can read. That is why this is pinned by a test and not only by a comment.
+# ─────────────────────────────────────────────────────────────────────────────
+# The binding here is deliberately `Uschampionship` — i.e. exactly `uppercasefirst(name)`. That is
+# the ONLY spelling the fallback can produce, so it is the only one this layout can use; see the
+# negative assertion at the end of the testset for the case it cannot rescue.
+module UsingScopedSharedModels
+  import PormG
+  import PormG.Models
+  export Uschampionship
+  Uschampionship = Models.Model("uschampionship",
+    id = Models.IDField(),
+    nome = Models.CharField(),
+  )
+end
+
+module UsingScopedAppModels
+  import PormG
+  import PormG.Models
+  # `using`, NOT `import` — this is the entire point of the fixture.
+  using ..UsingScopedSharedModels
+
+  Usdriver = Models.Model("usdriver",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    championships = Models.ManyToManyField(Uschampionship, related_name = "drivers"),
+  )
+  PormG.Models.set_models(@__MODULE__, "m2m_mock")
+end
+
+@testset "using-scoped M2M target keeps the binding fallback (#343)" begin
+  # Preconditions — the asymmetry the fallback exists for. If either of these flips, the rest of
+  # this testset is no longer testing what it claims, so assert them rather than assume them.
+  @test !(:Uschampionship in names(UsingScopedAppModels; all=true, imported=true))
+  @test isdefined(UsingScopedAppModels, :Uschampionship)
+
+  # The contract: registration COMPLETED (it threw while the fallback was removed), and the recorded
+  # binding is the guessed `uppercasefirst` spelling rather than one the scan found.
+  rel = Models.get_many_to_many_relation(UsingScopedAppModels.Usdriver, "championships")
+  @test rel.related_binding == "Uschampionship"
+
+  # And the guess is not merely stored — it RESOLVES, through the `isdefined` branch the identity
+  # scan cannot see. This is what makes the fallback load-bearing rather than cosmetic.
+  @test isdefined(UsingScopedAppModels, Symbol(rel.related_binding))
+  @test PormG.QueryBuilder._resolve_m2m_side_model(
+      UsingScopedAppModels, rel.related_binding, "uschampionship", "championships"
+    ) === UsingScopedSharedModels.Uschampionship
+
+  # The limit of the rescue, asserted so nobody reads more into the fallback than is there: it works
+  # only where the binding happens to equal `uppercasefirst(name)`. A `using`-scoped model whose
+  # binding carries an internal capital is still unreachable — the scan misses it AND the guess is
+  # the wrong spelling. That intersection is what #343 fixes for reverse foreign keys (which store
+  # the binding) and cannot fix for many-to-many, which still re-resolves by binding (#68/#41).
+  @test uppercasefirst("dim_cnes") != "Dim_CNES"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # BUG-1 documentation: PormGModel.getproperty struct-field guard is intentional.
 # The `sym in fieldnames(typeof(m))` branch must stay BEFORE the M2M check because
 # has_many_to_many_accessor() itself accesses m.cache and m.related_objects, which
@@ -391,11 +460,16 @@ end
   @test rev.owner_model_resolved === M2M.Driver
   @test rev.related_model_resolved === M2M.Driver_championship
 
-  # deepcopy SHARES the resolved slots (the deepcopy_internal override) instead of cloning the
-  # related-model graph. This is also REQUIRED for correctness: a resolved model carries a
-  # `_module::Module`, and Julia cannot deepcopy a Module — so without the override, deep-copying
-  # a relation (e.g. via deepcopy(model.related_objects)) would throw "deepcopy of Modules not
-  # supported". The override copies the value fields and shares the two model references.
+  # deepcopy SHARES the resolved slots instead of cloning the related-model graph, and this is
+  # REQUIRED for correctness: a resolved model carries a `_module::Module`, and Julia cannot deepcopy
+  # a Module — so without sharing, deep-copying a relation (e.g. via deepcopy(model.related_objects))
+  # would throw "deepcopy of Modules not supported".
+  #
+  # The sharing comes from the `Model_Type` deepcopy hook (#157), NOT from a hook on this struct.
+  # #65 shipped a hand-written `deepcopy_internal(::ManyToManyRelation, …)`; #157 later made it
+  # redundant (a relation is immutable, so Base rebuilds one whose every field is `===` the
+  # original's once the model slots share), and #343 removed it. These assertions are unchanged and
+  # still hold — they now pin the DEFAULT behavior, which is the point.
   fwd_copy = deepcopy(fwd)
   @test fwd_copy.owner_model_resolved === M2M.Driver_championship  # same object (===), not a clone
   @test fwd_copy.related_model_resolved === M2M.Driver

--- a/test/unit/test_reverse_join_mixed_case_binding.jl
+++ b/test/unit/test_reverse_join_mixed_case_binding.jl
@@ -1,0 +1,240 @@
+# julia --project=. test/unit/test_reverse_join_mixed_case_binding.jl
+#
+# #343 — a reverse relation must reach a model whose Julia BINDING carries internal capitals.
+#
+# Until #343 every reverse consumer recovered the child's binding by respelling its logical name:
+# `Symbol(uppercasefirst(string(related_objects[key][3])))`. That slot is written through
+# `get_model_name`, which lowercases unconditionally, so the reconstruction could only ever produce
+# `Xxxxx` — first letter capital, everything else lower. And it is not a matter of a smarter fold:
+# since #300 a positional model name is REJECTED unless already lowercase, so the capitals were
+# never stored anywhere to recover.
+#
+# The result was that any binding like `Dim_CNES`, `CustomUser` or `Cust_adminHOD` was unreachable
+# in reverse and raised `UndefVarError: Dim_cnes` — ten of 668 models across the consuming apps,
+# including a central dimension table. Forward FKs were unaffected (`.to` carries the class name),
+# which is why it went unnoticed: every binding in `test/integration/db_*/models.jl` is spelled
+# exactly `uppercasefirst(lowercase(name))`, so no existing fixture could reproduce it.
+#
+# The fixture below is the shape the Django importer actually emits — a lowercase positional name
+# (#300-legal) under a mixed-case binding — pinned by test_import_django_models.jl's
+# `Dim_CNES = Models.Model("dim_cnes"` assertion. Each testset targets one of the four sites that
+# used to reconstruct: build_joins.jl first-hop, build_joins.jl multi-hop loop, ctes.jl
+# `_resolve_join_target_model`, and deletion.jl `find_related_objects!`.
+#
+# Everything here renders against a mock backend — no database. The pre-#343 failure was an
+# `UndefVarError` at query-BUILD time, so `inspect_query` traverses the identical code path a
+# `list()` would; there is no row-level behavior to observe because no SQL was produced at all.
+
+using Test
+using PormG
+using PormG.Models
+using PormG.QueryBuilder: inspect_query
+
+# Dedicated mock + config key — uniquely named so they never clash with other unit files' mock
+# structs when runtests.jl includes them all into the same module.
+struct MockSQLiteMixedCaseBinding <: PormG.PormGSQLite end
+PormG.backend_sqlite_version(::MockSQLiteMixedCaseBinding) = 3045000
+
+PormG.config["mixed_case_binding_mock"] = PormG.Configuration.Settings(
+  connections = MockSQLiteMixedCaseBinding(),
+  change_data = true,
+  db_def_folder = "mixed_case_binding_mock"
+)
+
+module MixedCaseBindingModels
+import PormG
+import PormG.Models
+
+# Plain binding — the parent every reverse hop starts from.
+Dim_Unidade = Models.Model("dim_unidade",
+  id = Models.IDField(),
+  nome = Models.CharField(),
+)
+
+# THE regression subject. `uppercasefirst(lowercase("dim_cnes"))` is "Dim_cnes", which is NOT this
+# binding — so before #343 every reverse consumer threw `UndefVarError: Dim_cnes` here. No explicit
+# related_name, so this exercises the implicit-accessor producer branch.
+Dim_CNES = Models.Model("dim_cnes",
+  id = Models.IDField(),
+  nome = Models.CharField(),
+  unidade = Models.ForeignKey(Dim_Unidade, pk_field = "id", on_delete = "CASCADE"),
+)
+
+# Second mixed-case binding, reached only as the SECOND hop of a chained reverse path, and declared
+# with an explicit related_name so the other producer branch is covered too.
+CustomUser = Models.Model("customuser",
+  id = Models.IDField(),
+  login = Models.CharField(),
+  cnes = Models.ForeignKey(Dim_CNES, pk_field = "id", on_delete = "CASCADE", related_name = "usuarios"),
+)
+
+PormG.Models.set_models(@__MODULE__, "mixed_case_binding_mock")
+end
+
+const MC = MixedCaseBindingModels
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The producer: set_models must RECORD the binding, because nothing can recover it later.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - related_objects records the binding (#343)" begin
+    # Implicit accessor: the key is the child's logical name, lowercase.
+    rel = MC.Dim_Unidade.related_objects["dim_cnes"]
+    @test rel isa Models.ReverseRelation
+    @test rel.fk_field == :unidade          # FK column on the CHILD
+    @test rel.target_pk == :id              # column on the PARENT that the FK references
+    @test rel.model_name == :dim_cnes       # logical name — lowercase, and lossy by construction
+
+    # The two slots #343 added. `binding` is what respelling could never produce, and
+    # `model_resolved` is what makes the lookup unnecessary in the first place.
+    @test rel.binding === :Dim_CNES
+    @test rel.model_resolved === MC.Dim_CNES
+
+    # The precise loss: the old reconstruction applied to the stored name yields a binding that is
+    # not defined in the module. This is the bug, expressed as an assertion.
+    @test Symbol(uppercasefirst(String(rel.model_name))) === :Dim_cnes
+    @test !isdefined(MC, :Dim_cnes)
+    @test isdefined(MC, rel.binding)
+
+    # Explicit related_name arm of the producer, second mixed-case binding.
+    rel2 = MC.Dim_CNES.related_objects["usuarios"]
+    @test rel2 isa Models.ReverseRelation
+    @test rel2.fk_field == :cnes
+    @test rel2.binding === :CustomUser
+    @test rel2.model_resolved === MC.CustomUser
+    @test !isdefined(MC, :Customuser)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_joins.jl — first hop. Pre-#343 this threw UndefVarError before rendering anything.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - reverse join renders (build_joins first hop)" begin
+    q = MC.Dim_Unidade.objects
+    q.values("nome", "dim_cnes__nome")
+
+    sql = inspect_query(q)[:sql_text]
+
+    @test contains(sql, "JOIN")
+    @test contains(sql, "dim_cnes")
+
+    # Pin the ON clause LITERALLY, both sides. A `contains(sql, "dim_cnes")` check passes even if
+    # key_a and key_b are transposed, and this diff rewrote exactly those two assignments — so the
+    # cheap assertion cannot see the one mistake the change was most able to make.
+    # key_a is the PARENT's referenced column (dim_unidade.id); key_b is the CHILD's FK column
+    # (dim_cnes.unidade). Transposing them yields ON "Tb"."unidade" = "Tb_1"."id", which is wrong
+    # and which every regex-shaped assertion in this file would still accept.
+    @test occursin("INNER JOIN \"dim_cnes\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"unidade\"", sql)
+end
+
+@testset "Mixed-case binding - reverse filter routes to :where" begin
+    q = MC.Dim_Unidade.objects
+    q.values("nome")
+    q.filter("dim_cnes__nome" => "unidade-x")
+
+    insp = inspect_query(q)
+
+    @test insp[:parameter_buckets][:where] == ["unidade-x"]
+    @test contains(insp[:sql_text], "dim_cnes")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_joins.jl — the multi-hop `new_object` loop, a SECOND mixed-case binding deep in the path.
+# This also covers the `foreign_table_name` propagation: the first hop hands the resolved model to
+# the next iteration, which before #343 received a respelled binding string and re-`getfield`ed it.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - chained reverse join (build_joins loop)" begin
+    q = MC.Dim_Unidade.objects
+    q.values("nome", "dim_cnes__usuarios__login")
+
+    sql = inspect_query(q)[:sql_text]
+
+    @test contains(sql, "dim_cnes")
+    @test contains(sql, "customuser")
+    # Two reverse hops means at least two joins.
+    @test length(collect(eachmatch(r"JOIN", sql))) >= 2
+
+    # Both hops pinned literally — see the first-hop testset for why the regex form is not enough.
+    # The second hop is the one that consumes the model handed forward by the first, so a break in
+    # the `foreign_table_name` propagation shows up here as a wrong alias or a missing join.
+    @test occursin("INNER JOIN \"dim_cnes\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"unidade\"", sql)
+    @test occursin("INNER JOIN \"customuser\" AS \"Tb_2\" ON \"Tb_1\".\"id\" = \"Tb_2\".\"cnes\"", sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ctes.jl — `_resolve_join_target_model`, reached through on(). Sibling coverage for the
+# lowercase-binding case lives in test_alignment_sqlite.jl "Related Objects - on() ...".
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - on() resolves the reverse target (ctes)" begin
+    q = MC.Dim_Unidade.objects
+    q.on("dim_cnes", "nome" => "on-value")
+    q.values("nome", "dim_cnes__nome")
+
+    insp = inspect_query(q)
+    sql = insp[:sql_text]
+
+    # on() puts the predicate in the ON clause, so its parameter lands in the :join bucket.
+    @test insp[:parameter_buckets][:join] == ["on-value"]
+    @test contains(sql, "LEFT JOIN")
+    @test contains(sql, "dim_cnes")
+end
+
+@testset "Mixed-case binding - on() through a chained reverse path (ctes)" begin
+    q = MC.Dim_Unidade.objects
+    q.on("dim_cnes", "usuarios__login" => "chain-value")
+    q.values("nome", "dim_cnes__nome")
+
+    insp = inspect_query(q)
+
+    @test "chain-value" in insp[:parameter_buckets][:join]
+    @test contains(insp[:sql_text], "LEFT JOIN")
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# deletion.jl — `find_related_objects!`. It walks related_objects to build the cascade plan and
+# resolved the child by respelling the binding, so a cascade through Dim_CNES threw before #343.
+# `show_query=:dict` builds the plan without executing it; the mock pool also short-circuits the
+# related-existence probe, and the resolution happens before that check regardless.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - cascade delete plan (deletion)" begin
+    q = MC.Dim_Unidade.objects.filter("id" => 7)
+
+    insp = q.delete(show_query = :dict)
+
+    # Inbound FKs mean a multi-step cascade plan rather than a single dict.
+    @test insp isa Vector
+    @test length(insp) >= 2
+
+    # A step must target the mixed-case child's table, reached via its stored model.
+    @test any(step -> contains(lowercase(step[:sql_text]), "dim_cnes"), insp)
+
+    # The last step is the root DELETE on the model we asked to delete.
+    root_step = insp[end]
+    @test root_step[:operation] == :delete
+    @test contains(lowercase(root_step[:model]), "dim_unidade")
+
+    for step in insp
+        @test haskey(step, :operation)
+        @test haskey(step, :sql_text)
+        @test step[:operation] in (:delete, :update)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The relation is shared, not cloned, and re-registration reproduces an EQUAL one. #343 removed
+# ManyToManyRelation's hand-written deepcopy hook on the strength of this property, so pin it for
+# the struct that replaced the tuple.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Mixed-case binding - ReverseRelation deepcopy shares and set_models is idempotent" begin
+    rel = MC.Dim_Unidade.related_objects["dim_cnes"]
+    copy_rel = deepcopy(rel)
+
+    # An immutable whose every field is `===`-stable is itself `===`-stable: the Symbols are
+    # interned and the model routes through the Model_Type share hook (#157) rather than descending
+    # into `_module::Module`, which would throw.
+    @test copy_rel.model_resolved === MC.Dim_CNES
+    @test copy_rel === rel
+
+    original = deepcopy(MC.Dim_Unidade.related_objects)
+    PormG.Models.set_models(MC, "mixed_case_binding_mock")
+    @test MC.Dim_Unidade.related_objects == original
+    @test MC.Dim_Unidade.related_objects["dim_cnes"].binding === :Dim_CNES
+end


### PR DESCRIPTION
Closes #343.

## The defect

`Model_Type.related_objects` mapped a reverse accessor to a bare 4-tuple whose third slot was the
child's **logical** name — written through `get_model_name`, which lowercases unconditionally. Four
query-builder sites recovered the child's Julia binding by respelling that slot as
`Symbol(uppercasefirst(...))`, which can only ever produce `Xxxxx`.

That is not a case-folding bug that a smarter fold would fix. Since #300 a positional model name is
*rejected* unless already lowercase, so the capitals were never stored anywhere — the binding was not
folded, it was **absent**. `dim_cnes` cannot become `Dim_CNES` by any string function.

Measured blast radius: **10 of 668** models across the internal apps, including `Dim_CNES`, a central
dimension table. `inspectdb` and the Django importer hit it by construction — they emit
`Driver_Profile = Models.Model("driver_profile", db_table = "Driver_Profile", …)`, so the reverse
lookup asks for `Driver_profile`. Forward FKs were unaffected (`.to` carries the class name), which is
why it went unnoticed for so long: every one of the ~48 bindings in both integration models files is
exactly `uppercasefirst(lowercase(name))`, so **the suite could not reproduce it at all**.

## Two corrections to the issue's own analysis

The issue named two reconstruction sites. There were four, plus a propagation path — verified by
running a probe against `main`:

```
binding actually defined -> :Dim_CNES = true | :Dim_cnes = false

  FAIL  build_joins first hop      ->  UndefVarError: `Dim_cnes` not defined
  FAIL  build_joins multi-hop      ->  UndefVarError: `Dim_cnes` not defined
  FAIL  ctes on("dim_cnes", ...)   ->  UndefVarError: `Dim_cnes` not defined
  FAIL  deletion cascade plan      ->  UndefVarError: `Dim_cnes` not defined
```

1. **`ctes.jl:194` is a full reconstruction**, not the harmless positional read the issue described.
   The contrast there is the best argument for the fix: the many-to-many arm two lines above reads a
   *stored* `related_binding` and works.
2. **`build_joins.jl` overwrote `foreign_table_name` with the reconstructed binding**, which then fed
   three further `getfield` sites. Patching only the two lines the issue named would have left
   multi-hop reverse paths broken.

## The fix

Replace the tuple with a `ReverseRelation` struct mirroring `ManyToManyRelation`, which already
solved exactly this for M2M under #65:

```julia
@kwdef struct ReverseRelation
  fk_field::Symbol            # FK column on the CHILD model
  target_pk::Symbol           # referenced column on the PARENT
  model_name::Symbol          # CHILD's logical name, prefix-stripped, lowercased
  binding::Symbol             # CHILD's Julia binding — the fix
  model_resolved::PormGModel  # the CHILD model itself
end
```

`set_models` records both new slots from `_collect_models_and_bindings` — one module walk that keeps
the binding instead of discarding it, rather than calling the O(N) identity scan once per foreign key
(~450k `invokelatest` calls on a 670-model app). The four consumers read the resolved model; none
respells a name. `build_joins` now carries the model forward rather than a binding string, which also
repairs a **fifth** site — the terminal `_solve_field` — that was only unreachable because the join
above threw first.

`model_resolved` is deliberately non-nullable: a nullable slot would invite a `=== nothing` fallback
back into the consumers, which is the bug wearing a hat.

### Also in this PR

- **Dropped the tuple's 4th slot** (the child's own pk). Nothing in `src/` read it and it is derivable
  from the stored model. *Consequence accepted:* the producer no longer calls `get_model_pk_field`, so
  a child model with two primary keys **plus** an FK is no longer rejected at registration. No test
  asserted that, and the guard still fires from eight other sites.
- **Retired `capitalize_symbol`** — `deletion.jl` was its only caller.
- **Retired `ManyToManyRelation`'s hand-written `deepcopy_internal`.** #157's `Model_Type` share hook
  superseded it; its comment claimed to be what prevents the "deepcopy of Modules not supported"
  throw, which stopped being true when #157 landed. Verified empirically that Base's default produces
  a copy that is `===` the original.
- **Dropped `deletion.jl`'s django-prefix strip** (a guaranteed no-op — `get_model_name` strips at
  registration) and two destructured-but-never-read locals.

## What was deliberately NOT done

**`_find_model_binding_name`'s lossy `uppercasefirst` fallback is kept.** I removed it first, on the
reading that an identity scan followed by a guess is dead defensive code. The full unit suite stayed
green. **Independent review caught that it is load-bearing**, and I reproduced the mechanism:

```
names(App; all=true, imported=true) = [:App, :Driver, :Models, :PormG, :eval, :include]
isdefined(App, :Championship)       = true      # brought in by `using ..Shared`
```

`names(…; imported=true)` does not list `using`-brought bindings; `isdefined` does — and
`_resolve_m2m_side_model` tests `isdefined`. So the guess still resolves for a `using`-scoped model.
Removing it broke that layout **silently**, because both `set_models` callers that matter (the
injected `__init__` and the Revise callback) catch bare, so the symptom is "no models registered", not
an error. Reverted to byte-identical behavior, and now pinned by a test that fails if it is deleted
again. Root cause filed as **#354**.

**`Models.jl`'s M2M through-model synthesis got a comment only.** `_load_current_models` includes into
a throwaway module and deliberately never runs `set_models`, so `_module` is `nothing` there and the
identity scan is unreachable — and those two binding slots are write-only on that path anyway.

**No `UPGRADING.md` entry.** Nothing that worked stops working; the reverse-join syntax and the
accessor keys are unchanged; for the ten affected models the change is `UndefVarError` → working. The
value *shape* did change, so I grepped every sibling project under `C:/Sistemas`: **zero** consuming-app
reads of `related_objects` (the only hits were in an old copy of the library itself). `docs/` and
`README.md` are clean too.

**No integration regression for the mixed-case case itself.** The pre-fix failure is `UndefVarError` at
query-*build* time — no SQL is produced at all — so there is no row-level behavior for integration to
observe, and adding a mixed-case model to the integration models files would create a new table and
force a full both-engine bootstrap. Covered at the unit layer instead.

## Verification

- **Red-before-green confirmed**, not assumed — the probe above, run against stashed `main` code.
- **New unit file** `test_reverse_join_mixed_case_binding.jl`: all four sites plus the producer, with a
  fixture matching what the Django importer emits (lowercase name, mixed-case binding). ON clauses are
  pinned **literally** on both hops, because a `contains(sql, "dim_cnes")` assertion cannot see a
  `key_a`/`key_b` transposition — the one mistake this diff was most able to make.
- **`using`-scoped M2M regression**, mutation-checked: re-introducing the deleted fallback makes it
  fail at load.
- **Unit: 6126/6126.**
- **Integration, both engines:** PostgreSQL `test_reverse_joins.jl` **42/42** (including the chained
  multi-hop and second-`related_name` cases that exercise the loop branch rewritten here), plus
  `test_deletes.jl`, `test_many_to_many.jl`, `test_cjoin.jl` — all exit 0. Full SQLite suite: **1982
  pass / 1 broken**.
- Guards green: docstring coverage, public exports, error-type drift, model deepcopy, kernel layering.

## Known loose end

One unit-suite run reported `6117 passed, 1 failed`; I could not identify which test and it has not
recurred in six subsequent full runs. This diff adds no task, lock, timer, or connection interaction,
and `ConnectionPool.jl` / `Configuration.jl` / the transaction path are untouched — but I did not
prove it unrelated, so I am not claiming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
