### PR TITLE
docs: split merged admonition in connection_yml.md

### DIFF
--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -77,6 +77,7 @@ At the core of `connection.yml` is the `config` sub-dictionary. This section gov
 !!! warning "Unrecognised keys are warned with suggestions"
     Only valid user-facing keys (`change_db`, `change_data`, `django_prefix`, `time_zone`, `log_queries`, `log_level`, `log_to_file`, `model_file`) are accepted under `config:`. Any unrecognised key emits a `@warn` on load naming the key and the environment, along with a "did you mean" suggestion if the key is a near-miss typo (e.g. `djago_prefix` → `django_prefix`).
 
+!!! warning "Both default to `false`, and a misplaced key is silent"
     Omit the `config:` block and you get `change_data: false` **and** `change_db: false` — writes
     raise `WritesDisabledError` and migrations are rejected. Both keys are only read from the
     `config:` sub-dictionary of the environment you actually loaded; the same key at the top level,


### PR DESCRIPTION
## Summary
- PR #367 (#365) restricted `connection.yml` `config:` keys to an allowlist and added a new "Unrecognised keys are warned with suggestions" admonition, but deleted the title line of the adjacent "Both default to `false`, and a misplaced key is silent" admonition without separating the two indented bodies.
- Documenter treats indented content after a blank line as a continuation of the same admonition block, so the two unrelated warnings (typo suggestions vs. write-permission defaults) collapsed into a single box under the wrong heading.
- Restores the dropped title so the two warnings render as separate boxes again.

## Test plan
- [x] `julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` — clean build
- [x] Inspected the rendered `docs/build/configuration/connection_yml.html` — confirms two distinct `<div class="admonition">` blocks, each with its own correct heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)