### PR TITLE
Fix bulk_insert/bulk_copy reusing one auto_add UUID for every row

### DIFF
--- a/docs/src/write/bulk.md
+++ b/docs/src/write/bulk.md
@@ -48,13 +48,7 @@ Qualifications:
 - **A field you leave out of `columns=` is out of scope, not "your data".** If your frame carries a column for it, those cells are not written — you said not to write that field. On `bulk_insert()`/`bulk_copy()` PormG still supplies the field's default or timestamp, which is what lets a partial `columns=` insert satisfy the model's `null=false` columns.
 - `bulk_update(..., columns = [...])` does **not** synthesize a static `default` for an absent column — that would overwrite live rows merely because your frame lacks the column. `auto_now`/`auto_now_add` still inject, so timestamps stay current.
 - **`match_on` key columns are not null-checked.** They identify rows rather than being written, so a blank cell in one does not raise — it simply matches nothing, since `column = NULL` is never true. Before this rule changed, such a blank was quietly back-filled with the field's `default` and matched the default-valued row instead. (`filters=` fields are exempt from the check too, but they carry constants rather than `DataFrame` columns, so no cell can be blank there.)
-- An auto-increment primary key column whose values are **all** blank counts as absent, so the database allocates the ids. See [Auto-Generated Primary Keys](#Auto-Generated-Primary-Keys). This does **not** extend to a `UUIDField(auto_add = true)` primary key — carrying that column blank now raises. Fill it yourself, which works because a present column is honored verbatim:
-
-    ```julia
-    df[!, :token] = [UUIDs.uuid4() for _ in 1:DataFrames.nrow(df)]
-    ```
-
-    Dropping the column is *not* the fix: the absent path currently mints one UUID for the whole batch ([#334](https://github.com/PingoLee/PormG.jl/issues/334)), so a multi-row insert collides on the key.
+- An auto-increment primary key column whose values are **all** blank counts as absent, so the database allocates the ids. A `UUIDField(auto_add = true)` primary key follows the same rule too — see [Auto-Generated Primary Keys](#Auto-Generated-Primary-Keys) for both.
 
 ---
 
@@ -156,6 +150,12 @@ Do not prefill an auto-increment primary key with `max(id) + 1` before calling `
 - If you want to load explicit primary key values, provide a value for every row. Mixed blank and explicit values are rejected because the bulk path cannot safely express a row-by-row mix of generated and manual ids.
 
 This keeps id allocation concurrency-safe and avoids the collision risks of a client-side `SELECT MAX(id)` allocator.
+
+A `UUIDField(primary_key = true, auto_add = true)` column follows the same absent/all-blank/mixed rules ([#334](https://github.com/PingoLee/PormG.jl/issues/334)): omit the column, or carry it with every cell blank, and PormG mints a fresh, **distinct** `uuid4()` per row; mix blank and explicit cells and it raises, same as an auto-increment pk. `allocate_primary_keys()` (below) does **not** support pre-reserving UUID pks, though — there is nothing to reserve from a database sequence. Generate the values locally instead, before the bulk call, if you need them ahead of the insert:
+
+```julia
+df[!, :token] = [UUIDs.uuid4() for _ in 1:DataFrames.nrow(df)]
+```
 
 ### Pre-allocating Primary Keys for Cross-Table FK Wiring
 

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -381,8 +381,28 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
     is_pk = col_row.pk > 0
     
     if is_pk
+      if base_type == "UUID"
+        # #334: a UUID primary key is the ONE non-integer pk type this reader can safely
+        # reconstruct as its real field type, mirroring the same narrow carve-out in the
+        # PostgreSQL reader just above in this file (see its comment for why this is NOT
+        # generalized to "any non-integer pk" — `UUIDField` uniquely carries neither the
+        # max_length/max_digits hazard nor a construction-time refusal that other non-integer
+        # field types can hit when forced into `primary_key = true`).
+        #
+        # UNREACHABLE today for a table PormG itself created: `sqlite_type_map_reverse` (below,
+        # DDL-generation direction) renders every `UUIDField` column — pk or not — as bare `TEXT`,
+        # same as CharField/TextField/JSONField/ImageField (the collapse the `else` branch of the
+        # non-pk arm already documents), never as a literal `UUID` column type. This branch exists
+        # for a hand-written or foreign SQLite schema that DOES declare a column type as `UUID`
+        # (SQLite accepts any type name), and costs nothing to keep. It does NOT close the gap for
+        # PormG-generated schemas — `test/integration/db_2/models.jl`'s comment on
+        # `Bulk_uuid_pk_scratch` explains why that fixture has no SQLite counterpart instead.
+        field = Models.UUIDField(null=false, primary_key=true,
+            default=_normalize_sqlite_default(default_val, :UUIDField))
+      else
         # In SQLite, INTEGER PRIMARY KEY often implies AUTOINCREMENT behavior
         field = Models.IDField(null=false, primary_key=true, auto_increment=(base_type == "INTEGER"))
+      end
     elseif haskey(fk_map, col_name)
         fk_info = fk_map[col_name]
         # Same #292 gap as the DDL-regex path above: `default_val` was in scope and used two
@@ -1294,9 +1314,36 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # @pormg_debug col == "qt_referencia bigint DEFAULT (0)::numeric"
 
       # println(col)
-      
-      # Create field instance      
-      field = if primary_key
+
+      # Create field instance
+      field = if primary_key && col_type == "uuid"
+          # #334: a UUID primary key is the ONE non-integer pk type this reader can safely
+          # reconstruct as its real field type. Force-converting EVERY primary key to IDField
+          # (the `elseif primary_key` branch below) silently discarded it, so `makemigrations`
+          # proposed re-typing it back to bigint on every single run against a model that never
+          # declared an IDField at all. No existing fixture exercised a UUID primary key before
+          # #334, which is why this went unnoticed. Deliberately NOT generalized to "any
+          # non-integer pk": `test_introspection_guards.jl` pins IDField as the correct fallback
+          # for a VARCHAR/NUMERIC primary key specifically BECAUSE those can crash otherwise — a
+          # `NUMERIC` pk parsed as `DecimalField(primary_key=true)` refuses construction outright
+          # (`models/fields.jl`, "DecimalField cannot be used as a Primary Key"), and a VARCHAR pk
+          # would try to assign `max_length` onto whatever field resulted. `UUIDField` carries
+          # neither hazard: no `max_length`/`max_digits`, and `primary_key=true` is always legal.
+          # `db_index` is the literal `true`, not the `db_index` variable, matching the IDField
+          # branch: the `indexes` CTE above explicitly excludes primary-key indexes
+          # (`NOT i.indisprimary`), so `db_index` would read back `false` for any primary key.
+          #
+          # `unique` is the COMPUTED local variable here, deliberately NOT the literal `true` the
+          # IDField branch hardcodes. IDField's own constructor defaults `unique=true`, so hardcoding
+          # it there always agrees with a plain `IDField()` declaration; UUIDField's constructor
+          # defaults `unique=false` (uniqueness on a pk column comes from the PRIMARY KEY constraint
+          # itself, not a separate `UNIQUE` one), so a declared `UUIDField(primary_key=true, ...)`
+          # with no explicit `unique=true` would otherwise permanently disagree with a hardcoded
+          # `true` here — the primary-key branch of `_NON_SCHEMA_FIELD_ATTRS`'s comparison (above in
+          # `planner.jl`) has no exception for `:unique`, so that mismatch alone would keep
+          # `makemigrations` proposing an alteration regardless of the `:auto_add` exemption below.
+          Models.UUIDField(primary_key=true, unique=unique, null=false, db_index=true, default=default_value)
+      elseif primary_key
           Models.IDField(generated=generated, generated_always=generated_always, unique=true, null=false, db_index=true)
       elseif haskey(fk_map, col_name)
         fk_info = fk_map[col_name]

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -26,9 +26,15 @@
 #     and `alter_field` has nothing to emit for them: every `DateTimeField(auto_now_add=true)`
 #     produced an empty alteration on every `makemigrations`, forever (#325). On SQLite that empty
 #     alteration was still a full table rebuild.
+#   * `auto_add` (UUIDField) is the same story as `auto_now`/`auto_now_add` just above: PormG
+#     mints the UUID in Julia on write (`UUIDs.uuid4()`), never as a column DEFAULT, so
+#     introspection always reads it back as `false` regardless of the declared value. Left out of
+#     this tuple until #334 — unnoticed only because no fixture had ever declared `auto_add=true`
+#     on a field introspection also had to reconstruct (a primary key, or any column round-tripped
+#     through `assert_no_schema_drift`).
 const _NON_SCHEMA_FIELD_ATTRS = (:blank, :on_delete, :related_name, :verbose_name, :editable,
                                  :how, :formatter, :db_column, :db_index,
-                                 :auto_now, :auto_now_add)
+                                 :auto_now, :auto_now_add, :auto_add)
 
 function _hash_field_name(model_name::Symbol, field_name::Union{String, Symbol}; apend_number::Int64=5)::String
   _hash = randstring(8) 

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -129,12 +129,29 @@ function _is_auto_generated_bulk_primary_key(field_meta)
     getfield(field_meta, :auto_increment)
 end
 
+# #334: a UUIDField(primary_key = true, auto_add = true) is also PormG-minted, but through
+# `auto_add` rather than `auto_increment`. `_is_auto_generated_bulk_primary_key` alone must stay
+# auto_increment-only — `allocate_primary_keys` uses it to find a pk to reserve sequence values
+# for, and a UUID pk has no sequence to reserve from. This is the wider "the DataFrame may leave
+# this pk column out or blank; PormG can mint it" check, used only by the blank-rescue below.
+function _is_pormg_minted_bulk_primary_key(field_meta)
+  return _is_auto_generated_bulk_primary_key(field_meta) ||
+    (field_meta.primary_key && field_meta.type == "UUID" && field_meta.auto_add)
+end
+
 # The single deliberate exception to the #331 rule ("a column the DataFrame carries is caller data;
-# PormG never rewrites its cells"): an auto-generated primary key column whose values are ALL blank
-# counts as ABSENT and is dropped from `mapping`/`fields_df` entirely, so the backend allocates the
-# ids. Note it REMOVES the column rather than rewriting cells, so the rule itself still holds — a
-# blank the caller wrote is never silently replaced by a different value. Mixed blank/explicit stays
-# a hard error. Documented for users in docs/src/write/bulk.md → Auto-Generated Primary Keys.
+# PormG never rewrites its cells"): a PormG-minted primary key column — auto-increment, or a UUID
+# `auto_add` (#334) — whose values are ALL blank counts as ABSENT and is dropped from
+# `mapping`/`fields_df` entirely, so the backend/PormG allocates the ids. Note it REMOVES the
+# column rather than rewriting cells, so the rule itself still holds — a blank the caller wrote is
+# never silently replaced by a different value. Mixed blank/explicit stays a hard error. Documented
+# for users in docs/src/write/bulk.md → Auto-Generated Primary Keys.
+#
+# #334 exception-type note: before this fix, a UUID `auto_add` pk never reached this function at
+# all (the old narrow predicate excluded it), so a mixed blank/explicit UUID pk column fell through
+# to the ordinary NOT NULL sweep and raised `InvalidValueError`. It now hits the SAME mixed-value
+# guard below as an auto-increment pk always has, and raises `QueryBuildError` — intentional, not a
+# regression: the two pk kinds now agree on both the error type and the message shape.
 function _drop_blank_auto_primary_keys!(df::DataFrames.DataFrame,
   model::PormGModel,
   fields_df::Vector{String},
@@ -147,7 +164,7 @@ function _drop_blank_auto_primary_keys!(df::DataFrames.DataFrame,
     haskey(mapping, field) || continue
 
     f_meta = model.fields[field]
-    _is_auto_generated_bulk_primary_key(f_meta) || continue
+    _is_pormg_minted_bulk_primary_key(f_meta) || continue
 
     col_name = mapping[field]
     blank_mask = map(_is_blank_bulk_primary_key_value, df[!, col_name])
@@ -478,7 +495,11 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   mapping = Dict{String, String}() # model_field => df_column
 
   # What PormG fills into a column the DataFrame does NOT carry: a static `default`, an
-  # auto_now/auto_now_add timestamp, or a UUID `auto_add` value. Returns (should_fill, value).
+  # auto_now/auto_now_add timestamp, or a UUID `auto_add` value. Returns
+  # (should_fill, value_or_values, per_row). `per_row` is true only for the UUID `auto_add` case,
+  # where `value_or_values` is already a Vector sized to `DataFrames.nrow(df)` — one fresh UUID
+  # per row. For every other fill kind `per_row` is false and `value_or_values` is the single
+  # value broadcast across the whole batch, unchanged from before #334.
   #
   # #331: this is consulted ONLY where the field has no mapped source column in the frame — both
   # call sites below are guarded on exactly that (`!haskey(mapping, field)` in one arm, the
@@ -496,24 +517,27 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   # `pit_stops` binds `laps`'s default instead of the frame's numbers. Narrow (it needs the name
   # collision) but silent. The guard belongs at the injection sites, not here.
   #
-  # Second hole (#334): the UUID branch below calls `uuid4()` ONCE per field, and the injection
-  # sites broadcast that one value across the frame — so every row of an `auto_add` UUID column
-  # gets the same value, colliding immediately on a primary key. Correct for the temporal fills
-  # this idiom was written for (one `now()` per batch is intentional), wrong for UUIDs.
+  # #334 (fixed): the UUID branch below used to call `uuid4()` ONCE per field, and the two
+  # injection sites broadcast that single value across the whole frame — every row of an
+  # absent `auto_add` UUID column got the SAME value, colliding immediately on a primary or
+  # unique column. It now returns one fresh UUID PER ROW (`per_row = true`), while the
+  # temporal fills stay deliberately ONE value per batch (one `now()` per batch is
+  # intentional, matching `_prepare_row_insert!`'s comment above). The two injection sites
+  # stay generic: they branch on `per_row`, never on field type.
   #
   # The chain is deliberately EXCLUSIVE and default-first, mirroring `_prepare_row_insert!`
   # (execution.jl:557-572): a field carrying BOTH a static `default` and `auto_now` takes the
   # default, on the single-row and bulk paths alike.
   function resolve_absent_column_fill(f_meta)
     if f_meta.default !== nothing
-      return true, f_meta.default
+      return true, f_meta.default, false
     elseif f_meta.type == "TIMESTAMPTZ"
       if operation in [:insert, :copy] && (f_meta.auto_now_add || f_meta.auto_now)
         value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formatter(now(TimeZone(settings.time_zone)))
-        return true, value
+        return true, value, false
       elseif operation == :update && f_meta.auto_now
         value = settings === nothing ? now(TimeZone("UTC")) : f_meta.formatter(now(TimeZone(settings.time_zone)))
-        return true, value
+        return true, value, false
       end
     elseif f_meta.type == "DATE"
       if operation in [:insert, :copy] && (f_meta.auto_now_add || f_meta.auto_now)
@@ -524,17 +548,18 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
         # Sanitization handles both `Date` objects and date strings correctly, so
         # bypassing the formatter is intentional. If `DateField` ever gains a
         # custom value-transforming formatter, this path must be updated to call it.
-        return true, today()
+        return true, today(), false
       elseif operation == :update && f_meta.auto_now
-        return true, today()
+        return true, today(), false
       end
     elseif f_meta.type == "UUID" && f_meta.auto_add
       if operation in [:insert, :copy]
-        return true, UUIDs.uuid4()
+        # #334: one distinct UUID per row, not one for the whole batch.
+        return true, [UUIDs.uuid4() for _ in 1:DataFrames.nrow(df)], true
       end
     end
 
-    return false, nothing
+    return false, nothing, false
   end
   
   # 1. Identify mappings and check required columns
@@ -637,7 +662,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       if !haskey(mapping, field)
         # ABSENT column: the field was requested via `columns=` but the DataFrame has no column
         # for it. The fill rule applies — inject one whole column of the fill value.
-        should_auto_populate, fill_value = resolve_absent_column_fill(f_meta)
+        should_auto_populate, fill_value, per_row = resolve_absent_column_fill(f_meta)
 
         if should_auto_populate
           # For an explicit-scope UPDATE (columns= was provided), a static `default` must NOT be
@@ -650,7 +675,9 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
             # Add new column to DF and update mapping
             # Use first mapped column as a length reference
             ref_col = isempty(mapping) ? 1 : mapping[collect(keys(mapping))[1]]
-            df[!, field] = map(x -> fill_value, df[!, ref_col])
+            # #334: per_row means fill_value is already a Vector, one distinct value per row
+            # (currently only the UUID auto_add case) — otherwise broadcast the one value.
+            df[!, field] = per_row ? fill_value : map(x -> fill_value, df[!, ref_col])
             mapping[field] = field
           end
         elseif f_meta.primary_key
@@ -682,7 +709,7 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       # is a worse contract than the one above. (A *narrow* deferral, only when `field in
       # names(df)`, would keep genuinely-absent columns injected and so would not break
       # auto_now_add stamping — the objection is the contract, not a NOT NULL failure.)
-      should_auto_populate, fill_value = resolve_absent_column_fill(f_meta)
+      should_auto_populate, fill_value, per_row = resolve_absent_column_fill(f_meta)
 
       if should_auto_populate
         # For an explicit-scope UPDATE (columns= was provided), a static `default`
@@ -693,7 +720,8 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
         is_explicit_update = operation == :update && !isempty(normalized_columns)
         if !(is_explicit_update && is_static_default)
           ref_col = isempty(mapping) ? 1 : mapping[collect(keys(mapping))[1]]
-          df[!, field] = map(x -> fill_value, df[!, ref_col])
+          # #334: see the sibling injection site above.
+          df[!, field] = per_row ? fill_value : map(x -> fill_value, df[!, ref_col])
           mapping[field] = field
           push!(fields_df, field)
         end

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -247,6 +247,21 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   photo = Models.ImageField(null = true)
 )
 
+# Scratch fixture for #334 — UUIDField(primary_key = true, auto_add = true), to prove
+# bulk_insert/bulk_copy mint a DISTINCT uuid4() per row, and that an all-blank present column is
+# rescued (dropped, treated absent) rather than raising. No existing fixture combines
+# primary_key + auto_add on a UUIDField.
+#
+# PostgreSQL-only, deliberately: this model has NO SQLite counterpart in `db_sl/models.jl` — see
+# the comment there for why (SQLite cannot introspect a UUID primary key distinctly from any other
+# TEXT-collapsed primary key type; a pre-existing SQLite migration-engine limitation, not a #334
+# regression). `bulk_copy` itself is PostgreSQL-only anyway, so nothing goes untested by omitting
+# the SQLite side.
+Bulk_uuid_pk_scratch = Models.Model("bulk_uuid_pk_scratch",
+  token = Models.UUIDField(primary_key = true, auto_add = true),
+  label = Models.CharField(),
+)
+
 # Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME
 # values as bulk_insert/create() (the field formatter is applied — e.g. a naive DateTime is
 # labelled UTC) and must distinguish an empty string from NULL. Nullable char/float/bool/datetime

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -247,6 +247,19 @@ Bulk_update_payload_scratch = Models.Model("bulk_update_payload_scratch",
   photo = Models.ImageField(null = true)
 )
 
+# No SQLite counterpart for #334's `Bulk_uuid_pk_scratch` (db_2/models.jl) — deliberate, not an
+# oversight. SQLite collapses UUIDField, TextField, JSONField and ImageField all onto bare `TEXT`
+# (see the comment in `src/migrations/introspection.jl`'s SQLite reader — CharField is NOT in this
+# group, it keeps a length suffix, `TEXT(n)`), so a UUID primary key is indistinguishable from a
+# TextField/JSONField/ImageField primary key by introspection alone — and
+# `Dialect.describes_same_column` refuses its usual "different declared type, same physical
+# column" leniency for ANY primary key, on either backend, on purpose. Declaring this
+# fixture here would make `assert_no_schema_drift` propose the same bogus alteration forever, for
+# a reason that has nothing to do with #334's actual bug (which is fully backend-agnostic and
+# already covered by the DB-free unit tests). The #334 integration coverage that needs a real
+# `bulk_copy` call is PostgreSQL-only anyway (`bulk_copy` itself is a COPY-protocol feature with no
+# SQLite equivalent), so nothing here goes untested on this backend.
+
 # Fixture for the bulk_copy data-fidelity regression (#86): bulk_copy must store the SAME
 # values as bulk_insert/create() (the field formatter is applied — e.g. a naive DateTime is
 # labelled UTC) and must distinguish an empty string from NULL. Nullable char/float/bool/datetime

--- a/test/integration/test_bulk_copy.jl
+++ b/test/integration/test_bulk_copy.jl
@@ -474,6 +474,64 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# #334: bulk_insert / bulk_copy mint a DISTINCT UUID auto_add value per row
+# Before the fix, `resolve_absent_column_fill` minted `uuid4()` ONCE per field and the
+# injection site broadcast that single value across the whole DataFrame — every row of an
+# absent `auto_add` UUID column got the SAME value. On a plain column that only wastes an
+# opportunity; on a PRIMARY KEY (or any unique) column it makes every multi-row bulk write
+# fail outright. `Bulk_uuid_pk_scratch` is built specifically to prove this:
+# `UUIDField(primary_key = true, auto_add = true)`, no ForeignKey, no seeding needed. This
+# also extends the blank-auto-pk rescue above (`_drop_blank_auto_primary_keys!`) to UUID
+# `auto_add` primary keys, which it did not recognize before #334.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "#334: absent/blank UUID auto_add primary key mints a distinct value per row" begin
+    purge = () -> begin
+        q = M.Bulk_uuid_pk_scratch.objects
+        q.filter("label__@startswith" => "i334-")
+        q.exists() && q.delete()
+    end
+    purge()
+
+    try
+        @testset "bulk_insert: absent column" begin
+            bulk_insert(M.Bulk_uuid_pk_scratch.objects,
+                DataFrames.DataFrame(label = ["i334-bi-a", "i334-bi-b", "i334-bi-c"]))
+            rows = M.Bulk_uuid_pk_scratch.objects.filter(
+                "label__@in" => ["i334-bi-a", "i334-bi-b", "i334-bi-c"]).list()
+            @test length(rows) == 3
+            tokens = [row[:token] for row in rows]
+            @test all(!isnothing, tokens) && all(!ismissing, tokens)
+            @test length(unique(tokens)) == 3   # pre-#334: PK collision/crash
+        end
+
+        @testset "bulk_copy: absent column" begin
+            bulk_copy(M.Bulk_uuid_pk_scratch.objects,
+                DataFrames.DataFrame(label = ["i334-bc-a", "i334-bc-b", "i334-bc-c"]))
+            rows = M.Bulk_uuid_pk_scratch.objects.filter(
+                "label__@in" => ["i334-bc-a", "i334-bc-b", "i334-bc-c"]).list()
+            @test length(rows) == 3
+            tokens = [row[:token] for row in rows]
+            @test all(!isnothing, tokens) && all(!ismissing, tokens)
+            @test length(unique(tokens)) == 3
+        end
+
+        @testset "bulk_insert: present, all-blank column is rescued" begin
+            bulk_insert(M.Bulk_uuid_pk_scratch.objects,
+                DataFrames.DataFrame(token = Union{Missing, String}[missing, missing],
+                                      label = ["i334-rescue-a", "i334-rescue-b"]))
+            rows = M.Bulk_uuid_pk_scratch.objects.filter(
+                "label__@in" => ["i334-rescue-a", "i334-rescue-b"]).list()
+            @test length(rows) == 2
+            tokens = [row[:token] for row in rows]
+            @test all(!isnothing, tokens) && all(!ismissing, tokens)
+            @test length(unique(tokens)) == 2
+        end
+    finally
+        purge()
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # bulk_copy: binary payloads survive the CSV COPY stream byte-for-byte (#296)
 # bulk_copy does not bind parameters — it formats each cell and streams CSV into
 # `COPY … FROM STDIN`. A binary payload therefore takes a completely different route to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,7 @@ end
     @testset "SQLite Rebuild Index Filter (#116)" include("unit/test_sqlite_index_filter.jl")
     @testset "FK Rename Rebuild Gate (#150)" include("unit/test_fk_rename_rebuild.jl")
     @testset "Migration Diff Fail-Safe (#69)" include("unit/test_migration_diff_failsafe.jl")
+    @testset "Migration Diff: auto_add is not schema drift (#334)" include("unit/test_migration_planner_auto_add.jl")
     @testset "Model_to_str Render Failure (#70/#134)" include("unit/test_model_to_str_render_failure.jl")
     @testset "Migration Format Stability (v1)" include("unit/test_migration_format_v1.jl")
     @testset "Schema Conventions Freeze (#33)" include("unit/test_schema_conventions.jl")

--- a/test/unit/test_bulk_default_fill_scope.jl
+++ b/test/unit/test_bulk_default_fill_scope.jl
@@ -38,6 +38,7 @@ using PormG
 using PormG.Models: Model, IDField, IntegerField, CharField, DateTimeField, UUIDField
 using PormG.QueryBuilder: bulk_copy, bulk_insert, bulk_update
 using PormG: InvalidValueError, PormGError
+using UUIDs
 import DataFrames
 
 # Mock connection under a dedicated key so this file cannot contaminate (or be
@@ -73,6 +74,14 @@ Bdfs_pitlane = Model("bdfs_pitlane",
 )
 Bdfs_pitlane.connect_key = "bdfs_mock"
 
+# A UUID auto_add PRIMARY KEY, for the #334 blank-rescue testset — `Bdfs_stint.token` is not a
+# pk, so it cannot exercise `_drop_blank_auto_primary_keys!`.
+Bdfs_uuid_pk = Model("bdfs_uuid_pk",
+    token  = UUIDField(primary_key = true, auto_add = true),
+    driver = CharField(),
+)
+Bdfs_uuid_pk.connect_key = "bdfs_mock"
+
 # ------------------------------------------------------------------
 # Read a bound value back BY COLUMN NAME rather than by a hard-coded index.
 #
@@ -102,6 +111,18 @@ function source_param_for(res, col)
     idx = findfirst(==(col), cols)
     idx === nothing && error("column $(col) is not in the source list: $(res[:sql_text])")
     return res[:parameters][idx]
+end
+
+# Every bound value for `col`, across all rows — for asserting per-row DISTINCTNESS (#334) rather
+# than just presence. `parameters` is a flat, row-major vector: bulk_insert renders one
+# `VALUES (?,?),(?,?),...` clause per row in the same column order, so column `idx` out of `n`
+# total columns appears at flat positions `idx, idx+n, idx+2n, ...`.
+function params_for(res, col)
+    cols = insert_columns(res)
+    idx = findfirst(==(col), cols)
+    idx === nothing && error("column $(col) is not in the INSERT: $(res[:sql_text])")
+    n = length(cols)
+    return res[:parameters][idx:n:end]
 end
 
 @testset "#331: PormG fills only absent columns" begin
@@ -237,6 +258,56 @@ end
         @test !ismissing(param_for(res, "checked_at"))
         @test !ismissing(param_for(res, "updated_at"))
         @test !ismissing(param_for(res, "token"))
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # #334: absent UUID auto_add column — a distinct value per row, not one per batch
+    # `resolve_absent_column_fill` used to call `uuid4()` ONCE per field and the injection
+    # site broadcast that single value across the whole frame, so every row of an absent
+    # `auto_add` UUID column got the identical value — an immediate collision on a primary
+    # or unique column. The other three fill kinds (static default, TIMESTAMPTZ auto_now/
+    # auto_now_add, DATE auto_now/auto_now_add) are deliberately UNCHANGED: one value per
+    # batch remains correct and is asserted below alongside the UUID fix so a future change
+    # cannot silently make everything per-row.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "#334: absent UUID auto_add column mints a distinct value per row" begin
+        res = bulk_insert(Bdfs_stint.objects,
+                          DataFrames.DataFrame(driver = ["Fangio", "Moss", "Hawthorn"]),
+                          show_query = :dict)
+
+        tokens = params_for(res, "token")
+        @test length(tokens) == 3
+        @test all(!ismissing, tokens)
+        @test length(unique(tokens)) == 3   # pre-#334: all three were the SAME uuid4()
+
+        # Control: the temporal and static fill kinds must stay ONE value for the whole
+        # batch — this fix must not turn them per-row too.
+        @test length(unique(params_for(res, "checked_at"))) == 1
+        @test length(unique(params_for(res, "updated_at"))) == 1
+        @test all(==(0), params_for(res, "laps"))
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # #334: a blank UUID auto_add PRIMARY KEY column is rescued, not raised
+    # `_drop_blank_auto_primary_keys!` only recognized `auto_increment` primary keys before
+    # this fix — a UUID `auto_add` pk has no `auto_increment` field at all, so an all-blank
+    # present column fell through to the NOT NULL check and raised. It is now rescued the
+    # same way: dropped, treated as absent, and minted per row by the fix above. A mixed
+    # blank/explicit column still raises — unchanged.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "#334: an all-blank UUID auto_add primary key column is rescued, not raised" begin
+        res = bulk_insert(Bdfs_uuid_pk.objects,
+                          DataFrames.DataFrame(token = [missing, missing], driver = ["Senna", "Prost"]),
+                          show_query = :dict)
+        tokens = params_for(res, "token")
+        @test length(tokens) == 2
+        @test all(!ismissing, tokens)
+        @test length(unique(tokens)) == 2   # dropped → absent → per-row mint, not a raise
+
+        # Mixed blank/explicit still raises, unchanged.
+        @test_throws PormG.QueryBuildError bulk_insert(Bdfs_uuid_pk.objects,
+            DataFrames.DataFrame(token = [string(uuid4()), missing], driver = ["Senna", "Prost"]),
+            show_query = :dict)
     end
 
     # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_migration_planner_auto_add.jl
+++ b/test/unit/test_migration_planner_auto_add.jl
@@ -1,0 +1,87 @@
+# ==============================================================================
+# #334: `auto_add` alone is not schema drift
+#
+# Introspection can never read `auto_add` back — PormG mints a UUID in Julia on write, never
+# as a column DEFAULT (same reasoning `_NON_SCHEMA_FIELD_ATTRS`'s header comment already gives
+# for `auto_now`/`auto_now_add`, in `src/migrations/planner.jl`), so the "live" side of a
+# live-vs-declared comparison always reconstructs `auto_add = false` regardless of what the
+# declared model says. Before #334, `auto_add` was simply missing from that exclusion tuple —
+# unnoticed only because no fixture anywhere declared `auto_add = true` on a field a diff ever
+# had to reconcile.
+#
+# A dedicated file rather than an addition to `test/unit/test_migration_planner.jl`: that file
+# is commented out of `test/runtests.jl` (unrelated to #334, predates it, no comment explaining
+# why) and so gets zero CI protection — this narrow check needs its own registered home.
+#
+# THREE assertions, not one, because a single end-to-end "does the plan stay empty" check turns
+# out NOT to be a mutation gate here: `Dialect.alter_field` has no SQL-emitting branch for
+# `:auto_add` at all (checked directly, `IMPLEMENTED` list), so an `:auto_add`-only diff renders
+# to an empty alteration string regardless of whether `_NON_SCHEMA_FIELD_ATTRS` excludes it —
+# `_configure_order_dict_migration_plan`'s `value == "" && return` silently drops it either way.
+# Reverting the exclusion (confirmed by hand: `git stash` on `planner.jl` alone, same test file,
+# same PostgreSQL bootstrap) still produces an empty plan — just with a spurious `@warn "The
+# attributes [:auto_add] are not implemented in alter_field function"` on every single
+# `makemigrations` run. So the exclusion's real, provable effect is suppressing that warning, not
+# preventing a plan-level regression (an unrelated safety net already does that). Assertion 1
+# below is the actual mutation gate — a direct membership check on what #334 changed; assertion 2
+# proves the log-silence consequence; assertion 3 is the plan-emptiness end state, kept because
+# it IS the user-visible outcome, with its limits stated rather than overclaimed.
+# ==============================================================================
+
+using Test
+using Logging
+using PormG
+using PormG.Models
+using PormG.Migrations
+import PormG: PormGModel, PormGPostgres
+
+struct MigrationPlannerAutoAddMockPg <: PormGPostgres end
+
+@testset "#334: a UUIDField primary key differing only in auto_add is not proposed as drift" begin
+    mock_conn_pg = MigrationPlannerAutoAddMockPg()
+    settings = PormG.Configuration.Settings()
+    settings.change_db = true
+
+    # 1. THE mutation gate: direct membership check on the tuple #334 actually changed. Reverting
+    # the fix fails this immediately and unconditionally, independent of `alter_field`/`Dialect`
+    # downstream behavior.
+    @test :auto_add in Migrations._NON_SCHEMA_FIELD_ATTRS
+
+    live_table = Models.Model("uuid_pk_test",
+        token = Models.UUIDField(primary_key=true, auto_add=false, unique=false, null=false, db_index=true),
+        label = Models.CharField(max_length=100),
+    )
+    declared_table = Models.Model("uuid_pk_test",
+        token = Models.UUIDField(primary_key=true, auto_add=true, unique=false, null=false, db_index=true),
+        label = Models.CharField(max_length=100),
+    )
+    current_schema = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(
+        :uuid_pk_test => Dict{Symbol, Union{Bool, PormGModel}}(:model => declared_table, :exist => false)
+    )
+
+    # 2. The behavioral consequence that DOES distinguish "excluded" from "not excluded": with the
+    # exclusion, `_compare_model_field`-style diffing never puts `:auto_add` in `colect_not_equal`,
+    # so `Dialect.alter_field` is never asked to render it and never logs its "not implemented"
+    # warning. `min_level = Logging.Warn` with no expected specs asserts ZERO Warn-or-above log
+    # records — the same idiom `test/unit/test_connection_pool_leak.jl` uses for "no warn expected".
+    plan = @test_logs min_level = Logging.Warn Migrations.get_migration_plan(
+        PormGModel[live_table], current_schema, mock_conn_pg, settings)
+
+    # 3. The end-state outcome, stated honestly: an EMPTY plan here is the correct, user-visible
+    # result — but per the header comment, `Dialect.alter_field`'s missing `:auto_add`
+    # implementation plus the empty-string guard in `_configure_order_dict_migration_plan` would
+    # ALSO produce an empty plan even without the exclusion above. This assertion documents the
+    # outcome; assertions 1 and 2 are what actually prove the exclusion did something.
+    @test !haskey(plan, :uuid_pk_test) || isempty(plan[:uuid_pk_test])
+
+    # Negative control: the SAME two models, but now also disagreeing on `null` — a real,
+    # DDL-visible difference `alter_field` DOES implement. Proves the comparison is genuinely
+    # exercised (both models route through the "same type" branch and get compared field-by-field)
+    # rather than `get_migration_plan` short-circuiting to an empty result for some other reason.
+    live_table_null_mismatch = Models.Model("uuid_pk_test",
+        token = Models.UUIDField(primary_key=true, auto_add=false, unique=false, null=true, db_index=true),
+        label = Models.CharField(max_length=100),
+    )
+    plan_with_real_diff = Migrations.get_migration_plan(PormGModel[live_table_null_mismatch], current_schema, mock_conn_pg, settings)
+    @test haskey(plan_with_real_diff, :uuid_pk_test) && !isempty(plan_with_real_diff[:uuid_pk_test])
+end


### PR DESCRIPTION
## Summary

- `bulk_insert`/`bulk_copy` minted a single UUID for an absent `UUIDField(auto_add = true)` column and reused it for every row in the batch — `create()` correctly mints a distinct UUID per row. On a primary key or unique column this collided immediately on row 2 of any multi-row write.
- `resolve_absent_column_fill` (`src/querybuilder/execution_bulk.jl`) now returns a `per_row` flag alongside the fill value: the UUID `auto_add` case pre-builds a `Vector` of distinct `uuid4()` values sized to the frame; every other fill kind (static `default`, `auto_now`/`auto_now_add`) is unchanged — one value per batch.
- Folded in, per discussion: an all-blank `UUIDField(primary_key = true, auto_add = true)` column is now rescued (dropped, treated absent, minted per row) the same way an all-blank auto-increment primary key already is, instead of raising.

## A second bug found during verification

Adding an integration fixture with a UUID primary key surfaced a separate, pre-existing bug: PostgreSQL/SQLite schema introspection (`src/migrations/introspection.jl`) unconditionally force-converted **any** primary key column back to `IDField`, discarding a UUID pk's real type. This produced permanent migration drift (`makemigrations` proposing to re-type the column back to bigint on every run) for any model with a non-auto-increment primary key — previously unexercised because no fixture anywhere declared one.

Fixed narrowly: only a `uuid`-typed primary key is now reconstructed as `UUIDField` instead of `IDField`. **Deliberately not generalized** to "any non-integer pk" — an existing guard test (`test/unit/test_introspection_guards.jl`) pins `IDField` as the correct fallback for a VARCHAR/NUMERIC primary key specifically, because those can crash otherwise (`DecimalField(primary_key=true)` refuses construction; a VARCHAR pk would try to assign `max_length` onto whatever field resulted).

Also added `:auto_add` to `_NON_SCHEMA_FIELD_ATTRS` (`src/migrations/planner.jl`) — introspection can never read `auto_add` back (it's a Julia-side mint, not a column DEFAULT), matching how `auto_now`/`auto_now_add` are already excluded from the schema diff.

**SQLite limitation, documented, not fixed:** SQLite renders every `UUIDField` column as bare `TEXT`, indistinguishable from TextField/JSONField/ImageField by introspection, and `Dialect.describes_same_column`'s type-reconciliation leniency explicitly excludes primary keys on both backends. This is a genuine, inherent limitation — the new `Bulk_uuid_pk_scratch` integration fixture is PostgreSQL-only by design (`bulk_copy` itself is already PostgreSQL-only, so nothing goes untested), with the SQLite `models.jl` carrying an explanatory comment instead.

## Verification

- Full unit suite: `julia --project=. test/runtests.jl` → 6386/6386
- PostgreSQL integration (`db_2`): 2042/2042, including `test_migration_bootstrap.jl`'s schema-drift self-check
- SQLite integration (`db_sl`): clean (1982 pass + 1 pre-existing unrelated broken test)
- Docs rebuild: clean, no broken cross-references
- Independent review: 4 rounds via a fresh subagent, all findings addressed and mutation-tested (see review notes below)

## Deliberately not done

- No new `UPGRADING.md` entry — per the file's own rule ("not for changes that don't force a consuming-app edit"), and the already-shipped `#331` entry (version 0.4.0) was left untouched rather than mutated, since editing a stamped entry's body without bumping its version makes `upgrade_guide(from = v"0.4.0")` invisible to exactly the apps that need to see it (caught in review round 1).
- `test/unit/test_migration_planner.jl` is commented out of `test/runtests.jl` (predates this PR, unrelated, no explanation) — flagged to the user, new coverage went into a fresh, properly-registered file (`test_migration_planner_auto_add.jl`) instead of reviving unaudited pre-existing content.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)