### PR TITLE
perf(#352): rewrite date-bucket comparisons into sargable column ranges

### DIFF
--- a/docs/src/read/functions_and_dates.md
+++ b/docs/src/read/functions_and_dates.md
@@ -116,6 +116,41 @@ query = M.Race.objects.filter("date__@date" => "1991-10-20")
 query = M.Race.objects.filter("date__@date" => Date(1991, 10, 20))
 ```
 
+### Index-friendly ranges on a `DateField`
+
+Comparison suffixes work on these buckets too, and on a plain `DateField` column PormG rewrites
+them into a range **directly on the column** rather than comparing a formatted string:
+
+```julia
+# Every race from October 1991 onwards
+query = M.Race.objects.filter("date__@yyyy_mm__@gte" => "1991-10")
+# renders:  "Tb"."date" >= $1        with $1 = "1991-10-01"
+
+# Every race up to and including December 1991
+query = M.Race.objects.filter("date__@yyyy_mm__@lte" => "1991-12")
+# renders:  "Tb"."date" < $1         with $1 = "1992-01-01"
+```
+
+Because the column is not wrapped in a function call, an index on it applies and the query
+planner can estimate how many rows the filter selects — on a large table this is the difference
+between an index range scan and a full scan with a poisoned join plan.
+
+Note that `@lte` includes the *whole* final bucket (it becomes `<` the following period's first
+day), while `@lt` excludes the named bucket entirely. The same holds for `@year`.
+
+`@year` requires a whole year in the range 1–9999 — an `Integer`, a whole-valued number, or a
+numeric string. A value no single date can express (a fraction, a year outside that range, or a
+`Bool`) raises a `FilterError` rather than silently comparing against an unusable bound.
+
+!!! note "Scope of the rewrite"
+    The rewrite applies to `@yyyy_mm`, `@date` and `@year` on a **plain `DateField`** referenced
+    directly on the queried model. A `DateTimeField` keeps the formatted-string comparison, since
+    `to_char` on a timestamp renders in the session time zone and the range boundaries would shift
+    around midnight. Fields reached through a join, and the `@month`/`@day`/`@quarter`/
+    `@quadrimester` buckets (which repeat every year rather than covering one contiguous range),
+    also keep the original rendering. For the cases it covers the rewrite selects the same rows as
+    before — only the query plan changes.
+
 ---
 
 ## String Functions

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -1018,8 +1018,156 @@ function _resolve_json_operator_field(v::SQLTypeOper, instruc::SQLInstruction)
   return v.column._as === nothing ? nothing : get(instruc.tab_field_cache, v.column._as, nothing)
 end
 
+# #352: sargable rewrite for `col__@yyyy_mm` / `col__@year` / `col__@date` comparisons.
+#
+# `to_char(col, 'YYYY-MM') <= $1` (and the EXTRACT(YEAR ...) equivalent) puts a function call on
+# the indexed column: no index on `col` applies, and PostgreSQL cannot estimate selectivity
+# through it (issue #352 measured a 193x row-count misestimate cascading into an 18+ minute plan).
+# Rewritten as a plain comparison/range on the raw column:
+#
+#   @exact (bare `=`)  col >= F AND col < N
+#   @gte               col >= F
+#   @gt                col >= N
+#   @lte               col < N
+#   @lt                col < F
+#
+# where F = first day of the bucket period and N = first day of the following period. `@date`
+# needs no range at all (F == the literal) since to_char at day granularity on a DATE column
+# preserves chronological order exactly — the rewrite there is just "drop the to_char".
+#
+# Scope (v1, deliberately narrow):
+#   - Only a bare (non-joined) column: a dotted join path only resolves its field TYPE after the
+#     join has rendered, which this function runs before — falling through to the existing
+#     to_char/EXTRACT rendering is always correct, just non-sargable for that case.
+#   - Only a plain DATE column (`_is_date_field`) — TIMESTAMPTZ/TIMESTAMP are excluded because
+#     to_char renders in the session TimeZone, so naively computing F/N would shift the boundary
+#     around midnight. Left on the existing rendering.
+#   - Only a plain scalar RHS (String/Number) — an F()/subquery/Case RHS falls through unchanged.
+#
+# Returns the rendered SQL string, or `nothing` to fall through to the existing rendering.
+function _render_sargable_date_range(v::SQLTypeOper, instruc::SQLInstruction)::Union{String,Nothing}
+  isa(v.column, SQLTypeField) || return nothing
+  fobj = v.column.field
+  isa(fobj, FObject) || return nothing
+  raw_field = fobj.column
+  isa(raw_field, String) || return nothing
+  contains(raw_field, "__") && return nothing                       # bare-field-only in v1
+  v.operator in ("=", ">=", ">", "<=", "<") || return nothing
+  (v.values isa AbstractString || v.values isa Number) || return nothing
+  haskey(instruc.object.model.fields, raw_field) || return nothing
+  f_meta = instruc.object.model.fields[raw_field]
+  _is_date_field(f_meta) || return nothing                          # DATE only, not TIMESTAMP(TZ)
+
+  bucket = if fobj.function_name == "EXTRACT_DATE" && get(fobj.kwargs, "format", nothing) == "YYYY-MM"
+    :yyyy_mm
+  elseif fobj.function_name == "EXTRACT_DATE" && get(fobj.kwargs, "format", nothing) == "YYYY-MM-DD"
+    :date
+  elseif fobj.function_name == "EXTRACT" && get(fobj.kwargs, "part", nothing) == "YEAR" && !haskey(fobj.kwargs, "format")
+    :year
+  else
+    return nothing
+  end
+
+  column_sql = _get_select_query(raw_field, instruc)
+  bind(x) = add_parameter!(instruc, f_meta.formatter(x))
+
+  if bucket == :date
+    # Same granularity as the column: no range, operator unchanged — just drop the to_char.
+    return string(column_sql, " ", v.operator, " ", bind(v.values))
+  end
+
+  first_of_period, next_period = bucket == :yyyy_mm ? _yyyy_mm_bucket_bounds(v.values) : _year_bucket_bounds(v.values)
+
+  if v.operator == ">="
+    return string(column_sql, " >= ", bind(first_of_period))
+  elseif v.operator == ">"
+    return string(column_sql, " >= ", bind(next_period))
+  elseif v.operator == "<="
+    return string(column_sql, " < ", bind(next_period))
+  elseif v.operator == "<"
+    return string(column_sql, " < ", bind(first_of_period))
+  else # "="
+    p1, p2 = bind(first_of_period), bind(next_period)
+    return string("(", column_sql, " >= ", p1, " AND ", column_sql, " < ", p2, ")")
+  end
+end
+
+# Reuses Models.format_yyyy_mm for shape/type validation (String "YYYY-MM" regex, or 6-digit
+# Integer YYYYMM), then parses the normalized string for range math. format_yyyy_mm does NOT
+# validate the month is 01-12 (only the regex shape) — Dates.Date(y, m, 1) does, and its
+# ArgumentError is caught and rethrown as a FilterError so a filter-level defect isn't a bare
+# Dates.jl exception (consistent with the catch/rethrow pattern below for BETWEEN-style errors).
+# A year outside 1..9999 cannot be expressed as a date bound: `Dates.Date` happily accepts year 0
+# and negatives and stringifies them as "0000-01-01" / "-0005-01-01", which both backends reject at
+# execution with an opaque server-side error — and `format_date_sql(::Date)` is a bare `string(...)`
+# that validates nothing. Takes any `Real` so it can run before `Int(...)` narrowing.
+function _check_year_bound(y::Real)
+  (1 <= y <= 9999) || throw(FilterError("The year \e[31m$(y)\e[0m is out of the range a date bound can express (1-9999)."))
+  return nothing
+end
+
+function _yyyy_mm_bucket_bounds(value)::Tuple{Dates.Date,Dates.Date}
+  normalized = Models.format_yyyy_mm(value)   # throws InvalidValueError on bad shape/type
+  y = parse(Int, normalized[1:4])
+  m = parse(Int, normalized[6:7])
+  # The regex admits "0000-01", which would render the unusable "0000-01-01". Same bound as @year.
+  _check_year_bound(y)
+  try
+    first_of_period = Dates.Date(y, m, 1)
+    return first_of_period, first_of_period + Dates.Month(1)
+  catch e
+    throw(FilterError("The value \e[31m$(value)\e[0m is not a valid YYYY-MM bucket: $(sprint(showerror, e))"))
+  end
+end
+
+# Resolve `@year`'s RHS to a calendar year, accepting every value shape the pre-#352 rendering
+# accepted via `Models.format_number_sql` — Integer, Decimal, and a whole-valued Float (an ETL
+# app pulling a year out of a Float64 DataFrame column is the common case), plus a numeric
+# String. Narrowing this would be a breaking change for consuming apps, not a tightening.
+#
+# What IS rejected, because the range rewrite cannot express it while `EXTRACT(YEAR ...)` could:
+#   - Bool (`Bool <: Integer` in Julia; format_number_sql carries a ::Bool overload for exactly
+#     this trap) — `false` would silently become year 0.
+#   - a fractional year (1991.7) — no single date bound represents it.
+#   - a year outside 1..9999 — `Dates.Date` accepts year 0 and negatives and renders them
+#     "0000-01-01" / "-0005-01-01", which both backends reject at execution with an opaque
+#     server-side error; `format_date_sql(::Date)` is a bare `string(...)` and validates nothing.
+# The string branch parses base-10 explicitly: `tryparse(Int, "0x10")` returns 16 in Julia, so
+# the default would silently accept a hex literal as a year.
+function _year_bucket_bounds(value)::Tuple{Dates.Date,Dates.Date}
+  # The range check runs BEFORE `Int(...)` narrowing on every numeric branch: `Int(big(10)^20)`
+  # and `Int(1e30)` throw a raw `InexactError`, which is not a PormGError at all and whose message
+  # never mentions a year filter. `isinteger(1e30)` is `true`, so the whole-year guard alone does
+  # not stop it. Comparing first works on any Real — BigInt, BigFloat, Rational, Decimal.
+  y = if value isa Bool
+    throw(FilterError("A __@year filter requires a year, not a Bool; got \e[31m$(value)\e[0m."))
+  elseif value isa Integer
+    _check_year_bound(value)
+    Int(value)
+  elseif value isa Real
+    isinteger(value) || throw(FilterError("The value \e[31m$(value)\e[0m is not a whole year for a __@year filter."))
+    _check_year_bound(value)
+    Int(value)
+  elseif value isa AbstractString
+    n = tryparse(Int, strip(value), base=10)
+    n === nothing && throw(FilterError("The value \e[31m$(value)\e[0m is not a valid year for a __@year filter."))
+    _check_year_bound(n)
+    n
+  else
+    throw(FilterError("A __@year filter requires a year as an Integer, a whole Real, or a numeric String; got $(typeof(value))."))
+  end
+  first_of_period = Dates.Date(y, 1, 1)
+  return first_of_period, first_of_period + Dates.Year(1)
+end
+
 function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
   @pormg_debug false
+  # #352: rewrite a non-sargable date-bucket comparison (to_char/EXTRACT on the column) into a
+  # plain range/comparison directly on the column, so an index on the column — and the planner's
+  # selectivity estimate — both apply. See _render_sargable_date_range for scope.
+  sargable = _render_sargable_date_range(v, instruc)
+  sargable !== nothing && return sargable
+
   column = _get_filter_query(v.column, instruc)
   # #27: JSONB containment/overlap operators (@>, ?, ?|, ?&) — dedicated binding + PG-only render.
   if v.operator in JSON_CONTAINMENT_OPERATORS

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -416,6 +416,77 @@ end
     @test size(df, 1) == 1
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Date Operations: sargable comparison rewrite (#352)
+# `date__@yyyy_mm`/`date__@year`/`date__@date` comparisons (`=`/`@gte`/`@gt`/`@lte`/`@lt`) against
+# `Race.date` (a plain DateField) rewrite to a range/comparison directly on the column — no
+# to_char/EXTRACT — instead of the previous non-sargable rendering. Each bucket comparison is
+# pinned against an INDEPENDENT baseline — the same window written as a plain date comparison,
+# which never goes through the bucket-transform path — so the asymmetric boundary mapping
+# (`@lte`/`@gt` bind the FOLLOWING period's start; `@lt`/`@gte` bind the bucket's OWN start) is
+# verified absolutely, not just for internal self-consistency, against live data on both backends.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Date Operations — sargable comparison rewrite (#352)" begin
+    # The 1991 season's sole October race is the Japanese GP, 1991-10-20 (pinned above: 1 row).
+    # No to_char (PostgreSQL) / strftime (SQLite) should appear — the comparison runs on the raw
+    # column now, dialect-agnostic.
+    sql_lte = M.Race.objects.filter("date__@yyyy_mm__@lte" => "1991-10").list(show_query=:sql)
+    @test !occursin("to_char", lowercase(sql_lte)) && !occursin("strftime", lowercase(sql_lte))
+
+    query = M.Race.objects.filter("date__@yyyy_mm__@lte" => "1991-10")
+    count_lte = query.count()
+    query = M.Race.objects.filter("date__@yyyy_mm__@lt" => "1991-10")
+    count_lt = query.count()
+    query = M.Race.objects.filter("date__@yyyy_mm__@gte" => "1991-10")
+    count_gte = query.count()
+    query = M.Race.objects.filter("date__@yyyy_mm__@gt" => "1991-10")
+    count_gt = query.count()
+    query = M.Race.objects.filter("date__@yyyy_mm" => "1991-10")
+    count_eq = query.count()
+
+    @test count_eq == 1                # only the Japanese GP falls in October 1991
+    @test count_lte == count_lt + 1    # @lte INCLUDES the October race that @lt EXCLUDES
+    @test count_gte == count_gt + 1    # @gte INCLUDES the October race that @gt EXCLUDES
+
+    # Independent baseline: the same windows expressed as plain date comparisons, which never
+    # went through the bucket-transform path at all. The delta assertions above are only
+    # self-consistent (both sides could be wrong by the same amount and still pass); these pin
+    # the ABSOLUTE boundary, so a strict/non-strict slip on the upper bound fails here.
+    @test count_lte == M.Race.objects.filter("date__@lt" => "1991-11-01").count()
+    @test count_lt  == M.Race.objects.filter("date__@lt" => "1991-10-01").count()
+    @test count_gte == M.Race.objects.filter("date__@gte" => "1991-10-01").count()
+    @test count_gt  == M.Race.objects.filter("date__@gte" => "1991-11-01").count()
+
+    # The 1991 season has 16 races (pinned above). Same asymmetry check, at year granularity.
+    sql_year = M.Race.objects.filter("date__@year__@gte" => 1991).list(show_query=:sql)
+    @test !occursin("extract", lowercase(sql_year)) && !occursin("strftime", lowercase(sql_year))
+
+    query = M.Race.objects.filter("date__@year__@lte" => 1991)
+    y_lte = query.count()
+    query = M.Race.objects.filter("date__@year__@lt" => 1991)
+    y_lt = query.count()
+    query = M.Race.objects.filter("date__@year__@gte" => 1991)
+    y_gte = query.count()
+    query = M.Race.objects.filter("date__@year__@gt" => 1991)
+    y_gt = query.count()
+
+    @test y_lte == y_lt + 16
+    @test y_gte == y_gt + 16
+    # Absolute boundary, same reasoning as the yyyy_mm case above.
+    @test y_lte == M.Race.objects.filter("date__@lt" => "1992-01-01").count()
+    @test y_lt  == M.Race.objects.filter("date__@lt" => "1991-01-01").count()
+    @test y_gte == M.Race.objects.filter("date__@gte" => "1991-01-01").count()
+    @test y_gt  == M.Race.objects.filter("date__@gte" => "1992-01-01").count()
+
+    # `@date` is already at column granularity: no range needed, the operator passes straight
+    # through against the parsed literal.
+    query = M.Race.objects.filter("date__@date__@lte" => "1991-10-20")
+    d_lte = query.count()
+    query = M.Race.objects.filter("date__@date__@lt" => "1991-10-20")
+    d_lt = query.count()
+    @test d_lte == d_lt + 1            # exactly the Japanese GP itself
+end
+
 @testset "Comparison and In Operations" begin
   query = M.Result.objects;
   query.filter("positionorder__@lt" => 3);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ end
     @testset "pormg_lower UDF (#78)" include("unit/test_pormg_lower_udf.jl")
     @testset "Aggregate Fan-out Guard (#74)" include("unit/test_aggregate_fanout.jl")
     @testset "Date Bucket Operator (yyyy_mm)" include("unit/test_date_bucket_operator.jl")
+    @testset "Sargable Date Range Rewrite (#352)" include("unit/test_sargable_date_range.jl")
     @testset "Date/Time Function SQL Parity (#25)" include("unit/test_date_functions_sql.jl")
     @testset "Deep FK Traversal (3 hops)" include("unit/test_deep_fk_traversal.jl")
     @testset "Window Function SQL Generation" include("unit/test_window_functions.jl")

--- a/test/unit/test_date_bucket_operator.jl
+++ b/test/unit/test_date_bucket_operator.jl
@@ -1,18 +1,26 @@
 """
 Unit tests for the `__@yyyy_mm` date-bucket filter operator.
 
-`field__@yyyy_mm` is the month-bucket operator: it renders the column through
-`to_char(col, 'YYYY-MM')` and binds the comparison value after normalising it via
+`field__@yyyy_mm` is the month-bucket operator, normalising the comparison value via
 `Models.format_yyyy_mm` (constants.jl: "yyyy_mm" => "Y_M";
 functions.jl: `Y_M(x) = ToChar(x, "YYYY-MM", formatter = Models.format_yyyy_mm)`).
+
+#352: on a bare `DateField` column, a comparison (`=`/`@gte`/`@gt`/`@lte`/`@lt`) against a
+`__@yyyy_mm` bucket is rewritten to a sargable range directly on the column — `happened >= \$1 AND
+happened < \$2` — instead of `to_char(happened,'YYYY-MM') = \$1`, so an index on `happened` applies
+and the planner can estimate selectivity. See `_render_sargable_date_range` in
+`build_helpers.jl` and the cross-cutting contract (asymmetry, TIMESTAMPTZ/joined-field exclusion)
+in `test_sargable_date_range.jl`. The rendering here only changes for the *filter* path — a bare
+`to_char(...)` still appears when the column is projected via `.values("field__@yyyy_mm")`, or
+when the filter target is a `DateTimeField`/joined column (out of scope for the rewrite).
 
 Why a dedicated file?
   - `test_operators.jl` covers the comparison / string / null suffixes but not the
     date-bucket transforms.
   - This operator carries a *custom value normaliser* (`format_yyyy_mm`) with its own
     accept/reject contract, and it is heavily used by downstream consumers
-    (e.g. "competencia"/"periodo" month filters). A silent change to the rendered
-    `to_char(...)` token or to the value normalisation would break those queries with
+    (e.g. "competencia"/"periodo" month filters). A silent change to the value
+    normalisation, or to the rendered range boundaries, would break those queries with
     no other failing test — so the contract is pinned here, with no live DB required
     (`show_query=:dict`).
 """
@@ -46,27 +54,31 @@ const _Ev = _YmTestEvent
   # =========================================================================
   # 1. String value already in YYYY-MM form
   # =========================================================================
-  @testset "YYYY-MM string → to_char(col,'YYYY-MM') = \$1" begin
+  @testset "YYYY-MM string → sargable range (happened >= \$1 AND happened < \$2)" begin
     res = _Ev.objects.filter("happened__@yyyy_mm" => "1991-10").list(show_query=:dict)
 
-    # Column is rendered through to_char with the YYYY-MM format mask.
-    @test occursin("to_char", lowercase(res[:sql_text]))
-    @test contains(res[:sql_text], "'YYYY-MM'")
+    # #352: bare `=` on a DateField bucket rewrites to a range on the raw column — no to_char.
+    @test !occursin("to_char", lowercase(res[:sql_text]))
     @test contains(res[:sql_text], "happened")
-    # Value is bound, never interpolated into the SQL text.
-    @test res[:parameters] == ["1991-10"]
-    @test !contains(res[:sql_text], "1991-10")
+    # Half-open interval: the lower bound is inclusive, the upper bound STRICT. Asserted as the
+    # full space-delimited predicate so a `<` → `<=` mutation (which would wrongly include the
+    # following month's first day) fails here — `occursin("<", …)` alone is true for "<=" too.
+    @test occursin(" >= \$1", res[:sql_text]) && occursin(" < \$2", res[:sql_text])
+    @test !occursin(" <= \$2", res[:sql_text])
+    # Bounds are bound as parameters, never interpolated into the SQL text.
+    @test res[:parameters] == ["1991-10-01", "1991-11-01"]
+    @test !contains(res[:sql_text], "1991-10-01")
   end
 
   # =========================================================================
   # 2. Integer YYYYMM is normalised to a "YYYY-MM" bound parameter
   # =========================================================================
-  @testset "Integer YYYYMM is normalised to YYYY-MM" begin
+  @testset "Integer YYYYMM is normalised to a YYYY-MM-DD range" begin
     res = _Ev.objects.filter("happened__@yyyy_mm" => 202501).list(show_query=:dict)
 
-    @test contains(res[:sql_text], "'YYYY-MM'")
-    # 202501 → "2025-01" (the dash is inserted by format_yyyy_mm).
-    @test res[:parameters] == ["2025-01"]
+    @test !occursin("to_char", lowercase(res[:sql_text]))
+    # 202501 → "2025-01" (the dash is inserted by format_yyyy_mm) → [2025-01-01, 2025-02-01).
+    @test res[:parameters] == ["2025-01-01", "2025-02-01"]
 
     # The normaliser itself, pinned directly:
     @test format_yyyy_mm(202501) == "2025-01"
@@ -96,11 +108,45 @@ const _Ev = _YmTestEvent
       "id__@gte"           => 10,
     ).list(show_query=:dict)
 
-    @test contains(res[:sql_text], "'YYYY-MM'")
+    @test !occursin("to_char", lowercase(res[:sql_text]))
     @test contains(res[:sql_text], ">=")
-    @test "2025-01" in res[:parameters]
+    @test "2025-01-01" in res[:parameters]
+    @test "2025-02-01" in res[:parameters]
     @test 10 in res[:parameters]
-    @test length(res[:parameters]) == 2
+    @test length(res[:parameters]) == 3
+  end
+
+  # =========================================================================
+  # 5. #352 — comparison suffixes rewrite to the asymmetric range boundaries
+  # =========================================================================
+  @testset "Comparison suffixes bind the correct boundary (asymmetry trap)" begin
+    # The operator assertions are deliberately written as `" < \$1"` / `" >= \$1"` — the full
+    # rendered predicate, space-delimited. A bare `occursin("<", sql)` is ALSO true for "<=",
+    # so it cannot tell a strict bound from a non-strict one: a `<` → `<=` mutation (which would
+    # wrongly include the following period's first day) passes it. The rendering is
+    # `string(column_sql, " ", op, " ", ph)`, so " < \$1" does not match " <= \$1".
+
+    # @gte / @lt bind the FIRST day of the bucket (F).
+    res_gte = _Ev.objects.filter("happened__@yyyy_mm__@gte" => "1991-10").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_gte[:sql_text]))
+    @test occursin(" >= \$1", res_gte[:sql_text]) && !occursin(" > \$1", res_gte[:sql_text])
+    @test res_gte[:parameters] == ["1991-10-01"]
+
+    res_lt = _Ev.objects.filter("happened__@yyyy_mm__@lt" => "1991-10").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_lt[:sql_text]))
+    @test occursin(" < \$1", res_lt[:sql_text]) && !occursin(" <= \$1", res_lt[:sql_text])
+    @test res_lt[:parameters] == ["1991-10-01"]
+
+    # @gt / @lte bind the NEXT period's first day (N) — NOT the same bound as @gte/@lt.
+    res_gt = _Ev.objects.filter("happened__@yyyy_mm__@gt" => "1991-10").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_gt[:sql_text]))
+    @test occursin(" >= \$1", res_gt[:sql_text]) && !occursin(" > \$1", res_gt[:sql_text])
+    @test res_gt[:parameters] == ["1991-11-01"]
+
+    res_lte = _Ev.objects.filter("happened__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_lte[:sql_text]))
+    @test occursin(" < \$1", res_lte[:sql_text]) && !occursin(" <= \$1", res_lte[:sql_text])
+    @test res_lte[:parameters] == ["1991-11-01"]
   end
 
 end

--- a/test/unit/test_sargable_date_range.jl
+++ b/test/unit/test_sargable_date_range.jl
@@ -1,0 +1,196 @@
+"""
+Unit tests for the sargable date-bucket range rewrite (#352).
+
+`_render_sargable_date_range` (`build_helpers.jl`) rewrites a comparison against a date-bucket
+transform (`__@yyyy_mm`, `__@date`, `__@year`) on a bare `DateField` column into a plain
+range/comparison directly on the column — `col >= \$1 AND col < \$2` instead of
+`to_char(col,'YYYY-MM') = \$1` — so an index on the column applies and the planner can estimate
+selectivity (issue #352: a 193x row-count misestimate cascaded into an 18+ minute plan on one
+production query).
+
+This file pins the cross-cutting contract shared by all three bucket types — the asymmetric
+boundary mapping (`@lt`/`@lte` and `@gt`/`@gte` bind DIFFERENT bounds), the `@date` "no range
+needed" simplification, and the two deliberate v1 exclusions (TIMESTAMPTZ/TIMESTAMP columns,
+joined/dotted fields) — with no live DB (`show_query=:dict`). The `__@yyyy_mm`-specific
+value-normalisation contract (`format_yyyy_mm` accept/reject shapes) and that bucket's own
+asymmetry-boundary assertions are already pinned in the sibling `test_date_bucket_operator.jl`;
+this file focuses on `@year`, `@date`, and the negative gates that apply across all three.
+"""
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, DateField, DateTimeField, ForeignKey
+import Decimals
+
+# ---------------------------------------------------------------------------
+# Mock fixture (no live database): a bare DateField, a DateTimeField (TIMESTAMPTZ — must be
+# excluded from the rewrite), and an FK to a related model with its own DateField (joined path —
+# also must be excluded from the rewrite in v1).
+# ---------------------------------------------------------------------------
+if !isdefined(Main, :_SdrTeam)
+  _SdrTeam = Model("sdr_teams",
+    id      = IDField(),
+    founded = DateField(),
+  )
+  _SdrTeam.connect_key = "default"; _SdrTeam._module = Main
+
+  _SdrEvent = Model("sdr_events",
+    id        = IDField(),
+    happened  = DateField(),
+    logged_at = DateTimeField(),
+    teamid    = ForeignKey(_SdrTeam, pk_field="id"),
+  )
+  _SdrEvent.connect_key = "default"; _SdrEvent._module = Main
+
+  struct _MockPostgresSargable <: PormG.PormGPostgres end
+  PormG.config["default"] = PormG.Configuration.Settings(
+    connections = _MockPostgresSargable(),
+    change_data = true,
+  )
+end
+
+const _SdrEv = _SdrEvent
+
+@testset "Sargable date-bucket range rewrite (#352)" begin
+
+  # =========================================================================
+  # 1. @year — asymmetric boundary mapping: F = Jan 1 of year, N = Jan 1 of year+1.
+  #    @gte/@lt bind F; @gt/@lte bind N. Swapping @lt/@lte shifts the window a whole year.
+  # =========================================================================
+  @testset "@year comparison suffixes bind the correct boundary" begin
+    # Operator assertions use the full space-delimited predicate (" < \$1", not "<"): a bare
+    # `occursin("<", sql)` is also true for "<=", so it cannot distinguish a strict upper bound
+    # from a non-strict one, and a `<` → `<=` mutation would pass it unnoticed.
+    res_gte = _SdrEv.objects.filter("happened__@year__@gte" => 1991).list(show_query=:dict)
+    @test !occursin("extract", lowercase(res_gte[:sql_text]))
+    @test occursin(" >= \$1", res_gte[:sql_text]) && !occursin(" > \$1", res_gte[:sql_text])
+    @test res_gte[:parameters] == ["1991-01-01"]
+
+    res_lt = _SdrEv.objects.filter("happened__@year__@lt" => 1991).list(show_query=:dict)
+    @test !occursin("extract", lowercase(res_lt[:sql_text]))
+    @test occursin(" < \$1", res_lt[:sql_text]) && !occursin(" <= \$1", res_lt[:sql_text])
+    @test res_lt[:parameters] == ["1991-01-01"]
+
+    res_gt = _SdrEv.objects.filter("happened__@year__@gt" => 1991).list(show_query=:dict)
+    @test occursin(" >= \$1", res_gt[:sql_text]) && !occursin(" > \$1", res_gt[:sql_text])
+    @test res_gt[:parameters] == ["1992-01-01"]
+
+    res_lte = _SdrEv.objects.filter("happened__@year__@lte" => 1991).list(show_query=:dict)
+    @test occursin(" < \$1", res_lte[:sql_text]) && !occursin(" <= \$1", res_lte[:sql_text])
+    @test res_lte[:parameters] == ["1992-01-01"]
+
+    # Bare `=` is a 2-parameter half-open range, parenthesised: >= F AND < N (upper bound STRICT).
+    res_eq = _SdrEv.objects.filter("happened__@year" => 1991).list(show_query=:dict)
+    @test res_eq[:parameters] == ["1991-01-01", "1992-01-01"]
+    @test occursin(" >= \$1", res_eq[:sql_text]) && occursin(" < \$2", res_eq[:sql_text])
+    @test !occursin(" <= \$2", res_eq[:sql_text])
+    @test occursin("(", res_eq[:sql_text]) && occursin(")", res_eq[:sql_text])
+  end
+
+  # =========================================================================
+  # 1b. @year value contract — every shape the pre-#352 rendering accepted via
+  #     Models.format_number_sql still works, so the rewrite is not a breaking change for
+  #     consuming apps (an ETL app reading a year out of a Float64 DataFrame column is the
+  #     common case). What IS rejected is what a single date bound cannot express.
+  # =========================================================================
+  @testset "@year accepts every numeric shape the old rendering accepted" begin
+    # `Decimals.Decimal(1991)`, not `Decimals.decimal(1991)` — the lowercase helper was REMOVED in
+    # Decimals 0.5, which `[compat]` allows and a fresh CI resolve lands on. The type constructor
+    # exists in both 0.4 and 0.5.
+    for v in (1991, "1991", 1991.0, Int32(1991), Decimals.Decimal(1991))
+      res = _SdrEv.objects.filter("happened__@year__@gte" => v).list(show_query=:dict)
+      @test res[:parameters] == ["1991-01-01"]
+    end
+  end
+
+  @testset "@year rejects values no date bound can express" begin
+    # Non-numeric string.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => "abc").list(show_query=:dict)
+    # Hex-looking string: tryparse(Int, "0x10") is 16 in Julia, so base=10 must be explicit or
+    # this silently becomes year 16.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => "0x10").list(show_query=:dict)
+    # Bool — `Bool <: Integer` in Julia, so `false` would silently become year 0.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => false).list(show_query=:dict)
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => true).list(show_query=:dict)
+    # Fractional year — no single date bound represents it.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => 1991.7).list(show_query=:dict)
+    # Out of the range a rendered date literal can express: Dates.Date(0,1,1) stringifies to
+    # "0000-01-01" and Date(-5,1,1) to "-0005-01-01", which both backends reject at execution.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => 0).list(show_query=:dict)
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => -5).list(show_query=:dict)
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => 999999).list(show_query=:dict)
+    # Values too large for Int64: the range check must run BEFORE `Int(...)` narrowing, or these
+    # escape as a raw InexactError (not a PormGError, and its message never mentions a year).
+    # `isinteger(1e30)` is true, so the whole-year guard alone does not catch that one.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => big(10)^20).list(show_query=:dict)
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => 1e30).list(show_query=:dict)
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@year__@gte" => typemax(UInt64)).list(show_query=:dict)
+    # Same guard on the yyyy_mm path — "0000-01" clears format_yyyy_mm's regex.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@yyyy_mm__@gte" => "0000-01").list(show_query=:dict)
+  end
+
+  # =========================================================================
+  # 2. @date — same granularity as the column: no range, just drop the to_char, operator as-is.
+  # =========================================================================
+  @testset "@date drops the to_char entirely — operator passes through unchanged" begin
+    # The operator is matched space-delimited (" < \$1", not "<"). Substring-matching a bare
+    # operator does not discriminate — occursin("<", "… <= \$1") and occursin("=", "… >= \$1")
+    # are both true — so a branch hardcoding the wrong operator would pass 3 of these 5.
+    for (suffix, op) in [("", "="), ("__@gte", ">="), ("__@gt", ">"), ("__@lte", "<="), ("__@lt", "<")]
+      res = _SdrEv.objects.filter("happened__@date$(suffix)" => "1991-10-20").list(show_query=:dict)
+      @test !occursin("to_char", lowercase(res[:sql_text]))
+      @test occursin(" $(op) \$1", res[:sql_text])
+      @test res[:parameters] == ["1991-10-20"]
+    end
+  end
+
+  # =========================================================================
+  # 3. Negative gate — TIMESTAMPTZ/TIMESTAMP columns keep the existing to_char/EXTRACT
+  #    rendering: to_char on a timestamptz renders in the session TimeZone, so naively computing
+  #    a month/year boundary would shift it around midnight. Deliberately excluded, not a gap.
+  # =========================================================================
+  @testset "DateTimeField (TIMESTAMPTZ) is excluded from the rewrite" begin
+    res = _SdrEv.objects.filter("logged_at__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+    @test occursin("to_char", lowercase(res[:sql_text]))
+    @test res[:parameters] == ["1991-10"]
+
+    res_year = _SdrEv.objects.filter("logged_at__@year__@gte" => 1991).list(show_query=:dict)
+    @test occursin("extract", lowercase(res_year[:sql_text]))
+  end
+
+  # =========================================================================
+  # 4. Negative gate — a joined/dotted field keeps the existing rendering. A joined path only
+  #    resolves its field TYPE after the join renders, which this rewrite runs before — v1 scope
+  #    is bare fields only; the joined case falls through to the existing (correct, just
+  #    non-sargable) rendering rather than risk resolving the wrong alias mid-render.
+  # =========================================================================
+  @testset "Joined field is excluded from the rewrite" begin
+    res = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+    @test occursin("to_char", lowercase(res[:sql_text]))
+    @test res[:parameters] == ["1991-10"]
+  end
+
+  # =========================================================================
+  # 5. Invalid bounds raise FilterError, not a bare Dates.jl ArgumentError.
+  # =========================================================================
+  @testset "Invalid calendar bounds raise FilterError" begin
+    # "2026-13" passes format_yyyy_mm's regex shape but is not a real calendar month.
+    @test_throws PormG.FilterError _SdrEv.objects.filter("happened__@yyyy_mm__@lte" => "2026-13").list(show_query=:dict)
+  end
+
+  # =========================================================================
+  # 6. Qor composition — the compound range renders parenthesised and groups correctly when
+  #    OR-combined with a sibling filter.
+  # =========================================================================
+  @testset "Compound range groups correctly inside a Qor" begin
+    res = _SdrEv.objects.filter(
+      Qor("id__@gte" => 1000, "happened__@yyyy_mm" => "1991-10")
+    ).list(show_query=:dict)
+    @test occursin(" OR ", res[:sql_text])
+    @test !occursin("to_char", lowercase(res[:sql_text]))
+    @test 1000 in res[:parameters]
+    @test "1991-10-01" in res[:parameters]
+    @test "1991-11-01" in res[:parameters]
+  end
+
+end


### PR DESCRIPTION
Closes #352

## The problem

Date-part lookups rendered the transform **on the column** — `to_char("Tb"."data", 'YYYY-MM') <= $1` — which is not sargable. No index on the column applies, and PostgreSQL cannot estimate selectivity through the function call. The issue measured a **193× row-count underestimate** cascading through five joins into an 18+ minute plan; the equivalent range comparison returned in **148 ms**.

Django solves this with `YearLookup`, rewriting `__year__gte=2020` into `date >= '2020-01-01'` rather than `EXTRACT(year FROM date) >= 2020`.

## The rewrite

`_render_sargable_date_range` intercepts the comparison before the column is rendered, emitting a plain range on the raw column. With `F` = first day of the bucket period and `N` = first day of the following period:

| lookup | rewrite |
|---|---|
| `@exact` (bare `=`) | `col >= F AND col < N` |
| `@gte` | `col >= F` |
| `@gt`  | `col >= N` |
| `@lte` | `col < N` |
| `@lt`  | `col < F` |

**The boundaries are asymmetric on purpose** — `@lte` maps to `< N` while `@lt` maps to `< F`. Swapping them shifts the window by a whole period, silently. `@date` needs no range at all: day granularity already matches the column, so the rewrite is just dropping the `to_char` with the operator unchanged.

Emitted SQL is now dialect-free for the covered cases, removing the `to_char`/`strftime` divergence between PostgreSQL and SQLite entirely.

## What is deliberately NOT covered

Each of these falls through to the existing rendering — correct, merely non-sargable:

- **Joined/dotted paths.** A dotted path only resolves its field *type* after the join renders, which this intercept runs before. Resolving that ordering is a separable follow-up (see below).
- **`DateTimeField` (TIMESTAMPTZ/TIMESTAMP).** `to_char` on a timestamptz renders in the session `TimeZone`, so computing `F`/`N` in UTC would shift the boundary around midnight. Django handles this with a dedicated per-backend `year_lookup_bounds_for_datetime_field`; that is real work, not a one-liner.
- **`@month`/`@day`/`@quarter`/`@quadrimester`.** They repeat every year rather than covering one contiguous range over the column.
- **Non-scalar RHS** (`F()`, subquery, `Case`) — no single literal bound exists.

## `@year` value contract

Accepts everything the previous rendering accepted via `format_number_sql` — `Integer`, whole-valued `Real`, `Decimal`, numeric `String` — so no consuming app needs an edit.

Rejects what no single date bound can express, with a `FilterError`:
- `Bool` — `Bool <: Integer` in Julia, so `false` would silently become year 0
- fractional years
- years outside `1..9999` — `Dates.Date` renders these as `"0000-01-01"` / `"-0005-01-01"`, which both backends then reject with an opaque server-side error

The range check runs **before** `Int()` narrowing, so `1e30` (`isinteger` → `true`) and `big(10)^20` raise a `FilterError` rather than a raw `InexactError`. The string branch parses `base=10` explicitly — `tryparse(Int, "0x10")` is `16` in Julia.

## Verification

| Check | Result |
|---|---|
| Full unit suite | 6486 / 6486 |
| `test_sargable_date_range.jl` (new) | 57 / 57 |
| `test_date_bucket_operator.jl` | 32 / 32 |
| Integration `db_2` (PostgreSQL) | full suite 2050/2050; new testset 16/16 |
| Integration `db_sl` (SQLite) | full suite 1990 pass / 1 pre-existing skip; new testset 16/16 |
| Test file vs **Decimals 0.5** in a scratch env | 57 / 57 |
| Doc examples vs live database | both reproduce exactly |

The integration testset pins each bucket comparison against an **independent baseline** — the same window written as a plain date filter, which provably never routes through the rewrite (a single-element lookup path collapses to a bare `String`, failing the `isa(…, FObject)` gate). Verified non-circular by mutation: changing `Month(1)` → `Month(2)` moves the bucket counts while the baselines hold.

Local green ≠ CI green here: `Manifest.toml` is gitignored and `[compat]` allows `Decimals = "0.4, 0.5"`. The local env is pinned at 0.4.1, so the test file was verified separately against 0.5.1 in a scratch env — `Decimals.decimal` was removed in 0.5 and would have errored on CI.

## Review

Two independent review passes (fresh reader, no memory of writing the code) surfaced 8 defects, all fixed. The two most valuable:

- **CI-blocking:** `Decimals.decimal` does not exist in Decimals 0.5.
- **Green theater:** the original asymmetry assertions had *zero* coverage of upper-bound strictness — `occursin("<", sql)` is also true for `"<="`, so a `<` → `<=` mutation passed 100% green in both test files. Assertions now match the full space-delimited predicate; the same mutation now fails in both.

Also caught: an earlier revision of this PR silently narrowed `@year` to reject `Float64`/`Decimal` — a genuine breaking change introduced while believing it was a tightening. Reverted to full acceptance.

## Deliberately not done

- **No `UPGRADING.md` entry.** The rule is an entry only for changes that *force* a consuming-app source edit. Audited the actual downstream repos rather than reasoning abstractly: `esus_back` has **one** `@year` occurrence and it is commented out; the other internal apps have zero usage of either bucket. Its 55 `@yyyy_mm` sites all pass `"YYYY-MM"` strings through the unchanged `format_yyyy_mm` contract. Flagging for the maintainer's release-gating call: year `0` used as a "no lower bound" sentinel is the one realistic pattern that would now throw.
- **Joined-path coverage** is left as a follow-up. Worth noting the size: in `esus_back`, ~28% of date-bucket comparison sites are joined paths (`atend__dt_inicio__@yyyy_mm__*`, `atend__data__@yyyy_mm__*`, `pront__pront__dt_nascimento__@yyyy_mm__*`) that get no benefit from this PR — and those join onto the large fact tables where the planner damage is worst. Happy to file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
