### PR TITLE
fix(#335): a bulk fill never takes a caller-supplied column name

### DIFF
--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -39,6 +39,34 @@ end
 # whole-column replacement/addition is safe here.
 _bulk_working_frame(df_o::DataFrames.DataFrame) = DataFrames.select(df_o, :; copycols = false)
 
+# #335: the name space PormG's own injected fill columns live in, kept disjoint from the caller's.
+# `_prepare_bulk_df!` fills a whole column for every field the frame has no column for; before
+# #335 it wrote to `df[!, field]` — the FIELD's name — which destroyed caller data whenever an
+# explicit `columns=` Pair mapped some OTHER field to a source column of that name. The rule now
+# is unconditional and needs no reachability argument: **a fill never takes a caller-supplied
+# column name.** See `inject_fill_column!` inside `_prepare_bulk_df!`.
+#
+# The `:` is a TRIPWIRE, not decoration. It fails `SAFE_IDENTIFIER_PATTERN` (`sanitization.jl`),
+# so if a future refactor ever pipes a `mapping` VALUE into `quote_identifier` the build throws
+# instead of silently emitting a wrong column name into SQL. Today nothing does: every SQL column
+# list is built from `fields_df`/`joined_columns` through `Models.model_column`, never from
+# `names(df)`.
+const _BULK_FILL_PREFIX = "__pormg:fill:"
+
+# True for a working-frame column PormG injected rather than the caller supplying it. Used by the
+# three places that would otherwise treat an internal name as the caller's own column:
+# `_resolve_match_column!`'s ignored-column warning and its not-found message, and
+# `_depuration_values_bulk_insert`'s error.
+#
+# Deliberately a bare prefix test, and deliberately asymmetric with the WRITE side: the injection
+# uniquifies against `names(df)` so a caller column named like the prefix is never overwritten,
+# while these readers would misread it — a swallowed warning, a column omitted from an error list,
+# or a caller's own column reported as a "PormG-supplied default/auto value".
+# Accepted — the consequence is cosmetic text, the name is one no caller writes by accident, and a
+# reader-side escape would have to thread the real injected-name set through three call sites to
+# buy nothing else.
+_is_injected_fill_column(name::AbstractString) = startswith(name, _BULK_FILL_PREFIX)
+
 # #107 "one border crossing": `columns=` is the ONLY place a DataFrame column is mapped
 # to a model field. `match_on=` selects merge keys by bare model-field name; its old
 # `"df_col" => "model_field"` pair form is rejected with a migration error below.
@@ -509,13 +537,13 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
   # parameters that shadowed the enclosing ones with the same values, which read as if a caller
   # could vary them; they come from the enclosing scope now.
   #
-  # KNOWN HOLE (#335), pre-existing and NOT closed by #331: the injection sites write to
-  # `df[!, field]`, using the field's own name as the frame column. If an explicit `columns=` Pair
-  # maps some OTHER field to a source column that happens to be named `field`, that write lands on
-  # the column the other field reads from and destroys the caller's values. E.g.
-  # `columns = ["laps" => "pit_stops"]` on a model that also declares a defaulted `laps`:
-  # `pit_stops` binds `laps`'s default instead of the frame's numbers. Narrow (it needs the name
-  # collision) but silent. The guard belongs at the injection sites, not here.
+  # #335 (fixed): the injection sites used to write to `df[!, field]`, using the field's own name
+  # as the frame column. If an explicit `columns=` Pair mapped some OTHER field to a source column
+  # that happened to be named `field`, that write landed on the column the other field reads from
+  # and destroyed the caller's values — e.g. `columns = ["laps" => "pit_stops"]` on a model that
+  # also declares a defaulted `laps` made `pit_stops` bind `laps`'s default instead of the frame's
+  # numbers, silently. Both sites now route through `inject_fill_column!` below, which never writes
+  # to a caller-supplied name at all.
   #
   # #334 (fixed): the UUID branch below used to call `uuid4()` ONCE per field, and the two
   # injection sites broadcast that single value across the whole frame — every row of an
@@ -561,7 +589,69 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
 
     return false, nothing, false
   end
-  
+
+  # Inject one whole column of `fill_value` for a field the frame has no column for, and point
+  # `mapping` at it. Returns `true` when a column was injected, `false` when the explicit-scope
+  # UPDATE guard suppressed it. Captures `df`/`mapping`/`operation`/`normalized_columns` from the
+  # enclosing scope, like `resolve_absent_column_fill` above.
+  #
+  # #335: the destination is ALWAYS a private `_BULK_FILL_PREFIX` column, never the field's own
+  # name and never any name the caller supplied. That is the whole fix, and it is deliberately
+  # UNCONDITIONAL: a redirect that fired only on a detected collision would carry a reachability
+  # proof ("no other field reads this name") that a later edit to the `columns=` handling above
+  # could silently invalidate. One rule, one code path, nothing to re-derive.
+  #
+  # No VALUE read of the working frame is affected: `_drop_blank_auto_primary_keys!`, the three
+  # per-row loops in `bulk_insert`/`bulk_copy`/`bulk_update`, `_ensure_unique_bulk_update_keys!`
+  # and `_depuration_values_bulk_insert` all index through `mapping[field]`, and every SQL column
+  # list comes from `fields_df`/`joined_columns` → `Models.model_column`. A same-named column the
+  # caller supplied but `columns=` excluded therefore keeps its values in the working frame
+  # instead of being overwritten, with no change to what is bound — see the scope note in the
+  # second arm below.
+  #
+  # What the redirect DOES change is the frame's NAME SET, and one predicate reads it:
+  # `_is_legacy_dynamic_filter` tests `f.first in names(df)`. An injected field no longer puts its
+  # own name there, so `filters = ["<auto-populated-field>" => "<model-field>"]` — pre-#335 caught
+  # by the `filters=` deprecation error, because the injection had just put that name in the frame
+  # — is now classified as the constant predicate the caller literally wrote.
+  #
+  # Be precise about the cost, because it is NOT error-for-error: on a field whose formatter
+  # accepts the right-hand string the call now RUNS, adding a `WHERE <field> = '<model-field>'`
+  # predicate that matches nothing, where before it raised "move this to match_on=". Accepted for
+  # one reason only — `_is_legacy_dynamic_filter` is half of a shim already marked for deletion
+  # (see the DEPRECATION SHIM block below), so #335 narrows the reach of a helper that is on its
+  # way out rather than degrading permanent behavior. No `UPGRADING.md` entry is owed: the bar
+  # there is a change that FORCES a consuming-app source edit, and a call that was raising a
+  # migration error was already being told to change.
+  #
+  # Whole-column ADDITION only, never a write into an existing slot — the #132 zero-copy invariant
+  # (see `_bulk_working_frame`). The uniquifying loop is what keeps it an addition: a caller column
+  # already named like the prefix would otherwise be clobbered, which is #335 over again.
+  function inject_fill_column!(field::String, f_meta, fill_value, per_row::Bool)
+    # For an explicit-scope UPDATE (columns= was provided), a static `default` must NOT be
+    # synthesized: that would overwrite live rows merely because the DataFrame lacks the column.
+    # Temporal auto_now/auto_now_add injections are always allowed — an intentional ORM
+    # side-effect. Unchanged by #331; #335 folded it in from both call sites so the two arms are
+    # provably identical rather than only visually identical.
+    operation == :update && !isempty(normalized_columns) && f_meta.default !== nothing &&
+      return false
+
+    target = "$(_BULK_FILL_PREFIX)$(field)"
+    suffix = 1
+    while target in names(df)
+      suffix += 1
+      target = "$(_BULK_FILL_PREFIX)$(field):$(suffix)"
+    end
+
+    # #334: `per_row` means fill_value is already a Vector, one distinct value per row (currently
+    # only the UUID auto_add case) — otherwise broadcast the one value. `nrow` replaced a `ref_col`
+    # pick that grabbed an arbitrary `mapping` key purely for its length and indexed `df[!, 1]`
+    # when `mapping` was empty (a latent `BoundsError` on a column-less frame).
+    df[!, target] = per_row ? fill_value : fill(fill_value, DataFrames.nrow(df))
+    mapping[field] = target
+    return true
+  end
+
   # 1. Identify mappings and check required columns
   if !isempty(normalized_columns)
     for column in normalized_columns
@@ -662,24 +752,16 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       if !haskey(mapping, field)
         # ABSENT column: the field was requested via `columns=` but the DataFrame has no column
         # for it. The fill rule applies — inject one whole column of the fill value.
+        #
+        # Reachable only through the bare-string branch of `columns=` whose column is NOT in
+        # `names(df)` (the `push!(fields_df, column)` above), so `field ∉ names(df)` holds here
+        # unconditionally: this site never had a name to collide with, and its `inject_fill_column!`
+        # call is for symmetry with the other arm, not because #335 could bite here. Stated
+        # explicitly so a later edit to that branch does not read this as a guarantee it provides.
         should_auto_populate, fill_value, per_row = resolve_absent_column_fill(f_meta)
 
         if should_auto_populate
-          # For an explicit-scope UPDATE (columns= was provided), a static `default` must NOT be
-          # synthesized: that would overwrite live rows merely because the DataFrame lacks the
-          # column. Temporal auto_now/auto_now_add injections are always allowed — an intentional
-          # ORM side-effect. Same guard as the never-requested branch below. Unchanged by #331.
-          is_static_default = f_meta.default !== nothing
-          is_explicit_update = operation == :update && !isempty(normalized_columns)
-          if !(is_explicit_update && is_static_default)
-            # Add new column to DF and update mapping
-            # Use first mapped column as a length reference
-            ref_col = isempty(mapping) ? 1 : mapping[collect(keys(mapping))[1]]
-            # #334: per_row means fill_value is already a Vector, one distinct value per row
-            # (currently only the UUID auto_add case) — otherwise broadcast the one value.
-            df[!, field] = per_row ? fill_value : map(x -> fill_value, df[!, ref_col])
-            mapping[field] = field
-          end
+          inject_fill_column!(field, f_meta, fill_value, per_row)
         elseif f_meta.primary_key
           # It's a PK, we'll collect it later
         elseif !f_meta.null && operation in [:insert, :copy]
@@ -706,25 +788,21 @@ function _prepare_bulk_df!(df::DataFrames.DataFrame, model::PormGModel,
       #
       # Deferring to the frame here instead — reading the excluded column's values — was
       # considered and rejected: it would make `columns=` stop deciding what gets written, which
-      # is a worse contract than the one above. (A *narrow* deferral, only when `field in
-      # names(df)`, would keep genuinely-absent columns injected and so would not break
-      # auto_now_add stamping — the objection is the contract, not a NOT NULL failure.)
+      # is a worse contract than the one above.
+      #
+      # #335 changed WHERE the injection lands, not WHAT gets bound: the excluded field still
+      # binds its default, but the fill goes to a private column, so the caller's same-named
+      # column now keeps its values in the working frame instead of being overwritten. Nothing
+      # reads it — every consumer goes through `mapping` — so the SQL and the parameters are
+      # identical either way. (This is also why the "narrow deferral" once sketched here is moot:
+      # it proposed reading `df[!, field]` when `field in names(df)`, which is exactly the
+      # aliasing #335 removed.)
       should_auto_populate, fill_value, per_row = resolve_absent_column_fill(f_meta)
 
       if should_auto_populate
-        # For an explicit-scope UPDATE (columns= was provided), a static `default`
-        # must NOT leak into fields_df.  Temporal auto_now/auto_now_add injections
-        # are always allowed because they are an intentional ORM side-effect.
-        # For INSERT/COPY, or UPDATE with columns=nothing, behavior is unchanged.
-        is_static_default = f_meta.default !== nothing
-        is_explicit_update = operation == :update && !isempty(normalized_columns)
-        if !(is_explicit_update && is_static_default)
-          ref_col = isempty(mapping) ? 1 : mapping[collect(keys(mapping))[1]]
-          # #334: see the sibling injection site above.
-          df[!, field] = per_row ? fill_value : map(x -> fill_value, df[!, ref_col])
-          mapping[field] = field
-          push!(fields_df, field)
-        end
+        # A suppressed static default returns false, so the field stays out of fields_df — the
+        # explicit-scope UPDATE rule, now enforced inside the helper for both arms at once.
+        inject_fill_column!(field, f_meta, fill_value, per_row) && push!(fields_df, field)
       elseif f_meta.primary_key
         push!(pk_field, field)
       end
@@ -780,7 +858,13 @@ function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
   resolved = if haskey(mapping, field)
     # `columns=` mapping wins. If the df ALSO carries a column named exactly like the
     # field, it is ignored in favor of the declared mapping — surface that loudly.
-    if mapping[field] != field && field in names(df)
+    #
+    # #335: an INJECTED fill column is not a `columns=` mapping, so it must not trip this. Since
+    # #335 every injection points `mapping[field]` at a private name, which makes the first
+    # conjunct true for every auto-populated field — without the prefix test this would fire on
+    # e.g. `match_on = ["updated_at"]` for an auto_now `updated_at` and report a `mapped_source`
+    # the caller never wrote. Pre-#335 the identity mapping made it silently false instead.
+    if !_is_injected_fill_column(mapping[field]) && mapping[field] != field && field in names(df)
       @warn "bulk_update: $(kind) resolved through the columns= mapping; the same-named DataFrame column is ignored" field=field mapped_source=mapping[field] ignored_column=field
     end
     mapping[field]
@@ -789,11 +873,25 @@ function _resolve_match_column!(df::DataFrames.DataFrame, model::PormGModel,
   else
     # No mapping and no exact same-named column. A column differing only in case is a
     # loud error, not a silent fold (see the case-sensitive matching contract above).
-    candidates = _case_fold_candidates(field, names(df))
+    #
+    # #335: this runs AFTER `_prepare_bulk_df!`, so the working frame also carries PormG's own
+    # fill columns. Report — and offer as "did you mean" candidates — only what the caller
+    # actually supplied; a `columns:` list containing `__pormg:fill:updated_at` reads as a bug in
+    # PormG, not as help. Filtering the CANDIDATE source matters more than the message: a
+    # candidate is interpolated into a paste-ready `columns = [..., "X" => "field"]` suggestion,
+    # so a leaked internal name there would be actively wrong advice rather than noise.
+    #
+    # The rule for post-injection `names(df)` readers is LISTINGS, not membership: any reader that
+    # SHOWS the frame's columns owes this filter, while the two membership tests above
+    # (`field in names(df)` at the warn condition and at the identity fallback) are provably
+    # exempt and deliberately left lazy — `field` comes from `model.field_names`, and #317 forbids
+    # a model field name from starting with `_`, so it can never equal an injected name.
+    caller_columns = filter(!_is_injected_fill_column, names(df))
+    candidates = _case_fold_candidates(field, caller_columns)
     isempty(candidates) ||
       throw(UnknownFieldError(_bulk_case_mismatch_msg(:update, field, candidates,
         "columns = [..., \"$(candidates[1])\" => \"$(field)\"]")))
-    throw(UnknownFieldError("bulk_update: $(kind) column \e[4m\e[31m$(field)\e[0m not found in the DataFrame (columns: $(names(df))) and no columns= mapping targets that field"))
+    throw(UnknownFieldError("bulk_update: $(kind) column \e[4m\e[31m$(field)\e[0m not found in the DataFrame (columns: \e[4m\e[32m$(caller_columns)\e[0m) and no columns= mapping targets that field"))
   end
 
   mapping[field] = resolved
@@ -1287,7 +1385,12 @@ function _depuration_values_bulk_insert(fields::Vector{String}, mapping::Dict{St
     try
       model.fields[field].formatter(row[col_name])
     catch e
-      throw(InvalidValueError("Error in bulk processing, the field \e[4m\e[31m$(field)\e[0m (col: $(col_name)) in row \e[4m\e[31m$(index)\e[0m has a value that can't be formatted: \e[4m\e[31m$(row[col_name])\e[0m"))
+      # #335: `col_name` is PormG's own private fill column whenever the value was auto-populated,
+      # and printing that name would point the caller at a DataFrame column they never wrote. Name
+      # the source of the value instead.
+      source = _is_injected_fill_column(col_name) ?
+        "PormG-supplied default/auto value" : "col: $(col_name)"
+      throw(InvalidValueError("Error in bulk processing, the field \e[4m\e[31m$(field)\e[0m ($(source)) in row \e[4m\e[31m$(index)\e[0m has a value that can't be formatted: \e[4m\e[31m$(row[col_name])\e[0m"))
     end
   end  
 end

--- a/test/integration/test_bulk_copy.jl
+++ b/test/integration/test_bulk_copy.jl
@@ -979,5 +979,65 @@ end
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# #335: a `columns=` Pair's source column survives a same-named field's default
+#
+# `test_result_set_default` is declared `default = 1` and is NOT named in `columns=`, so
+# PormG supplies its default. The DataFrame column carrying the real FK ids is *named after
+# that field* and mapped onto `test_result` — the exact collision #335 is about. Pre-#335 the
+# injected `1` was written over that column before the row loop read it, so both FK columns
+# landed on `resultid = 1` and the caller's ids were silently gone.
+#
+# Unit coverage (`test/unit/test_bulk_fill_column_collision.jl`) proves the bound parameters,
+# but `bulk_copy` returns before its row loop, so `show_query` cannot reach its values at all:
+# the CSV wire is only observable against a real PostgreSQL. That is what this testset is for —
+# do not collapse it into the unit file.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "#335: a columns= Pair's source column is not clobbered by another field's default" begin
+    cleanup_names = ["copy-collide-a", "copy-collide-b"]
+
+    purge = () -> begin
+        cleanup = M.Just_a_test_deletion.objects
+        cleanup.filter("name__@in" => cleanup_names)
+        cleanup.exists() && cleanup.delete()
+    end
+    purge()
+
+    try
+        # Two distinct ids, neither of which can be 1: `_bulk_copy_fk_ids` is ordered ascending
+        # from the smallest existing `resultid` (>= 1), so the 2nd and 3rd entries are >= 2. That
+        # is what makes the assertion discriminating — pre-#335 both rows bound the default 1.
+        mapped_ids = [_bulk_copy_fk_ids[2], _bulk_copy_fk_ids[3]]
+        @test all(!=(1), mapped_ids)
+
+        df = DataFrames.DataFrame(
+            name = cleanup_names,
+            test_result_set_default = mapped_ids,   # named after a DIFFERENT, defaulted field
+        )
+
+        bulk_copy(M.Just_a_test_deletion.objects, df,
+                  columns = ["name", "test_result_set_default" => "test_result"])
+
+        stored = M.Just_a_test_deletion.objects.filter(
+            "name__@in" => cleanup_names
+        ).order_by(
+            "name"
+        ).values(
+            "name", "test_result", "test_result_set_default"
+        ).list()
+
+        @test length(stored) == 2
+        # The caller's ids reached the column they were mapped to...
+        @test [row[:test_result] for row in stored] == mapped_ids
+        # ...and the field that merely shares the NAME still got its own default, so redirecting
+        # the fill did not cost the fill.
+        @test all(row -> row[:test_result_set_default] == 1, stored)
+        # The caller's DataFrame was never written through (#132), collision or not.
+        @test df.test_result_set_default == mapped_ids
+    finally
+        purge()
+    end
+end
+
 end # End of if adapter_name != "SQLite"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,7 @@ end
     @testset "Configuration API" include("unit/test_configuration_api.jl")
     @testset "bulk_update Column Scope" include("unit/test_bulk_update_column_scope.jl")
     @testset "Bulk Default-Fill Scope (#331)" include("unit/test_bulk_default_fill_scope.jl")
+    @testset "Bulk Fill-Column Collision (#335)" include("unit/test_bulk_fill_column_collision.jl")
     @testset "Bulk No-Mutation Contract (#132)" include("unit/test_bulk_no_mutation.jl")
     @testset "Bulk Parameter-Limit Chunking (#84)" include("unit/test_bulk_param_limit.jl")
     @testset "bulk_insert ON CONFLICT (#123)" include("unit/test_bulk_on_conflict.jl")

--- a/test/unit/test_bulk_fill_column_collision.jl
+++ b/test/unit/test_bulk_fill_column_collision.jl
@@ -1,0 +1,373 @@
+# ============================================================
+# test/unit/test_bulk_fill_column_collision.jl
+#
+# Regression suite for #335 — WHERE PormG writes a value it supplies itself.
+#
+# THE RULE:
+#   A fill never takes a caller-supplied column name. Every auto-populated
+#   column is written to a private `__pormg:fill:<field>` name in the working
+#   frame, and `mapping` points at it.
+#
+# Before #335 the two injection sites in `_prepare_bulk_df!` wrote to
+# `df[!, field]` — the MODEL FIELD's own name. When an explicit `columns=`
+# Pair mapped some OTHER field to a source column carrying that name, the
+# injection landed on top of it and destroyed the caller's values before they
+# were read. Silent: the SQL still named both fields, and both bound the
+# defaulted field's value.
+#
+#     columns = ["driver", "laps" => "pit_stops"]      # on a model declaring BOTH
+#     params:   ["Senna", 0, 0, "Prost", 0, 0]         # pre-#335 — 3 and 5 are gone
+#     params:   ["Senna", 3, 0, "Prost", 5, 0]         # post-#335
+#
+# On `bulk_update` the same defect surfaced as a baffling error instead, when
+# the injected type disagreed with the reader field's — an `auto_now` stamp
+# landing in a column an Int field was mapped to.
+#
+# Sibling files, deliberately not duplicated here — and the reason they are the
+# real guard for this change:
+#   - test_bulk_default_fill_scope.jl — WHICH fills happen and when (#331/#334).
+#   - test_bulk_update_column_scope.jl — the `columns=` scope contract.
+# #335 redirects EVERY injection, not only colliding ones, so those two files
+# asserting unchanged bound parameters is what proves the redirect is invisible.
+# Run them alongside this file, never instead of it.
+#
+# Deterministic and DB-free: a mock PostgreSQL connection with
+# `show_query = :dict`. `bulk_copy` is the exception — it returns before its row
+# loop, so its values are asserted one layer down, on `_prepare_bulk_df!` itself.
+# ============================================================
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, IntegerField, CharField, DateTimeField, UUIDField
+using PormG.QueryBuilder: bulk_copy, bulk_insert, bulk_update
+using PormG.QueryBuilder: _prepare_bulk_df!, _normalize_bulk_columns, _bulk_working_frame
+using PormG.QueryBuilder: _BULK_FILL_PREFIX, _is_injected_fill_column
+using UUIDs
+import DataFrames
+
+# Mock connection under a dedicated key so this file cannot contaminate (or be
+# contaminated by) other unit files sharing Main in runtests.jl.
+struct BulkFillCollisionMockPg <: PormG.PormGPostgres end
+PormG.config["bfcc_mock"] = PormG.Configuration.Settings(
+    connections = BulkFillCollisionMockPg(),
+    change_data = true,
+)
+
+# The issue's own model. Two defaulted integer fields is the minimum shape that can
+# collide: the frame's `laps` column carries the pit-stop count, mapped explicitly onto
+# `pit_stops`, while the model ALSO declares a defaulted `laps` that takes no part.
+Bfcc_stint = Model("bfcc_stint",
+    id        = IDField(),
+    driver    = CharField(),
+    laps      = IntegerField(default = 0, null = true),
+    pit_stops = IntegerField(default = 0),
+)
+Bfcc_stint.connect_key = "bfcc_mock"
+
+# The `bulk_update`-reachable variant. An explicit `columns=` SUPPRESSES static defaults on
+# `:update` (they would overwrite live rows merely because the frame lacks the column), so the
+# static-default collision above simply cannot fire there. `auto_now` still injects — it is an
+# intentional ORM side-effect — which makes a temporal field the only shape that reproduces
+# #335 on an update. It is also the shape from the issue report: an `auto_now` timestamp landing
+# in the column an Int field was mapped to, surfacing as a type error naming a field the caller
+# never mentioned.
+Bfcc_lap = Model("bfcc_lap",
+    id         = IDField(),
+    points     = IntegerField(null = true),
+    updated_at = DateTimeField(auto_now = true, null = true),
+)
+Bfcc_lap.connect_key = "bfcc_mock"
+
+# A UUID `auto_add` PRIMARY KEY, for the `_drop_blank_auto_primary_keys!` route. That drop is the
+# ONLY way a `per_row = true` fill (one distinct UUID per row, #334) can reach a collision: it
+# deletes the pk's own mapping mid-flight while leaving a second field still reading that column.
+Bfcc_token = Model("bfcc_token",
+    token = UUIDField(primary_key = true, auto_add = true),
+    note  = CharField(null = true),
+)
+Bfcc_token.connect_key = "bfcc_mock"
+
+# Several fill kinds at once, for the blanket "no fill takes a caller name" assertion.
+Bfcc_sheet = Model("bfcc_sheet",
+    id         = IDField(),
+    driver     = CharField(),
+    laps       = IntegerField(default = 0, null = true),
+    pit_stops  = IntegerField(default = 0),
+    checked_at = DateTimeField(auto_now_add = true, null = true),
+    token      = UUIDField(auto_add = true, null = true),
+)
+Bfcc_sheet.connect_key = "bfcc_mock"
+
+# ------------------------------------------------------------------
+# Read bound values back BY COLUMN NAME, never by a hard-coded index — an INSERT
+# renders its column list in the same order it binds parameters, so a column's
+# position in that list is its parameter index. Present columns come first and
+# injected ones are appended, so index literals would be brittle here in exactly
+# the way #335 makes interesting.
+#
+# Prefixed `bfcc_` because test_bulk_default_fill_scope.jl defines the same three
+# helpers at top level and both files land in Main under runtests.jl.
+# ------------------------------------------------------------------
+function bfcc_insert_columns(res)
+    m = match(r"INSERT INTO\s+\S+\s*\((.*?)\)\s*VALUES"s, res[:sql_text])
+    m === nothing && error("could not parse an INSERT column list from: $(res[:sql_text])")
+    return [strip(c, ['"', ' ', '\n', '\r', '\t']) for c in split(m.captures[1], ",")]
+end
+
+# Every bound value for `col`, across all rows. `parameters` is flat and row-major:
+# column `idx` out of `n` appears at positions `idx, idx+n, idx+2n, ...`.
+function bfcc_params_for(res, col)
+    cols = bfcc_insert_columns(res)
+    idx = findfirst(==(col), cols)
+    idx === nothing && error("column $(col) is not in the INSERT: $(res[:sql_text])")
+    return res[:parameters][idx:length(cols):end]
+end
+
+# The bulk_update VALUES source list plays the same role for an UPDATE.
+function bfcc_source_params_for(res, col)
+    m = match(r"AS\s+source\s*\((.*?)\)"s, res[:sql_text])
+    m === nothing && error("could not parse a source column list from: $(res[:sql_text])")
+    cols = [strip(c, ['"', ' ', '\n', '\r', '\t']) for c in split(m.captures[1], ",")]
+    idx = findfirst(==(col), cols)
+    idx === nothing && error("column $(col) is not in the source list: $(res[:sql_text])")
+    return res[:parameters][idx:length(cols):end]
+end
+
+# Run `_prepare_bulk_df!` exactly as the three public entry points do — normalize `columns=`,
+# wrap the caller's frame zero-copy, prepare. Returns the working frame too, because for
+# `bulk_copy` (which returns before its row loop) that frame is the only place the values are
+# observable at this layer.
+function bfcc_prepare(model, df_o, columns, operation)
+    df = _bulk_working_frame(df_o)
+    mapping, fields_df, pk_exist, pk_field =
+        _prepare_bulk_df!(df, model, _normalize_bulk_columns(columns), operation, nothing)
+    return df, mapping, fields_df, pk_exist, pk_field
+end
+
+@testset "#335: a fill never takes a caller-supplied column name" begin
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_insert: the issue's reproduction, verbatim.
+    # The frame's "laps" column holds the pit-stop count and is mapped onto `pit_stops`;
+    # the model's own defaulted `laps` takes no part in the write and must be filled.
+    # Pre-#335 the fill for `laps` overwrote df["laps"], so `pit_stops` bound 0 instead
+    # of 3 and 5 — silent, wrong data on a documented first-class API.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_insert: a Pair's source column survives a same-named field's default" begin
+        df = DataFrames.DataFrame(driver = ["Senna", "Prost"], laps = [3, 5])
+
+        res = bulk_insert(Bfcc_stint.objects, df,
+                          columns = ["driver", "laps" => "pit_stops"],
+                          show_query = :dict)
+
+        # The caller's numbers reach the column they were mapped to.
+        @test bfcc_params_for(res, "pit_stops") == [3, 5]
+        # ...and the field that merely shares the NAME still gets its own default, so a
+        # `null = false` column is not left unsatisfied. Redirecting preserves the fill;
+        # skipping it would have pushed the failure to the database.
+        @test bfcc_params_for(res, "laps") == [0, 0]
+        @test bfcc_params_for(res, "driver") == ["Senna", "Prost"]
+        # Whole-batch shape: three columns, two rows, nothing dropped or duplicated.
+        @test sort(bfcc_insert_columns(res)) == ["driver", "laps", "pit_stops"]
+        @test res[:parameter_count] == 6
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_update: the same defect, reported as a type error about a field the caller
+    # never mentioned. `updated_at` is auto_now, so it injects even under an explicit
+    # `columns=`; pre-#335 that stamp landed on the frame column `points` was mapped to,
+    # and validation rejected the timestamp AS `points`.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_update: auto_now no longer stamps over a Pair's source column" begin
+        df = DataFrames.DataFrame(record_id = [1, 2], updated_at = [10, 20])
+
+        res = bulk_update(Bfcc_lap.objects, df,
+                          columns  = ["updated_at" => "points", "record_id" => "id"],
+                          match_on = ["id"],
+                          show_query = :dict)
+
+        # Pre-#335 this call did not merely bind the wrong value — it THREW, with
+        # `field "points": expected Int64 …, got String("2026-…")`.
+        @test bfcc_source_params_for(res, "points") == [10, 20]
+        @test bfcc_source_params_for(res, "id") == [1, 2]
+        # The auto_now stamp still happens; it just lands somewhere private now.
+        @test "updated_at" in [strip(c, ['"', ' ']) for c in
+              split(match(r"AS\s+source\s*\((.*?)\)"s, res[:sql_text]).captures[1], ",")]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # bulk_copy: `show_query` returns before the row loop, so the bound values cannot be
+    # inspected at that layer. Assert one level down instead — on the working frame and
+    # the mapping `_prepare_bulk_df!` hands back, which is what the COPY chunk builder
+    # reads (`src = df[i:end_idx, mapping[field]]`).
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "bulk_copy: the working frame keeps the Pair's source values" begin
+        df_o = DataFrames.DataFrame(driver = ["Senna", "Prost"], laps = [3, 5])
+        df, mapping, fields_df, _, _ =
+            bfcc_prepare(Bfcc_stint, df_o, ["driver", "laps" => "pit_stops"], :copy)
+
+        # The Pair's mapping is untouched — `pit_stops` still reads the frame's "laps".
+        @test mapping["pit_stops"] == "laps"
+        @test df[!, mapping["pit_stops"]] == [3, 5]
+        # ...and `laps`'s own fill went somewhere the caller did not name.
+        @test _is_injected_fill_column(mapping["laps"])
+        @test df[!, mapping["laps"]] == [0, 0]
+        @test sort(fields_df) == ["driver", "laps", "pit_stops"]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The second live reproducer, and the only one that reaches a `per_row = true` fill.
+    # `_drop_blank_auto_primary_keys!` runs BEFORE the fill loop: an all-blank auto pk
+    # column is treated as absent, so it deletes `mapping["token"]` — but the Pair
+    # `"token" => "note"` still reads that same frame column. Pre-#335 the per-row UUID
+    # mint then landed on it and `note` bound three fresh UUIDs instead of NULL.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "an all-blank UUID auto_add pk does not mint over its other reader" begin
+        df = DataFrames.DataFrame(token = [missing, missing, missing])
+
+        res = bulk_insert(Bfcc_token.objects, df,
+                          columns = ["token", "token" => "note"],
+                          show_query = :dict)
+
+        # `note` reads the frame's blanks — the caller asked for NULL and gets NULL.
+        @test all(ismissing, bfcc_params_for(res, "note"))
+        # The pk is still minted, still one distinct value per row (#334 stays honored).
+        tokens = bfcc_params_for(res, "token")
+        @test length(tokens) == 3
+        @test all(!ismissing, tokens)
+        @test length(unique(tokens)) == 3
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The contract itself, stated directly rather than through one collision at a time:
+    # for EVERY auto-populated field, the destination is a private name absent from the
+    # caller's frame. This is what makes the fix need no reachability argument.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "every injected fill lands on a private name" begin
+        df_o = DataFrames.DataFrame(driver = ["Fangio", "Moss"], laps = [7, 9])
+        caller_names = names(df_o)
+        df, mapping, fields_df, _, _ =
+            bfcc_prepare(Bfcc_sheet, df_o, ["driver", "laps" => "pit_stops"], :insert)
+
+        # `laps`, `checked_at` and `token` are all absent from the write's scope and all
+        # carry a fill; none of them may point at a name the caller supplied.
+        for field in ["laps", "checked_at", "token"]
+            @test haskey(mapping, field)
+            @test startswith(mapping[field], _BULK_FILL_PREFIX)
+            @test !(mapping[field] in caller_names)
+        end
+        # Fields the caller DID map keep pointing at the caller's own columns.
+        @test mapping["driver"] == "driver"
+        @test mapping["pit_stops"] == "laps"
+        @test df[!, mapping["pit_stops"]] == [7, 9]
+        # `id` is an auto pk with nothing to fill — it stays out of the write entirely.
+        @test !("id" in fields_df)
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The private namespace is not a free pass: a caller column already named like one
+    # would be clobbered by the fill, which is #335 all over again one level deeper.
+    # The uniquifying loop keeps every injection a column ADDITION, never a replacement.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "a caller column named like the private prefix is not clobbered" begin
+        squatter = "$(_BULK_FILL_PREFIX)pit_stops"
+        df_o = DataFrames.DataFrame("driver" => ["Hawthorn"], squatter => [99])
+
+        df, mapping, _, _, _ = bfcc_prepare(Bfcc_stint, df_o, [], :insert)
+
+        # The fill stepped aside rather than overwriting the caller's cells.
+        @test mapping["pit_stops"] != squatter
+        @test df[!, squatter] == [99]
+        @test df[!, mapping["pit_stops"]] == [0]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The #132 no-mutation contract, re-asserted under a collision: the redirect adds a
+    # column to the working frame, and the frame is a `copycols = false` wrapper, so the
+    # addition must not reach the caller — neither as a new column nor as a rebound vector.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "the caller's DataFrame is untouched by a redirected fill (#132)" begin
+        df = DataFrames.DataFrame(driver = ["Senna", "Prost"], laps = [3, 5])
+        # Take the identity from the frame, not from the literal: the DataFrame
+        # constructor copies its columns (`copycols = true`), so the array passed in is
+        # never the one the frame holds.
+        laps_vector = df[!, "laps"]
+
+        bulk_insert(Bfcc_stint.objects, df,
+                    columns = ["driver", "laps" => "pit_stops"], show_query = :dict)
+
+        @test names(df) == ["driver", "laps"]
+        @test df[!, "laps"] === laps_vector      # same vector object, not a copy
+        @test df[!, "laps"] == [3, 5]            # and its cells were never written through
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The private names must not escape into anything the caller reads. Two consumers run
+    # AFTER the injection and would otherwise present an internal column as if the caller
+    # had supplied it — neither is reachable from the assertions above, so both are pinned
+    # here directly. (`_depuration_values_bulk_insert`'s branch is the third such consumer
+    # and is deliberately NOT pinned: reaching it needs a PormG-generated value that fails
+    # its own field's formatter, and every route to one is rejected by the field
+    # constructors. Not the same as unreachable — the field structs are mutable and do not
+    # validate on `setproperty!`, so assigning a bad `.default` after construction would get
+    # there — but nothing a caller writes through the public API does.)
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "private fill names do not escape into caller-facing output" begin
+        # `updated_at` is auto_now and excluded by columns=, so it is injected; the frame also
+        # carries a column of that name. Without the prefix test in `_resolve_match_column!`,
+        # `mapping["updated_at"] != "updated_at"` is now true and the warning fires, telling the
+        # caller their column was "ignored in favor of the columns= mapping" — a mapping they
+        # never declared, naming a source column that does not exist for them.
+        # `id` is deliberately NOT mapped here: `match_on` names `updated_at`, so anything else
+        # in `columns=` becomes a SET target, and a primary key may not be one.
+        df_warn = DataFrames.DataFrame(new_points = [9], updated_at = ["1999-01-01T00:00:00"])
+        # An empty pattern list asserts NO log records are emitted.
+        @test_logs bulk_update(Bfcc_lap.objects, df_warn,
+                               columns  = ["new_points" => "points"],
+                               match_on = ["updated_at"],
+                               show_query = :dict)
+
+        # The not-found message lists the frame's columns as a "here is what you have" hint. It
+        # must list what the CALLER has: a `columns:` entry reading `__pormg:fill:updated_at`
+        # looks like a bug in PormG rather than help.
+        df_missing = DataFrames.DataFrame(record_id = [1], new_points = [9])
+        err = try
+            bulk_update(Bfcc_lap.objects, df_missing,
+                        columns  = ["new_points" => "points"],
+                        match_on = ["id"],
+                        show_query = :dict)
+            nothing
+        catch e
+            e
+        end
+        # Not decoration: without it, an `err === nothing` (no throw at all) would make the
+        # negative assertion below pass vacuously through `sprint(showerror, nothing)`.
+        @test err isa PormG.UnknownFieldError
+        msg = sprint(showerror, err)
+        @test !occursin(_BULK_FILL_PREFIX, msg)
+        # ...and the other side of it. `!occursin` alone would stay green if the whole
+        # `(columns: ...)` hint were deleted, which is the failure it exists to prevent.
+        @test occursin("record_id", msg)
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────────
+    # The mirror case from the issue's checklist: a Pair whose TARGET FIELD name matches
+    # an unmapped frame column. Resolution is mapping-first (#107), so the declared Pair
+    # wins and the same-named frame column is simply not read. No data is lost and no fix
+    # is owed — pinned here so the asymmetry with the fixed case is on the record.
+    # ─────────────────────────────────────────────────────────────────────────────
+    @testset "mirror case: a Pair's target field name matching an unmapped column" begin
+        # "laps" is a model field AND a frame column, but the caller mapped `laps` to "src".
+        df = DataFrames.DataFrame(driver = ["Clark"], src = [42], laps = [999])
+
+        res = bulk_insert(Bfcc_stint.objects, df,
+                          columns = ["driver", "src" => "laps"],
+                          show_query = :dict)
+
+        # The declared mapping decides; the frame's own "laps" column is ignored, not blended.
+        @test bfcc_params_for(res, "laps") == [42]
+        # `pit_stops` is out of scope and gets its default, as `columns=` asks.
+        @test bfcc_params_for(res, "pit_stops") == [0]
+    end
+
+end


### PR DESCRIPTION
Closes #335.

## The bug

`_prepare_bulk_df!` fills a whole column for every model field the caller's `DataFrame` has no
column for. Both injection sites wrote that fill to **`df[!, field]` — the model field's own
name**. When an explicit `columns=` Pair mapped a *different* field to a source column carrying
that name, the injection landed on top of it and destroyed the caller's values before they were
read.

```julia
# model declares BOTH `laps` (default = 0) and `pit_stops`
df = DataFrame(driver = ["Senna", "Prost"], laps = [3, 5])
bulk_insert(Stint.objects, df, columns = ["driver", "laps" => "pit_stops"])
```

| | bound parameters |
|---|---|
| before | `["Senna", 0, 0, "Prost", 0, 0]` ← the caller's 3 and 5 are gone |
| after | `["Senna", 3, 0, "Prost", 5, 0]` |

Silent — the SQL still named both fields, and both bound the defaulted field's value. On
`bulk_update` the same defect surfaced as a type error naming a field the caller never mentioned,
when an `auto_now` stamp landed in a column an Int field was mapped to.

## The fix

One rule: **a fill never takes a caller-supplied column name.** Both sites now route through a
single `inject_fill_column!` closure that always writes to a private `__pormg:fill:<field>` column,
uniquified against `names(df)`, and points `mapping` at it.

**Unconditional, not collision-only.** A redirect firing only on a detected collision would carry a
reachability proof — "no other field reads this name" — that a later edit to the `columns=`
handling could silently invalidate. One rule, one code path, nothing to re-derive.

**Why it is invisible.** No *value* read of the working frame goes by field name: the three per-row
loops, `_drop_blank_auto_primary_keys!`, `_ensure_unique_bulk_update_keys!` and
`_depuration_values_bulk_insert` all index through `mapping[field]`, and every SQL column list is
built from `fields_df`/`joined_columns` via `Models.model_column`. Bound parameters are unchanged
in every non-colliding case — which is what the existing `test_bulk_default_fill_scope.jl` and
`test_bulk_update_column_scope.jl` assert, so those two files staying green is the real evidence
here, more than the new file.

**The `:` in the prefix is a tripwire**, not decoration: it fails `SAFE_IDENTIFIER_PATTERN`, so if a
future refactor ever pipes a `mapping` value into `quote_identifier`, the build throws instead of
silently emitting a wrong column name into SQL.

Also in this change:

- The explicit-scope UPDATE guard is folded into the helper, so the two arms are provably identical
  rather than only visually identical.
- `fill(fill_value, nrow(df))` replaces `map(x -> fill_value, df[!, ref_col])`, dropping an
  arbitrary-`Dict`-key pick and a latent `BoundsError` (`df[!, 1]` when `mapping` was empty).
- **Three consumers** that would otherwise present a private name as the caller's own column are
  fixed: `_resolve_match_column!`'s ignored-column `@warn`, its not-found message (which also
  filters the case-fold *candidate source*, so a leaked name can never reach a paste-ready
  `columns=` suggestion), and `_depuration_values_bulk_insert`'s error text.

## Two corrections to the issue text

- Its line numbers (`:588` / `:631`) were stale; the sites are `:677` and `:722` on `main`.
- Its guess that the first site "presumably has the same exposure" is **wrong**. That arm is
  entered only for a `columns=` bare string whose column is *absent* from the frame, so
  `field ∉ names(df)` holds there unconditionally — it never had a name to collide with. It is
  covered anyway, because both sites share the helper; the code says so explicitly, so a later edit
  to that branch does not read the symmetry as a guarantee it provides.

## Tests

New `test/unit/test_bulk_fill_column_collision.jl` — 9 testsets, 42 assertions, DB-free (mock
PostgreSQL + `show_query = :dict`):

- the issue's reproduction on `bulk_insert`;
- the `auto_now` variant, which is the **only** shape that reproduces on `bulk_update` (an explicit
  `columns=` suppresses static defaults there);
- `bulk_copy` values at the `_prepare_bulk_df!` layer — it returns before its row loop, so
  `show_query` cannot reach them;
- the all-blank UUID `auto_add` primary key route through `_drop_blank_auto_primary_keys!`, the only
  path that reaches a `per_row` fill;
- the unconditional contract, the prefix uniquifier, #132 non-mutation under a collision, the mirror
  case from the issue's checklist, and the three consumer fixes.

One PostgreSQL round-trip regression in `test/integration/test_bulk_copy.jl` — the only path whose
CSV wire the unit layer cannot reach.

**Mutation-tested**: 5 of the 8 original testsets fail or error against the pre-fix source, and both
consumer-guard assertions fail when their guards are reverted. The three that pass pre-fix are not
theater — #132 and the mirror case assert already-correct behavior, and the prefix-squatter test is
the sole guard for the uniquifying loop (deleting the loop fails 2 of its 3 assertions).

## Verification

| Rung | Result |
|---|---|
| New file alone | 42/42 |
| Pinned-behavior guards (6 files) | green |
| Full unit suite | 6897/6897 |
| `test_bulk_copy.jl` on `db_2` | exit 0, new `#335` testset 5/5 |

Rung 5 not owed — the diff is `src/querybuilder/` only: no migrations, no field types, no driver
round-trip, no pool/transaction code, no include-chain change.

## Deliberate deltas, recorded

1. **A same-named column the caller supplied but `columns=` excluded is no longer clobbered in the
   working frame.** No SQL or parameter change; nothing reads it.
2. **`_is_legacy_dynamic_filter` reads `f.first in names(df)`**, and an injected field no longer puts
   its own name there. `filters = ["<auto-populated-field>" => "<model-field>"]` is now read as the
   constant predicate the caller wrote instead of raising the `filters=` migration error. Verified
   by execution: on a field whose formatter accepts the right-hand string the call **runs**, adding
   a predicate that matches nothing, where before it raised. Accepted because
   `_is_legacy_dynamic_filter` is half of a shim already marked *"TO REMOVE after the deprecation
   window"* — this narrows the reach of a helper on its way out.

**No `UPGRADING.md` entry and no `Project.toml` bump.** The bar is a change that *forces* a
consuming-app source edit; a fix to something already broken does not, and the one behavior delta
above affected a call that was already raising a migration error telling the caller to change it.

**No docs change.** `docs/src/write/bulk.md` already promises the fixed behavior — *"A column that
is present is your data, and PormG never rewrites its cells"*. The bug violated a promise the docs
already make.

## Deliberately not done

- **No test for `_depuration_values_bulk_insert`'s injected branch.** Reaching it needs a
  PormG-generated value that fails its own field's formatter, and every route through the field
  constructors is rejected at construction. Recorded in the test header, including the caveat that
  "unreachable" would be an overclaim — the field structs are mutable and do not validate on
  `setproperty!`.
- **Follow-ups filed rather than fixed here**: #379 (`match_on` binds an injected fill instead of
  the caller's same-named column — pre-existing, confirmed byte-identical before and after this PR)
  and #380 (`columns=` silently last-wins on a duplicated target). #379 is the one to read next: its
  last task depends on this PR's `@warn` guard, which deliberately suppresses the very signal that
  issue is about.

## Review

Two independent review rounds by a fresh reader. Six findings in the first pass, three defects
found *in the fixes* in the delta pass — all addressed, including one comment that was factually
wrong until execution proved it (delta #2 above). Nothing declined without a stated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
