### PR TITLE
Decouple PostgreSQL sequence syncing from django_prefix (#344)

### DIFF
--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -90,6 +90,14 @@ At the core of `connection.yml` is the `config` sub-dictionary. This section dec
 - **`true`**: DDL operations (Data Definition Language) are permitted. PormG's migration subsystem is authorized to create tables, alter columns, and perform schema patches directly against the database.
 - **`false`**: Blocks schema changes. All `Migrations.migrate()` commands will be defensively rejected, protecting your production database from unintended, automated alteration.
 
+!!! note "DDL only"
+    `change_db` governs schema changes and nothing else. Earlier versions also secretly switched
+    PostgreSQL sequence synchronisation on, so the `change_db: false` production posture shown above
+    silently stopped repairing `id` sequences after an explicit-primary-key insert — until a later
+    insert failed with a duplicate-key error. Sequence repair no longer consults this key (or
+    `django_prefix`); see
+    [Sequence synchronisation](../schema_conventions.md#Sequence-synchronisation).
+
 ## PostgreSQL Extensions
 
 PostgreSQL extensions can be declared in the active environment block with a simple `extensions` list.

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -129,6 +129,64 @@ for working alongside a Django app, whose tables are named `<app_label>_<model>`
 The physical-table rule is unchanged: the table is still `name`, which is always lowercase —
 `django_prefix` only shapes how `name` is generated and how accessors read.
 
+!!! note "Naming only — it does not switch any behaviour on"
+    That list is exhaustive. In particular, `django_prefix` has **no** effect on PostgreSQL sequence
+    synchronisation: setting it does not enable the repair, and leaving it unset does not disable it.
+    Earlier versions silently did both, so a connection that dropped the prefix also stopped
+    resyncing its `id` sequences and eventually failed inserts with a duplicate-key error. Sequence
+    repair is now decided solely by whether the insert supplied an explicit primary key — see
+    [Sequence synchronisation](#Sequence-synchronisation) below.
+
+## Sequence synchronisation
+
+A PostgreSQL `SERIAL`/`IDENTITY` column only advances its sequence when the **database** generates
+the value. Insert a row with an explicit primary key and the sequence stays where it was; a later
+auto-generated key then collides with the row you inserted by hand.
+
+PormG repairs this automatically. Whenever a write supplies an explicit primary key —
+`create`, `get_or_create`, `update_or_create`, `bulk_insert`, `bulk_copy` — it resynchronises the
+sequence afterwards, to `MAX(pk) + 1` on PostgreSQL and by rewriting `sqlite_sequence` on SQLite.
+
+**No configuration governs it.** The repair is not gated by `change_db` or `django_prefix` on either
+engine; an insert that cannot drift the sequence never pays for it. (`change_data: false` is a
+different matter — it rejects the write itself, long before any resync would run.)
+
+### What differs between the engines
+
+| | PostgreSQL | SQLite |
+| :--- | :--- | :--- |
+| Mechanism | resolve the column's owned sequence, then `setval` it to `MAX(pk) + 1` | upsert into `sqlite_sequence` |
+| `bulk_copy` | supported | not supported — raises `BackendCapabilityError` |
+| `bulk_insert` self-heal | on an unexpected duplicate-key error, repairs and retries the chunk once | no retry; the error propagates |
+| A failed repair | see below | always propagates |
+
+### When the repair itself fails
+
+On PostgreSQL the handling depends on whether the write is inside a transaction, because a failed
+statement there is not a local event — PostgreSQL marks the whole transaction aborted, rejects every
+later statement, and answers the `COMMIT` with a rollback.
+
+- **Inside a transaction the error propagates.** Returning a row that the pending rollback is about
+  to erase would be worse than raising. This is always the case for `bulk_insert` and `bulk_copy`,
+  which run in a transaction by construction, and for any write inside your own `atomic` block.
+- **Outside one, PormG logs a warning and continues** — naming the table, the column, and the
+  sequence when it got as far as resolving one. This applies to a failure of the database round-trip
+  or the connection pool; anything else (including a cancellation) still raises. The row is already
+  committed and only the *next* auto-generated key is at risk. On PostgreSQL the row-level writers
+  (`create`, `get_or_create`, `update_or_create`) run transaction-free by design, so this is their
+  normal path.
+
+If the primary-key column has no *owned* sequence — a table PormG did not create, or a natural key —
+PormG looks for PostgreSQL's conventional `<table>_<column>_seq` **in the table's own schema**, and
+does nothing if it is absent. One consequence is worth knowing: PostgreSQL truncates generated object
+names at 63 bytes, so a table and column whose combined name exceeds that owns a sequence under a
+shortened name this lookup will not find. The skipped resync is logged at debug level together with
+the name it expected — run with `JULIA_DEBUG=PormG` to see it.
+
+A recurring cause is a role holding `USAGE` but not `UPDATE` on the sequence: PostgreSQL requires
+`UPDATE` for `setval` while `nextval` accepts either, so such a role inserts rows perfectly well and
+can never resync. The logged exception tells you whether that is what happened.
+
 ## Primary keys
 
 PormG does **not** auto-create an `id` primary key for a native model. You declare one explicitly:

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -21,12 +21,18 @@ import PormG: PormGError, FieldAccessError, UnknownFieldError, LazyTraversalErro
   DoesNotExist, MultipleObjectsReturned,
   # Not thrown here — CAUGHT here: last()/save()/delete() convert Models' composite-pk failure
   # into an actionable QueryBuildError (#239).
-  ModelDefinitionError
+  ModelDefinitionError,
+  # Also CAUGHT, not thrown (#344): the two abstract roots `_update_sequence` allowlists when it
+  # decides whether a failed sequence repair is tolerable. Everything outside them propagates.
+  DatabaseError, PoolError
 import PormG: PormGsuffix, PormGtransform, JSON_CONTAINMENT_OPERATORS, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
 import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task, finalize_transaction_connection!
+# #344: "was this failure a cancellation?" — sees through the DatabaseError wrapper the pool applies,
+# which a bare `e isa InterruptException` test cannot (every driver error crosses `_as_database_error`).
+import PormG.ConnectionPool: _await_abandoned
 import PormG.Configuration: with_tx_context, ensure_model_transaction_scope, transaction_connection_for,
 	get_sqlite_reserved_primary_key_max, register_sqlite_reserved_primary_key_max!,
 	in_transaction_context,

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -935,15 +935,26 @@ _sql_literal(value::AbstractString)::String = replace(String(value), "'" => "''"
 
 # Quote an identifier WITHOUT charset validation (#59) — escape-only, unlike `quote_identifier`,
 # which also rejects anything outside SAFE_IDENTIFIER_PATTERN. For identifiers that come from the
-# database catalog (a `pg_sequences` row) or that PormG constructs itself: they are not user input,
-# and validating them would newly reject legacy names that previously worked.
+# database catalog (a `pg_class` row) or from a model's own `db_table`: neither is free-form user
+# input on this path, and validating them would newly reject legacy names that previously worked.
+#
+# Load-bearing for the unowned-sequence fallback (#344): `setval`'s first argument is `regclass`,
+# so PostgreSQL re-parses it as an identifier and CASE-FOLDS any unquoted part. A catalog row
+# reading `public | Db_Table_id_seq` interpolated bare becomes `public.db_table_id_seq`, which does
+# not exist. `pg_get_serial_sequence` returns its answer already quoted, which is why the owned path
+# never needed this.
 _quote_ident_raw(name::AbstractString)::String = "\"$(replace(String(name), "\"" => "\"\""))\""
 
+# A model's physical table as a SQL *string literal* holding a *quoted identifier* — `'"Db_Table"'`.
+# The shape both `pg_get_serial_sequence` and `to_regclass` need: each takes TEXT that it re-parses
+# as an identifier, so an unquoted mixed-case name folds to lowercase and resolves to nothing (#59).
+# Correct for an all-lowercase name too. The two escapes are disjoint — `_quote_ident_raw` only
+# touches `"`, `_sql_literal` only `'` — so composing them cannot double-process.
+_table_ident_literal(model::PormGModel)::String =
+  _sql_literal(_quote_ident_raw(Models.model_table_name(model)))
+
 function _get_owned_sequence_name(connection::PormGPostgres, model::PormGModel, field::String; ignore_tx::Bool = false)
-  # `pg_get_serial_sequence` takes TEXT that it re-parses as an identifier, so an unquoted
-  # mixed-case table folds to lowercase and resolves to nothing. Pass the double-quoted form inside
-  # the literal — `'"Db_Table"'` — which is also correct for an all-lowercase name (#59).
-  table_literal = _sql_literal("\"$(replace(Models.model_table_name(model), "\"" => "\"\""))\"")
+  table_literal = _table_ident_literal(model)
   sequence_df = fetch(
     connection,
     "SELECT pg_get_serial_sequence('$(table_literal)', '$(_sql_literal(field))');";
@@ -961,77 +972,157 @@ end
 function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field::Vector{String}, settings::PormGSettings; ignore_tx::Bool = false)
   @pormg_debug true
 
-  !(settings.change_db || settings.django_prefix !== nothing) && return nothing
-
+  # There is deliberately NO configuration gate here (#344) — do not add one back.
+  #
+  # `!(settings.change_db || settings.django_prefix !== nothing) && return nothing` used to sit on
+  # this line, and it was a second guard for an outcome the call sites already decide. A PostgreSQL
+  # sequence can only drift when the INSERT supplied an explicit primary key, and every caller
+  # already tests exactly that: `pk_exist` (set in `_prepare_row_insert!` only when the insert dict
+  # contains a pk field), or — in `execution_bulk.jl`'s recovery path — a duplicate-key error that
+  # actually happened. So the old line could never prevent a wasted sync, only suppress a needed one.
+  #
+  # What it suppressed: every connection with `change_db: false` (the documented production posture)
+  # and every connection built by `register_connection`, which defaults both flags off. Those
+  # silently accumulated sequence drift, and the bulk duplicate-key self-heal — resync, then retry
+  # the same INSERT — re-ran an unrepaired statement and failed identically.
+  #
+  # `settings` is still read below — but only to ask whether we are inside the caller's
+  # transaction when a repair fails, never to decide whether to attempt one.
   for field in pk_field
     # Resolve the PK field to its physical column (db_column when set) — #50.
     col = Models.model_column(model, field)
-    sequence_name = _get_owned_sequence_name(connection, model, col; ignore_tx=ignore_tx)
+    sequence_name = nothing
 
-    if isnothing(sequence_name)
-      # Fallback for Django-managed tables where sequence ownership is not set:
-      # scan pg_sequences for any sequence whose name starts with the table name.
-      seqs_df = fetch(
-        connection,
+    # The WHOLE body is guarded, not just `setval` (#344). The two catalog reads below run on every
+    # explicit-pk insert now that the gate is gone, and they can fail the same ways `setval` can —
+    # a pool timeout on the extra acquisition, a connection dropped between the INSERT and the
+    # resync. Outside a transaction those would otherwise raise *after* the row was durably
+    # committed, which is the exact "successful create() looks failed" outcome this design avoids.
+    try
+      sequence_name = _get_owned_sequence_name(connection, model, col; ignore_tx=ignore_tx)
+
+      if isnothing(sequence_name)
+        # Fallback for a PK column with no OWNED sequence — a Django-managed table, or a natural
+        # key. Matched on PostgreSQL's conventional `<table>_<column>_seq` and restricted to the
+        # search path.
+        #
+        # NOT `LIKE '<table>%'`, which is what this used to be: that matches any sequence sharing
+        # the prefix — `f1_driver` and `f1_driverstanding` both answer `LIKE 'f1_driver%'` — and the
+        # result was unordered with row 1 taken blind, so a resync could `setval` a NEIGHBOURING
+        # table's sequence to this table's MAX(pk). With `is_called=false` the victim table then
+        # hands out a colliding id on its next insert. Removing the gate above made that path
+        # reachable on every connection, so it is tightened here rather than left to widen.
+        #
         # NOT lowercased (#59): PostgreSQL names the implicit sequence for a quoted `"Db_Table"` as
-        # `Db_Table_id_seq`, and LIKE is case-sensitive — folding here would match nothing and the
-        # sequence would silently never sync. Matches `_fix_sequence_name`'s pattern below.
-        "SELECT sequencename FROM pg_sequences WHERE sequencename LIKE '$(_sql_literal(Models.model_table_name(model)))%'";
+        # `Db_Table_id_seq`, and the comparison is case-sensitive — folding would match nothing.
+        # Constrained to the TABLE'S OWN namespace, not merely to some schema on the search path.
+        # A membership test (`schemaname = ANY(current_schemas(…))`) is not equivalent, and the gap
+        # is the same corruption in schema form: with `search_path = tenant, public`, a
+        # `tenant.drivers` whose own sequence is absent would match `public.drivers_id_seq` — which
+        # belongs to `public.drivers` — and the `setval` below would set it from
+        # `MAX(tenant.drivers.id)`, because the table in that statement is referenced unqualified.
+        #
+        # `to_regclass` resolves by exactly the same search_path rule as that unqualified reference,
+        # so pinning the sequence to its `relnamespace` makes the two agree by construction — as
+        # strict as the table, not stricter. It also yields at most one row (`relname` is unique per
+        # namespace), so no ordering or tiebreak is needed. `to_regclass` returns NULL rather than
+        # raising for a missing relation, so a vanished table degrades to zero rows and the
+        # `continue` below.
+        conventional = string(Models.model_table_name(model), "_", col, "_seq")
+        seqs_df = fetch(
+          connection,
+          "SELECT n.nspname AS schemaname, c.relname AS sequencename " *
+          "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " *
+          "WHERE c.relkind = 'S' AND c.relname = '$(_sql_literal(conventional))' " *
+          "AND c.relnamespace = (SELECT relnamespace FROM pg_class WHERE oid = to_regclass('$(_table_ident_literal(model))'))";
+          ignore_tx=ignore_tx,
+        ) |> DataFrames.DataFrame
+
+        if size(seqs_df, 1) == 0
+          # Not an error: a natural-key PK legitimately has no sequence, and `pk_exist` fires for
+          # those too, so @debug rather than @warn keeps ordinary inserts quiet.
+          #
+          # `expected=` is what makes the other case diagnosable. PostgreSQL truncates a generated
+          # object name at 63 bytes, so a table+column pair longer than that owns a sequence whose
+          # real name is shorter than `conventional` and will not be found here. Logging the name we
+          # searched for is the difference between a puzzling non-sync and an obvious one.
+          @debug "No sequence to resync for this primary key" table=Models.model_table_name(model) column=col expected=conventional
+          continue
+        end
+        # Quoted, not interpolated bare: `setval` takes regclass and case-folds unquoted parts, so
+        # `public.Db_Table_id_seq` would be looked up as `public.db_table_id_seq` and fail.
+        sequence_name = string(_quote_ident_raw(seqs_df[1, :schemaname]), ".",
+                               _quote_ident_raw(seqs_df[1, :sequencename]))
+      end
+
+      safe_field_name = quote_identifier(col, connection)
+      safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
+      fetch(
+        connection,
+        "SELECT setval('$(_sql_literal(sequence_name))', COALESCE((SELECT MAX($safe_field_name) FROM $safe_table_name), 0) + 1, false)";
         ignore_tx=ignore_tx,
-      ) |> DataFrames.DataFrame
-      
-      size(seqs_df, 1) == 0 && continue
-      sequence_name = seqs_df[1, :sequencename]
-    end
+      )
+    catch e
+      # A cancellation is never ours to swallow. `e isa InterruptException` would NOT catch it:
+      # every driver failure crosses `_as_database_error`, which wraps the interrupt in a
+      # `StatementError`. `_await_abandoned` sees through that wrapper.
+      #
+      # This MUST stay ahead of the allowlist below, and the order is not stylistic: a cancellation
+      # arrives as `StatementError(…, InterruptException())`, which IS a `DatabaseError`, so an
+      # allowlist running first would swallow every Ctrl-C on this path.
+      _await_abandoned(e) && rethrow()
 
-    safe_field_name = quote_identifier(col, connection)
-    safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
-    fetch(
-      connection,
-      "SELECT setval('$sequence_name', COALESCE((SELECT MAX($safe_field_name) FROM $safe_table_name), 0) + 1, false)";
-      ignore_tx=ignore_tx,
-    )
+      # Swallow ONLY what this block set out to tolerate: a failure of the database round-trip
+      # itself. Widening the `try` to the whole loop body also brought `quote_identifier` and
+      # `safe_table_identifier` inside it, and those are PormG's fail-closed identifier guards —
+      # they raise `InvalidValueError`, which is a `PormGError` but NOT a `DatabaseError`. Reporting
+      # a rejected `db_column` as "sequence resync failed, check your GRANTs" would bury the real
+      # error and break the fail-closed contract.
+      #
+      # An allowlist, not "rethrow non-DatabaseError PormGErrors": `PoolTimeoutError <: PoolError`
+      # is also outside the `DatabaseError` branch and IS one we mean to tolerate. `PoolError` is
+      # the one family that reaches here un-wrapped, because `acquire_connection` runs outside
+      # `fetch`'s own try and so never crosses `_as_database_error`.
+      #
+      # Anything raised on THIS task — a bug in this function, PormG's fail-closed identifier
+      # guards — propagates. Note the limit of that claim: a failure raised inside the driver task
+      # is wrapped into a `DatabaseError` before it arrives, so it is tolerated regardless of what
+      # it originally was. That is the intended reading of "the round-trip failed".
+      !(e isa DatabaseError || e isa PoolError) && rethrow()
+
+      # Inside a transaction this failure is NOT recoverable and must propagate. PostgreSQL poisons
+      # a transaction the moment any statement in it errors: every later statement returns "current
+      # transaction is aborted, commands ignored until end of transaction block", and the COMMIT is
+      # answered with ROLLBACK. Swallowing would hand the caller a PormGRow for a row that is
+      # already doomed, which is strictly worse than raising.
+      #
+      # This is the common path for the bulk writers: `bulk_insert` and `bulk_copy` ALWAYS run
+      # inside a transaction (`execution_bulk.jl:1004`, `:1176` — ambient, or their own
+      # `run_in_transaction`). On PostgreSQL the row-level writers are the opposite: `insert`,
+      # `_update_or_create` and `_get_or_create` deliberately run transaction-free (`ON CONFLICT` is
+      # atomic on its own, `execution.jl:924-928`), so they take the warn path unless the caller
+      # opened an `atomic` block.
+      #
+      # `!ignore_tx` is currently always true — no call site overrides the kwarg — but the condition
+      # belongs with the check: `ignore_tx=true` makes `fetch` take a separate pooled connection,
+      # which leaves the caller's transaction untouched and the failure genuinely recoverable.
+      if !ignore_tx && transaction_connection_for(settings) !== nothing
+        rethrow()
+      end
+
+      # Outside a transaction the INSERT was its own committed statement, so the row is durable and
+      # only the NEXT auto-generated key is at risk. Report and carry on.
+      #
+      # The message names the LIKELY cause without asserting it: a role holding USAGE but not UPDATE
+      # on the sequence hits this every time (PostgreSQL requires UPDATE for `setval` while
+      # `nextval` accepts either, so such a role inserts rows fine and can never resync) — but a
+      # pool timeout or a dropped connection lands here too, and sending that operator to GRANT
+      # would be a wild goose chase. `exception=e` carries the truth.
+      @warn "Sequence resync failed — the next auto-generated primary key may collide. If the cause is a permission error, the role needs UPDATE on the sequence." model=model.name table=Models.model_table_name(model) column=col sequence=something(sequence_name, "unresolved") exception=e
+    end
   end
 end
 
-function _fix_sequence_name(connection::PormGPostgres, model::PormGModel; ignore_tx::Bool = false) # TODO maby i need use Migration get_sequence_name aproach
-  pk_field = [field for field in keys(model.fields) if model.fields[field].primary_key]
-  # #197 review: guard BEFORE anything indexes pk_field[1] — the empty-PK check used to sit
-  # after an indexing condition, so BoundsError always won and the guard could never fire.
-  length(pk_field) == 0 && throw(QueryBuildError("Cannot fix the PK sequence for model $(model.name): the model does not define a primary key."))
-  length(pk_field) > 1 && throw(QueryBuildError("Cannot fix the PK sequence for model $(model.name): composite primary keys are not supported here."))
-  # PostgreSQL names a table's implicit sequence after the table itself, so the pattern and the
-  # rename target both follow the RESOLVED physical name (db_table when set, #59). Byte-identical to
-  # the previous `model.name |> lowercase` for every already-lowercase model.
-  table_name = Models.model_table_name(model)
-  sequences = fetch(connection, """SELECT *
-      FROM pg_sequences
-      WHERE sequencename LIKE '$(_sql_literal(table_name))%';"""; ignore_tx=ignore_tx) |> DataFrames.DataFrame
-  for (index, row) in enumerate(eachrow(sequences))
-    if index == 1 && row.sequencename != "$(table_name)_$(pk_field[1])_seq"
-      # Both sequence names are IDENTIFIERS, so they are quoted rather than escaped as literals — but
-      # via `_quote_ident_raw`, NOT `quote_identifier`. The latter also *validates* the charset and
-      # throws, which would newly abort this call for a legacy sequence named with a `-`, a space or
-      # a leading digit that previously interpolated bare and worked. `row.sequencename` comes from
-      # the `pg_sequences` catalog, not from user input, so escaping is the correct posture here.
-      new_seq = _quote_ident_raw("$(table_name)_$(pk_field[1])_seq")
-      fetch(connection, "ALTER SEQUENCE $(_quote_ident_raw(row.sequencename)) RENAME TO $(new_seq);"; ignore_tx=ignore_tx)
-    else
-      fetch(connection, "DROP SEQUENCE $(_quote_ident_raw(row.sequencename));"; ignore_tx=ignore_tx)
-    end
-  end
-end
-
-# function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field::Vector{String})
-#   sequences = fetch(connection, """SELECT *
-#       FROM pg_sequences
-#       WHERE sequencename LIKE '$(model.name |> lowercase)%';""") |> DataFrames.DataFrame
-#   for row in eachrow(sequences)
-#     if row.sequenceowner == model.name
-#       fetch(connection, "SELECT setval('$(row.sequencename)', (SELECT MAX($(pk_field[1])) FROM $(model.name)), true);")
-#     end
-#   end
-# end
 function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::PormGSettings)
   for field in pk_field
     safe_field_name = quote_identifier(Models.model_column(model, field), connection)  # db_column (#50)

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -218,8 +218,9 @@ later insert fails durably burns its range (a harmless gap, exactly like Postgre
   `Vector{Union{Missing,Int}}` pk column, the missing-able element type is dropped after
   allocation.
 - The PostgreSQL backend currently assumes the model lives in the default search path
-  (typically `public`). Models in other schemas are not supported by this helper — the
-  same limitation applies to `_update_sequence`.
+  (typically `public`). Models in other schemas are not supported by this helper.
+  (`_update_sequence` no longer shares the limitation: since #344 it resolves the sequence
+  through the table's own `relnamespace`.)
 
 # Example
 ```julia
@@ -929,10 +930,6 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   # Resolve settings
   settings, connection, conn_key = get_settings(objct)
 
-  django_prefix = settings.django_prefix === nothing ? false : true
-
-  
-
   # check if is allowed to insert
   !settings.change_data && throw(_write_not_allowed("bulk_insert", conn_key))
 
@@ -986,7 +983,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
         param_placeholders = [add_parameter!(parameters, model.fields[field].formatter(row[mapping[field]])) for field in fields_df]
         # param_placeholders = add_parameter!(parameters, values)
       catch e
-        _depuration_values_bulk_insert(fields_df, mapping, model, row, index, django_prefix)
+        _depuration_values_bulk_insert(fields_df, mapping, model, row, index)
         e isa PormGError && rethrow()   # keep the taxonomy type; the depuration log above carries the row context
         throw(InvalidValueError("Error in bulk_insert, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
       end
@@ -994,7 +991,7 @@ function bulk_insert(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
       count += 1
       if count == effective_chunk || index == total
         # @pormg_debug
-        res = _bulk_insert(model, connection, fields_df, rows, pk_exist, pk_field, settings, django_prefix, show_query, parameters; on_conflict_sql = on_conflict_sql)
+        res = _bulk_insert(model, connection, fields_df, rows, pk_exist, pk_field, settings, show_query, parameters; on_conflict_sql = on_conflict_sql)
         push!(results, res)
         count = 0
         rows = String[]
@@ -1193,7 +1190,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
 end
 bulk_copy(model::PormGModel, df::DataFrames.DataFrame; kwargs...) = bulk_copy(model |> object, df; kwargs...)
 
-function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{String, String}, model::PormGModel, row::DataFrames.DataFrameRow, index::Integer, django_prefix::Bool)
+function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{String, String}, model::PormGModel, row::DataFrames.DataFrameRow, index::Integer)
   for field in fields
     # Check if field exists in the mapping and row
     col_name = get(mapping, field, field)
@@ -1298,7 +1295,7 @@ end
 function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGSQLite},
   fields::Vector{String}, rows::Vector{String},
   pk_exist::Bool, pk_field::Vector{String}, settings::PormGSettings,
-  django_prefix::Bool, show_query::Symbol, parameters:: AbstractPormGParam;
+  show_query::Symbol, parameters:: AbstractPormGParam;
   on_conflict_sql::Union{Nothing, String} = nothing)
 
   # Security: Quote table name and physical column names (db_column when set, #50).
@@ -1535,7 +1532,7 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
 
         param_placeholders = [add_parameter!(instruction.parameters, model.fields[field].formatter(row[mapping[field]])) for field in joined_columns]
       catch e
-        _depuration_values_bulk_insert(fields_df, mapping, model, row, index, settings.django_prefix !== nothing)
+        _depuration_values_bulk_insert(fields_df, mapping, model, row, index)
         e isa PormGError && rethrow()   # keep the taxonomy type; the depuration log above carries the row context
         throw(InvalidValueError("Error in bulk_update, row $(index) for model $(model.name) failed validation or formatting: $(e)"))
       end

--- a/test/unit/test_bulk_on_conflict.jl
+++ b/test/unit/test_bulk_on_conflict.jl
@@ -213,7 +213,6 @@ end
       true,
       ["id"],
       settings,
-      false,
       :execute,
       params;
       on_conflict_sql = "ON CONFLICT DO NOTHING",   # pre-rendered clause; non-nothing gates the retry off

--- a/test/unit/test_sequence_sync.jl
+++ b/test/unit/test_sequence_sync.jl
@@ -39,9 +39,11 @@ end
 @testset "Sequence synchronization uses owned serial sequence" begin
   empty!(SEQUENCE_SYNC_SQL)
 
+  # No `change_db=true` here since #344 — it used to be load-bearing (the only way past the
+  # `!(settings.change_db || settings.django_prefix !== nothing)` gate), and it is now noise.
+  # `_update_sequence` reads no setting at all on the PostgreSQL path.
   settings = PormG.Configuration.Settings(
     connections=MockSequencePostgres(),
-    change_db=true,
     change_data=true,
   )
 
@@ -58,6 +60,322 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: no configuration gate (#344)
+# `_update_sequence` used to open with
+#   !(settings.change_db || settings.django_prefix !== nothing) && return nothing
+# which silently disabled PostgreSQL sequence repair for every connection with
+# `change_db: false` (the documented production posture) and every connection built
+# by `register_connection`, which defaults both flags off. Nothing logged, nothing
+# returned — a skipped sync was indistinguishable from a performed one, so the
+# sequence drifted until an auto-pk insert raised a duplicate-key error.
+#
+# The drift condition is already decided by the CALLERS (`pk_exist`), so the gate
+# could only ever suppress a needed sync. These assertions pin its absence: restoring
+# the line must turn the `change_db=false` case red.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Sequence synchronization ignores change_db and django_prefix (#344)" begin
+  # (a) The configuration the old gate silenced: writes allowed, no DDL rights, no prefix.
+  #     This is what `register_connection` produces and what the docs' own `prod:` block sets.
+  empty!(SEQUENCE_SYNC_SQL)
+  gated_settings = PormG.Configuration.Settings(
+    connections  = MockSequencePostgres(),
+    change_db    = false,
+    change_data  = true,
+  )
+  @test gated_settings.django_prefix === nothing   # the other half of the old gate, unset
+
+  PormG.QueryBuilder._update_sequence(SequenceDriver, gated_settings.connections, ["id"], gated_settings)
+
+  # Both statements must be issued — the resolve and the repair. Under the old gate this was 0.
+  @test length(SEQUENCE_SYNC_SQL) == 2
+  @test occursin("pg_get_serial_sequence", SEQUENCE_SYNC_SQL[1])
+  @test occursin("setval('public.legacy_driver_id_seq'", SEQUENCE_SYNC_SQL[2])
+
+  # (b) Setting a django_prefix must not change anything. It used to be one of the two ways to
+  #     switch syncing ON, which is exactly the coupling #344 removes: a naming knob that
+  #     silently doubled as a correctness switch.
+  empty!(SEQUENCE_SYNC_SQL)
+  prefixed_settings = PormG.Configuration.Settings(
+    connections   = MockSequencePostgres(),
+    change_db     = false,
+    change_data   = true,
+    django_prefix = "f1",
+  )
+
+  PormG.QueryBuilder._update_sequence(SequenceDriver, prefixed_settings.connections, ["id"], prefixed_settings)
+
+  @test length(SEQUENCE_SYNC_SQL) == 2
+  # Identical SQL: the prefix shapes generated model names, never the physical table read here.
+  @test occursin("setval('public.legacy_driver_id_seq'", SEQUENCE_SYNC_SQL[2])
+  @test occursin("FROM \"drivers\"", SEQUENCE_SYNC_SQL[2])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: the unowned-sequence fallback cannot hit a NEIGHBOURING table (#344)
+# When `pg_get_serial_sequence` returns NULL — a Django-managed table, or a natural key —
+# PormG falls back to the catalog. That lookup used to be
+#   WHERE sequencename LIKE '<table>%'
+# with no ORDER BY and row 1 taken blind. `f1_driver` and `f1_driverstanding` BOTH answer
+# `LIKE 'f1_driver%'`, so the resync could setval a different table's sequence to this
+# table's MAX(pk); with is_called=false that table then issues a colliding id on its next
+# insert. Removing the configuration gate made this reachable on every connection, so the
+# lookup is now an exact match on PostgreSQL's conventional `<table>_<column>_seq`,
+# restricted to the search path.
+# ─────────────────────────────────────────────────────────────────────────────
+struct MockUnownedSequence <: PormG.PormGPostgres end
+
+function fetch(connection::MockUnownedSequence, sql::String;
+  conn = nothing,
+  params = nothing,
+  ignore_tx::Bool = false)
+  push!(SEQUENCE_SYNC_SQL, sql)
+
+  if occursin("pg_get_serial_sequence", sql)
+    return DataFrame(pg_get_serial_sequence=[missing])          # no OWNED sequence
+  elseif occursin("pg_class", sql)
+    # MIXED CASE on purpose. An all-lowercase fixture cannot see the case-folding bug below:
+    # `setval` takes regclass, so an unquoted `public.Drivers_Id_seq` is re-parsed and folded to
+    # `public.drivers_id_seq`, which does not exist. PostgreSQL names the implicit sequence of a
+    # quoted `"Db_Table"` this way, which is exactly the #59 case the lookup preserves.
+    return DataFrame(schemaname=["public"], sequencename=["Drivers_Id_seq"])
+  end
+
+  return DataFrame()
+end
+
+@testset "Unowned-sequence fallback matches the exact sequence name (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockUnownedSequence(),
+    change_data = true,
+  )
+
+  PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+
+  @test length(SEQUENCE_SYNC_SQL) == 3          # resolve, catalog fallback, setval
+  fallback = SEQUENCE_SYNC_SQL[2]
+
+  # The exact conventional name, not a prefix match. This is the assertion that fails if the
+  # `LIKE '<table>%'` form ever comes back.
+  @test occursin("c.relname = 'drivers_id_seq'", fallback)
+  @test !occursin("LIKE", fallback)
+  # Pinned to the TABLE'S OWN namespace via to_regclass — not merely to some schema on the
+  # search path. A membership test would let `tenant.drivers` match `public.drivers_id_seq`
+  # (which belongs to `public.drivers`) and resync it from MAX(tenant.drivers.id).
+  @test occursin("to_regclass", fallback)
+  @test occursin("c.relnamespace = ", fallback)
+  # Sequences only — `relname` is unique per namespace per relkind, so this also guarantees at
+  # most one row and makes any ORDER BY/tiebreak unnecessary.
+  @test occursin("c.relkind = 'S'", fallback)
+  # The table is passed as a quoted identifier inside the literal, so a mixed-case db_table
+  # resolves instead of folding to nothing (#59).
+  @test occursin("to_regclass('\"drivers\"')", fallback)
+
+  # Schema-qualified AND quoted. Bare `public.Drivers_Id_seq` would be case-folded by regclass
+  # parsing into a relation that does not exist — silently outside a transaction, and as a hard
+  # failure inside one.
+  @test occursin("setval('\"public\".\"Drivers_Id_seq\"'", SEQUENCE_SYNC_SQL[3])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: a setval failure is reported, not propagated — IN AUTOCOMMIT (#344)
+# Scoped to the no-transaction case on purpose: inside a transaction the same failure
+# propagates instead, which the testset further down asserts. Here the INSERT was its own
+# committed statement, so the row is durable and only the NEXT auto-generated key is at
+# risk; raising would make a succeeded create() look failed. The expected cause is a role
+# holding USAGE but not UPDATE on the sequence (PostgreSQL requires UPDATE for setval,
+# while nextval accepts either), so the role can insert rows and still be unable to resync.
+# ─────────────────────────────────────────────────────────────────────────────
+struct MockSetvalDenied <: PormG.PormGPostgres end
+
+# What `setval` throws. Production NEVER surfaces a bare driver exception here: every failure
+# leaving the pool crosses `_as_database_error`, which wraps anything that is not already a
+# PormGError in a `DatabaseError` subtype. A mock that throws a raw `ErrorException` would let a
+# `catch e; e isa InterruptException` test look correct while being unreachable in production, so
+# the mock reproduces the wrapper.
+const SETVAL_DENIED = Ref{Any}(
+  PormG.StatementError("PostgreSQL", ErrorException("ERROR:  permission denied for sequence legacy_driver_id_seq")))
+
+function fetch(connection::MockSetvalDenied, sql::String;
+  conn = nothing,
+  params = nothing,
+  ignore_tx::Bool = false)
+  push!(SEQUENCE_SYNC_SQL, sql)
+
+  if occursin("pg_get_serial_sequence", sql)
+    return DataFrame(pg_get_serial_sequence=["public.legacy_driver_id_seq"])
+  elseif occursin("setval", sql)
+    throw(SETVAL_DENIED[])
+  end
+
+  return DataFrame()
+end
+
+@testset "Sequence resync failure warns instead of throwing (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSetvalDenied(),
+    change_data = true,
+  )
+
+  # match_mode=:any so an unrelated @debug/@info from the call path cannot fail the assertion.
+  @test_logs (:warn, r"Sequence resync failed") match_mode = :any begin
+    PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+  end
+
+  # It still ATTEMPTED the repair — the warning is not a substitute for trying.
+  @test length(SEQUENCE_SYNC_SQL) == 2
+  @test occursin("setval", SEQUENCE_SYNC_SQL[2])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: only DATABASE failures are tolerated (#344)
+# The try covers the whole loop body, which means it also covers PormG's fail-closed
+# identifier guards (`quote_identifier` / `safe_table_identifier` → `_validate_identifier`).
+# Those raise `InvalidValueError` — a PormGError but NOT a DatabaseError — and relabelling
+# one as "sequence resync failed, check your GRANTs" would bury a real error and break the
+# fail-closed contract. The catch allowlists `DatabaseError` and `PoolError`; everything
+# else propagates.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "A non-database error during resync is not swallowed (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSequencePostgres(),
+    change_data = true,
+  )
+
+  # `db_table` is deliberately NOT shape-validated at declaration (#59), so an illegal identifier
+  # survives to `safe_table_identifier` inside the try.
+  bad = Model("badseq", db_table = "no spaces allowed!", id = IDField(), forename = CharField())
+  bad.connect_key = "sequence_sync_default"
+
+  # No transaction, so the warn path is the one being bypassed here — this raises because of the
+  # allowlist, not because of the transaction check.
+  #
+  # The message is checked, not just the type: `@test_throws InvalidValueError` alone cannot tell
+  # "the table-identifier guard fired inside the try" from "some other InvalidValueError fired
+  # anywhere", and that distinction is the whole point of the assertion.
+  try
+    PormG.QueryBuilder._update_sequence(bad, settings.connections, ["id"], settings)
+    @test false   # unreachable: the guard must raise
+  catch e
+    @test e isa PormG.InvalidValueError
+    @test occursin("no spaces allowed!", sprint(showerror, e))
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: the allowlist's POSITIVE half (#344)
+# The testset above proves the allowlist rejects what it must. This one proves it still
+# accepts what it should: a `PoolError` — the one family that reaches the catch UN-wrapped,
+# because `acquire_connection` runs outside `fetch`'s own try and never crosses
+# `_as_database_error`. Without this, only the negative half of the guard is pinned and
+# narrowing the allowlist to `DatabaseError` alone would go unnoticed.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "A pool failure during resync is tolerated (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSetvalDenied(),
+    change_data = true,
+  )
+
+  original = SETVAL_DENIED[]
+  SETVAL_DENIED[] = PormG.ConnectionPool.PoolTimeoutError("PostgreSQL", 4, 4, 3, 5.0)
+  try
+    @test SETVAL_DENIED[] isa PormG.PoolError
+    @test !(SETVAL_DENIED[] isa PormG.DatabaseError)   # genuinely the other allowlist branch
+
+    @test_logs (:warn, r"Sequence resync failed") match_mode = :any begin
+      PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+    end
+  finally
+    SETVAL_DENIED[] = original
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: a CANCELLATION is never swallowed (#344)
+# The warn path must not eat a Ctrl-C. The subtlety is that the obvious guard,
+# `e isa InterruptException`, is unreachable: every failure leaving the pool crosses
+# `_as_database_error`, which wraps the interrupt in a `StatementError`. So the guard
+# has to see through the taxonomy wrapper — `_await_abandoned` is the helper that does
+# (ConnectionPool.jl:176, "It sees through a DatabaseError too").
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "A cancellation during resync is never swallowed (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSetvalDenied(),
+    change_data = true,
+  )
+
+  original = SETVAL_DENIED[]
+  SETVAL_DENIED[] = PormG.StatementError("PostgreSQL", InterruptException())
+  try
+    # The premise: this value is NOT an InterruptException, so a naive `e isa InterruptException`
+    # guard reads false and drops through to the warning. That is the bug being pinned.
+    @test !(SETVAL_DENIED[] isa InterruptException)
+
+    # No transaction context here, so the ONLY thing that can make this raise is the
+    # cancellation check — otherwise it takes the warn-and-continue path.
+    thrown = try
+      PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+      nothing
+    catch e
+      e
+    end
+
+    @test thrown !== nothing
+    @test PormG.ConnectionPool._await_abandoned(thrown)
+  finally
+    SETVAL_DENIED[] = original
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: inside a transaction the failure must PROPAGATE (#344)
+# The warn-instead-of-throw rule above holds only in autocommit, where the INSERT
+# was its own committed statement. Inside a transaction PostgreSQL poisons the whole
+# transaction as soon as any statement errors — every later statement returns
+# "current transaction is aborted" and the COMMIT is answered with a rollback.
+# Swallowing there would return a PormGRow for a row that is already doomed.
+#
+# This is the BULK writers' normal path: `bulk_insert` and `bulk_copy` always run in a
+# transaction (execution_bulk.jl:1004, :1176). The row-level PostgreSQL writers are the
+# opposite — `insert`, `_update_or_create` and `_get_or_create` deliberately run
+# transaction-free (execution.jl:924-928 wraps in run_in_transaction only for SQLite),
+# so they take the warn path unless the caller opened an `atomic` block.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Sequence resync failure inside a transaction propagates (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSetvalDenied(),
+    change_data = true,
+  )
+
+  # Stand in for the caller already being inside run_in_transaction on THIS pool.
+  thrown = PormG.Configuration.with_tx_context(settings.connections, :mock_tx_conn) do
+    # Precondition: the helper `_update_sequence` consults must actually see the context,
+    # otherwise this testset would pass for the wrong reason.
+    @test PormG.Configuration.transaction_connection_for(settings) !== nothing
+    try
+      PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+      nothing
+    catch e
+      e
+    end
+  end
+
+  @test thrown !== nothing                                                   # it raised, not warned
+  @test occursin("permission denied for sequence", sprint(showerror, thrown))  # the ORIGINAL cause
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Sequence Sync: Retry bulk insert after sequence repair
 # Verifies that a duplicate PK during `bulk_insert` triggers one sequence sync
 # and then retries the same INSERT instead of forcing the caller to rerun it.
@@ -66,9 +384,10 @@ end
   empty!(SEQUENCE_SYNC_SQL)
   INSERT_ATTEMPTS[] = 0
 
+  # `change_db` deliberately left at its `false` default (#344): the self-heal must work on the
+  # connections the old gate silenced, which is exactly where a drifted sequence shows up.
   settings = PormG.Configuration.Settings(
     connections=MockSequencePostgres(),
-    change_db=true,
     change_data=true,
   )
 
@@ -106,7 +425,6 @@ end
     true,
     ["id"],
     settings,
-    false,
     :execute,
     params,
   )


### PR DESCRIPTION
Closes #344.

Prerequisite for #345, which moves table naming to per-model `db_table` so a multi-app Django project can carry `core_`, `access_` and `imports_` at once. Connections that set `django_prefix` for naming will legitimately stop setting it — and, before this change, would have silently lost sequence syncing as a side effect.

## The bug

`django_prefix` is documented purely as a table-**naming** convenience — *"it only shapes how `name` is generated and how accessors read"*. It also gated PostgreSQL sequence repair:

```julia
# execution.jl:964
!(settings.change_db || settings.django_prefix !== nothing) && return nothing
```

With that closed, an INSERT carrying an explicit primary key never advanced the sequence, so a later auto-generated key collided and the write failed with a duplicate-key error. Nothing was logged, no return value said so, and every caller discards the result — a skipped repair was **indistinguishable from a performed one**.

Affected **today**, independently of #345:

| Configuration | Synced? |
|---|---|
| Scaffolded by `PormG.setup()` (`change_db: true`) | yes |
| Every connection from `register_connection` (dynamic / multi-tenant) | **no** |
| The `prod:` block in PormG's own docs (`change_db: false`) | **no** |
| Any `connection.yml` omitting the `config:` block | **no** |

The sharpest symptom: `bulk_insert`'s duplicate-key self-heal (`execution_bulk.jl:1352`) catches the error, calls `_update_sequence` to repair the sequence, then re-runs the identical INSERT. With the gate closed the repair was a no-op and the retry failed identically — **the recovery path was guaranteed dead for exactly the connections that needed it.**

## The change is a deletion

The gate was not merely misplaced, it was **redundant**. A sequence can only drift when the insert supplied an explicit primary key, and the callers already test exactly that: `pk_exist` (set in `_prepare_row_insert!` only when the insert dict contains a pk field) guards eight of the nine call sites, and the ninth — the bulk duplicate-key recovery — fires on an *observed* collision. A second gate could never prevent a wasted repair, only suppress a needed one.

This also aligns the engines: the SQLite `_update_sequence` never had a gate and always synced. That divergence was undocumented, which the ruleset forbids.

**No new setting, deliberately.** The issue proposed replacing the gate with `sync_sequences`; that predates the `pk_exist` finding, and would add a knob to control a guard that should not exist. A cross-framework check found **zero** global sequence-sync flags in Django, Rails, SQLAlchemy, Ecto or Prisma — Django's nearest shapes are a test-only class attribute defaulting to `False` and an internal per-call keyword; Rails gates on `respond_to?`, a capability probe. A global boolean is a shape the field examined and declined.

## Bugs found while making that safe

Each has its own regression test.

**A failed `setval` inside a transaction must propagate.** PostgreSQL poisons a transaction the moment any statement errors — every later statement is refused and the `COMMIT` is answered with a rollback. Warning and continuing would hand the caller a `PormGRow` for a row that is already doomed. `bulk_insert` and `bulk_copy` always run in a transaction, so swallowing would have **discarded whole batches while reporting success**. Outside a transaction the row is committed and only the *next* key is at risk, so there the failure is reported and execution continues.

**The unowned-sequence fallback could corrupt a neighbouring table.** It ran `WHERE sequencename LIKE '<table>%'` with no `ORDER BY`, taking row 1 blind — and `f1_driver` and `f1_driverstanding` both answer `LIKE 'f1_driver%'`. A repair could `setval` another table's sequence to this table's `MAX(pk)`; with `is_called=false` that table then issued a colliding id. Pre-existing, but removing the gate would have exposed every connection to it.

The lookup is now an exact match on `<table>_<column>_seq` pinned to the table's **own namespace** via `to_regclass(…)` → `relnamespace`. Restricting to the search path is *not* equivalent — that is a membership test, so with `search_path = tenant, public` a `tenant.drivers` whose own sequence is absent would still match `public.drivers_id_seq` (belonging to `public.drivers`) and set it from `MAX(tenant.drivers.id)`, because the table in the same statement is referenced unqualified. `to_regclass` resolves by exactly that unqualified rule, so the two agree by construction and at most one row can match.

**A cancellation was being swallowed.** `e isa InterruptException` is unreachable here: every driver failure crosses `_as_database_error`, which wraps it in a `StatementError`. Now uses `_await_abandoned`, which sees through the wrapper. The check must stay **ahead** of the allowlist below it, since a Ctrl-C arrives as a `DatabaseError`.

**The catch allowlists `DatabaseError` and `PoolError` only**, so PormG's fail-closed identifier guards (`InvalidValueError`) are never relabelled as *"sequence resync failed, check your GRANTs"*. `PoolError` is in the list because `acquire_connection` runs outside `fetch`'s own `try` and reaches the catch un-wrapped.

## Dead code removed

Reachable only through the gate, or never at all: `_fix_sequence_name` (zero callers) and the `django_prefix::Bool` parameter threaded through `_bulk_insert` and `_depuration_values_bulk_insert` but read by neither.

## Verification

- **Full unit suite 6234/6234**; docs build clean.
- `test/unit/test_sequence_sync.jl`: **10 testsets, 42 assertions**.
- **Mutation-tested: 13 mutations, all killed**, each by the testset written for it — including reverting the gate, reverting to the `LIKE` match, dropping the namespace constraint, dropping the identifier quoting, and narrowing the allowlist in each direction.
- **Three independent review rounds, 18 findings, all resolved.** Every round found defects in the previous round's fixes:
  - Round 2 caught a regression *this PR had introduced*: the schema-qualified sequence name was unquoted, and `setval` takes `regclass`, so `public.Drivers_Id_seq` was looked up as `public.drivers_id_seq`. For a mixed-case `db_table` that turned a silent no-op into a **hard failure** inside a transaction.
  - Round 3 caught that restricting the fallback to the search path was a membership test rather than a link to the table's schema — the original corruption in schema form.

## Deliberately not done

- **No `UPGRADING.md` entry.** No consuming app must edit source: configs keep their existing keys, no setting is added or removed, and the behavior change is a repair that only fires where the sequence was already drifting.
- **The issue's `deletion.jl` task is already complete** — #343 (`a138258`) removed that `django_prefix` read and recorded that it was a proven no-op. Nothing to decouple there.
- **Truncated sequence names are not resolved.** PostgreSQL truncates generated object names at 63 bytes, shortening the table and column parts *independently*, so neither a prefix of the conventional name nor a `LIKE` is a sound key — a fuzzy match would reintroduce the class of bug this PR removes. The skipped resync is logged with the name it expected (`JULIA_DEBUG=PormG`) and documented.
- **Scope widened beyond the gate**, on the reasoning that deleting the gate widens the fallback bug's reach from prefixed connections to all of them. The fallback fix is the only change here that affects connections working correctly today.

## Not verified against a live database

No integration run: this awaits the maintainer's approval and a free `db_2`. The natural slice is `test/integration/test_db_column_db.jl` (*"primary key with db_column round-trips (sequence sync)"*) and `test/integration/test_bulk_copy.jl` (*"Test with automated sequence update"*) — both fixtures set `change_db: true`, so both exercise the pass side and should stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
