### PR TITLE
Fix generated model binding/name collisions across one file (#338)

### DIFF
--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -116,6 +116,37 @@ exactly as it always has, so no existing schema changes and nothing needs re-mig
     from the models' *logical* names, so pinning `db_table` on a model does not silently rename a join
     table PormG generated for you.
 
+### Generated files: colliding bindings and names are disambiguated
+
+`inspectdb`-style import (`import_models_from_sqlite` / `import_models_from_postgres` /
+`import_models_from_django`) derives both the Julia **binding** and — when the positional name would
+otherwise be empty, e.g. an all-underscore table — the **positional name** from the table name. Two
+tables can independently arrive at the same one: `driver profile` sanitizes to the same binding an
+already-legal `driver_profile` also produces; a table literally named `models` collides with the
+generated file's own `import PormG.Models` line.
+
+Within a single generated file, each newly-derived binding and positional name is checked against
+everything already emitted into that file and, on a collision, suffixed with a digit — never another
+underscore, mirroring how a hostile *field* name is disambiguated (see
+[Field Naming Rules](fields.md#Field-Naming-Rules)). Without this, the second colliding
+`Binding = Models.Model(...)` line would silently overwrite the first Julia global when the file is
+loaded — no error, no warning, one model just gone.
+
+!!! note "`db_table` is pinned automatically when disambiguation would otherwise be wrong"
+    The positional name can *be* the physical table (whenever `db_table` is not otherwise set,
+    PormG falls back to it at query time). Suffixing it blindly would leave a model that loads
+    cleanly but queries a table that does not exist — worse than the collision it replaces. So when
+    disambiguating the positional name changes it and nothing already pins `db_table`, PormG pins
+    the original name to `db_table` for you — the same escape valve described above.
+
+!!! note "Residual limitation: `ForeignKey` target resolution"
+    A `ForeignKey`'s `.to` is derived independently, from the live parent table name, and resolved by
+    binding-name lookup alone. If disambiguation suffixes the binding a `.to` was counting on, the
+    reference still resolves — just to whichever sibling kept the un-suffixed binding, not necessarily
+    the table the key originally pointed at. This is not new: before disambiguation existed, every such
+    reference was already ambiguous, since both tables shared one binding. Review a generated file's
+    foreign keys by hand when your schema has tables whose names collide after sanitizing.
+
 ### `django_prefix` interop
 
 A connection may set `django_prefix` in its `connection.yml` (default: unset). It is a convenience

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -1,7 +1,7 @@
 module Generator
 
 import PormG
-import PormG: MODEL_PATH, PormGSettings, DB_PATH
+import PormG: MODEL_PATH, PormGSettings, DB_PATH, GENERATED_MODULE_RESERVED_BINDINGS
 import OrderedCollections: OrderedDict
 
 """
@@ -86,12 +86,16 @@ test:
     nothing
 end
 
-function generate_models_from_db(file::String, Instructions::Vector{Any}, settings::PormGSettings; path::String = MODEL_PATH) :: Nothing 
+function generate_models_from_db(file::String, Instructions::Vector{Any}, settings::PormGSettings; path::String = MODEL_PATH) :: Nothing
+
+  # #338: built from the same list Model_to_str's caller seeds its binding-collision `taken` set
+  # with, so the boilerplate this file actually imports and the collision guard can never drift.
+  reserved_import = join(filter(!=("Models"), GENERATED_MODULE_RESERVED_BINDINGS), ", ")
 
   open(joinpath(path, file), "w") do f
     write(f, """module $(basename(file) |> x -> replace(x, ".jl" => ""))\n
     import PormG.Models
-    import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING, PROTECT
+    import PormG.Models: $(reserved_import)
 
     """)
     for table in Instructions
@@ -175,12 +179,14 @@ function create_models_jl(path::String, filename::String = "models.jl")::Nothing
         return nothing
     end
 
+    reserved_import = join(filter(!=("Models"), GENERATED_MODULE_RESERVED_BINDINGS), ", ")
+
     open(models_file, "w") do f
         write(f, """
 module $module_name
 
 import PormG.Models
-import PormG.Models: RESTRICT, CASCADE, SET_NULL, SET_DEFAULT, DO_NOTHING, PROTECT
+import PormG.Models: $(reserved_import)
 
 # Define your models here
 # Example:

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -345,6 +345,10 @@ export sqlite_type_map, postgres_type_map, sqlite_type_map_reverse, postgres_typ
 # on_delete handlers
 export CASCADE, RESTRICT, PROTECT, SET_NULL, SET_DEFAULT, DO_NOTHING
 
+# Generated-module boilerplate registry (#338) — single source for Generator.jl's `import
+# PormG.Models: ...` line and Model_to_str's per-file binding-collision dedup seed.
+export GENERATED_MODULE_RESERVED_BINDINGS
+
 # `register_ignore_tables!` is exported by constants.jl itself (it is part of the documented
 # downstream-extension surface), so it needs no re-listing here.
 

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -38,6 +38,7 @@ import PormG.Models: format_model_name, model_table_name, fk_target_table
 import PormG: connection, config, get_constraints_pk, get_constraints_unique, get_constraints_check, get_constraints_byte_length_check
 import PormG: PormGModel, PormGField, PormGSettings, PormGBackend, PormGPostgres, PormGSQLite
 import PormG: sqlite_type_map, postgres_type_map, sqlite_ignore_schema, postgres_ignore_table, _EXTRA_IGNORE_TABLES
+import PormG: GENERATED_MODULE_RESERVED_BINDINGS
 import PormG: MODEL_PATH, PormGSettings, DB_PATH
 import PormG.AdvisoryLock
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -966,6 +966,20 @@ function _julia_field_identifier(column::AbstractString,
   return ident
 end
 
+# Disambiguate `ident` against names already claimed elsewhere in the same generated file (#338),
+# appending a digit — never another underscore, matching `_julia_field_identifier`'s convention.
+# Unlike that function, this has no `raw_keys`-style second concern: a generated file has exactly
+# one binding and one positional name per model, not a set of columns a rename must not steal from.
+function _dedupe_taken(ident::String, taken::Set{String})::String
+  base = ident
+  suffix = 2
+  while ident in taken
+    ident = "$(base)$(suffix)"
+    suffix += 1
+  end
+  return ident
+end
+
 # Physical SQL column for a field given its declared identity `name` (#50). Returns
 # `db_column` when the field carries a non-empty one, else the field name. The
 # default (column == field name) keeps every existing schema unchanged; only fields
@@ -1504,7 +1518,7 @@ end
 Converts a model object to a string representation to create the model.
 
 # Arguments
-    Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false)::String
+    Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false, taken_bindings::Set{String}=Set{String}(), taken_names::Set{String}=Set{String}())::String
 - `model::Union{Model_Type, PormGModel}`: The model object to convert.
 - `settings::PormGSettings`: Connection settings; supplies `django_prefix` and the target output folder.
 - `contants_julia::Vector{String}=reserved_words`: identifiers the *generated* field name must avoid —
@@ -1518,6 +1532,18 @@ Converts a model object to a string representation to create the model.
   `false` for the Django importer, whose `model.name` is a **Python class name**: there the physical
   table genuinely is the lowercased form, and pinning the class spelling would invent a table that
   does not exist. The two are indistinguishable from the name alone, so the caller states which it has.
+- `taken_bindings::Set{String}=Set{String}()`: Julia bindings already claimed elsewhere in the SAME
+  generated file (#338) — mutated in place: this call's resolved binding is added before returning.
+  Two tables whose names would otherwise render the same binding (e.g. `driver profile` and
+  `driver_profile`) get the second suffixed with a digit instead of silently shadowing the first at
+  `include` time. A caller rendering more than one model into one file must share ONE set across every
+  call; the default fresh set reproduces the old, uncollision-checked behavior for a single call.
+  (Named `taken_bindings`, not `taken` — the latter is already a local inside this function for
+  per-field identifier dedup; a same-named kwarg would silently shadow it.)
+- `taken_names::Set{String}=Set{String}()`: same idea, for the positional name (the first string
+  argument to `Model(...)`) rather than the binding. When dedup changes the name AND nothing already
+  pins `db_table`, the pre-dedup name is pinned as `db_table` so the model still addresses the right
+  table — see the implementation comment at the positional-name computation below.
 
 # Returns
 - `String`: The string representation of the model object. A field whose rendering fails is
@@ -1537,7 +1563,7 @@ users = Models.Model("users",
 )
 ```
 """
-function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false)::String
+function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSettings; contants_julia::Vector{String}=reserved_words, name_is_physical_table::Bool=false, taken_bindings::Set{String}=Set{String}(), taken_names::Set{String}=Set{String}())::String
   fields::String = ""
   render_failures::Vector{String} = String[]
   django_prefix::Bool = settings.django_prefix === nothing ? false : true
@@ -1660,6 +1686,13 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSetti
   model_var_name = (Base.isidentifier(_plain_var) && !isempty(lstrip(_plain_var, '_'))) ? _plain_var :
     uppercasefirst(_julia_field_identifier(String(model.name), contants_julia,
                                            Set{String}(), Set{String}()))
+  # #338: two tables can independently arrive at the same binding above — via either branch, since
+  # the fast path deliberately bypasses the sanitizer's own dedup. Applied uniformly, AFTER either
+  # path, against the caller's shared `taken_bindings`: the second model in a batch gets a digit
+  # suffix instead of silently overwriting the first model's Julia global when the generated file is
+  # `include`d.
+  model_var_name = _dedupe_taken(model_var_name, taken_bindings)
+  push!(taken_bindings, model_var_name)
   # Round-trip the physical table name as `db_table=` (#59). Two sources, one kwarg:
   #
   #  1. An explicit `db_table` on the model — emitted verbatim so a reload reproduces it.
@@ -1710,6 +1743,23 @@ function Model_to_str(model::Union{Model_Type, PormGModel}, settings::PormGSetti
     lowercase(_julia_field_identifier(_lowered, contants_julia, Set{String}(), Set{String}()))
   else
     _lowered
+  end
+  # #338: two tables can independently arrive at the same POSITIONAL name too — not just the
+  # all-underscore case above, but also e.g. `Driver` (pin_introspected, db_table already pinned)
+  # and `driver` (not pin_introspected, db_table_abs still `nothing` above) both lowering to
+  # "driver". Dedup against the caller's shared `taken_names` same as the binding above — but unlike
+  # the binding, this string can BE the physical table (`model_table_name` falls back to it whenever
+  # `db_table` is unset), so a dedup that invents "driver2" with nothing pinning "driver" would leave
+  # the model loading cleanly while querying a table that does not exist — worse than the shadowing
+  # bug this issue is about. So: when dedup actually changes the string AND nothing already pinned
+  # the table (`db_table_abs === nothing`), pin the PRE-dedup name explicitly, the same way
+  # `pin_introspected` already pins one for a leading-underscore/mixed-case name above.
+  _pre_dedupe_name_abs = model_name_abs
+  model_name_abs = _dedupe_taken(model_name_abs, taken_names)
+  push!(taken_names, model_name_abs)
+  if model_name_abs != _pre_dedupe_name_abs && db_table_abs === nothing
+    db_table_abs = _pre_dedupe_name_abs
+    db_table_part = ", db_table = $(format_string(db_table_abs))"
   end
   # Marker comments sit directly above the model definition in the generated file (#70).
   marker = isempty(render_failures) ? "" : join(render_failures, "\n") * "\n"

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -314,3 +314,8 @@ function PROTECT end
 function SET_NULL end
 function SET_DEFAULT end
 function DO_NOTHING end
+
+# Names a generated models file's own boilerplate already binds (#338) — the module import plus the
+# six on_delete handlers above. Single source for Generator.jl's `import PormG.Models: ...` line and
+# the cross-model binding-collision dedup seed in Models.jl/importers.jl, so the two cannot drift.
+const GENERATED_MODULE_RESERVED_BINDINGS = ["Models", "RESTRICT", "CASCADE", "SET_NULL", "SET_DEFAULT", "DO_NOTHING", "PROTECT"]

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -70,9 +70,14 @@ function import_models_from_sqlite(db::String = "db";
   end
 
   # Collect all create instructions
+  # #338: one binding/name registry PER GENERATED FILE, shared across every model rendered into it —
+  # seeded with what the file's own boilerplate already imports, so a table literally named "models"
+  # collides too. Without this, two tables that render the same binding silently shadow one another.
+  taken_bindings = Set{String}(GENERATED_MODULE_RESERVED_BINDINGS)
+  taken_names = Set{String}()
   Instructions::Vector{Any} = []
   for model in models_array
-    push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
+    push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names))
   end
 
   generate_models_from_db(file, Instructions, settings; path=model_path)
@@ -133,16 +138,19 @@ function import_models_from_postgres(db::String;
   
   # Convert the database schema to models
   models_array = convert_schema_to_models(conn, ignore_table=ignore_table, include_table=include_table)
-  
+
   if isempty(models_array)
       @warn("No tables found in the database to import.")
       return nothing
   end
-  
+
   # Convert each model to string representation
+  # #338: one binding/name registry per generated file — see import_models_from_sqlite for why.
+  taken_bindings = Set{String}(GENERATED_MODULE_RESERVED_BINDINGS)
+  taken_names = Set{String}()
   Instructions::Vector{Any} = []
   for model in models_array
-      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
+      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names))
   end
   
   # Generate the models file
@@ -171,16 +179,19 @@ function import_models_from_postgres(;db::PormGPostgres = connection(),
     
   # Convert the database schema to models
   models_array = convert_schema_to_models(db, ignore_table=ignore_table, include_table=include_table)
-  
+
   if isempty(models_array)
       @warn("No tables found in the database to import.")
       return nothing
   end
-  
+
   # Convert each model to string representation
+  # #338: one binding/name registry per generated file — see import_models_from_sqlite for why.
+  taken_bindings = Set{String}(GENERATED_MODULE_RESERVED_BINDINGS)
+  taken_names = Set{String}()
   Instructions::Vector{Any} = []
   for model in models_array
-      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true))
+      push!(Instructions, Models.Model_to_str(model, settings; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names))
   end
   
   # Generate the models file
@@ -638,6 +649,11 @@ function import_models_from_django(
   # and the first model is gone. `graph.index` already keeps the first definition for base
   # resolution; this keeps emission agreeing with it.
   seen_names = Set{String}()
+  # #338: the GENERAL case of the same defect `seen_names` above guards one instance of — two
+  # DIFFERENT class names can still sanitize/uppercasefirst to the same Julia binding. One registry
+  # per generated file, shared across every class rendered into it.
+  taken_bindings = Set{String}(GENERATED_MODULE_RESERVED_BINDINGS)
+  taken_names = Set{String}()
 
   for class in graph.classes
     class_name = class.name
@@ -797,7 +813,7 @@ function import_models_from_django(
           end
         end
 
-        rendered = Models.Model_to_str(model, render_settings)
+        rendered = Models.Model_to_str(model, render_settings; taken_bindings=taken_bindings, taken_names=taken_names)
         push!(Instructions, isempty(markers) ? rendered : join(markers, "\n") * "\n" * rendered)
     end
 

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -291,6 +291,12 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
       # throws `ModelDefinitionError` at `set_models`, and regenerating produced the identical
       # broken file. Routed through `_fk_default_or_warn` so an unrepresentable default warns
       # rather than throwing from inside introspection.
+      # #338: this `uppercasefirst` must match the BINDING `Model_to_str` derives for the target
+      # table — `_resolve_target_model` resolves `.to` by binding lookup alone. If that binding
+      # collides with a sibling table's and gets suffixed with a digit, `.to` still names this
+      # un-suffixed spelling and can resolve to the wrong model. Pre-existing ambiguity, not
+      # introduced by #338's dedup — see docs/src/schema_conventions.md → "Generated files:
+      # colliding bindings and names are disambiguated".
       field_instance = Models.ForeignKey(uppercasefirst(fk_map[column_name]["fk_table"] |> string); pk_field=fk_map[column_name]["fk_column"] |> string,
       on_delete=_normalize_introspected_on_delete(fk_map[column_name]["on_delete"]),
       on_update=fk_map[column_name]["on_update"], deferrable=!(fk_map[column_name]["on_deferable"] === nothing), null=(nullable === nothing),
@@ -393,6 +399,8 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
         # with the `unique` flag below, a live `INTEGER UNIQUE REFERENCES parent(id)` now regenerates
         # LOSSLESSLY as `INTEGER UNIQUE` + the foreign key, where an O2O would regenerate as `TEXT`
         # with no foreign key. The flag is what #318 is actually about; the field type is not.
+        # #338: same binding-collision caveat as the FK path above — `.to` resolves by binding
+        # lookup alone, so a suffixed sibling binding can leave this pointing at the wrong model.
         field = Models.ForeignKey(uppercasefirst(fk_info.table); pk_field=fk_info.to,
             on_delete=_normalize_introspected_on_delete(fk_info.on_delete), null=nullable,
             default=_fk_default_or_warn(_normalize_sqlite_default(default_val, fk_type_sym), table_name, col_name))
@@ -1292,6 +1300,7 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
           Models.IDField(generated=generated, generated_always=generated_always, unique=true, null=false, db_index=true)
       elseif haskey(fk_map, col_name)
         fk_info = fk_map[col_name]
+        # #338: same binding-collision caveat as the other FK introspection paths in this file.
         fk_table = uppercasefirst(fk_info.table)
         fk_column = fk_info.pk
         # #292: `on_delete` is now carried (it was never even queried), and `default_value` goes

--- a/test/unit/test_importers.jl
+++ b/test/unit/test_importers.jl
@@ -90,4 +90,64 @@ end
     end
   end
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # 4. End-to-end regression for #338: two REAL tables in the same database that render to the
+  #    same Julia binding must not have the second silently vanish — pre-fix, the SECOND
+  #    `Binding = Models.Model(...)` line overwrites the first's Julia global when the generated
+  #    file is `include`d, with no error anywhere. Unit coverage for the dedup itself lives in
+  #    test_model_to_str_identifiers.jl; this proves import_models_from_sqlite's loop actually
+  #    shares one taken_bindings/taken_names pair across the whole file, not just that Model_to_str
+  #    supports it.
+  # ───────────────────────────────────────────────────────────────────────────
+  @testset "colliding table names both survive the generated file (#338)" begin
+    mktempdir() do dir
+      dbfile   = joinpath(dir, "scratch_collision.sqlite")
+      modeldir = joinpath(dir, "generated_models_collision")
+      mkpath(modeldir)
+
+      pool = SQLiteConnectionPool(dbfile; pool_size = 1)
+      # "driver profile" sanitizes to the binding `Driver_profile` — the SAME binding the
+      # already-legal `driver_profile` uppercasefirst's to. (Not `driver`/`Driver`: SQLite table
+      # names are case-insensitive, so that pair can't exist as two tables in one database.)
+      fetch(pool, "CREATE TABLE \"driver profile\" (id INTEGER PRIMARY KEY);")
+      fetch(pool, "CREATE TABLE driver_profile (id INTEGER PRIMARY KEY);")
+
+      key = "importer_collision_test"
+      PormG.config[key] = Configuration.Settings(
+        connections   = pool,
+        db_def_folder = modeldir,
+        change_data   = true,
+      )
+      try
+        PormG.Migrations.import_models_from_sqlite(key)
+
+        outfile = joinpath(modeldir, "automatic_models.jl")
+        @test isfile(outfile)
+        content = read(outfile, String)
+
+        # Both bindings present and DISTINCT in the source text — the whole point of the fix.
+        @test occursin("Driver_profile = Models.Model(", content)
+        @test occursin("Driver_profile2 = Models.Model(", content)
+
+        # And the file actually loads, with BOTH models independently addressable — neither
+        # shadowed the other — each still pointing at its own real physical table.
+        # `Base.invokelatest`: `Base.eval` below bumps the world age (Julia 1.12), so reading the
+        # freshly-defined bindings back in this same closure needs the LATEST world, not the one
+        # captured when the enclosing `mktempdir` do-block was compiled.
+        scratch = Module(:ImporterCollisionScratch338)
+        Base.eval(scratch, :(using PormG))
+        Base.eval(scratch, Meta.parse(content))   # the generated `module automatic_models ... end`
+        Base.invokelatest() do
+          gen_mod = getfield(scratch, :automatic_models)
+          m1 = getfield(gen_mod, Symbol("Driver_profile"))
+          m2 = getfield(gen_mod, Symbol("Driver_profile2"))
+          @test Set([PormG.model_table_name(m1), PormG.model_table_name(m2)]) ==
+                Set(["driver profile", "driver_profile"])
+        end
+      finally
+        delete!(PormG.config, key)
+      end
+    end
+  end
+
 end

--- a/test/unit/test_model_to_str_identifiers.jl
+++ b/test/unit/test_model_to_str_identifiers.jl
@@ -316,4 +316,84 @@ _columns(m) = Set(field_db_column(f, k) for (k, f) in m.fields)
     @test occursin("teams = Models.ManyToManyField(\"Team\")", Model_to_str(ok, MTS_SETTINGS))
   end
 
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #338: every test above calls `Model_to_str` ONCE, so its default fresh `taken`/`taken_names`
+  # sets never see a collision. A real importer call site shares ONE pair of sets across every
+  # model it renders into the same generated file — that is what these tests do. Without the fix,
+  # the SECOND `Binding = Models.Model(...)` line silently overwrites the first Julia global when
+  # the generated file is `include`d: no error, no warning, one model just vanishes.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "cross-model binding/name collisions are disambiguated, not silently shadowed (#338)" begin
+
+    # "driver profile" sanitizes to `Driver_profile`; "driver_profile" is already legal and
+    # `uppercasefirst`s to the SAME string.
+    @testset "driver profile / driver_profile" begin
+      taken_bindings = Set{String}()
+      taken_names = Set{String}()
+      m1 = Model("driver profile", Dict{String, PormGField}("id" => IDField()))
+      m2 = Model("driver_profile", Dict{String, PormGField}("id" => IDField()))
+      g1 = Model_to_str(m1, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+      g2 = Model_to_str(m2, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+      b1 = first(split(g1, " = "))
+      b2 = first(split(g2, " = "))
+      @test b1 == "Driver_profile"
+      @test b2 != b1 && Base.isidentifier(b2)   # the whole point — no shared binding
+      r1 = _reload(g1)
+      r2 = _reload(g2)
+      @test PormG.model_table_name(r1) == "driver profile"
+      @test PormG.model_table_name(r2) == "driver_profile"
+      # Neither shadowed the other — both bindings independently resolve to their own model.
+      @test getfield(MTS_MOD, Symbol(b1)).name == "driver profile"
+      @test getfield(MTS_MOD, Symbol(b2)).name == "driver_profile"
+    end
+
+    # A live table literally named "models" collides with the generated file's OWN
+    # `import PormG.Models` line, not with a sibling model — the seed, not another call, catches it.
+    @testset "a table named models collides with the generated import" begin
+      taken_bindings = Set{String}(PormG.GENERATED_MODULE_RESERVED_BINDINGS)
+      taken_names = Set{String}()
+      m = Model("models", Dict{String, PormGField}("id" => IDField()))
+      generated = Model_to_str(m, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+      binding = first(split(generated, " = "))
+      @test binding == "Models2"          # not "Models" — would shadow `import PormG.Models`
+      @test PormG.model_table_name(_reload(generated)) == "models"
+    end
+
+    # All-underscore tables all sanitize to the same positional name "col" — three of them must not
+    # all collapse to one.
+    @testset "an all-underscore trio gets three distinct positional names" begin
+      taken_bindings = Set{String}()
+      taken_names = Set{String}()
+      positions = String[]
+      for tbl in ["_", "__", "___"]
+        m = Model(tbl, Dict{String, PormGField}("id" => IDField()))
+        generated = Model_to_str(m, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+        @test PormG.model_table_name(_reload(generated)) == tbl   # db_table is always pinned on this branch
+        push!(positions, something(match(r"Models\.Model\(\"([^\"]*)\"", generated)).captures[1])
+      end
+      @test length(positions) == length(Set(positions))
+    end
+
+    # THE TRAP: dedup on the positional name must not just invent "driver2" and walk away — that
+    # string can BE the physical table (`model_table_name` falls back to it whenever `db_table` is
+    # unset). A naive unconditional dedup would leave this model loading cleanly while querying a
+    # table that does not exist — worse than the shadowing bug #338 reports. "Driver" is processed
+    # FIRST (mixed-case ⇒ `db_table` already pinned to "Driver", positional slot "driver"); "driver"
+    # is processed SECOND and collides on both the binding ("Driver") and the positional name
+    # ("driver") — it must come out re-pinned, not silently wrong.
+    @testset "positional-name dedup re-pins db_table instead of inventing a nonexistent table" begin
+      taken_bindings = Set{String}()
+      taken_names = Set{String}()
+      m1 = Model("Driver", Dict{String, PormGField}("id" => IDField()))
+      m2 = Model("driver", Dict{String, PormGField}("id" => IDField()))
+      g1 = Model_to_str(m1, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+      g2 = Model_to_str(m2, MTS_SETTINGS; name_is_physical_table=true, taken_bindings=taken_bindings, taken_names=taken_names)
+      @test occursin("Driver = Models.Model(\"driver\"", g1)
+      @test occursin("db_table = \"Driver\"", g1)
+      @test occursin("Driver2 = Models.Model(\"driver2\"", g2)    # binding ALSO collided — suffixed too
+      @test occursin("db_table = \"driver\"", g2)                 # re-pinned to the pre-dedup name
+      @test PormG.model_table_name(_reload(g2)) == "driver"       # NOT "driver2"
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary

- `Model_to_str` derived a generated model's Julia **binding** and **positional name** from its table name per-call, with no knowledge of sibling models rendered into the same generated file. Two tables could independently arrive at the same binding (e.g. `driver profile` sanitizes to the same binding an already-legal `driver_profile` produces, or a table literally named `models` collides with the generated file's own `import PormG.Models` line), and the second `Binding = Models.Model(...)` line would silently overwrite the first Julia global at `include` time — no error, no warning, one model just gone.
- `Model_to_str` now takes `taken_bindings`/`taken_names` registries, shared across every model rendered into one file by all four importer call sites (`import_models_from_sqlite`, both `import_models_from_postgres` methods, `import_models_from_django`). A collision is suffixed with a digit — never another underscore, mirroring the existing per-field identifier dedup convention.
- Closed a trap the naive reading of the fix would have shipped: blindly deduping the *positional* name can silently point a model at a table that does not exist, since `model_table_name` falls back to the positional name whenever `db_table` isn't set. The fix re-pins `db_table` to the pre-dedup name whenever dedup actually changes it and nothing already pins the table.
- A new `GENERATED_MODULE_RESERVED_BINDINGS` constant (`src/constants.jl`, exported via `src/Kernel.jl`) replaces two previously-duplicated hardcoded `import PormG.Models: RESTRICT, CASCADE, ...` literals in `src/Generator.jl`, and seeds the binding-collision registry so a table named `models` is caught too.
- Documented a known, accepted residual limitation: a `ForeignKey`'s `.to` still resolves by binding-name lookup alone, computed independently at introspection time — if a collision suffixes the binding it was counting on, it can resolve to the wrong sibling. Not new (pre-fix both tables shared one binding, equally ambiguous); called out in `docs/src/schema_conventions.md` and in code comments at each `uppercasefirst(fk_table)` call site.

## Test plan

- [x] New unit tests: `test/unit/test_model_to_str_identifiers.jl` — 157/157 passing, including a cross-model collision testset covering the `driver profile`/`driver_profile` pair, a table named `models`, an all-underscore trio, and the `Driver`/`driver` positional-name re-pin trap.
- [x] New end-to-end regression test: `test/unit/test_importers.jl` — 8/8 passing, two colliding tables through the real `import_models_from_sqlite` pipeline, generated file loads with both models independently addressable.
- [x] Full unit suite: `julia --project=. test/runtests.jl` — 6226/6226 passing.
- [x] Integration slice against `db_2` (PostgreSQL): `test/integration/test_importers_introspection.jl` — 35/35 passing.
- [x] Docs build clean (`docs/make.jl`), `docs/src/schema_conventions.md` updated with the new collision/dedup/`db_table`-pinning behavior and the FK residual-limitation caveat.
- [x] Independent review by a fresh subagent (no memory of writing the code), two rounds — first pass found no blocking defects; second pass (re-reviewing the delta after applying the first pass's suggestion) caught a comment that mislabeled a code path as "Postgres" when it was SQLite, fixed.

## Deliberately not done

- No `UPGRADING.md` entry — `Model_to_str` is not exported/public API; the new kwargs are additive with safe defaults, so this forces no consuming-app source edit.
- Did not fix the residual `ForeignKey.to` binding-lookup ambiguity noted above — pre-existing, and materially bigger than this issue's scope (would mean resolving `.to` through `db_table` instead of a derived binding). Documented instead.
- Declined a review suggestion to add PostgreSQL-specific importer test coverage — that gap predates this PR and applies to the importer generally, not to the #338 fix specifically.

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)