### PR TITLE
Fix using-scoped models invisibility in model registration and M2M resolution (#354)

### DIFF
--- a/src/Models.jl
+++ b/src/Models.jl
@@ -209,7 +209,9 @@ A vector containing all the models defined in the module.
 """
 function get_all_models(modules::Module; symbol::Bool=false)::Vector{Union{Symbol, PormGModel}}
   model_names = []
+  seen_names = Set{Symbol}()
   for name in names(modules; all=true, imported=true)
+    push!(seen_names, name)
     # Check if the attribute is an instance of Model_Type
     # Use invokelatest to avoid World Age issues in Julia 1.12+
     attr = try
@@ -224,10 +226,28 @@ function get_all_models(modules::Module; symbol::Bool=false)::Vector{Union{Symbo
       push!(model_names, symbol ? name : attr)
     end
   end
+  # #354: Miss-path second pass for `using`-scoped models (invisible to `imported=true`).
+  for name in names(modules; all=true, imported=true, usings=true)
+    Base.binding_module(modules, name) === Base && continue
+    name in seen_names && continue
+    attr = try
+        Base.invokelatest(getfield, modules, name)
+    catch
+        nothing
+    end
+    if isa(attr, PormGModel)
+      symbol && (name in model_names) && continue
+      !symbol && any(m === attr for m in model_names) && continue
+      if attr.name == ""
+        attr.name = name |> format_model_name
+      end
+      push!(model_names, symbol ? name : attr)
+    end
+  end
   return model_names
 end
 
-# One walk, two outputs: the model vector `set_models` iterates, and the model → binding map it
+# Two passes, two outputs: the model vector `set_models` iterates, and the model → binding map it
 # records into `ReverseRelation.binding` (#343).
 #
 # Split from `get_all_models` rather than folded into its `symbol` kwarg, which returns the Symbol
@@ -236,16 +256,19 @@ end
 # a real app's ~670 models is ~450k `invokelatest` calls per `set_models`. Here the binding is simply
 # not thrown away in the first place.
 #
-# Airtight by construction: both outputs come from the SAME iteration, so every model in `models` is
-# a key of `bindings`, no fallback spelling is needed — and none is offered, because a fallback
-# spelling is exactly what #343 was.
+# Airtight by construction: every `push!(models, ...)` is paired with a `get!(bindings, ...)` in
+# both passes, so every model in `models` is a key of `bindings`. The second pass (#354) catches
+# `using`-scoped models invisible to `imported=true`, filtered by `Base.binding_module` to avoid
+# sweeping in ~1100 implicit `Base` names.
 #
 # `get!` keeps the FIRST binding when one model object is bound under several names, matching
 # `_find_model_binding_name`; `names` returns sorted symbols, so that choice is deterministic.
 function _collect_models_and_bindings(modules::Module)
   models = PormGModel[]
   bindings = IdDict{PormGModel, Symbol}()
+  seen_names = Set{Symbol}()
   for name in names(modules; all=true, imported=true)
+    push!(seen_names, name)
     # Use invokelatest to avoid World Age issues in Julia 1.12+
     attr = try
         Base.invokelatest(getfield, modules, name)
@@ -255,6 +278,24 @@ function _collect_models_and_bindings(modules::Module)
     isa(attr, PormGModel) || continue
     # Same binding-derived name fill as `get_all_models` — load-bearing for `Model(; fields...)`,
     # which leaves `name` empty and relies on registration to derive it from the binding.
+    if attr.name == ""
+      attr.name = name |> format_model_name
+    end
+    push!(models, attr)
+    get!(bindings, attr, name)
+  end
+  # #354: Miss-path second pass for `using`-scoped models (invisible to `imported=true`).
+  # Filtered by `Base.binding_module` to exclude implicit `using Base` names.
+  for name in names(modules; all=true, imported=true, usings=true)
+    Base.binding_module(modules, name) === Base && continue
+    name in seen_names && continue
+    attr = try
+        Base.invokelatest(getfield, modules, name)
+    catch
+        nothing
+    end
+    isa(attr, PormGModel) || continue
+    haskey(bindings, attr) && continue
     if attr.name == ""
       attr.name = name |> format_model_name
     end
@@ -2250,38 +2291,20 @@ end
 # stores the two bindings on the relation; the reverse-FK path gets its binding straight from
 # `_collect_models_and_bindings` instead, which is a great deal cheaper than one scan per relation.
 #
-# The `uppercasefirst` fallback is lossy in exactly the way #343 is about — it can only ever spell
-# `Xxxxx` — and #343 tried to replace it with a throw. DO NOT: it is load-bearing, for a reason the
-# scan above cannot see. `names(_module; all=true, imported=true)` does NOT list bindings introduced
-# by `using` (only explicitly `import`ed ones), while `isdefined`/`getfield` DO reach them. So for a
-# model declared in one module and pulled into the registering module with `using`, the scan misses,
-# yet `_resolve_m2m_side_model`'s binding branch (`build_joins.jl`, which tests `isdefined`) resolves
-# the guessed `Xxxxx` spelling successfully. Throwing here broke that working layout — and broke it
-# quietly, because both `set_models` callers that matter (the injected `__init__` in `Utils.jl` and
-# the Revise callback) swallow the exception, so the symptom is "no models registered", not an error.
+# Two-pass structure (fixed in #354): the fast path scans `names(_module; all=true, imported=true)`,
+# which lists locally-defined and explicitly `import`ed bindings. The miss path scans with
+# `usings=true`, which additionally lists bindings introduced by `using`. The miss path uses
+# identity matching (`attr === model`) as its filter, so no `binding_module` guard is needed.
 #
-# Pinned by `test_many_to_many.jl` → "using-scoped M2M target keeps the binding fallback". A comment
-# did not stop this deletion the first time, so the guard is a test.
-#
-# What the fallback does NOT rescue, so nobody reads more into it than is there: it works only where
-# the binding happens to equal `uppercasefirst(name)`. A `using`-scoped model whose binding carries
-# an internal capital (`Dim_CNES`) still fails here and on `main` alike — `isdefined(mod, :Dim_cnes)`
-# is false, and `_resolve_m2m_side_model`'s name-scan fallback misses for the same `names()` reason,
-# so it raises `QueryBuildError`. That intersection is what `ReverseRelation` fixes for reverse
-# foreign keys and cannot fix for many-to-many, because the M2M path still re-resolves by binding
-# instead of reading `related_model_resolved` (#68/#41).
+# The `uppercasefirst` fallback is retained as a last resort for the edge case where a model object
+# exists but is not bound under any name in the module (both scans exhausted). DO NOT delete it:
+# #343 tried that and broke registration silently, because both `set_models` callers that matter
+# (the injected `__init__` in `Utils.jl` and the Revise callback) swallow exceptions.
 #
 # The reverse-FK path depends on none of this: `set_models` records its binding directly from
 # `_collect_models_and_bindings`. This helper is many-to-many-only.
-#
-# The real repair is making `using`-scoped models visible to registration at all, and it is NOT the
-# one-word change it looks like. `names(...; usings=true)` exists on the 1.12 floor, but `using Base`
-# is implicit in every module, so it returns ~1112 names where `imported=true` returns 3 (measured on
-# 1.12.6). Both this scan and `_collect_models_and_bindings` do a `getfield` per name, so a straight
-# substitution turns registration into a ~1100-name sweep per module on a 670-model app, and drags in
-# any `PormGModel` an unrelated package re-exported. It needs a filter — `usings=true` on the miss
-# path only, or screening by `parentmodule`/`Base.binding_module`. Tracked in #354.
 function _find_model_binding_name(_module::Module, model::PormGModel)::String
+  # Fast path: explicit imports and locally-defined names.
   for name in names(_module; all=true, imported=true)
     attr = try
       Base.invokelatest(getfield, _module, name)
@@ -2290,6 +2313,17 @@ function _find_model_binding_name(_module::Module, model::PormGModel)::String
     end
     attr === model && return String(name)
   end
+  # Miss path (#354): `using`-scoped names are invisible to `imported=true` but reachable by identity.
+  for name in names(_module; all=true, imported=true, usings=true)
+    attr = try
+      Base.invokelatest(getfield, _module, name)
+    catch
+      nothing
+    end
+    attr === model && return String(name)
+  end
+  # Final fallback: guess from the model's logical name. Works only for Xxxxx-style bindings;
+  # kept for backward compatibility.
   return uppercasefirst(String(model.name))
 end
 

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -305,15 +305,16 @@ end
 # The shape: a model declared in one module and pulled into the REGISTERING module with `using`.
 # `names(mod; all=true, imported=true)` does not list `using`-brought bindings (only explicitly
 # `import`ed ones), so the identity scan misses — but `isdefined`/`getfield` do reach them, and
-# `_resolve_m2m_side_model` tests `isdefined`. So the guessed spelling resolves and the layout works.
+# `_resolve_m2m_side_model` tests `isdefined`. So the binding resolves and the layout works.
 #
 # Deleting the fallback breaks it QUIETLY: the injected `__init__` in `Utils.jl` and the Revise
 # callback both swallow a `set_models` throw, so the symptom is "no models registered at all", not an
 # error anyone can read. That is why this is pinned by a test and not only by a comment.
 # ─────────────────────────────────────────────────────────────────────────────
-# The binding here is deliberately `Uschampionship` — i.e. exactly `uppercasefirst(name)`. That is
-# the ONLY spelling the fallback can produce, so it is the only one this layout can use; see the
-# negative assertion at the end of the testset for the case it cannot rescue.
+# #354: the `usings=true` miss-path in `_find_model_binding_name` and `_collect_models_and_bindings`
+# now finds `using`-scoped bindings directly. For `Xxxxx`-style bindings like `Uschampionship`, the
+# scan result is identical to the old `uppercasefirst` guess. The mixed-case fixture below
+# (`Dim_CNES`) is the case that discriminates — only the scan can spell it correctly.
 module UsingScopedSharedModels
   import PormG
   import PormG.Models
@@ -338,30 +339,80 @@ module UsingScopedAppModels
   PormG.Models.set_models(@__MODULE__, "m2m_mock")
 end
 
-@testset "using-scoped M2M target keeps the binding fallback (#343)" begin
-  # Preconditions — the asymmetry the fallback exists for. If either of these flips, the rest of
-  # this testset is no longer testing what it claims, so assert them rather than assume them.
+module UsingScopedMixedCaseSharedModels
+  import PormG
+  import PormG.Models
+  export Dim_CNES
+  Dim_CNES = Models.Model("dim_cnes",
+    id = Models.IDField(),
+    code = Models.CharField(),
+  )
+end
+
+module UsingScopedMixedCaseAppModels
+  import PormG
+  import PormG.Models
+  # `using`, NOT `import` — testing mixed-case using-scoped model visibility (#354).
+  using ..UsingScopedMixedCaseSharedModels
+
+  UsUser = Models.Model("ususer",
+    id = Models.IDField(),
+    name = Models.CharField(),
+    cnes_units = Models.ManyToManyField(Dim_CNES, related_name = "users"),
+  )
+  PormG.Models.set_models(@__MODULE__, "m2m_mock")
+end
+
+@testset "using-scoped M2M target resolved via usings=true scan (#343/#354)" begin
+  # Preconditions: `using`-scoped names are invisible to `imported=true` but reachable via
+  # the `usings=true` miss-path added in #354.
   @test !(:Uschampionship in names(UsingScopedAppModels; all=true, imported=true))
   @test isdefined(UsingScopedAppModels, :Uschampionship)
 
-  # The contract: registration COMPLETED (it threw while the fallback was removed), and the recorded
-  # binding is the guessed `uppercasefirst` spelling rather than one the scan found.
+  # The binding is found by the `usings=true` scan (not the `uppercasefirst` fallback).
+  # Before #354 this was a guess; now it is an exact match. The string is identical either way
+  # for `Xxxxx`-style bindings, but the code path is different.
   rel = Models.get_many_to_many_relation(UsingScopedAppModels.Usdriver, "championships")
   @test rel.related_binding == "Uschampionship"
 
-  # And the guess is not merely stored — it RESOLVES, through the `isdefined` branch the identity
-  # scan cannot see. This is what makes the fallback load-bearing rather than cosmetic.
+  # The binding resolves via `isdefined`, which sees `using`-scoped names.
   @test isdefined(UsingScopedAppModels, Symbol(rel.related_binding))
   @test PormG.QueryBuilder._resolve_m2m_side_model(
       UsingScopedAppModels, rel.related_binding, "uschampionship", "championships"
     ) === UsingScopedSharedModels.Uschampionship
+end
 
-  # The limit of the rescue, asserted so nobody reads more into the fallback than is there: it works
-  # only where the binding happens to equal `uppercasefirst(name)`. A `using`-scoped model whose
-  # binding carries an internal capital is still unreachable — the scan misses it AND the guess is
-  # the wrong spelling. That intersection is what #343 fixes for reverse foreign keys (which store
-  # the binding) and cannot fix for many-to-many, which still re-resolves by binding (#68/#41).
-  @test uppercasefirst("dim_cnes") != "Dim_CNES"
+@testset "using-scoped model with mixed-case binding is fully registered (#354)" begin
+  # Preconditions: Dim_CNES is brought in via using, so it is invisible to `imported=true`
+  @test !(:Dim_CNES in names(UsingScopedMixedCaseAppModels; all=true, imported=true))
+  @test isdefined(UsingScopedMixedCaseAppModels, :Dim_CNES)
+
+  # get_all_models includes the using-scoped model
+  all_models = Models.get_all_models(UsingScopedMixedCaseAppModels)
+  @test UsingScopedMixedCaseSharedModels.Dim_CNES in all_models
+
+  # Registration set _module and connect_key on the using-scoped model
+  @test UsingScopedMixedCaseSharedModels.Dim_CNES._module === UsingScopedMixedCaseAppModels
+  @test UsingScopedMixedCaseSharedModels.Dim_CNES.connect_key == "m2m_mock"
+
+  # M2M relation correctly recorded the exact binding, NOT the lossy "Dim_cnes" guess
+  rel = Models.get_many_to_many_relation(UsingScopedMixedCaseAppModels.UsUser, "cnes_units")
+  @test rel.related_binding == "Dim_CNES"
+
+  # The exact binding resolves cleanly in _resolve_m2m_side_model
+  @test PormG.QueryBuilder._resolve_m2m_side_model(
+      UsingScopedMixedCaseAppModels, rel.related_binding, "dim_cnes", "cnes_units"
+    ) === UsingScopedMixedCaseSharedModels.Dim_CNES
+end
+
+@testset "_find_model_binding_name uppercasefirst fallback when both scans miss" begin
+  # The fallback is the last resort when a model object is not bound by name in the module.
+  # Construct a model that is not assigned to any binding in any module.
+  unbound_model = Models.Model("orphan_test",
+    id = Models.IDField(),
+  )
+  # Neither scan can find it — the fallback produces uppercasefirst("orphan_test") = "Orphan_test".
+  @test PormG.Models._find_model_binding_name(UsingScopedAppModels, unbound_model) == "Orphan_test"
 end
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Model registration previously enumerated modules with \
ames(_module; all=true, imported=true)\ in \get_all_models\, \_collect_models_and_bindings\, and \_find_model_binding_name\. In Julia, \
ames()\ without \usings=true\ does not list bindings introduced by \using\. This caused models brought in via \using\ to be invisible to registration (leaving \_module\ as \
othing\) and caused \_find_model_binding_name\ to fall back to a lossy \uppercasefirst\ guess (\Dim_cnes\ instead of \Dim_CNES\), which failed on query-time M2M resolution with \QueryBuildError\.

## Changes Made
- Added a \usings=true\ miss-path pass to \_collect_models_and_bindings\ (filtered by \Base.binding_module(modules, name) !== Base\ to exclude implicit Base exports), setting \_module\ and \connect_key\ on \using\-scoped models.
- Added a \usings=true\ miss-path pass to \get_all_models\ (filtered by \Base.binding_module\) to ensure module model listings include \using\-scoped models.
- Added a \usings=true\ miss-path pass to \_find_model_binding_name\ using exact identity matching (\ttr === model\), cleanly finding exact bindings for mixed-case \using\-scoped models like \Dim_CNES\.
- Extended unit test suite in \	est/unit/test_many_to_many.jl\ with fixtures and assertions verifying \using\-scoped mixed-case model registration and M2M side resolution.
- Updated comments and test assertions to reflect the two-pass structure.

Closes #354