### PR TITLE
perf(#373): make date-bucket lookups sargable through a join

### DIFF
--- a/docs/src/read/functions_and_dates.md
+++ b/docs/src/read/functions_and_dates.md
@@ -131,6 +131,22 @@ query = M.Race.objects.filter("date__@yyyy_mm__@lte" => "1991-12")
 # renders:  "Tb"."date" < $1         with $1 = "1992-01-01"
 ```
 
+The same applies to a date column reached **through a join**, at any depth and through any relation
+— a foreign key, a reverse relation, or a many-to-many:
+
+```julia
+# Results from races in October 1991 — the range lands on the joined table's column
+query = M.Result.objects.filter("raceid__date__@yyyy_mm" => "1991-10")
+# renders:  ("Tb_1"."date" >= $1 AND "Tb_1"."date" < $2)
+
+# Drivers born from 1960 onwards
+query = M.Result.objects.filter("driverid__dob__@year__@gte" => 1960)
+# renders:  "Tb_1"."dob" >= $1       with $1 = "1960-01-01"
+```
+
+(The `Tb_N` alias is assigned per query in join order — a query joining both paths above would
+reach `dob` through `"Tb_2"`.)
+
 Because the column is not wrapped in a function call, an index on it applies and the query
 planner can estimate how many rows the filter selects — on a large table this is the difference
 between an index range scan and a full scan with a poisoned join plan.
@@ -143,13 +159,18 @@ numeric string. A value no single date can express (a fraction, a year outside t
 `Bool`) raises a `FilterError` rather than silently comparing against an unusable bound.
 
 !!! note "Scope of the rewrite"
-    The rewrite applies to `@yyyy_mm`, `@date` and `@year` on a **plain `DateField`** referenced
-    directly on the queried model. A `DateTimeField` keeps the formatted-string comparison, since
-    `to_char` on a timestamp renders in the session time zone and the range boundaries would shift
-    around midnight. Fields reached through a join, and the `@month`/`@day`/`@quarter`/
-    `@quadrimester` buckets (which repeat every year rather than covering one contiguous range),
-    also keep the original rendering. For the cases it covers the rewrite selects the same rows as
-    before — only the query plan changes.
+    The rewrite applies to `@yyyy_mm`, `@date` and `@year` on a **plain `DateField`**, whether the
+    column sits on the queried model or is reached through a join. Two things keep the original
+    rendering: a `DateTimeField`, because `to_char` on a timestamp renders in the session time zone
+    and the range boundaries would shift around midnight; and the `@month`/`@day`/`@quarter`/
+    `@quadrimester` buckets, which repeat every year rather than covering one contiguous range over
+    the column.
+
+    For every value the bucket can express, the rewrite selects the same rows as before — only the
+    query plan changes. The one behavioural difference is at the edges: because the comparison is
+    now computed as a date bound, a value that no date bound can represent (`"1991-13"`, a
+    fractional or out-of-range year, a `Bool`) raises a `FilterError` instead of building SQL that
+    silently matched nothing. Joined paths and columns on the queried model behave identically here.
 
 ---
 

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -1035,10 +1035,11 @@ end
 # needs no range at all (F == the literal) since to_char at day granularity on a DATE column
 # preserves chronological order exactly — the rewrite there is just "drop the to_char".
 #
-# Scope (v1, deliberately narrow):
-#   - Only a bare (non-joined) column: a dotted join path only resolves its field TYPE after the
-#     join has rendered, which this function runs before — falling through to the existing
-#     to_char/EXTRACT rendering is always correct, just non-sargable for that case.
+# #373 extended the rewrite to a JOINED path (`fk__col__@yyyy_mm`), which #352 had left out
+# because the terminal field's TYPE — what the DATE-only gate below needs — is not readable off
+# `instruc.object.model`. See `_resolve_bucket_column` for how that is answered.
+#
+# Scope:
 #   - Only a plain DATE column (`_is_date_field`) — TIMESTAMPTZ/TIMESTAMP are excluded because
 #     to_char renders in the session TimeZone, so naively computing F/N would shift the boundary
 #     around midnight. Left on the existing rendering.
@@ -1051,13 +1052,11 @@ function _render_sargable_date_range(v::SQLTypeOper, instruc::SQLInstruction)::U
   isa(fobj, FObject) || return nothing
   raw_field = fobj.column
   isa(raw_field, String) || return nothing
-  contains(raw_field, "__") && return nothing                       # bare-field-only in v1
   v.operator in ("=", ">=", ">", "<=", "<") || return nothing
   (v.values isa AbstractString || v.values isa Number) || return nothing
-  haskey(instruc.object.model.fields, raw_field) || return nothing
-  f_meta = instruc.object.model.fields[raw_field]
-  _is_date_field(f_meta) || return nothing                          # DATE only, not TIMESTAMP(TZ)
 
+  # The bucket gate runs BEFORE the column is resolved: resolving a joined path renders its join,
+  # and a non-bucket transform (`@month`, `@quarter`, …) must never reach that.
   bucket = if fobj.function_name == "EXTRACT_DATE" && get(fobj.kwargs, "format", nothing) == "YYYY-MM"
     :yyyy_mm
   elseif fobj.function_name == "EXTRACT_DATE" && get(fobj.kwargs, "format", nothing) == "YYYY-MM-DD"
@@ -1068,7 +1067,10 @@ function _render_sargable_date_range(v::SQLTypeOper, instruc::SQLInstruction)::U
     return nothing
   end
 
-  column_sql = _get_select_query(raw_field, instruc)
+  f_meta, column_sql = _resolve_bucket_column(raw_field, instruc)
+  f_meta === nothing && return nothing
+  _is_date_field(f_meta) || return nothing                          # DATE only, not TIMESTAMP(TZ)
+
   bind(x) = add_parameter!(instruc, f_meta.formatter(x))
 
   if bucket == :date
@@ -1090,6 +1092,59 @@ function _render_sargable_date_range(v::SQLTypeOper, instruc::SQLInstruction)::U
     p1, p2 = bind(first_of_period), bind(next_period)
     return string("(", column_sql, " >= ", p1, " AND ", column_sql, " < ", p2, ")")
   end
+end
+
+# Terminal field metadata + rendered SQL for the column a date-bucket comparison targets, or
+# `(nothing, "")` to fall through to the existing rendering.
+#
+# A bare column reads its metadata straight off the queried model. A JOINED path (#373) cannot:
+# `FObject.column` still holds the unsplit dotted string at this point, and the terminal field only
+# becomes knowable once the path has actually been walked. So the path is RENDERED first and the
+# type read back out of `tab_field_cache`, which `_build_row_join` populates as it goes.
+#
+# Rendering first is the design, not a compromise. `_build_row_join` is the only authority on which
+# model and field a dotted path resolves to — forward FK, reverse relation, many-to-many, and the
+# `driver` → `driver_id` short-form rewrite whose ambiguity against a declared `related_name` is
+# documented on `_resolve_fk_short_form`. Re-deriving that walk here would be a SECOND resolver able
+# to disagree with the renderer, and a disagreement puts the date range on a different table's
+# column with no error and wrong rows. Nothing is saved by not rendering, either: the rewritten
+# predicate references the joined column, so the join is built either way.
+#
+# The early render is side-effect-free in every way that matters here: `build_joins.jl` binds no
+# parameters, and `_insert_join` dedups on (a, b, key_a, key_b, alias_a) — so when the DATE gate
+# rejects the field, the fall-through renders the same path again and gets the same alias back.
+# Identical SQL, one extra traversal.
+function _resolve_bucket_column(raw_field::String, instruc::SQLInstruction)
+  if !contains(raw_field, "__")
+    f_meta = get(instruc.object.model.fields, raw_field, nothing)
+    f_meta === nothing && return (nothing, "")
+    return _checked_bucket_column(f_meta, raw_field, _get_select_query(raw_field, instruc), instruc)
+  end
+
+  # A CTE-rooted path needs no special case, which is worth recording because it is not obvious.
+  # A CTE model's column types are INFERRED (`_set_field_from_sql_function`, ctes.jl), so the
+  # question is whether one can ever be typed DATE while the column holds something else. It cannot:
+  # a plain-column projection reads the real field; COUNT/SUM yield IntegerField; CASE/WHEN route
+  # through `_infer_case_output_type`, which only ever returns Integer/Float/CharField; MIN/MAX
+  # carry the base DateField and genuinely produce a date; and every OTHER function — `ToChar`
+  # included, which is what would actually produce a "1991-10" text column — is rejected outright
+  # when the CTE model is built. So the DATE gate is as trustworthy here as anywhere else.
+  column_sql = _get_select_query(raw_field, instruc)
+  f_meta = get(instruc.tab_field_cache, raw_field, nothing)
+  f_meta === nothing && return (nothing, "")
+  return _checked_bucket_column(f_meta, String(last(split(raw_field, "__"))), column_sql, instruc)
+end
+
+# Drift guard: the rewrite may only range on a column that IS the one `f_meta` describes. That holds
+# by construction on every branch today — `_build_row_join` renders the terminal column through
+# `_solve_field` and caches `last_field` from the same model and segment — which is precisely why it
+# is worth pinning. If the correspondence ever breaks, the rewrite falls back to the existing
+# (correct, merely non-sargable) rendering instead of quietly ranging on some other column.
+# Fail-safe, never fail-loud: a mismatch is a PormG-internal invariant, not a user error.
+function _checked_bucket_column(f_meta, last_segment::String, column_sql::String, instruc::SQLInstruction)
+  expected = quote_identifier(Models.field_db_column(f_meta, last_segment), instruc.connection)
+  endswith(column_sql, string(".", expected)) || return (nothing, "")
+  return (f_meta, column_sql)
 end
 
 # Reuses Models.format_yyyy_mm for shape/type validation (String "YYYY-MM" regex, or 6-digit
@@ -1162,9 +1217,10 @@ end
 
 function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
   @pormg_debug false
-  # #352: rewrite a non-sargable date-bucket comparison (to_char/EXTRACT on the column) into a
+  # #352/#373: rewrite a non-sargable date-bucket comparison (to_char/EXTRACT on the column) into a
   # plain range/comparison directly on the column, so an index on the column — and the planner's
-  # selectivity estimate — both apply. See _render_sargable_date_range for scope.
+  # selectivity estimate — both apply. Covers joined paths as well as bare ones; see
+  # _render_sargable_date_range and _resolve_bucket_column for scope.
   sargable = _render_sargable_date_range(v, instruc)
   sargable !== nothing && return sargable
 

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -487,6 +487,71 @@ end
     @test d_lte == d_lt + 1            # exactly the Japanese GP itself
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Date Operations: sargable rewrite through a JOIN (#373)
+# #352 covered bare columns only, because a dotted path's terminal field type is not readable
+# before the join renders. #373 answers that by rendering the path first and reading the terminal
+# field back out of `tab_field_cache` — the same walk that produced the alias — so the rewrite now
+# fires on `raceid__date__@yyyy_mm` too. That is the larger half of the exposure: a joined date
+# filter sits on a fact table reached through a join, exactly where a row-count misestimate does
+# the most damage to the plan above it.
+#
+# Same verification shape as the #352 block: every bucket comparison pinned against an INDEPENDENT
+# plain-date baseline over the SAME join path, which never routes through the rewrite — so the
+# asymmetric boundary mapping is verified absolutely against live data on both backends, not just
+# for internal self-consistency.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Date Operations — sargable rewrite through a join (#373)" begin
+    # `Result.raceid` → `Race.date` (a plain DateField on the JOINED table). No to_char
+    # (PostgreSQL) / strftime (SQLite): the comparison runs on the joined column itself.
+    sql_join = M.Result.objects.filter("raceid__date__@yyyy_mm__@lte" => "1991-10").list(show_query=:sql)
+    @test !occursin("to_char", lowercase(sql_join)) && !occursin("strftime", lowercase(sql_join))
+    # The join the predicate depends on is still emitted — the rewrite moves the comparison onto
+    # the joined column, it never drops the join.
+    @test occursin("join", lowercase(sql_join))
+
+    j_lte = M.Result.objects.filter("raceid__date__@yyyy_mm__@lte" => "1991-10").count()
+    j_lt  = M.Result.objects.filter("raceid__date__@yyyy_mm__@lt"  => "1991-10").count()
+    j_gte = M.Result.objects.filter("raceid__date__@yyyy_mm__@gte" => "1991-10").count()
+    j_gt  = M.Result.objects.filter("raceid__date__@yyyy_mm__@gt"  => "1991-10").count()
+    j_eq  = M.Result.objects.filter("raceid__date__@yyyy_mm"       => "1991-10").count()
+
+    # Absolute boundaries, against plain-date comparisons over the same join path.
+    @test j_lte == M.Result.objects.filter("raceid__date__@lt"  => "1991-11-01").count()
+    @test j_lt  == M.Result.objects.filter("raceid__date__@lt"  => "1991-10-01").count()
+    @test j_gte == M.Result.objects.filter("raceid__date__@gte" => "1991-10-01").count()
+    @test j_gt  == M.Result.objects.filter("raceid__date__@gte" => "1991-11-01").count()
+    @test j_eq  == M.Result.objects.filter("raceid__date__@gte" => "1991-10-01",
+                                           "raceid__date__@lt"  => "1991-11-01").count()
+    # The October 1991 rows are what @lte includes and @lt excludes — a non-trivial delta, so the
+    # equalities above are not all comparing zero to zero.
+    @test j_eq > 0
+    @test j_lte == j_lt + j_eq
+    @test j_gte == j_gt + j_eq
+
+    # A SECOND join target, so the coverage is not one FK's accident: `Result.driverid` →
+    # `Driver.dob`, a DateField on a different table, at year granularity.
+    sql_dob = M.Result.objects.filter("driverid__dob__@year__@gte" => 1960).list(show_query=:sql)
+    @test !occursin("extract", lowercase(sql_dob)) && !occursin("strftime", lowercase(sql_dob))
+
+    d_gte = M.Result.objects.filter("driverid__dob__@year__@gte" => 1960).count()
+    d_lt  = M.Result.objects.filter("driverid__dob__@year__@lt"  => 1960).count()
+    @test d_gte == M.Result.objects.filter("driverid__dob__@gte" => "1960-01-01").count()
+    @test d_lt  == M.Result.objects.filter("driverid__dob__@lt"  => "1960-01-01").count()
+    @test d_gte > 0 && d_lt > 0
+
+    # Two joined bucket filters over DIFFERENT join paths in one query: each must rewrite onto its
+    # own alias, and both joins must still be emitted. (The TIMESTAMPTZ exclusion through a join is
+    # pinned in test/unit/test_sargable_date_range.jl — the F1 schema has no DateTimeField reachable
+    # by a join from a seeded table.)
+    both = M.Result.objects.filter("raceid__date__@yyyy_mm__@lte" => "1991-10",
+                                   "driverid__dob__@year__@gte" => 1960)
+    sql_both = both.list(show_query=:sql)
+    @test !occursin("to_char", lowercase(sql_both)) && !occursin("extract", lowercase(sql_both))
+    @test both.count() == M.Result.objects.filter("raceid__date__@lt"  => "1991-11-01",
+                                                  "driverid__dob__@gte" => "1960-01-01").count()
+end
+
 @testset "Comparison and In Operations" begin
   query = M.Result.objects;
   query.filter("positionorder__@lt" => 3);

--- a/test/unit/test_date_bucket_operator.jl
+++ b/test/unit/test_date_bucket_operator.jl
@@ -9,10 +9,11 @@ functions.jl: `Y_M(x) = ToChar(x, "YYYY-MM", formatter = Models.format_yyyy_mm)`
 `__@yyyy_mm` bucket is rewritten to a sargable range directly on the column — `happened >= \$1 AND
 happened < \$2` — instead of `to_char(happened,'YYYY-MM') = \$1`, so an index on `happened` applies
 and the planner can estimate selectivity. See `_render_sargable_date_range` in
-`build_helpers.jl` and the cross-cutting contract (asymmetry, TIMESTAMPTZ/joined-field exclusion)
-in `test_sargable_date_range.jl`. The rendering here only changes for the *filter* path — a bare
-`to_char(...)` still appears when the column is projected via `.values("field__@yyyy_mm")`, or
-when the filter target is a `DateTimeField`/joined column (out of scope for the rewrite).
+`build_helpers.jl` and the cross-cutting contract (asymmetry, the TIMESTAMPTZ exclusion, and the
+joined-path coverage added by #373) in `test_sargable_date_range.jl`. The rendering here only
+changes for the *filter* path — a bare `to_char(...)` still appears when the column is projected via
+`.values("field__@yyyy_mm")`, or when the filter target is a `DateTimeField` (out of scope for the
+rewrite in either direction, since `to_char` on a timestamp renders in the session TimeZone).
 
 Why a dedicated file?
   - `test_operators.jl` covers the comparison / string / null suffixes but not the

--- a/test/unit/test_sargable_date_range.jl
+++ b/test/unit/test_sargable_date_range.jl
@@ -8,48 +8,96 @@ range/comparison directly on the column — `col >= \$1 AND col < \$2` instead o
 selectivity (issue #352: a 193x row-count misestimate cascaded into an 18+ minute plan on one
 production query).
 
+#373 extended the rewrite to a JOINED path (`teamid__founded__@yyyy_mm__@lte`), which #352 had
+excluded because the terminal field's type is not readable before the join renders. The resolution
+is now delegated to `_build_row_join` itself (it writes the terminal field into `tab_field_cache`
+as it walks), so forward FK, reverse-relation, multi-hop and many-to-many paths all resolve through
+the SAME code that renders the column — there is no second resolver able to disagree with it.
+
 This file pins the cross-cutting contract shared by all three bucket types — the asymmetric
 boundary mapping (`@lt`/`@lte` and `@gt`/`@gte` bind DIFFERENT bounds), the `@date` "no range
-needed" simplification, and the two deliberate v1 exclusions (TIMESTAMPTZ/TIMESTAMP columns,
-joined/dotted fields) — with no live DB (`show_query=:dict`). The `__@yyyy_mm`-specific
-value-normalisation contract (`format_yyyy_mm` accept/reject shapes) and that bucket's own
-asymmetry-boundary assertions are already pinned in the sibling `test_date_bucket_operator.jl`;
-this file focuses on `@year`, `@date`, and the negative gates that apply across all three.
+needed" simplification, the joined-path coverage, and the one deliberate exclusion
+(TIMESTAMPTZ/TIMESTAMP columns) — with no live DB (`show_query=:dict`). The
+`__@yyyy_mm`-specific value-normalisation contract (`format_yyyy_mm` accept/reject shapes) and that
+bucket's own asymmetry-boundary assertions are already pinned in the sibling
+`test_date_bucket_operator.jl`; this file focuses on `@year`, `@date`, the joined paths, and the
+negative gates that apply across all three.
 """
 
 using Test
 using PormG
-using PormG.Models: Model, IDField, DateField, DateTimeField, ForeignKey
+using PormG.Models: Model, IDField, DateField, DateTimeField, CharField, ForeignKey, ManyToManyField
+using PormG.Functions: ToChar
 import Decimals
 
 # ---------------------------------------------------------------------------
-# Mock fixture (no live database): a bare DateField, a DateTimeField (TIMESTAMPTZ — must be
-# excluded from the rewrite), and an FK to a related model with its own DateField (joined path —
-# also must be excluded from the rewrite in v1).
+# Mock fixture (no live database). The shapes the rewrite has to tell apart:
+#   _SdrTeam    — the join TARGET: a DateField (`founded`) plus a DateTimeField (`audited_at`), so
+#                 the TIMESTAMPTZ exclusion is exercised THROUGH a join, not only on a bare column.
+#   _SdrEvent   — the queried model: bare DateField/DateTimeField, an FK to _SdrTeam, and an M2M.
+#                 Its reverse accessor on _SdrTeam is named `events` (#373 reverse-path coverage).
+#   _SdrTag     — the M2M target, reached through a synthesized through-table.
+#   _SdrLog     — one hop further out, for the MULTI-HOP path `eventid__teamid__founded`.
+# Every model's date column is spelled DIFFERENTLY (`founded` / `happened` / `tagged` / `noted`) on
+# purpose: a mis-resolution that lands on the wrong model's date column is then visible in the
+# rendered SQL, instead of silently matching a same-named column on the wrong table.
 # ---------------------------------------------------------------------------
-if !isdefined(Main, :_SdrTeam)
-  _SdrTeam = Model("sdr_teams",
-    id      = IDField(),
-    founded = DateField(),
-  )
-  _SdrTeam.connect_key = "default"; _SdrTeam._module = Main
+#
+# The models live in their own submodule so `set_models` can run: reverse accessors
+# (`related_objects`) are wired by that call, not by `Model(...)`, and calling it against `Main`
+# would sweep in every other unit file's models when runtests.jl includes them all together.
+# Same isolation pattern as `test_reverse_join_mixed_case_binding.jl`.
+struct _MockPostgresSargable <: PormG.PormGPostgres end
+PormG.config["sargable_mock"] = PormG.Configuration.Settings(
+  connections = _MockPostgresSargable(),
+  change_data = true,
+  db_def_folder = "sargable_mock",
+)
 
-  _SdrEvent = Model("sdr_events",
-    id        = IDField(),
-    happened  = DateField(),
-    logged_at = DateTimeField(),
-    teamid    = ForeignKey(_SdrTeam, pk_field="id"),
-  )
-  _SdrEvent.connect_key = "default"; _SdrEvent._module = Main
+module SargableDateModels
+import PormG
+import PormG.Models
+using PormG.Models: Model, IDField, DateField, DateTimeField, CharField, ForeignKey, ManyToManyField
 
-  struct _MockPostgresSargable <: PormG.PormGPostgres end
-  PormG.config["default"] = PormG.Configuration.Settings(
-    connections = _MockPostgresSargable(),
-    change_data = true,
-  )
+_SdrTeam = Model("sdr_teams",
+  id         = IDField(),
+  founded    = DateField(),
+  audited_at = DateTimeField(),
+)
+
+_SdrTag = Model("sdr_tags",
+  id      = IDField(),
+  label   = CharField(),
+  tagged  = DateField(),
+  seen_at = DateTimeField(),   # the M2M-reachable TIMESTAMPTZ, for the double-render dedup check
+)
+
+_SdrEvent = Model("sdr_events",
+  id        = IDField(),
+  happened  = DateField(),
+  logged_at = DateTimeField(),
+  teamid    = ForeignKey(_SdrTeam, pk_field="id", related_name="events"),
+  tags      = ManyToManyField(_SdrTag, related_name="events"),
+)
+
+_SdrLog = Model("sdr_logs",
+  id      = IDField(),
+  noted   = DateField(),
+  eventid = ForeignKey(_SdrEvent, pk_field="id", related_name="logs"),
+)
+
+PormG.Models.set_models(@__MODULE__, "sargable_mock")
 end
 
-const _SdrEv = _SdrEvent
+const _SdrEv   = SargableDateModels._SdrEvent
+const _SdrTeam = SargableDateModels._SdrTeam
+const _SdrLog  = SargableDateModels._SdrLog
+
+# The WHERE clause of a single-filter query. Used for the baseline-equality assertions below: the
+# rewritten bucket comparison must render the SAME predicate text as an ordinary comparison against
+# the equivalent plain date, so alias, column, operator and bound are all pinned in one shot —
+# against a rendering that never routes through `_render_sargable_date_range` at all.
+_sdr_where(res) = strip(split(res[:sql_text], " WHERE ")[end])
 
 @testset "Sargable date-bucket range rewrite (#352)" begin
 
@@ -159,15 +207,147 @@ const _SdrEv = _SdrEvent
   end
 
   # =========================================================================
-  # 4. Negative gate — a joined/dotted field keeps the existing rendering. A joined path only
-  #    resolves its field TYPE after the join renders, which this rewrite runs before — v1 scope
-  #    is bare fields only; the joined case falls through to the existing (correct, just
-  #    non-sargable) rendering rather than risk resolving the wrong alias mid-render.
+  # 4. #373 — a DateField reached THROUGH A JOIN is rewritten too. This is the larger half of the
+  #    exposure: a joined date filter sits on a fact table reached through a join, which is exactly
+  #    where a row-count misestimate does the most damage to the plan above it.
   # =========================================================================
-  @testset "Joined field is excluded from the rewrite" begin
-    res = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+  @testset "Joined DateField is rewritten (#373)" begin
+    # Same asymmetric boundary mapping as the bare column, asserted the same way: the FULL
+    # space-delimited predicate, never a bare occursin("<", …) — that also matches "<=" and would
+    # let a strict/non-strict slip pass silently.
+    res_lte = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_lte[:sql_text]))
+    @test occursin(" < \$1", res_lte[:sql_text]) && !occursin(" <= \$1", res_lte[:sql_text])
+    @test res_lte[:parameters] == ["1991-11-01"]
+    # The join is still emitted — the rewritten predicate lives on the joined table's alias, so the
+    # rewrite never removes the join it needs.
+    @test occursin("JOIN", uppercase(res_lte[:sql_text]))
+    # …and it targets the TARGET model's date column (`founded`), not the queried model's own
+    # same-typed `happened`. A mis-resolution would silently range on the wrong table.
+    @test occursin("\"founded\"", res_lte[:sql_text]) && !occursin("\"happened\"", res_lte[:sql_text])
+
+    res_lt = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@lt" => "1991-10").list(show_query=:dict)
+    @test occursin(" < \$1", res_lt[:sql_text]) && !occursin(" <= \$1", res_lt[:sql_text])
+    @test res_lt[:parameters] == ["1991-10-01"]
+
+    res_gte = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@gte" => "1991-10").list(show_query=:dict)
+    @test occursin(" >= \$1", res_gte[:sql_text]) && !occursin(" > \$1", res_gte[:sql_text])
+    @test res_gte[:parameters] == ["1991-10-01"]
+
+    res_gt = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@gt" => "1991-10").list(show_query=:dict)
+    @test occursin(" >= \$1", res_gt[:sql_text]) && !occursin(" > \$1", res_gt[:sql_text])
+    @test res_gt[:parameters] == ["1991-11-01"]
+
+    res_eq = _SdrEv.objects.filter("teamid__founded__@yyyy_mm" => "1991-10").list(show_query=:dict)
+    @test res_eq[:parameters] == ["1991-10-01", "1991-11-01"]
+    @test occursin(" >= \$1", res_eq[:sql_text]) && occursin(" < \$2", res_eq[:sql_text])
+    @test !occursin(" <= \$2", res_eq[:sql_text])
+
+    # @year and @date over the same joined path.
+    res_year = _SdrEv.objects.filter("teamid__founded__@year__@gte" => 1991).list(show_query=:dict)
+    @test !occursin("extract", lowercase(res_year[:sql_text]))
+    @test res_year[:parameters] == ["1991-01-01"]
+
+    res_date = _SdrEv.objects.filter("teamid__founded__@date__@lt" => "1991-10-20").list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res_date[:sql_text]))
+    @test occursin(" < \$1", res_date[:sql_text]) && !occursin(" <= \$1", res_date[:sql_text])
+    @test res_date[:parameters] == ["1991-10-20"]
+  end
+
+  # =========================================================================
+  # 4b. #373 — the strongest "does not mis-resolve" guard: the rewritten predicate must be
+  #     TEXTUALLY IDENTICAL to the same comparison written as an ordinary plain-date filter, which
+  #     never routes through `_render_sargable_date_range` at all. One assertion pins the alias, the
+  #     column, the operator AND the bound — a walker that resolved the wrong table, the wrong
+  #     column, or a stale alias fails here even if every occursin() above still passed.
+  # =========================================================================
+  @testset "Joined rewrite renders the same predicate as the plain-date baseline (#373)" begin
+    for (path, model) in [
+          ("teamid__founded",          _SdrEv),   # forward FK, one hop
+          ("eventid__teamid__founded", _SdrLog),  # forward FK, MULTI-HOP
+          ("events__happened",         _SdrTeam), # REVERSE relation (related_name = "events")
+          ("tags__tagged",             _SdrEv),   # MANY-TO-MANY (through-table pair)
+        ]
+      rewritten = model.objects.filter("$(path)__@year__@gte" => 1991).list(show_query=:dict)
+      baseline  = model.objects.filter("$(path)__@gte" => "1991-01-01").list(show_query=:dict)
+      @test _sdr_where(rewritten) == _sdr_where(baseline)
+      @test rewritten[:parameters] == baseline[:parameters] == ["1991-01-01"]
+      @test !occursin("extract", lowercase(rewritten[:sql_text]))
+    end
+  end
+
+  # =========================================================================
+  # 4c. #373 negative gate — the DATE-only restriction survives the join. `to_char` on a
+  #     TIMESTAMPTZ renders in the session TimeZone, so computing the bucket boundary in UTC would
+  #     shift it around midnight; that reasoning is unchanged by how the column is reached.
+  # =========================================================================
+  @testset "Joined DateTimeField is still excluded (#373)" begin
+    res = _SdrEv.objects.filter("teamid__audited_at__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
     @test occursin("to_char", lowercase(res[:sql_text]))
     @test res[:parameters] == ["1991-10"]
+
+    res_year = _SdrEv.objects.filter("teamid__audited_at__@year__@gte" => 1991).list(show_query=:dict)
+    @test occursin("extract", lowercase(res_year[:sql_text]))
+
+    # THE load-bearing assumption of the #373 design, pinned here because nothing else would catch
+    # it: this is the path that renders the join TWICE — once by the rewrite (to read the terminal
+    # field's type out of `tab_field_cache`) and again by the fall-through rendering. `_insert_join`
+    # dedups on (a, b, key_a, key_b, alias_a), so exactly one join must survive. If that dedup ever
+    # stopped holding, every joined bucket filter on a TIMESTAMPTZ column would silently self-join
+    # — inflating row counts with no error, which is the worst failure mode this change could have.
+    @test length(collect(eachmatch(r"JOIN", res[:sql_text]))) == 1
+    @test length(collect(eachmatch(r"JOIN", res_year[:sql_text]))) == 1
+
+    # The dedup has to hold on EVERY alias-allocating path, not just the one-hop forward FK above.
+    # Reverse relations and many-to-many do not reach `_insert_join` the same way: the M2M branch
+    # goes through `_insert_many_to_many_joins`, which calls `_get_alias_name` TWICE (through-table
+    # + related table) before either row is deduped. A rejected TIMESTAMPTZ terminal on each of
+    # those shapes is what forces the double render.
+    for (path, model, joins) in [
+          ("eventid__teamid__audited_at", _SdrLog,  2),  # multi-hop forward FK
+          ("events__logged_at",           _SdrTeam, 1),  # reverse relation
+          ("tags__seen_at",               _SdrEv,   2),  # M2M: through-table + related table
+        ]
+      r = model.objects.filter("$(path)__@yyyy_mm__@lte" => "1991-10").list(show_query=:dict)
+      @test occursin("to_char", lowercase(r[:sql_text]))          # rejected → rendered twice
+      @test length(collect(eachmatch(r"JOIN", r[:sql_text]))) == joins
+      @test r[:parameters] == ["1991-10"]
+    end
+
+    # Same guarantee where the rewrite DOES fire, twice over the same path in one query.
+    res_two = _SdrEv.objects.filter("teamid__founded__@yyyy_mm__@gte" => "1991-01",
+                                    "teamid__founded__@yyyy_mm__@lte" => "1991-12").list(show_query=:dict)
+    @test length(collect(eachmatch(r"JOIN", res_two[:sql_text]))) == 1
+    @test res_two[:parameters] == ["1991-01-01", "1992-01-01"]
+  end
+
+  # =========================================================================
+  # 4d. #373 — a CTE-projected DateField is rewritten too, and that needs no special case, which is
+  #     worth pinning because it is not obvious. A CTE model's column types are INFERRED
+  #     (`_set_field_from_sql_function`), so the question is whether one can be typed DATE while
+  #     holding something else. It cannot: a plain-column projection reads the real field, COUNT/SUM
+  #     give IntegerField, CASE/WHEN route through `_infer_case_output_type` (Integer/Float/Char
+  #     only), MIN/MAX carry the base DateField and do produce a date — and every other function is
+  #     REJECTED when the CTE model is built. The last assertion pins that rejection, because it is
+  #     what rules out the one shape that would matter here: a `ToChar` projection, whose column
+  #     really would be TEXT holding "1991-10".
+  # =========================================================================
+  @testset "CTE-projected DateField is rewritten; ToChar cannot reach it (#373)" begin
+    inner = _SdrEv.objects.values("teamid", "happened")
+    res = _SdrEv.objects.
+      with("ev" => inner, join_field = "teamid" => "teamid").
+      filter("ev__happened__@yyyy_mm__@lte" => "1991-10").
+      list(show_query=:dict)
+    @test !occursin("to_char", lowercase(res[:sql_text]))
+    @test "1991-11-01" in res[:parameters]
+
+    # A ToChar projection never becomes a CTE column at all, so no DATE-typed CTE column can ever
+    # hold a formatted string. If this rejection is ever relaxed, the rewrite needs a CTE gate.
+    bad = _SdrEv.objects.values("teamid", "bucket" => ToChar("happened", "YYYY-MM"))
+    @test_throws PormG.QueryBuildError _SdrEv.objects.
+      with("evb" => bad, join_field = "teamid" => "teamid").
+      filter("evb__bucket__@yyyy_mm__@lte" => "1991-10").
+      list(show_query=:dict)
   end
 
   # =========================================================================


### PR DESCRIPTION
Closes #373.

## What changed

#352 made date-bucket comparisons sargable for **bare** columns. This extends the same rewrite to a date column reached **through a join**, so `atend__data__@yyyy_mm__@lte` now renders a range on the joined column instead of `to_char(...)` on it.

```
before:  to_char("Tb_1"."date", 'YYYY-MM') <= $1     -- $1 = "1991-10"
after:   "Tb_1"."date" < $1                          -- $1 = "1991-11-01"
```

Boundary mapping, bounds computation and the `@year` value contract are #352's, reused unchanged.

## Why "render first" instead of walking the FK chain

The issue proposed resolving the FK chain independently to answer the `DATE`-only type gate. That premise does not hold: the rewritten predicate must emit `"Tb_1"."date"`, and the only thing that produces that alias is `_build_row_join` — **so an independent walker renders the join too.** It is not "resolution without rendering"; it is a *second* resolver stacked on the same render.

And the two can disagree. `_resolve_fk_short_form` documents a live ambiguity — `driver` → `driver_id` versus a declared `related_name = "driver"` — that PormG once resolved *both ways* depending on `django_prefix`. A type-walker taking the forward-FK branch where the renderer takes the reverse branch would put a date range on **a different table's column**, with no error and wrong rows. That is precisely the failure mode #352 punted to avoid.

So the column is rendered first and the terminal field is read back out of `tab_field_cache`, which `_build_row_join` writes as it walks (`build_joins.jl:608`). One resolver, and it is the one that produced the alias.

This is not hypothetical for the motivating workload: the `esus_back` sites are spelled `atend__…`, where the FK field is `atend_id` — the short-form path itself.

## Side-effect safety (verified, not assumed)

- `build_joins.jl` binds **no** parameters, so nothing is bound or reordered.
- `_insert_join` dedups on `(a, b, key_a, key_b, alias_a)`. When the `DATE` gate rejects the field, the fall-through renders the same path again and gets the **same alias** back — identical SQL, one extra traversal.
- `_get_select_query(::SQLTypeFunction)` already makes the identical `_get_select_query(v.column, …)` call, and nothing renders between the intercept and the existing call site, so the join lands at the same position in `row_join` either way.

The dedup is pinned for one-hop FK, multi-hop, reverse **and** M2M — M2M allocates aliases through `_insert_many_to_many_joins`, a different path with two `_get_alias_name` calls before either row is deduped. A regression there would silently self-join and inflate row counts with the suite still green.

## Drift guard

`_checked_bucket_column` asserts the rendered column really is the one the cached field describes, falling through to the existing rendering if not. It holds by construction today on every branch — which is the point: if that correspondence ever breaks, the rewrite degrades to correct-but-slow instead of quietly ranging on another column. Fail-safe, never fail-loud.

## CTEs need no exclusion

Worth stating because it is not obvious. A CTE model's column types are *inferred*, so the question is whether one can be typed `DATE` while holding something else. It cannot: plain-column projections read the real field, COUNT/SUM give `IntegerField`, CASE/WHEN route through `_infer_case_output_type` (Integer/Float/Char only), MIN/MAX carry the base `DateField` and do produce a date — and every other function is **rejected outright** when the CTE model is built, `ToChar` included, which is the one that would actually produce a `"1991-10"` text column. A unit test pins that rejection, since it is what makes the rest safe.

## Behaviour note

Joined paths now reject values no date bound can express (`"1991-13"`, a fractional or out-of-range year, a `Bool`) instead of building SQL that silently matched nothing — matching what #352 already did for bare columns.

Audited against `esus_back` rather than reasoned about: all 29 joined call sites pass a `"YYYY-MM"` string from `get_periodo_quad` or an in-range integer year. No consuming-app edit is forced, so no `UPGRADING.md` entry and no `Project.toml` bump — same call as #352.

The audit also confirms the exposure this closes is the full set: `atend` resolves to `Prod_atend_ind`, whose `dt_inicio` is a plain `DateField` (the `DateTimeField` of the same name lives on `Tb_atend`, reached by a different FK).

## Acceptance criteria

- [x] Joined date-bucket comparison on a `DateField` renders a range on the joined column
- [x] Joined `DateTimeField` still falls through (timezone safety preserved)
- [x] Multi-hop paths covered
- [x] Reverse-relation and M2M segments do not mis-resolve — pinned by asserting the rewritten predicate is **textually identical** to the same comparison written as an ordinary plain-date filter, which never routes through the rewrite. One assertion pins alias, column, operator and bound together.
- [x] Unit coverage mirroring the existing negative gates
- [x] Integration coverage on both engines against an independent plain-date baseline

## Verification

| Check | Result |
|---|---|
| Full unit suite | 6824/6824 |
| `test_selection.jl` on `db_2` (PostgreSQL) | green; new testset 16/16 |
| Full integration suite on `db_sl` (SQLite) | 2014 pass, 1 broken (pre-existing skip) |
| `test_docs_error_type_drift.jl` | green (a "raises `FilterError`" doc claim was added) |

The `db_sl` fixture was stale before this branch existed — confirmed with a control run from an unmodified `main` checkout (identical failure, same line, a plain `resultid` filter). The full run above reseeded it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
