### PR TITLE
warn on unrecognised connection.yml config: keys with typo suggestions (#365)

### DIFF
--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -70,11 +70,13 @@ dev:
     time_zone: 'UTC'
 ```
 
-## Security and Write Permissions (`change_data` & `change_db`)
+## Configuration Settings (`config:`)
 
-At the core of `connection.yml` is the `config` sub-dictionary. This section decides whether the application acts internally as a read-only client or a full administrative client:
+At the core of `connection.yml` is the `config` sub-dictionary. This section governs runtime permissions, logging, timezones, and naming conventions for the loaded environment:
 
-!!! warning "Both default to `false`, and a misplaced key is silent"
+!!! warning "Unrecognised keys are warned with suggestions"
+    Only valid user-facing keys (`change_db`, `change_data`, `django_prefix`, `time_zone`, `log_queries`, `log_level`, `log_to_file`, `model_file`) are accepted under `config:`. Any unrecognised key emits a `@warn` on load naming the key and the environment, along with a "did you mean" suggestion if the key is a near-miss typo (e.g. `djago_prefix` → `django_prefix`).
+
     Omit the `config:` block and you get `change_data: false` **and** `change_db: false` — writes
     raise `WritesDisabledError` and migrations are rejected. Both keys are only read from the
     `config:` sub-dictionary of the environment you actually loaded; the same key at the top level,
@@ -113,6 +115,20 @@ sequence synchronisation, not Django-style short-form join paths. See
 `django_prefix: ''` means the same as omitting the key — an empty app label is the absence of one,
 not a prefix that happens to be empty. Earlier versions composed `"$(prefix)_"` regardless and
 derived table names beginning with `_`.
+
+### `time_zone`
+
+Optional (default: `"UTC"`). Sets the default timezone string (e.g. `'UTC'`, `'America/Sao_Paulo'`) used by `auto_now` and `auto_now_add` date/datetime fields.
+
+### Logging Settings
+
+- **`log_queries`** (default: `true`): `Bool` flag controlling whether queries are logged.
+- **`log_level`** (default: `debug`): Minimum log level for query logging (`"debug"`, `"info"`, `"warn"`, `"error"`).
+- **`log_to_file`** (default: `true`): `Bool` flag controlling whether logs are written to file.
+
+### `model_file`
+
+Optional (default: `"models.jl"`). Relative file name within the database definition folder where models are saved and loaded by the migration runner.
 
 !!! note "DDL only"
     `change_db` governs schema changes and nothing else. Earlier versions also secretly switched

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -6,6 +6,7 @@ import PormG: model_table_name  # physical table name (db_table when set, #59) â
 import PormG: ConfigurationError, InvalidConfigurationError  # semantic error taxonomy (#239); defined in Kernel
 import PormG: TransactionError  # cross-connection transaction misuse (#268); the config is valid, the call pattern is not
 import PormG: PORMG_DB_CONFIG_FILE_NAME, DB_PATH, MODEL_FILE, DATETIME_FORMAT, UTC_TIMEZONE, DEFAULT_POOL_TIMEOUT
+import PormG: _suggest_name  # typo suggestion helper (Kernel)
 import PormG: Generator
 import PormG: @pormg_debug
 # Backend generics â€” driver bodies live in the weakdep extensions (no direct LibPQ/SQLite here).
@@ -579,6 +580,24 @@ function _install_immutable_unaccent!(settings::PormGSettings)::Nothing
   return nothing
 end
 
+"""
+    VALID_CONFIG_KEYS
+
+Allowed user-facing keys in a `connection.yml` `config:` block (#365).
+Internal `Settings` fields (`app_env`, `db_def_folder`, `db_config_settings`, `connections`)
+are intentionally excluded to prevent tampering from YAML.
+"""
+const VALID_CONFIG_KEYS = (
+  "change_db",
+  "change_data",
+  "django_prefix",
+  "time_zone",
+  "log_queries",
+  "log_level",
+  "log_to_file",
+  "model_file",
+)
+
 function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{String,Any}
   db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME) 
 
@@ -598,14 +617,21 @@ function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{
   if  haskey(db_conn_data, settings.app_env)
       if haskey(db_conn_data[settings.app_env], "config") && isa(db_conn_data[settings.app_env]["config"], Dict)
         for (k, v) in db_conn_data[settings.app_env]["config"]
-          # Safely apply settings that exist in the Settings struct
-          if hasfield(Settings, Symbol(k))
-            if k == "log_level"
+          k_str = string(k)
+          if k_str in VALID_CONFIG_KEYS
+            if k_str == "log_level"
               for dl in Dict("debug" => Logging.Debug, "error" => Logging.Error, "info" => Logging.Info, "warn" => Logging.Warn)
-                occursin(dl[1], lowercase(string(v))) && setfield!(settings, Symbol(k), dl[2])
+                occursin(dl[1], lowercase(string(v))) && setfield!(settings, Symbol(k_str), dl[2])
               end
             else
-              setfield!(settings, Symbol(k), ((isa(v, String) && startswith(v, ":")) ? Symbol(v[2:end]) : v) )
+              setfield!(settings, Symbol(k_str), ((isa(v, String) && startswith(v, ":")) ? Symbol(v[2:end]) : v) )
+            end
+          else
+            did_you_mean = _suggest_name(k_str, VALID_CONFIG_KEYS)
+            if did_you_mean !== nothing
+              @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env did_you_mean=did_you_mean
+            else
+              @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env
             end
           end
         end

--- a/src/Kernel.jl
+++ b/src/Kernel.jl
@@ -272,6 +272,58 @@ even when the process itself is attached to a color terminal.
 _emsg(io::IO, msg::AbstractString) = _emsg(msg; color = get(io, :color, false))
 
 #═══════════════════════════════════════════════════════════════════════════════
+# SECTION: Typo suggestion helpers (#365)
+#
+# Shared string-distance / nearest-match candidate resolution used across layers
+# (operator typos in QueryBuilder, configuration typos in Configuration).
+#═══════════════════════════════════════════════════════════════════════════════
+
+"""
+    _levenshtein(a::AbstractString, b::AbstractString) -> Int
+
+Iterative Levenshtein edit distance (two-row, O(min(m,n)) memory). Runs only when
+building a typo suggestion, never on the happy path.
+"""
+function _levenshtein(a::AbstractString, b::AbstractString)::Int
+  av, bv = collect(a), collect(b)
+  m, n = length(av), length(bv)
+  m == 0 && return n
+  n == 0 && return m
+  prev = collect(0:n)
+  curr = Vector{Int}(undef, n + 1)
+  for i in 1:m
+    curr[1] = i
+    @inbounds for j in 1:n
+      cost = av[i] == bv[j] ? 0 : 1
+      curr[j + 1] = min(curr[j] + 1, prev[j + 1] + 1, prev[j] + cost)
+    end
+    prev, curr = curr, prev
+  end
+  return prev[n + 1]
+end
+
+"""
+    _suggest_name(input::AbstractString, candidates) -> Union{Nothing, String}
+
+Nearest candidate in `candidates` to `input`, or `nothing` when nothing is close enough
+to be a plausible typo (`2 * best_d <= length(input)`).
+"""
+function _suggest_name(input::AbstractString, candidates)::Union{Nothing,String}
+  isempty(input) && return nothing
+  best = nothing
+  best_d = typemax(Int)
+  for c in candidates
+    cstr = string(c)
+    d = _levenshtein(input, cstr)
+    if d < best_d
+      best_d = d
+      best = cstr
+    end
+  end
+  return (best !== nothing && 2 * best_d <= length(input)) ? best : nothing
+end
+
+#═══════════════════════════════════════════════════════════════════════════════
 # SECTION: Error taxonomy
 #
 # Must follow `_emsg` above — every subtype's inner constructor calls it.

--- a/src/PormG.jl
+++ b/src/PormG.jl
@@ -45,9 +45,9 @@ import DataFrames, OrderedCollections, Dates, Logging, YAML
 # definition of the public surface.
 include("Kernel.jl")
 using .Kernel
-# Underscore-private members are not exported by Kernel; import the two that are reached as
-# `PormG._emsg` / `PormG._EXTRA_IGNORE_TABLES` (both pinned by tests).
-import .Kernel: _emsg, _EXTRA_IGNORE_TABLES
+# Underscore-private members are not exported by Kernel; import those reached across
+# submodules or pinned by tests (e.g. `PormG._emsg`, `PormG._EXTRA_IGNORE_TABLES`, `PormG._suggest_name`).
+import .Kernel: _emsg, _EXTRA_IGNORE_TABLES, _levenshtein, _suggest_name
 # Physical-table-name resolution (#59). Deliberately NOT exported — internal plumbing reached as
 # `PormG.model_table_name`, so it stays off the public surface guard. Lives in Kernel because
 # layer-2 `Configuration` needs it and is included before `Models`.

--- a/src/QueryBuilder.jl
+++ b/src/QueryBuilder.jl
@@ -28,7 +28,7 @@ import PormG: PormGError, FieldAccessError, UnknownFieldError, LazyTraversalErro
 import PormG: PormGsuffix, PormGtransform, JSON_CONTAINMENT_OPERATORS, run_in_transaction
 import PormG: backend_num_affected_rows  # PG matched-row count (driver body in the weakdep extension)
 import PormG: backend_sqlite_version  # SQLite library-version probe for the bind-parameter limit (#84)
-import PormG: _emsg  # shared TTY-aware error-message strip helper (tools.jl)
+import PormG: _emsg, _suggest_name  # shared helpers (Kernel)
 import PormG.ConnectionPool: fetch, fetch_copy, with_transaction, with_savepoint, with_sqlite_write_lock, current_task, finalize_transaction_connection!
 # #344: "was this failure a cancellation?" — sees through the DatabaseError wrapper the pool applies,
 # which a bare `e isa InterruptException` test cannot (every driver error crosses `_as_database_error`).

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -124,43 +124,11 @@ end
 # "did you mean" suggestion for typos.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Iterative Levenshtein edit distance (two-row, O(min(m,n)) memory). Runs only when
-# building a typo suggestion, never on the happy path.
-function _levenshtein(a::AbstractString, b::AbstractString)::Int
-  av, bv = collect(a), collect(b)
-  m, n = length(av), length(bv)
-  m == 0 && return n
-  n == 0 && return m
-  prev = collect(0:n)
-  curr = Vector{Int}(undef, n + 1)
-  for i in 1:m
-    curr[1] = i
-    @inbounds for j in 1:n
-      cost = av[i] == bv[j] ? 0 : 1
-      curr[j + 1] = min(curr[j] + 1, prev[j + 1] + 1, prev[j] + cost)
-    end
-    prev, curr = curr, prev
-  end
-  return prev[n + 1]
-end
-
 # Nearest valid operator suffix to `suffix`, or nothing when nothing is close enough
 # to be a plausible typo (so garbage input does not get a nonsense suggestion).
-function _suggest_operator(suffix::AbstractString)::Union{Nothing,String}
-  best = nothing
-  best_d = typemax(Int)
-  for k in keys(PormGsuffix)
-    d = _levenshtein(suffix, k)
-    if d < best_d
-      best_d = d
-      best = k
-    end
-  end
-  # Suggest only when the edit is small relative to the typed length: keeps real
-  # near-misses (@notin→@nin, @containx→@contains) but rejects short garbage
-  # (@xy is 2 edits from @in — the whole word — so no suggestion).
-  return 2 * best_d <= length(suffix) ? best : nothing
-end
+# Uses the shared Kernel `_suggest_name` helper with the same threshold (#365).
+_suggest_operator(suffix::AbstractString)::Union{Nothing,String} =
+  _suggest_name(suffix, keys(PormGsuffix))
 
 # Consistent, actionable error for a filter operator that is not valid for the given
 # value shape. `field_path` is the split lookup (…, suffix); `shape` is a human word

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -1,5 +1,6 @@
 using Test
 using PormG
+import Logging
 
 if !haskey(ENV, "PORMG_ENV")
     ENV["PORMG_ENV"] = "test"
@@ -550,6 +551,153 @@ end
             @test err isa MDCE
             @test occursin("staging", err.msg)
             @test occursin("dev", err.msg) && occursin("test", err.msg)
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+end
+
+# ── #365: connection.yml unrecognised config keys + typo suggestions ──────────────────────────
+# An unrecognised key in a `config:` block must emit a structured `@warn` naming the key and the
+# environment. Plausible typos receive a `did_you_mean` nearest candidate; distant garbage does not.
+# Internal `Settings` fields (app_env, db_def_folder, etc.) are excluded from the allowlist.
+@testset "unrecognised config keys emit warnings with suggestions (#365)" begin
+    @testset "typo in config key suggests nearest valid key" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            open(joinpath(db_dir, "connection.yml"), "w") do f
+                write(f,
+                    "dev:\n" *
+                    "  adapter: SQLite\n" *
+                    "  database: \":memory:\"\n" *
+                    "  config:\n" *
+                    "    change_data: true\n" *
+                    "    djago_prefix: dash\n" *
+                    "    chnge_db: true\n" *
+                    "    timezone: 'UTC'\n"
+                )
+            end
+
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+
+            warns = filter(l -> l.level == Logging.Warn && occursin("unrecognised config key", l.message), logs)
+            @test length(warns) == 3
+
+            warn_map = Dict(String(Dict(w.kwargs)[:key]) => Dict(w.kwargs) for w in warns)
+            @test haskey(warn_map, "djago_prefix")
+            @test warn_map["djago_prefix"][:env] == "dev"
+            @test warn_map["djago_prefix"][:did_you_mean] == "django_prefix"
+
+            @test haskey(warn_map, "chnge_db")
+            @test warn_map["chnge_db"][:env] == "dev"
+            @test warn_map["chnge_db"][:did_you_mean] == "change_db"
+
+            @test haskey(warn_map, "timezone")
+            @test warn_map["timezone"][:env] == "dev"
+            @test warn_map["timezone"][:did_you_mean] == "time_zone"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "garbage key emits warning without did_you_mean" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            open(joinpath(db_dir, "connection.yml"), "w") do f
+                write(f,
+                    "dev:\n" *
+                    "  adapter: SQLite\n" *
+                    "  database: \":memory:\"\n" *
+                    "  config:\n" *
+                    "    completely_unknown_key: 123\n"
+                )
+            end
+
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+
+            warns = filter(l -> l.level == Logging.Warn && occursin("unrecognised config key", l.message), logs)
+            @test length(warns) == 1
+            w = first(warns)
+            kw = Dict(w.kwargs)
+            @test kw[:key] == "completely_unknown_key"
+            @test kw[:env] == "dev"
+            @test !haskey(kw, :did_you_mean)
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "internal Settings fields cannot be set from config: and are warned" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            open(joinpath(db_dir, "connection.yml"), "w") do f
+                write(f,
+                    "dev:\n" *
+                    "  adapter: SQLite\n" *
+                    "  database: \":memory:\"\n" *
+                    "  config:\n" *
+                    "    app_env: hacked_env\n" *
+                    "    db_def_folder: /tmp/fake\n" *
+                    "    connections: null\n"
+                )
+            end
+
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+
+            warns = filter(l -> l.level == Logging.Warn && occursin("unrecognised config key", l.message), logs)
+            @test length(warns) == 3
+
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.app_env == "dev"
+            @test s.db_def_folder == db_dir
+            @test s.connections !== nothing
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "all valid config: keys are accepted with no warning" begin
+        mktempdir() do temp_root
+            db_dir = joinpath(temp_root, "db"); mkpath(db_dir)
+            open(joinpath(db_dir, "connection.yml"), "w") do f
+                write(f,
+                    "dev:\n" *
+                    "  adapter: SQLite\n" *
+                    "  database: \":memory:\"\n" *
+                    "  config:\n" *
+                    "    change_db: true\n" *
+                    "    change_data: true\n" *
+                    "    django_prefix: myapp\n" *
+                    "    time_zone: 'America/Sao_Paulo'\n" *
+                    "    log_queries: false\n" *
+                    "    log_level: 'warn'\n" *
+                    "    log_to_file: false\n" *
+                    "    model_file: 'custom_models.jl'\n"
+                )
+            end
+
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+
+            unrec_warns = filter(l -> l.level == Logging.Warn && occursin("unrecognised config key", l.message), logs)
+            @test isempty(unrec_warns)
+
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.change_db == true
+            @test s.change_data == true
+            @test s.django_prefix == "myapp"
+            @test s.time_zone == "America/Sao_Paulo"
+            @test s.log_queries == false
+            @test s.log_level == Logging.Warn
+            @test s.log_to_file == false
+            @test s.model_file == "custom_models.jl"
 
             _cleanup_configuration_test_keys([db_dir])
         end

--- a/test/unit/test_kernel_layering.jl
+++ b/test/unit/test_kernel_layering.jl
@@ -26,6 +26,8 @@ using PormG
         @test parentmodule(PormG.PormGModel) === PormG.Kernel
         @test parentmodule(PormG.PormGField) === PormG.Kernel
         @test parentmodule(PormG._emsg) === PormG.Kernel
+        @test parentmodule(PormG._levenshtein) === PormG.Kernel
+        @test parentmodule(PormG._suggest_name) === PormG.Kernel
 
         # Kernel must not reach back into PormG — that is what makes it safe to include first.
         # `using PormG` inside Kernel would create the cycle this design removes.


### PR DESCRIPTION
Closes #365

### Summary of Changes
- **Layer 1 Shared Vocabulary** (\src/Kernel.jl\): Extracted \_levenshtein\ and \_suggest_name\ to \PormG.Kernel\ so edit-distance suggestions are shared across layers without circular dependencies.\
- **Operator Typo Suggestions** (\src/querybuilder/build_helpers.jl\): Re-implemented \_suggest_operator\ using \_suggest_name\.\
- **Allowlist & Diagnostics** (\src/Configuration.jl\): Defined \VALID_CONFIG_KEYS\ allowing only user-facing keys (\change_db\, \change_data\, \django_prefix\, \	ime_zone\, \log_queries\, \log_level\, \log_to_file\, \model_file\). Emits structured \@warn\ with \did_you_mean\ for unrecognized keys/typos and excludes internal \Settings\ fields.\
- **Tests & Docs**: Added comprehensive unit testset covering typo suggestions, garbage keys, internal field rejection, and valid key acceptance in \	est/unit/test_configuration_api.jl\. Pinned kernel module ownership in \	est/unit/test_kernel_layering.jl\. Updated \docs/src/configuration/connection_yml.md\.\

### Verification
- Full test suite passed (6,415 / 6,415 assertions)\
- Documentation build clean (\docs/make.jl\)