### PR TITLE
fix(#363): a through= model's db_table is the join table

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -974,7 +974,7 @@ manager.set([senna_id])          # returns (added=X, removed=Y)
 driver_rows = manager.all().values("surname", "nationality").list()
 ```
 
-Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table.
+Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table — including its `db_table`, if it declares one, which then names the join table in every query and mutator. The field-level `db_table` below applies to the auto-generated table only and is ignored when `through` is given.
 
 !!! warning
     **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add`, `remove`, `clear`, and `set`) will raise a `QueryBuildError`. Create or delete custom through model objects directly using the through model's objects manager instead.

--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -245,18 +245,6 @@ whole connection, and relationship accessor names strip it — so `racing_circui
 names that do not exist. Remove it from the connection's config; a single-app import that still wants
 it can pass `django_prefix=` to that call.
 
-!!! warning "Known limitation: an explicit `through=` model addresses the logical name ([#363](https://github.com/PingoLee/PormG.jl/issues/363))"
-    A `ManyToManyField` with an explicit `through=` builds its join from the through model's
-    **logical name**, not its `db_table`. Once a model carries a `db_table` that differs — which is
-    every model in an app-labelled import — that join addresses `vinculo` where the real table is
-    `racing_vinculo`.
-
-    This is not new to multi-app import: it bites any model with an explicit `db_table` (so, any
-    single-app import under a `django_prefix` too). Until [#363](https://github.com/PingoLee/PormG.jl/issues/363)
-    is fixed, give such a relation an explicit `db_table` on the through *model* that matches its
-    logical name, or query the through model directly. Auto-derived `ManyToManyField`s — the common
-    case — are unaffected: the importer pins their join table to Django's real spelling.
-
 ### When two apps use the same class name
 
 Both sides are app-qualified — never just the second one:

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -82,6 +82,26 @@ M2m_membership_scratch = Models.Model("m2m_membership_scratch",
 
 This pattern matches Django exactly and keeps your model definitions clean and readable.
 
+!!! note "The through model's `db_table` is the join table"
+    A through model is an ordinary model, so it may pin its physical table with
+    [`db_table`](schema_conventions.md#Pinning-an-explicit-table-name-with-db_table) like any other.
+    Keeping the model above and adding the pin:
+
+    ```julia
+    M2m_membership_scratch = Models.Model("m2m_membership_scratch",
+      db_table = "racing_membership",      # the real table, whatever the logical name is
+      id = Models.IDField(),
+      driver = Models.ForeignKey(M2m_driver_explicit_scratch, on_delete=Models.CASCADE),
+      team = Models.ForeignKey(M2m_team_scratch, on_delete=Models.CASCADE),
+      joined_year = Models.IntegerField()
+    )
+    ```
+
+    The join table PormG addresses is then `racing_membership` — in the joins behind `teams__name`
+    and `drivers__driverref`, and in the manager mutators for a through model that permits them.
+    The `db_table` option on the `ManyToManyField` itself names the *auto-generated* join table only;
+    with an explicit `through=` there is no generated table to name, so that option is ignored.
+
 ### Relationship Mutator Limitations on Custom Through Tables
 
 !!! warning

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -107,6 +107,7 @@ DriverProfile = Models.Model("driver_profile",
 | `CREATE TABLE`, `ALTER TABLE`, `CREATE INDEX`, `ADD CONSTRAINT` | ✔ |
 | `SELECT` / `INSERT` / `UPDATE` / `DELETE` | ✔ |
 | `JOIN` targets, including through a foreign key | ✔ |
+| The join table of a many-to-many with an explicit `through=` model | ✔ |
 | A `ForeignKey`'s `REFERENCES` target, when it points at this model | ✔ |
 | Migration add/drop/rename detection | ✔ |
 
@@ -126,13 +127,21 @@ exactly as it always has, so no existing schema changes and nothing needs re-mig
     from the models' *logical* names, so pinning `db_table` on a model does not silently rename a join
     table PormG generated for you.
 
-    The join **columns** follow the logical name too (`<model>_<pk field>`), which is why they are
+    On the auto-derived path the join **columns** follow the logical name too (`<model>_<pk field>`),
+    which is why they are
     unaffected by a `db_table` pin. Against a Django-owned schema that closes most of the gap but not
     all of it: Django's through table is `<the owning model's table>_<field>`, so the table needs the
     pin the importer applies, while the columns line up on their own — *provided the primary key is
     named `id`*. Django always spells its m2m columns `<model_name>_id`; PormG uses the target's
     actual pk field name, so a model keyed on `codigo` derives `matricula_codigo` where Django wrote
     `matricula_id`. Pin the field's `source_field` / `target_field` in that case.
+
+    All of the above is the *auto-generated* case. Give the field an explicit `through=` and the join
+    table **is** that model's table — its own `db_table` if it declares one — so the field-level
+    `db_table` has nothing left to name and is ignored. Same rule as Django, and the same rule the
+    Django importer already assumes when it declines to pin a `db_table` on a `through=` field. The
+    join columns are then the through model's own FK fields, so `source_field` / `target_field` is
+    again the pin to reach for when those field names differ from the physical columns.
 
 ### Generated files: colliding bindings and names are disambiguated
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -104,7 +104,15 @@ end
 
 @kwdef struct ManyToManyRelation
   field_name::String
-  through_model::String
+  # The PHYSICAL join table (#363) — `db_table` when the through model declares one, else the
+  # derived/logical spelling. It was named `through_model` and carried the through model's LOGICAL
+  # name on the explicit-`through=` branch, while all but one of its readers rendered it as a table:
+  # `safe_table_identifier` in the four manager mutators, and both through-table slots in
+  # `_insert_many_to_many_joins`. So an explicit through model with a `db_table` (every model from a
+  # prefixed or multi-app Django import, #345/#346) made every read and write address a table that
+  # does not exist. The name is now the contract: this slot is a table, never a model key. The one
+  # reader that wanted a model reads `through_model_resolved` below instead.
+  through_table::String
   owner_model::String
   owner_binding::String
   owner_pk::String
@@ -121,6 +129,25 @@ end
   # re-resolves by binding today; consuming these slots to retire that reflection is #68/#41.
   owner_model_resolved::Union{PormGModel, Nothing} = nothing
   related_model_resolved::Union{PormGModel, Nothing} = nothing
+  # The explicit `through=` model, resolved (#363). Unlike the two slots above it has a live reader:
+  # `QueryBuilder._m2m_has_extra_fields` needs the through model's FIELDS to decide whether the
+  # direct mutators are allowed, and it used to recover them by re-resolving `through_model` as a
+  # binding/logical name. That reflection is what made the slot's two meanings load-bearing at once;
+  # recording the model the way #343 records `ReverseRelation.model_resolved` retires it.
+  #
+  # `nothing` here is a discriminated-union TAG — "there is no through model, the join table is
+  # synthesized" — not the "resolution failed" nullability #343 argues against. That distinction is
+  # what keeps the `=== nothing` branch out of the consumers: a synthesized join table is `id` + the
+  # two FKs by construction (`synthesize_many_to_many_through_models`), so `nothing` answers the
+  # extra-fields question outright rather than sending the caller back to a module scan. The tag is
+  # exact: the slot is set on precisely the branch that resolves `field.through`, and that branch
+  # throws when the reference cannot be resolved.
+  #
+  # REQUIRED on purpose, unlike its two neighbours — they default because #65 bolted them onto an
+  # existing struct with no readers, whereas this one is the discriminant. A silent default would
+  # let a future constructor mean "auto-generated" by omission, which is the fail-open hole #363
+  # closed wearing a different hat.
+  through_model_resolved::Union{PormGModel, Nothing}
 end
 
 # What `related_objects` stores for a REVERSE FOREIGN KEY accessor — the sibling of
@@ -2503,7 +2530,10 @@ function _relation_from_many_to_many(
 
   owner_pk = String(owner_pk_sym)
   related_pk = String(related_pk_sym)
-  through_model_name = _many_to_many_table_name(owner_model, field_name, field, settings)
+  # The auto path already yields a PHYSICAL table: `_many_to_many_table_name` returns `field.db_table`
+  # verbatim when the field pins one, and the synthesized name otherwise (#59/#345).
+  through_table_name = _many_to_many_table_name(owner_model, field_name, field, settings)
+  through_resolved = nothing
   owner_column = field.source_field === nothing ? _many_to_many_column_name(owner_model, owner_pk) : field.source_field
   related_column = field.target_field === nothing ? _many_to_many_column_name(related_model, related_pk) : field.target_field
 
@@ -2518,7 +2548,13 @@ function _relation_from_many_to_many(
       throw(ModelDefinitionError("Cannot resolve explicit through model $(field.through) for $(owner_model.name).$(field_name)"))
     end
 
-    through_model_name = through_model.name
+    # The through model's PHYSICAL table (#363), not its logical `.name`. Same rule — and the same
+    # reason — as the related side in `_insert_many_to_many_joins`: the logical name is what
+    # IDENTIFIES the model, but this slot is rendered as a table. Reading `.name` here is what made
+    # every join and every mutator address `membership` where the real table is `racing_membership`.
+    # The model itself is recorded below, so nothing has to recover it from this string.
+    through_table_name = model_table_name(through_model)
+    through_resolved = through_model
     owner_column = field.source_field === nothing ? _infer_through_field(through_model, owner_model, "source") : field.source_field
     related_column = field.target_field === nothing ? _infer_through_field(through_model, related_model, "target") : field.target_field
     owner_fk = through_model.fields[owner_column]
@@ -2530,7 +2566,7 @@ function _relation_from_many_to_many(
   inverse_accessor = field.related_name === nothing ? get_model_name(owner_model, settings, false) : field.related_name
   return ManyToManyRelation(
     field_name=field_name,
-    through_model=through_model_name,
+    through_table=through_table_name,
     owner_model=owner_model.name,
     owner_binding=owner_binding,
     owner_pk=owner_pk,
@@ -2545,13 +2581,15 @@ function _relation_from_many_to_many(
     # load lifecycle) so the relation is a fully-resolved reference, not just strings.
     owner_model_resolved=owner_model,
     related_model_resolved=related_model,
+    # `nothing` on the auto path — see the slot's comment on `ManyToManyRelation` (#363).
+    through_model_resolved=through_resolved,
   )
 end
 
 function _reverse_many_to_many_relation(relation::ManyToManyRelation, reverse_accessor::String)::ManyToManyRelation
   return ManyToManyRelation(
     field_name=reverse_accessor,
-    through_model=relation.through_model,
+    through_table=relation.through_table,
     owner_model=relation.related_model,
     owner_binding=relation.related_binding,
     owner_pk=relation.related_pk,
@@ -2565,6 +2603,9 @@ function _reverse_many_to_many_relation(relation::ManyToManyRelation, reverse_ac
     # #65: swap the resolved sides to match the swapped string fields above.
     owner_model_resolved=relation.related_model_resolved,
     related_model_resolved=relation.owner_model_resolved,
+    # NOT swapped (#363): there is one join table and it sits between the two sides, so it is the
+    # same model read from either direction — unlike every slot above, which names one side.
+    through_model_resolved=relation.through_model_resolved,
   )
 end
 
@@ -2655,7 +2696,7 @@ function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dic
     source_model = model_info[:model]
     # These two labels are NOT real Julia bindings, and nothing here reads them as such: on this
     # lifecycle the relation is a transient carrier for the through-table SHAPE only — the five slots
-    # consumed below are `through_model`, `owner_column`, `related_column`, `owner_pk`, `related_pk`,
+    # consumed below are `through_table`, `owner_column`, `related_column`, `owner_pk`, `related_pk`,
     # and the relation is then discarded rather than stored on a model. So `_resolve_m2m_side_model`
     # never sees these, and their spelling cannot reach a `getfield`.
     #
@@ -2682,13 +2723,16 @@ function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dic
         Symbol(relation.owner_column) => ForeignKey(source_model, pk_field=relation.owner_pk, on_delete=CASCADE),
         Symbol(relation.related_column) => ForeignKey(target_model, pk_field=relation.related_pk, on_delete=CASCADE),
       )
-      through_model = Model(relation.through_model, through_fields)
+      # `through_table` is the physical name on both branches of `_relation_from_many_to_many`, but
+      # this loop only ever reaches the AUTO one (`field.through === nothing || continue` above), so
+      # the synthesized model's own name IS its table and the planner's physical keying holds (#363).
+      through_model = Model(relation.through_table, through_fields)
       through_model.cache["many_to_many_auto"] = Dict{String, Any}(
         "owner_column" => relation.owner_column,
         "related_column" => relation.related_column,
-        "unique_index" => "$(relation.through_model)_$(relation.owner_column)_$(relation.related_column)_uniq",
+        "unique_index" => "$(relation.through_table)_$(relation.owner_column)_$(relation.related_column)_uniq",
       )
-      through_key = Symbol(relation.through_model)
+      through_key = Symbol(relation.through_table)
       if haskey(expanded, through_key)
         existing = expanded[through_key][:model]
         existing_auto = existing.cache !== nothing ? get(existing.cache, "many_to_many_auto", nothing) : nothing
@@ -2696,7 +2740,7 @@ function synthesize_many_to_many_through_models(current_schema::Dict{Symbol, Dic
            get(existing_auto, "owner_column", nothing) != relation.owner_column ||
            get(existing_auto, "related_column", nothing) != relation.related_column
           throw(ModelDefinitionError(
-            "Auto-generated through table $(relation.through_model) for $(source_model.name).$(field_name) " *
+            "Auto-generated through table $(relation.through_table) for $(source_model.name).$(field_name) " *
             "collides with an existing model or another ManyToManyField. " *
             "Define an explicit `through=` model or override `db_table=` to disambiguate."))
         end

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -482,7 +482,7 @@ table with two foreign keys and a composite unique index.
 # Keyword Arguments
 - `through::Union{String, PormGModel, Nothing} = nothing`: explicit through model; skips auto table synthesis.
 - `related_name::Union{String, Nothing} = nothing`: reverse accessor on the target model.
-- `db_table::Union{String, Nothing} = nothing`: auto-through table name override.
+- `db_table::Union{String, Nothing} = nothing`: auto-through table name override. Ignored when `through` is given — the join table is then the through model's own table (its `db_table` if it declares one).
 - `source_field::Union{String, Nothing} = nothing`: through-table column pointing to the source model.
 - `target_field::Union{String, Nothing} = nothing`: through-table column pointing to the target model.
 """

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -175,9 +175,22 @@ function _insert_many_to_many_joins(
   join_type = previus_how == "LEFT" ? "LEFT" : "INNER"
 
   # #64: the PARENT-side join keys (owner_pk / related_pk) are field NAMES; resolve each to
-  # its physical column via the owning model's db_column. The through-table columns
-  # (owner_column / related_column) are the through table's own (auto-generated) columns and
-  # stay as-is. `model_column` is a strict no-op when the PK has no db_column.
+  # its physical column via the owning model's db_column. `model_column` is a strict no-op when the
+  # PK has no db_column.
+  #
+  # The through-table columns (owner_column / related_column) go in as-is, and that is a narrower
+  # claim than it used to be. On the AUTO path they are names PormG generated for a table PormG
+  # created, so there is nothing to resolve. On an explicit `through=` they come from
+  # `Models._infer_through_field`, which returns the FIELD NAME on a user's model — equal to the
+  # physical column exactly when that field declares no `db_column`.
+  #
+  # Django's default convention satisfies that (`driver` imports as the field `driver_id`, which is
+  # also Django's column), which is why an ordinary import joins correctly. A `db_column=` written in
+  # the Django source does NOT: the importer splats it onto the field it builds
+  # (`process_class_fields!`), so the field is `driver_id` while the column is whatever was pinned.
+  # The shape is origin-independent — hand-written models reach it the same way. That column axis is
+  # the unfixed sibling of #363, which settled the TABLE axis only; `source_field` / `target_field`
+  # on the ManyToManyField bypass `_infer_through_field` and are the escape hatch today.
   _module = instruct.object.model._module::Module
   owner_model = _resolve_m2m_side_model(_module, relation.owner_binding, relation.owner_model, relation.field_name)
   related_model = _resolve_m2m_side_model(_module, relation.related_binding, relation.related_model, relation.field_name)
@@ -186,7 +199,10 @@ function _insert_many_to_many_joins(
   through_row["a"] = parent_table
   through_row["alias_a"] = parent_alias
   through_row["key_a"] = Models.model_column(owner_model, relation.owner_pk)
-  through_row["b"] = relation.through_model
+  # #363: the through side's PHYSICAL table. This slot carried the through model's LOGICAL name
+  # whenever the relation came from an explicit `through=`, so a through model with a `db_table`
+  # joined against a table that does not exist. `through_table` is resolved once, at registration.
+  through_row["b"] = relation.through_table
   through_row["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
   through_row["key_b"] = relation.owner_column
   through_row["how"] = join_type
@@ -194,11 +210,12 @@ function _insert_many_to_many_joins(
   through_alias = _insert_join(instruct.row_join, through_row, instruct.row_path, "$(join_path)__through")
 
   related_row = sizehint!(Dict{String, Union{String, Vector{FilterType}}}(), 8)
-  related_row["a"] = relation.through_model
+  related_row["a"] = relation.through_table
   related_row["alias_a"] = through_alias
   related_row["key_a"] = relation.related_column
-  # The related side's PHYSICAL table (db_table when set, #59). `relation.related_model` carries the
-  # LOGICAL name, which is what identifies the model — but this slot is rendered as a table.
+  # The related side's PHYSICAL table (db_table when set, #59). Unlike `through_table` above,
+  # `relation.related_model` carries the LOGICAL name — that is what identifies the model — so this
+  # slot, which is rendered as a table, has to go through `model_table_name`.
   related_row["b"] = Models.model_table_name(related_model)
   related_row["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
   related_row["key_b"] = Models.model_column(related_model, relation.related_pk)

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -76,25 +76,32 @@ function _m2m_target_ids(manager::ManyToManyManager, targets)::Vector{Any}
   return ids
 end
 
+# Does the through table carry columns beyond `id` and the two relationship FKs? `true` disables the
+# direct mutators below — PormG cannot invent values for a column it does not know about.
+#
+# #363 made this STRUCTURAL. It used to re-resolve the through model out of the owner's module by
+# name and read a `QueryBuildError` as "not registered ⇒ auto-generated ⇒ safe to mutate", which is
+# fail-OPEN: any relation whose through model the scan could not reach silently unlocked the
+# mutators. That was reachable, not theoretical — `through = <a PormGModel object>` is taken inline
+# by `_relation_from_many_to_many`'s `field.through isa PormGModel` arm, with no module lookup at
+# all (it does not even reach `Models._resolve_model_reference`), so a model that
+# is not reachable BY NAME from the owner's module was invisible here while its extra columns were
+# very real. (Only by name: `Models.get_all_models` makes a second pass with `usings=true` since
+# #354, so a `using`-brought binding did resolve. A qualified `Other.Membership` reference, or a
+# model built and passed by value, did not.)
+#
+# The relation now records the model itself (`through_model_resolved`, `Models.jl`), so the question
+# is answered from the relation alone: no module, no reflection, no exception-as-signal. `nothing`
+# means the join table is synthesized by the migration planner, which builds it as exactly `id` plus
+# the two FKs — so `false` there is a fact about how that table is constructed, not an assumption
+# about a lookup that failed.
+#
+# `_m2m_model_from_binding` keeps one caller (the descriptor below), where a `QueryBuildError` is now
+# just an error rather than a signal; retiring that last reflection against `related_model_resolved`
+# is #68/#41.
 function _m2m_has_extra_fields(manager::ManyToManyManager)::Bool
-  owner_module = manager.owner_model._module
-  owner_module === nothing && return false
-
-  # Only catch PormGError ("binding not found") — the expected failure when
-  # the through model is auto-generated and not registered in the module.
-  # Any other exception (type error, module error, etc.) should propagate so
-  # the caller is not silently allowed to mutate a through table with extra fields.
-  through_model = try
-    _m2m_model_from_binding(owner_module, manager.relation.through_model, manager.relation.through_model)
-  catch e
-    # The binding-not-found signal from _m2m_model_from_binding is QueryBuildError (#231, was
-    # ArgumentError). Match THAT type, not the taxonomy root: since #239 `PormGError` also covers
-    # Models/config/migration failures, and catching the root here would silently swallow a future
-    # model-definition error raised deeper in this call path — exactly the "silently allowed to
-    # mutate a through table with extra fields" outcome the comment above warns against.
-    e isa QueryBuildError && return false
-    rethrow(e)
-  end
+  through_model = manager.relation.through_model_resolved
+  through_model === nothing && return false
 
   owner_col = manager.relation.owner_column
   related_col = manager.relation.related_column
@@ -132,7 +139,7 @@ function add(manager::ManyToManyManager, targets...)
   settings, connection, conn_key = _m2m_settings(manager)
   !settings.change_data && throw(_write_not_allowed("many-to-many add", conn_key))
 
-  table_name = safe_table_identifier(manager.relation.through_model, connection)
+  table_name = safe_table_identifier(manager.relation.through_table, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
   related_column = quote_identifier(manager.relation.related_column, connection)
   owner_value = _m2m_format_owner(manager)
@@ -184,7 +191,7 @@ function remove(manager::ManyToManyManager, targets...)
   settings, connection, conn_key = _m2m_settings(manager)
   !settings.change_data && throw(_write_not_allowed("many-to-many remove", conn_key))
 
-  table_name = safe_table_identifier(manager.relation.through_model, connection)
+  table_name = safe_table_identifier(manager.relation.through_table, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
   related_column = quote_identifier(manager.relation.related_column, connection)
   owner_value = _m2m_format_owner(manager)
@@ -212,7 +219,7 @@ function clear(manager::ManyToManyManager)
   parameters = get_parameter(connection)
   set_context!(parameters, :where)
   owner_placeholder = add_parameter!(parameters, _m2m_format_owner(manager))
-  table_name = safe_table_identifier(manager.relation.through_model, connection)
+  table_name = safe_table_identifier(manager.relation.through_table, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
   fetch(settings, "DELETE FROM $table_name WHERE $owner_column = $owner_placeholder;", parameters)
   return nothing
@@ -223,7 +230,7 @@ function _m2m_current_ids(manager::ManyToManyManager)::Vector{Any}
   parameters = get_parameter(connection)
   set_context!(parameters, :where)
   owner_placeholder = add_parameter!(parameters, _m2m_format_owner(manager))
-  table_name = safe_table_identifier(manager.relation.through_model, connection)
+  table_name = safe_table_identifier(manager.relation.through_table, connection)
   owner_column = quote_identifier(manager.relation.owner_column, connection)
   related_column = quote_identifier(manager.relation.related_column, connection)
   sql = "SELECT $related_column FROM $table_name WHERE $owner_column = $owner_placeholder;"

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -342,6 +342,35 @@ M2m_link_plain_scratch = Models.Model("m2m_link_plain_scratch",
   team = Models.ForeignKey(M2m_team_plain_scratch, on_delete=Models.CASCADE),
 )
 
+# Explicit through whose model declares a `db_table` (#363). Every other `through=` fixture in this
+# file has a logical name equal to its physical table, which is precisely why the bug survived: the
+# relation stored the LOGICAL name and rendered it as a table, and the two agreed everywhere it was
+# tested. This is the shape of every model in an app-labelled Django import (#345/#346).
+#
+# The physical name is a DIFFERENT STRING, not merely a different case — SQLite compares identifiers
+# case-insensitively, so a case-only difference would address the same table and `db_sl` could not
+# tell a fixed tree from a broken one.
+#
+# FK-only on purpose: the mutators are then permitted, so the raw-SQL write path
+# (`INSERT`/`DELETE ... FROM <through table>`) is exercised alongside the join path.
+M2m_squad_dbtable_scratch = Models.Model("m2m_squad_dbtable_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(unique=true)
+)
+
+M2m_tester_dbtable_scratch = Models.Model("m2m_tester_dbtable_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  squads = Models.ManyToManyField(M2m_squad_dbtable_scratch, through="M2m_enrolment_dbtable_scratch", related_name="testers")
+)
+
+M2m_enrolment_dbtable_scratch = Models.Model("m2m_enrolment_dbtable_scratch",
+  db_table = "m2m_enrolment_join_tbl",
+  id = Models.IDField(),
+  tester = Models.ForeignKey(M2m_tester_dbtable_scratch, on_delete=Models.CASCADE),
+  squad = Models.ForeignKey(M2m_squad_dbtable_scratch, on_delete=Models.CASCADE),
+)
+
 # Default reverse accessor (no related_name): target uses owner model name lowercase.
 M2m_brand_scratch = Models.Model("m2m_brand_scratch",
   id = Models.IDField(),

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -340,6 +340,35 @@ M2m_link_plain_scratch = Models.Model("m2m_link_plain_scratch",
   team = Models.ForeignKey(M2m_team_plain_scratch, on_delete=Models.CASCADE),
 )
 
+# Explicit through whose model declares a `db_table` (#363). Every other `through=` fixture in this
+# file has a logical name equal to its physical table, which is precisely why the bug survived: the
+# relation stored the LOGICAL name and rendered it as a table, and the two agreed everywhere it was
+# tested. This is the shape of every model in an app-labelled Django import (#345/#346).
+#
+# The physical name is a DIFFERENT STRING, not merely a different case — SQLite compares identifiers
+# case-insensitively, so a case-only difference would address the same table and `db_sl` could not
+# tell a fixed tree from a broken one.
+#
+# FK-only on purpose: the mutators are then permitted, so the raw-SQL write path
+# (`INSERT`/`DELETE ... FROM <through table>`) is exercised alongside the join path.
+M2m_squad_dbtable_scratch = Models.Model("m2m_squad_dbtable_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(unique=true)
+)
+
+M2m_tester_dbtable_scratch = Models.Model("m2m_tester_dbtable_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  squads = Models.ManyToManyField(M2m_squad_dbtable_scratch, through="M2m_enrolment_dbtable_scratch", related_name="testers")
+)
+
+M2m_enrolment_dbtable_scratch = Models.Model("m2m_enrolment_dbtable_scratch",
+  db_table = "m2m_enrolment_join_tbl",
+  id = Models.IDField(),
+  tester = Models.ForeignKey(M2m_tester_dbtable_scratch, on_delete=Models.CASCADE),
+  squad = Models.ForeignKey(M2m_squad_dbtable_scratch, on_delete=Models.CASCADE),
+)
+
 # Default reverse accessor (no related_name): target uses owner model name lowercase.
 M2m_brand_scratch = Models.Model("m2m_brand_scratch",
   id = Models.IDField(),

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -40,6 +40,12 @@ const _M2M_SCRATCH_TABLES = (
     "m2m_link_plain_scratch",
     "m2m_brand_scratch",
     "m2m_driver_default_reverse_scratch",
+    # #363. The through model is listed by its PHYSICAL name (`db_table`), which is what
+    # `table_exists` asks the database for — its logical name `m2m_enrolment_dbtable_scratch` is not
+    # a table at all, and listing that spelling would make this check miss forever.
+    "m2m_squad_dbtable_scratch",
+    "m2m_tester_dbtable_scratch",
+    "m2m_enrolment_join_tbl",
 )
 
 function _m2m_scratch_table_exists(pool, table_name::String)::Bool
@@ -383,6 +389,66 @@ end
     M.M2m_link_plain_scratch.objects.delete(allow_delete_all=true)
     M.M2m_driver_plain_scratch.objects.delete(allow_delete_all=true)
     M.M2m_team_plain_scratch.objects.delete(allow_delete_all=true)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #363: an explicit `through=` model that declares a `db_table`.
+#
+# The relation used to record the through model's LOGICAL name and render it as a table, so every
+# join and every mutator addressed `m2m_enrolment_dbtable_scratch` while the real table is
+# `m2m_enrolment_join_tbl`. Both engines answer that with "no such table" — this is the layer that
+# proves the SQL reaches something real, which no amount of rendered-string assertion can.
+#
+# Exercised here and nowhere else: the raw-SQL write path. `add`/`remove`/`clear`/`set` interpolate
+# the table name straight into INSERT/DELETE (they do not go through the join builder), so they are a
+# second, independent consumer of the same slot.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Many-to-Many: explicit through model with its own db_table (#363)" begin
+    M.M2m_enrolment_dbtable_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_tester_dbtable_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_squad_dbtable_scratch.objects.delete(allow_delete_all=true)
+
+    # Precondition. Without it every assertion below would pass vacuously against a fixture whose
+    # logical and physical spellings agree — the condition under which #363 is invisible.
+    @test M.M2m_enrolment_dbtable_scratch.name == "m2m_enrolment_dbtable_scratch"
+    @test PormG.model_table_name(M.M2m_enrolment_dbtable_scratch) == "m2m_enrolment_join_tbl"
+    @test table_exists(PormG.config[PORMG_DB_FOLDER].connections, "m2m_enrolment_join_tbl")
+
+    tester = M.M2m_tester_dbtable_scratch.objects.create("driverref" => "piquet")
+    squad_a = M.M2m_squad_dbtable_scratch.objects.create("name" => "Brabham")
+    squad_b = M.M2m_squad_dbtable_scratch.objects.create("name" => "Williams")
+
+    manager = M.M2m_tester_dbtable_scratch.squads(tester)
+
+    # WRITE path — INSERT straight into the physical through table.
+    @test manager.add(squad_a, squad_b) === nothing
+    @test Set([row[:name] for row in manager.all().list()]) == Set(["Brabham", "Williams"])
+
+    # The rows really landed in the db_table-named table, queried as a model in its own right.
+    @test M.M2m_enrolment_dbtable_scratch.objects.filter("tester" => tester[:id]).count() == 2
+
+    # WRITE path — DELETE. `set` runs remove+add inside one transaction, so it covers both.
+    diff = manager.set(squad_b)
+    @test diff.added == 0
+    @test diff.removed == 1
+    @test Set([row[:name] for row in manager.all().list()]) == Set(["Williams"])
+
+    # READ path — forward and reverse traversal both join through the physical table.
+    fwd = M.M2m_tester_dbtable_scratch.objects.filter("squads__name" => "Williams").values("driverref").list()
+    @test length(fwd) == 1
+    @test fwd[1][:driverref] == "piquet"
+
+    rev = M.M2m_squad_dbtable_scratch.objects.filter("testers__driverref" => "piquet").values("name").list()
+    @test length(rev) == 1
+    @test rev[1][:name] == "Williams"
+
+    @test manager.clear() === nothing
+    @test isempty(manager.all().list())
+    @test M.M2m_enrolment_dbtable_scratch.objects.filter("tester" => tester[:id]).count() == 0
+
+    M.M2m_enrolment_dbtable_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_tester_dbtable_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_squad_dbtable_scratch.objects.delete(allow_delete_all=true)
 end
 
 @testset "Many-to-Many: query and API surface" begin

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -33,6 +33,64 @@ end
 
 const M2M = ManyToManyUnitModels
 
+# ─────────────────────────────────────────────────────────────────────────────
+# #363 fixture: explicit `through=` models that declare a `db_table`.
+#
+# Every model here pins a physical table that differs from its logical name — the shape the Django
+# importer produces for an app-labelled project (#345/#346) and the one a hand-written model gets
+# from `db_table` (#59). No fixture in this file combined `through=` with `db_table` before, which is
+# exactly why #363 survived: the two spellings were always equal, so a slot that confused them read
+# as correct.
+#
+# TWO through models on purpose. `Membership` carries an extra column (`joined_year`) and
+# `Enrolment` carries only the two foreign keys, so the mutator guard is tested on both arms rather
+# than only on the one that refuses.
+# ─────────────────────────────────────────────────────────────────────────────
+module ManyToManyDbTableModels
+  import PormG
+  import PormG.Models
+
+  Team = Models.Model("team", db_table = "racing_team",
+    id = Models.IDField(),
+    name = Models.CharField(),
+  )
+
+  Driver = Models.Model("driver", db_table = "racing_driver",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    # A string forward reference, the documented form — `Membership` is declared below.
+    teams = Models.ManyToManyField(Team, through = "Membership", related_name = "drivers"),
+  )
+
+  Membership = Models.Model("membership", db_table = "racing_membership",
+    id = Models.IDField(),
+    driver = Models.ForeignKey(Driver, on_delete = Models.CASCADE),
+    team = Models.ForeignKey(Team, on_delete = Models.CASCADE),
+    joined_year = Models.IntegerField(null = true),   # the extra column that locks the mutators
+  )
+
+  Squad = Models.Model("squad", db_table = "racing_squad",
+    id = Models.IDField(),
+    name = Models.CharField(),
+  )
+
+  Tester = Models.Model("tester", db_table = "racing_tester",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    squads = Models.ManyToManyField(Squad, through = "Enrolment", related_name = "testers"),
+  )
+
+  Enrolment = Models.Model("enrolment", db_table = "racing_enrolment",
+    id = Models.IDField(),
+    tester = Models.ForeignKey(Tester, on_delete = Models.CASCADE),
+    squad = Models.ForeignKey(Squad, on_delete = Models.CASCADE),
+  )
+
+  PormG.Models.set_models(@__MODULE__, "m2m_mock")
+end
+
+const M2MDBT = ManyToManyDbTableModels
+
 @testset "ManyToManyField metadata and query generation" begin
   @test Models.is_many_to_many_field(M2M.Driver_championship.fields["drivers"])
   @test !("drivers" in M2M.Driver_championship.field_names)
@@ -244,55 +302,77 @@ end
   @test result_empty_vec === nothing
 end
 
-module BadBindingModule
-  import PormG
-  import PormG.Models
-  # Intentionally define the expected through-table name as a non-PormGModel
-  # so _m2m_model_from_binding raises QueryBuildError ("not a PormG model").
-  const drivers_championships_drivers = 42   # Integer, not PormGModel
+# Detach a registered model from its module, keeping everything else. Severing `_module` cuts EVERY
+# module-reflection route at once, which is the hostile input for the guard below.
+function _m2m_detach_module(model::PormGModel)
+  return Models.Model_Type(
+    name = model.name,
+    db_table = Models.model_has_db_table(model) ? Models.model_table_name(model) : nothing,
+    fields = model.fields,
+    field_names = model.field_names,
+    related_objects = model.related_objects,
+    connect_key = model.connect_key,
+    _module = nothing,
+    cache = Dict{String, Any}(),
+  )
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# BUG-3 regression: _m2m_has_extra_fields must only swallow QueryBuildError (binding
-# not found); any other exception should propagate so the caller cannot silently
-# proceed with a through model that has extra fields.
+# The extra-fields mutator guard is STRUCTURAL, not reflective (#363).
+#
+# `_m2m_has_extra_fields` decides whether `add`/`remove`/`clear`/`set` may write to the through table
+# at all. It used to answer by re-resolving the through model out of the owner's module by name and
+# reading a `QueryBuildError` as "not registered ⇒ auto-generated ⇒ safe" — fail-OPEN: every way the
+# lookup could miss silently unlocked the mutators on a table with columns PormG cannot fill.
+#
+# This replaces the old BUG-3 testset, whose premise (only swallow `QueryBuildError`) died with the
+# try/catch. Worth recording why that testset was weaker than it looked: its `BadBindingModule`
+# defined `drivers_championships_drivers`, but the real auto table is `driver_championships_drivers`
+# (singular `driver`), so the "binding exists but is not a model" path it claimed to exercise was
+# never reached — resolution failed at the name scan instead. It passed for the wrong reason, which
+# is the standing hazard of pinning a reflective mechanism rather than the property it should have.
+#
+# The property, now that the relation carries the through model itself: the answer does not depend on
+# module state at all. Every case below runs with `_module = nothing`.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "_m2m_has_extra_fields exception propagation (BUG-3)" begin
-  # Build a manager whose owner_model has _module set to a module that raises a
-  # TypeError when binding lookup is attempted (we simulate by using a model whose
-  # through_model binding exists as a non-PormGModel object in a module).
+@testset "the extra-fields mutator guard is structural, not reflective (#363)" begin
+  # ── The money assertion. Explicit `through=` + an extra column + a `db_table`, with no module to
+  # reflect through. Pre-#363 this returned `false` on the function's first line and the mutators
+  # went through, writing rows with `joined_year` unset.
+  rel_extras = Models.get_many_to_many_relation(M2MDBT.Driver, "teams")
+  severed_driver = _m2m_detach_module(M2MDBT.Driver)
+  mgr_extras = PormG.QueryBuilder.ManyToManyManager(severed_driver, M2MDBT.Team, rel_extras, 1)
+  @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_extras) == true
 
-  # The auto-generated through model for Driver_championship.drivers is
-  # "driver_championships_drivers". Since BadBindingModule doesn't have it as a
-  # PormGModel, _m2m_model_from_binding should raise QueryBuildError which is caught
-  # → returns false (no extra fields).
-  rel = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
-  fake_owner = Models.Model_Type(
-    name = M2M.Driver_championship.name,
-    fields = M2M.Driver_championship.fields,
-    field_names = M2M.Driver_championship.field_names,
-    related_objects = M2M.Driver_championship.related_objects,
-    connect_key = M2M.Driver_championship.connect_key,
-    _module = BadBindingModule,
-    cache = Dict{String,Any}(),
-  )
-  manager_bad = PormG.QueryBuilder.ManyToManyManager(fake_owner, M2M.Driver, rel, 1)
+  # All four mutators refuse, and they refuse BEFORE touching the connection: the guard is the first
+  # statement in each, ahead of `_m2m_target_ids`/`_m2m_settings`. That ordering is what makes the
+  # refusal testable without a database, so it is asserted rather than assumed.
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder.add(mgr_extras)
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder.remove(mgr_extras)
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder.clear(mgr_extras)
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder.set(mgr_extras)
 
-  # QueryBuildError is silently caught → returns false (through model "not found" is expected)
-  @test PormG.QueryBuilder._m2m_has_extra_fields(manager_bad) == false
+  # ── Negative control 1: the guard did not simply become "always true". An explicit `through=` whose
+  # model carries ONLY the two foreign keys still permits the mutators, `db_table` and all.
+  rel_plain = Models.get_many_to_many_relation(M2MDBT.Tester, "squads")
+  mgr_plain = PormG.QueryBuilder.ManyToManyManager(
+    _m2m_detach_module(M2MDBT.Tester), M2MDBT.Squad, rel_plain, 1)
+  @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_plain) == false
 
-  # A manager with _module = nothing should also return false safely
-  no_module_owner = Models.Model_Type(
-    name = M2M.Driver_championship.name,
-    fields = M2M.Driver_championship.fields,
-    field_names = M2M.Driver_championship.field_names,
-    related_objects = M2M.Driver_championship.related_objects,
-    connect_key = M2M.Driver_championship.connect_key,
-    _module = nothing,
-    cache = Dict{String,Any}(),
-  )
-  manager_no_mod = PormG.QueryBuilder.ManyToManyManager(no_module_owner, M2M.Driver, rel, 1)
-  @test PormG.QueryBuilder._m2m_has_extra_fields(manager_no_mod) == false
+  # ── Negative control 2: the auto-generated join table. `through_model_resolved === nothing` is the
+  # signal, and the answer is a fact about how the planner builds that table (`id` + the two FKs),
+  # not a lookup that failed.
+  rel_auto = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
+  @test rel_auto.through_model_resolved === nothing
+  mgr_auto = PormG.QueryBuilder.ManyToManyManager(
+    _m2m_detach_module(M2M.Driver_championship), M2M.Driver, rel_auto, 1)
+  @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_auto) == false
+
+  # ── `_m2m_model_from_binding` keeps exactly one caller (the descriptor) and still signals a miss
+  # with `QueryBuildError` (#231). It is no longer a SIGNAL anyone branches on — pinned here so the
+  # type does not drift now that the guard stopped catching it.
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder._m2m_model_from_binding(
+    ManyToManyDbTableModels, "NoSuchBinding", "no_such_model")
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -526,6 +606,11 @@ end
   @test fwd_copy.related_model_resolved === M2M.Driver
   @test fwd_copy.field_name == fwd.field_name                      # value fields still deep-copied
 
+  # #363's `through_model_resolved` is a third resolved slot and rides the same hook — checked here
+  # rather than given its own `deepcopy_internal`, which is what #343's comment asks of a new slot.
+  through_rel = Models.get_many_to_many_relation(M2MDBT.Driver, "teams")
+  @test deepcopy(through_rel).through_model_resolved === M2MDBT.Membership
+
   # A relation-bearing model whose own fields are all scalar (Driver is the M2M target) still
   # deep-copies cleanly — its related_objects reverse relation routes through the same override.
   # Guards that adding the resolved slots did not regress model deepcopy for such models.
@@ -579,4 +664,132 @@ end
   # reconciles them.
   pinned = Models.ManyToManyField("Dim_uf", db_table = "dash_dimibge_ufs")
   @test Models._many_to_many_table_name(post, "ufs", pinned, prefixed) == "dash_dimibge_ufs"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #363: an explicit `through=` model's `db_table` IS the join table.
+#
+# `ManyToManyRelation` recorded the through model's LOGICAL name and six of its seven readers
+# rendered that string as a table — the four manager mutators and both through-side slots of
+# `_insert_many_to_many_joins`. So `Model("membership", db_table = "racing_membership")` produced a
+# relation addressing `membership`, and every read and every write hit a table that does not exist.
+#
+# The slot is now `through_table` and is always physical; the model it used to stand in for is
+# recorded separately. This is the discriminating test: it asserts the recorded value AND the
+# rendered SQL, in both directions, because `_reverse_many_to_many_relation` is its own code path.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "explicit through= records the physical table, not the logical name (#363)" begin
+  # Precondition — without it every assertion below would pass vacuously on a fixture whose logical
+  # and physical spellings happen to agree, which is the condition that hid this bug for so long.
+  @test M2MDBT.Membership.name == "membership"
+  @test Models.model_table_name(M2MDBT.Membership) == "racing_membership"
+
+  fwd = Models.get_many_to_many_relation(M2MDBT.Driver, "teams")
+  @test fwd.through_table == "racing_membership"          # was "membership" — the bug
+  @test fwd.through_model_resolved === M2MDBT.Membership
+
+  # The reverse relation is built by a separate function and stores the swapped sides. The through
+  # table is NOT a side — one join table serves both directions — so it must be carried unchanged.
+  rev = Models.get_many_to_many_relation(M2MDBT.Team, "drivers")
+  @test rev.reverse
+  @test rev.through_table == "racing_membership"
+  @test rev.through_model_resolved === M2MDBT.Membership
+
+  # ── The half only SQL can prove. Note the shape of the negative assertion: a bare
+  # `occursin("membership", sql)` is vacuous here because "racing_membership" contains it, and a
+  # bare `!occursin("membership", sql)` can never pass. Both spellings must be tested as quoted
+  # identifiers, which is how every table reaches the rendered statement.
+  fwd_sql = M2MDBT.Driver.objects.filter(
+      "teams__name" => "Renault"
+    ).values(
+      "surname"
+    ).list(show_query=:dict)[:sql_text]
+  @test occursin("\"racing_membership\"", fwd_sql)
+  @test !occursin("\"membership\"", fwd_sql)
+  # The two sides join through it, so their physical tables are in the statement too (#59).
+  @test occursin("\"racing_driver\"", fwd_sql)
+  @test occursin("\"racing_team\"", fwd_sql)
+
+  rev_sql = M2MDBT.Team.objects.filter(
+      "drivers__surname" => "Senna"
+    ).values(
+      "name"
+    ).list(show_query=:dict)[:sql_text]
+  @test occursin("\"racing_membership\"", rev_sql)
+  @test !occursin("\"membership\"", rev_sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #363 did not disturb the AUTO-derived path.
+#
+# That path already stored a physical name (`_many_to_many_table_name` returns `field.db_table`
+# verbatim when the field pins one), so the fix had to leave it byte-identical. This matters beyond
+# tidiness: `synthesize_many_to_many_through_models` builds the join table's name AND its unique
+# index from this slot, so a value that shifted by even one character would make `makemigrations`
+# propose dropping a live index and creating a differently-named twin.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the auto-derived through table is unchanged by #363" begin
+  auto = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
+  @test auto.through_table == "driver_championships_drivers"
+  @test auto.through_model_resolved === nothing          # the "no through model" tag
+
+  # A field-level `db_table` pin still wins on the auto path — it names the synthesized join table,
+  # and it must NOT be confused with a through MODEL's `db_table` (#345, and the note in
+  # `docs/src/schema_conventions.md`).
+  owner = Models.Model("dim_uf", db_table = "dash_dim_uf", id = Models.IDField())
+  target = Models.Model("regiao", db_table = "dash_regiao", id = Models.IDField())
+  pinned = Models.ManyToManyField(target, db_table = "dash_dimibge_ufs")
+  pinned_rel = Models._relation_from_many_to_many(
+    owner, "Dim_uf", "ufs", pinned, target, "Regiao",
+    PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true),
+    model_map = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(),
+  )
+  @test pinned_rel.through_table == "dash_dimibge_ufs"
+  @test pinned_rel.through_model_resolved === nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CHARACTERIZATION test, not a #363 regression test — it passes against the pre-#363 tree too, and
+# saying so is the point. `synthesize_many_to_many_through_models` skips every relation that declares
+# `through=` (`field.through === nothing || continue`), so it never constructs one and never reads
+# the slot #363 changed; the planned table name comes from `model_table_name` (#59), which was
+# already correct. Nothing here can go red on the bug.
+#
+# It earns its place as the no-churn pin on the OTHER side of that `continue`. #363 rewrote what
+# `_relation_from_many_to_many` returns, and this loop consumes that return value to name both the
+# auto join table and its unique index — so this fixes the planner's output for the explicit path
+# while that rewrite lands.
+#
+# What the two `!haskey` assertions guard is narrower than "someone deletes the gate": deleting it
+# does not reach them at all. `through_key` would become `Symbol(model_table_name(Membership))` —
+# already in `expanded` from the first loop, with no `many_to_many_auto` cache — so
+# `synthesize_many_to_many_through_models` throws `ModelDefinitionError` and the testset fails by
+# erroring out. The assertions catch the quieter regression: the explicit branch starting to derive
+# an auto table name ALONGSIDE the real through model, which plans a phantom table instead of
+# throwing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an explicit through= model is planned as itself, not as a synthesized join table" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  # Keyed by PHYSICAL table, which is how the planner keys both sides of its diff (#59).
+  current_schema = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(
+    :racing_driver     => Dict{Symbol, Union{Bool, PormGModel}}(:model => M2MDBT.Driver,     :exist => false),
+    :racing_team       => Dict{Symbol, Union{Bool, PormGModel}}(:model => M2MDBT.Team,       :exist => false),
+    :racing_membership => Dict{Symbol, Union{Bool, PormGModel}}(:model => M2MDBT.Membership, :exist => false),
+  )
+
+  plan = Migrations.get_migration_plan(PormGModel[], current_schema, M2MMockPostgres(), settings, interactive=false)
+
+  @test haskey(plan, :racing_membership)
+  through_sql = join(values(plan[:racing_membership]), "\n")
+  @test occursin("CREATE TABLE", through_sql)
+  @test occursin("racing_membership", through_sql)
+
+  # No auto join table was synthesized alongside it: the through model IS the join table.
+  @test !haskey(plan, :driver_teams)
+  @test !haskey(plan, :racing_driver_teams)
+
+  # And the M2M field still owns no column on the source table.
+  source_sql = join(values(plan[:racing_driver]), "\n")
+  @test !occursin("\"teams\"", source_sql)
 end


### PR DESCRIPTION
Closes #363.

`ManyToManyRelation.through_model` carried two incompatible meanings. The auto branch stored a
physical table; the explicit `through=` branch stored `through_model.name`, the **logical** name.
Six of its seven readers rendered that string as a **table** — `safe_table_identifier` in
`add`/`remove`/`clear`/`_m2m_current_ids`, and both through-side slots of
`_insert_many_to_many_joins`. So a through model declaring `db_table` made every read and every
write address a table that does not exist.

Scope: every model from a prefixed or multi-app Django import (#345/#346), and any hand-written
`db_table` (#59). Auto-derived `ManyToManyField`s were never affected.

## The fix

Split the slot rather than pick one meaning:

```julia
through_table::String                              # always PHYSICAL
through_model_resolved::Union{PormGModel, Nothing} # the through model; nothing ⟺ auto-generated
```

`through_table` resolves once at construction through `model_table_name`, so the six table consumers
stay branch-free. `through_model_resolved` is a **required** kwarg — no `@kwdef` default — because it
is the discriminant: a silent default would let a future constructor mean "auto-generated" by
omission.

**The second slot is what makes the fix safe.** The one-line version — `model_table_name()` alone —
repairs the table and breaks the lookup. `_m2m_has_extra_fields` re-resolved the through model out of
the owner's module *by name* and read a `QueryBuildError` as *"auto-generated, so the mutators are
safe"*. Feed it a physical table and it stops resolving, silently re-enabling `add`/`set`/`remove`/
`clear` on a through table with columns PormG cannot fill. The guard now reads the recorded model —
no module, no reflection, no exception-as-signal — which also closes the pre-existing fail-open case
where the through model was unreachable by name from the owner's module (a qualified
`Other.Membership`, or a model passed by value).

The auto path is byte-identical: `synthesize_many_to_many_through_models` skips explicit-through
relations, and it derives both the join table's name and its unique-index name from this slot, so any
shift would have made `makemigrations` propose dropping a live index.

## Verification

| Layer | Result |
|---|---|
| Unit suite | 6807 / 6807 (run twice — before and after review fixes) |
| Integration, `db_sl` | 2014 / 2015, exit 0 (the 1 is a pre-existing `@test_broken`) |
| New `#363` integration testset | 16 / 16 |
| Docs build | exit 0 (run twice) |

**Red-before-green, demonstrated three ways rather than asserted:**

1. Reverting the one line to `through_model.name` → 6 of 13 assertions fail in the unit testset, in
   both join directions.
2. Simulating the *naive* one-line fix (physical table + the old reflective guard) → 5 of 9
   assertions fail in the guard testset; `add`/`remove` stop throwing entirely and `clear`/`set`
   reach the connection. That is the fail-open hole, reproduced.
3. Against the real SQLite database, the integration testset dies with
   `no such table: m2m_enrolment_dbtable_scratch` — the production symptom.

The integration fixture's `db_table` differs from its logical name by a **different string**, not
merely a different case: SQLite compares identifiers case-insensitively, so a case-only difference
would address the same table and `db_sl` could not tell a fixed tree from a broken one.

## Reviewed

Two independent review rounds (fresh context, `pormg-changed-code-review`), eight findings, all
resolved. The delta pass corrected a wrong correction of mine — see *Deferred* below.

Coverage deliberately removed: the old `BUG-3` testset pinned "only swallow `QueryBuildError`", a
mechanism that no longer exists. It is replaced by a testset asserting the property that mechanism
was failing to guarantee, run with `_module = nothing` so no module-reflection route survives. Worth
recording that the old fixture never tested what it claimed — its `BadBindingModule` defined
`drivers_championships_drivers` while the real auto table is `driver_championships_drivers`, so it
passed for the wrong reason.

## Deferred, deliberately

- **The COLUMN axis — #377.** `_infer_through_field` returns the through model's field *name*,
  rendered raw as a column, so a through FK declaring `db_column` addresses a column that does not
  exist. I first reported this as reachable only from hand-written models; that was wrong. The
  importer splats `db_column` onto the `<name>_id` field it builds (`process_class_fields!`), which
  `test/unit/test_import_django_project.jl:275` already pins — so Django-imported through models hit
  it too. Out of scope here (this PR settles the table axis), documented in the code, filed as #377.
- **`ManyToManyField(db_table = …, through = …)`.** `db_table` is silently ignored; the through
  model's table wins, as in Django. A `@warn` is arguable but is a behaviour change of its own. The
  docs and the docstring now state the precedence.

## Not verified

**PostgreSQL (`db_2`) was never run** — it was in use by another session throughout. It is the engine
that fails loudly on a wrong identifier, and the one where SQLite's case-folding cannot mask a
mistake, so it is the strongest remaining confirmation. Worth running before merge.

Unrelated but observed: the worktree's copied `f1.sqlite` predated several fixtures on `main`, and
applying that incremental migration **hung** — ~19 CPU-minutes with zero database writes. It did not
recur on a from-empty bootstrap, so it may be specific to the SQLite `ALTER TABLE` path against
drifted schema. No reproduction, so nothing filed.

## No `UPGRADING.md` entry, no `Project.toml` bump

The rule is *forces a consuming-app source edit*. `ManyToManyRelation` is internal and unexported,
and the behaviour this changes was already broken — no app can depend on it in a working state.
`esus_back` audited: one auto-derived `ManyToManyField`, no `through=`, no `through_model` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
