### PR TITLE
fix(#348): warn on unrecognised connection.yml keys outside config:

### DIFF
--- a/docs/src/configuration/advanced.md
+++ b/docs/src/configuration/advanced.md
@@ -15,6 +15,8 @@ dev:
   # ...
   pool_size: 10   # base 10 → grows to 100 under burst
 ```
+
+  A misspelled pool key (`pool:`, `poolsize:`, `pool_timout:`) is reported on load with a suggestion instead of silently leaving the default in place — see [Unrecognised keys](connection_yml.md#Unrecognised-keys).
 - **Acquire timeout (`pool_timeout`):** How long `acquire_connection` waits for a free connection before raising `PoolTimeoutError` — default **30 s**. Set `pool_timeout:` in `connection.yml` (seconds; fractional allowed) to *fail fast* instead of blocking a request while the pool is saturated:
 
   ```yaml

--- a/docs/src/configuration/connection_yml.md
+++ b/docs/src/configuration/connection_yml.md
@@ -70,20 +70,62 @@ dev:
     time_zone: 'UTC'
 ```
 
+## Environment-block Keys
+
+These are the keys PormG reads **directly under an environment block** — the peers of `config:`. Anything else in that block is not read by anything, and warns on load (see [Unrecognised keys](#Unrecognised-keys) below).
+
+| Key | Applies to | Meaning |
+|---|---|---|
+| `adapter` | both | **Required.** `PostgreSQL` or `SQLite`. A block without it raises `InvalidConfigurationError` on load. |
+| `database` | both | Database name (PostgreSQL) or file path (SQLite). A relative SQLite path resolves inside the config folder. |
+| `host` | both | Server host on PostgreSQL. **On SQLite it is the database file name and takes precedence over `database:`** — a historical quirk, not a typo. |
+| `url` | PostgreSQL | A complete connection string. When present, **every other PostgreSQL target key is ignored** — PormG passes it through verbatim. Setting it under `adapter: SQLite` does nothing and warns; use `database:` there. |
+| `username`, `password`, `port`, `hostaddr` | PostgreSQL | Standard credentials/target. Forwarded into the libpq DSN. |
+| `passfile`, `connect_timeout`, `client_encoding` | PostgreSQL | Forwarded into the libpq DSN verbatim. |
+| `sslmode`, `sslrootcert`, `sslcert`, `sslkey` | PostgreSQL | TLS settings, forwarded into the libpq DSN verbatim. |
+| `extensions` | PostgreSQL | List of extensions to require — see [PostgreSQL Extensions](#PostgreSQL-Extensions). Ignored with a warning on SQLite. |
+| `sqlite_split_read_write` | SQLite | Split the pool into read and write connections. |
+| `pool_size`, `pool_timeout`, `idle_timeout`, `max_lifetime`, `leak_detection_threshold`, `fail_fast_on_connect` | both | Connection-pool tuning — documented in [Advanced Configuration](advanced.md). |
+| `options` | both | Legacy nesting for `sqlite_split_read_write` only. Prefer setting that key directly on the block. |
+| `config` | both | The settings sub-dictionary described in the next section. |
+
+The PostgreSQL-only keys are inert under `adapter: SQLite`, so a block may carry both sets without harm. `hostaddr`, `port`, `password`, `passfile`, `connect_timeout`, `client_encoding` and the four `ssl*` keys reach libpq under exactly the names written here; `username` and `database` are translated to libpq's `user=` and `dbname=` for you.
+
 ## Configuration Settings (`config:`)
 
 At the core of `connection.yml` is the `config` sub-dictionary. This section governs runtime permissions, logging, timezones, and naming conventions for the loaded environment:
 
-!!! warning "Unrecognised keys are warned with suggestions"
-    Only valid user-facing keys (`change_db`, `change_data`, `django_prefix`, `time_zone`, `log_queries`, `log_level`, `log_to_file`, `model_file`) are accepted under `config:`. Any unrecognised key emits a `@warn` on load naming the key and the environment, along with a "did you mean" suggestion if the key is a near-miss typo (e.g. `djago_prefix` → `django_prefix`).
+### Unrecognised keys
 
-!!! warning "Both default to `false`, and a misplaced key is silent"
+!!! warning "A key PormG does not read is reported, never silently dropped"
+    Every level of the file is checked on load, and anything unrecognised emits a `@warn` naming the
+    key — plus a *"did you mean"* when the name is close to a real one:
+
+    - **Under `config:`** — only `change_db`, `change_data`, `django_prefix`, `time_zone`,
+      `log_queries`, `log_level`, `log_to_file` and `model_file` are accepted
+      (e.g. `djago_prefix` → `django_prefix`).
+    - **Directly under an environment block** — only the keys in the table above
+      (e.g. `sslmod` → `sslmode`). Spellings borrowed from other tools are recognised too:
+      `user` → `username`, `pool` → `pool_size`, `dbname` → `database`, `ENGINE` → `adapter`.
+    - **At the top level of the file** — anything that is not `default_env:` and not an environment
+      block (e.g. `defaultenv:` → `default_env`).
+    - **Between the two levels** — a `config:` setting written on the environment block, or an
+      environment key written under `config:`, is reported as misplaced and tells you where it
+      belongs, rather than being reported as unknown.
+
+    A malformed `config:` (one that is not a block of settings) and an unrecognised `log_level:`
+    value are reported the same way. An environment block that is not a block of settings, and one
+    with no `adapter:`, raise `InvalidConfigurationError` instead — they leave nothing to connect
+    with.
+
+!!! warning "Both default to `false`, and a key under the wrong environment is silent"
     Omit the `config:` block and you get `change_data: false` **and** `change_db: false` — writes
     raise `WritesDisabledError` and migrations are rejected. Both keys are only read from the
-    `config:` sub-dictionary of the environment you actually loaded; the same key at the top level,
-    or under a different environment, is **ignored without any error**. A config scaffolded by
-    `PormG.setup()` already sets `change_data: true`; one written by hand or registered through
-    `register_connection` does not.
+    `config:` sub-dictionary of the environment you actually loaded. Writing one at the environment
+    level instead now warns and names `config:` as its home, but writing it **under a different
+    environment** stays silent — only the active block is read, so there is nothing to check it
+    against. A config scaffolded by `PormG.setup()` already sets `change_data: true`; one written by
+    hand or registered through `register_connection` does not.
 
 ### `change_data`
 - **`true`**: DML operations (Data Manipulation Language) are permitted. You can `save()`, `update()`, and `delete()` records through PormG models.
@@ -195,6 +237,8 @@ The recommended pattern for a server is to let the **host** resolve its own envi
 
 !!! note "The bare `env:` key is ignored"
     A top-level `env:` key (as opposed to `default_env:`) does **nothing** — it was renamed to `default_env:`. If a stale config still has `env:`, PormG warns once on load and keeps using the environment resolved above.
+
+Any other top-level value that is not an environment block is warned about on load, with a `default_env` suggestion for near-misses like `defaultenv:` — a common way to lose the setting silently. An environment block written with an empty body (`prod:` with nothing under it) is still a block and is never flagged.
 
 ## Pre-connect hooks
 

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -65,7 +65,7 @@ Catch the umbrella when you want a category, the concrete type when you want a r
 | Call | Raises | When |
 |---|---|---|
 | `Configuration.load(...)` | `PormG.Configuration.MissingConfigurationError` | No `connection.yml` found; try `PormG.setup(path)` |
-| `Configuration.load(...)` | `InvalidConfigurationError` | Unknown adapter, unsupported extension, bad `extensions` shape |
+| `Configuration.load(...)` | `InvalidConfigurationError` | Unknown or missing adapter, unsupported extension, bad `extensions` shape, an environment block that is not a block of settings |
 | model definition | `FieldValidationError` / `ModelDefinitionError` | Bad field argument / bad model shape. Catch `DefinitionError` for both |
 | `makemigrations` / `migrate` | `InvalidMigrationError` | The migration or the schema it describes is not valid |
 | `migrate` on a destructive plan | `PormG.Migrations.DestructiveMigrationError` | Non-interactive run without `destructive = true`; carries `statements` |

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -401,8 +401,11 @@ function _build_connection_pool!(settings::PormGSettings, path::String)
   elseif settings.db_config_settings["adapter"] == "PostgreSQL"
     dns = String[]
 
-    # Check for direct URL/Connection String support
-    if haskey(settings.db_config_settings, "url") && settings.db_config_settings["url"] !== nothing
+    # Check for direct URL/Connection String support. A blank `url:` counts as unset, not as an
+    # empty DSN: gating on `!== nothing` meant `url: ''` discarded every credential below it and
+    # handed libpq an empty conninfo, which falls back to PGHOST/PGUSER or the local socket as the
+    # OS user — a fully-populated-looking config silently connecting to the wrong database (#348).
+    if !_is_unset(get(settings.db_config_settings, "url", nothing))
       dns_str = settings.db_config_settings["url"]
     else
       # Standard parameters loop
@@ -444,23 +447,11 @@ function _build_connection_pool!(settings::PormGSettings, path::String)
 end
 
 """
-    read_db_connection_data(db_settings_file::String) :: Dict{Any,Any}
+    _configured_extensions(settings::PormGSettings)::Vector{String}
 
-Attempts to read the database configuration file and returns the part corresponding to the current environment as a `Dict`.
-Does not check if `db_settings_file` actually exists so it can throw errors.
-If the database connection information for the current environment does not exist, it returns an empty `Dict`.
-
-# Examples
-```julia
-julia> Configuration.read_db_connection_data(...)
-Dict{Any,Any} with 6 entries:
-  "host"     => "localhost"
-  "password" => "..."
-  "username" => "..."
-  "port"     => 5432
-  "database" => "..."
-  "adapter"  => "PostgreSQL"
-```
+Normalize the environment block's `extensions:` value into a clean list of extension names.
+Accepts a list or a bare string, trims and lower-cases each entry, and drops empties. Returns
+an empty vector when the key is absent, `nothing`, or `missing`.
 """
 function _configured_extensions(settings::PormGSettings)::Vector{String}
   raw = get(settings.db_config_settings, "extensions", String[])
@@ -598,6 +589,186 @@ const VALID_CONFIG_KEYS = (
   "model_file",
 )
 
+"""
+    VALID_CONNECTION_KEYS
+
+Allowed keys directly under an environment block in `connection.yml` (#348) — the peers of
+`config:`. Every entry is read by `_build_connection_pool!` or `_configured_extensions`;
+anything else is dead weight in the file and is warned about on load.
+
+Keep `host` ahead of `hostaddr`: `_suggest_name` keeps the *first* minimum, and `hostname`
+is equidistant from both.
+"""
+const VALID_CONNECTION_KEYS = (
+  # Target
+  "adapter", "url", "database", "host", "hostaddr", "port", "username", "password",
+  # libpq passthrough (PostgreSQL only; forwarded verbatim into the DSN)
+  "passfile", "connect_timeout", "client_encoding",
+  "sslmode", "sslrootcert", "sslcert", "sslkey",
+  # Pool
+  "pool_size", "pool_timeout", "idle_timeout", "max_lifetime",
+  "leak_detection_threshold", "fail_fast_on_connect",
+  # Backend behaviour
+  "sqlite_split_read_write", "extensions",
+  # Nested blocks
+  "options", "config",
+)
+
+"""
+    VALID_OPTION_KEYS
+
+The only key ever read out of a nested `options:` block. `options:` exists solely as legacy
+nesting for `sqlite_split_read_write`, which is also accepted directly on the environment block.
+"""
+const VALID_OPTION_KEYS = ("sqlite_split_read_write",)
+
+"""
+    CONNECTION_KEY_ALIASES
+
+Spellings borrowed from *other tools* — libpq (`user`, `dbname`), ActiveRecord (`pool`), Django
+(`ENGINE`, `NAME`, `USER`) — rather than typos of PormG's own names. Edit distance cannot reach
+them and must not try: `user` is 4 edits from `username` on a 4-character word, and worse,
+`_suggest_name("pool", VALID_CONNECTION_KEYS)` lands on `port` (distance 2, inside the relative
+threshold), i.e. the flagship footgun would receive a *wrong* suggestion rather than none.
+
+Consulted **before** `_suggest_name` so it overrides that. Looked up case-folded, which covers
+Django's uppercase `DATABASES` keys for free.
+"""
+const CONNECTION_KEY_ALIASES = Dict{String,String}(
+  "user" => "username", "usr" => "username", "uid" => "username",
+  "pass" => "password", "passwd" => "password", "pwd" => "password",
+  "db" => "database", "dbname" => "database", "db_name" => "database", "name" => "database",
+  "pool" => "pool_size", "poolsize" => "pool_size", "max_pool_size" => "pool_size",
+  "hostname" => "host",
+  "engine" => "adapter", "driver" => "adapter",
+)
+
+# A key written with no value (`url:`) parses to `nothing`, and one written blank (`url: ''`) to an
+# empty string. Both mean "not set" — neither should be treated as a configured value.
+_is_unset(v) = v === nothing || (v isa AbstractString && isempty(strip(v)))
+
+# Ordered, not a Dict: `Dict` iteration order is unspecified, so a value matching two names
+# (e.g. "debug_info") previously resolved differently between runs.
+const LOG_LEVEL_NAMES = (("debug", Logging.Debug), ("info", Logging.Info),
+                         ("warn", Logging.Warn), ("error", Logging.Error))
+
+# Apply a `config: log_level:` value. Substring matching is deliberate — "warning" means `warn` —
+# but a value matching nothing used to leave the default in place silently (#348).
+function _apply_log_level!(settings::PormGSettings, v)::Nothing
+  text = lowercase(string(v))
+  for (name, level) in LOG_LEVEL_NAMES
+    if occursin(name, text)
+      settings.log_level = level
+      return nothing
+    end
+  end
+  @warn "connection.yml: unrecognised `log_level:` value; keeping the default" value=v env=settings.app_env supported=first.(LOG_LEVEL_NAMES)
+  return nothing
+end
+
+# Every message in this family is prefixed `connection.yml: ` on purpose — one `occursin` filter
+# then covers the whole family in tests, including the "a valid file emits none of them" guard.
+# No `maxlog`/`_id`: the output is bounded by the file's key count on a single `load()`, and the
+# repo's warn-once policy (src/AdvisoryLock.jl) exists for unbounded call sites, not this.
+function _warn_unknown_env_key(k::String, app_env::AbstractString)::Nothing
+  if k in VALID_CONFIG_KEYS
+    @warn "connection.yml: key belongs under the environment's `config:` block; ignored here" key=k env=app_env move_to="config"
+    return nothing
+  end
+
+  alias = get(CONNECTION_KEY_ALIASES, lowercase(k), nothing)
+  if alias !== nothing
+    @warn "connection.yml: unrecognised connection key; ignored" key=k env=app_env did_you_mean=alias
+    return nothing
+  end
+
+  suggestion = _suggest_name(k, VALID_CONNECTION_KEYS)
+  if suggestion !== nothing
+    @warn "connection.yml: unrecognised connection key; ignored" key=k env=app_env did_you_mean=suggestion
+    return nothing
+  end
+
+  # Only once nothing in this block's OWN vocabulary is close: a near-miss on a `config:` key is
+  # almost certainly a misplaced *and* misspelled setting (`timezone:` sitting at the env level).
+  # Deliberately NOT mirrored in the `config:` loop — there the same fallback resolves
+  # `connections` to `options` (distance 5 on an 11-character word), a false positive the #365
+  # tests pin.
+  misplaced = _suggest_name(k, VALID_CONFIG_KEYS)
+  if misplaced !== nothing
+    @warn "connection.yml: key belongs under the environment's `config:` block; ignored here" key=k env=app_env move_to="config" did_you_mean=misplaced
+    return nothing
+  end
+
+  @warn "connection.yml: unrecognised connection key; ignored" key=k env=app_env
+  return nothing
+end
+
+function _warn_unknown_env_keys(env_block::AbstractDict, app_env::AbstractString)::Nothing
+  for k in keys(env_block)
+    k_str = string(k)
+    k_str in VALID_CONNECTION_KEYS && continue
+    _warn_unknown_env_key(k_str, app_env)
+  end
+  return nothing
+end
+
+function _warn_unknown_option_keys(options::AbstractDict, app_env::AbstractString)::Nothing
+  for k in keys(options)
+    k_str = string(k)
+    k_str in VALID_OPTION_KEYS && continue
+    # The two levels are distinguished, not merged: sending a `config:` setting to the environment
+    # block would just earn it a second warning telling it to move again.
+    if k_str in VALID_CONNECTION_KEYS
+      @warn "connection.yml: key does not belong under `options:`; ignored" key=k_str env=app_env move_to="environment"
+    elseif k_str in VALID_CONFIG_KEYS
+      @warn "connection.yml: key does not belong under `options:`; ignored" key=k_str env=app_env move_to="config"
+    else
+      @warn "connection.yml: unrecognised `options:` key; ignored" key=k_str env=app_env supported=VALID_OPTION_KEYS
+    end
+  end
+  return nothing
+end
+
+# Environment-block NAMES are arbitrary user strings, so the only decidable rule at the file level
+# is "a value that is not a mapping". A block written with an empty body (`prod:` and nothing
+# under it) parses to `nothing`, so it is skipped too — it is a block, just an empty one.
+#
+# `app_env` is skipped as well: a malformed *active* block (`dev: somestring`) is not an unknown
+# key, and the caller raises a precise InvalidConfigurationError for it a few lines later. Without
+# this the user would get a misleading "unrecognised top-level key: dev" first.
+function _warn_unknown_top_level_keys(db_conn_data::AbstractDict, app_env::AbstractString)::Nothing
+  for (k, v) in db_conn_data
+    (v isa AbstractDict || v === nothing) && continue
+    k_str = string(k)
+    (k_str == "default_env" || k_str == "env" || k_str == app_env) && continue
+    if k_str in VALID_CONNECTION_KEYS || k_str in VALID_CONFIG_KEYS
+      @warn "connection.yml: setting found outside any environment block; ignored" key=k_str move_to="environment"
+    else
+      suggestion = _suggest_name(k_str, ("default_env",))
+      if suggestion !== nothing
+        @warn "connection.yml: unrecognised top-level key; ignored" key=k_str did_you_mean=suggestion
+      else
+        @warn "connection.yml: unrecognised top-level key; ignored" key=k_str
+      end
+    end
+  end
+  return nothing
+end
+
+"""
+    read_db_connection_data(path::String, settings::PormGSettings) :: Dict{String,Any}
+
+Read `<path>/connection.yml` and return the block for `settings.app_env`, after applying that
+block's `config:` settings onto `settings`.
+
+Validates as it goes (#348/#365): any key PormG does not read — at the file level, on the
+environment block, under `config:`, or under `options:` — emits a `@warn` naming the key, with a
+"did you mean" suggestion when the name is close to a real one. Keys written at the wrong level
+are reported as misplaced rather than unknown.
+
+Throws `MissingConfigurationError` when the file has no block for the selected environment, and
+`InvalidConfigurationError` when the block is not a mapping or has no `adapter:`.
+"""
 function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{String,Any}
   db_settings_file = joinpath(path, PORMG_DB_CONFIG_FILE_NAME) 
 
@@ -614,32 +785,72 @@ function read_db_connection_data(path::String, settings::PormGSettings) :: Dict{
     @warn "Ignoring the legacy top-level `env:` key in $(db_settings_file) — it was renamed to `default_env:` (#205) and a bare `env:` no longer selects an environment. Rename it to `default_env:` or remove it. Active environment: $(settings.app_env)." maxlog=1 _id=Symbol(:pormg_legacy_env_key_, db_settings_file)
   end
 
-  if  haskey(db_conn_data, settings.app_env)
-      if haskey(db_conn_data[settings.app_env], "config") && isa(db_conn_data[settings.app_env]["config"], Dict)
-        for (k, v) in db_conn_data[settings.app_env]["config"]
-          k_str = string(k)
-          if k_str in VALID_CONFIG_KEYS
-            if k_str == "log_level"
-              for dl in Dict("debug" => Logging.Debug, "error" => Logging.Error, "info" => Logging.Info, "warn" => Logging.Warn)
-                occursin(dl[1], lowercase(string(v))) && setfield!(settings, Symbol(k_str), dl[2])
-              end
-            else
-              setfield!(settings, Symbol(k_str), ((isa(v, String) && startswith(v, ":")) ? Symbol(v[2:end]) : v) )
-            end
+  # A key nobody reads is a silent misconfiguration (#348): warn at every level of the file — the
+  # environment block, its `options:` sub-block, and the file level — before the pool is built.
+  # The ordering is load-bearing: `_build_connection_pool!` injects ~14 `nothing` keys into this
+  # dict via `get!`, so validating after it would warn on PormG's own bookkeeping.
+  _warn_unknown_top_level_keys(db_conn_data, settings.app_env)
+
+  if haskey(db_conn_data, settings.app_env)
+    env_block = db_conn_data[settings.app_env]
+    env_block isa AbstractDict || throw(InvalidConfigurationError(
+      "environment \"$(settings.app_env)\" in $(db_settings_file) is not a block of settings. " *
+      "Indent its keys (`adapter:`, `database:`, …) underneath it."))
+
+    _warn_unknown_env_keys(env_block, settings.app_env)
+
+    # Checked here rather than in `_build_connection_pool!`, which used to index it unguarded and
+    # raise a bare `KeyError("adapter")` several frames from the file that lacked it (#348).
+    adapter = get(env_block, "adapter", nothing)
+    if _is_unset(adapter)
+      throw(InvalidConfigurationError(
+        "environment \"$(settings.app_env)\" in $(db_settings_file) has no `adapter:`. " *
+        "Set `adapter: PostgreSQL` or `adapter: SQLite`."))
+    end
+
+    # `url:` is honoured only by the PostgreSQL branch of `_build_connection_pool!`. Under SQLite
+    # it is dropped and the pool silently falls back to `host:`/`database:` — or, with neither, to
+    # an in-memory database that vanishes at exit. Same class of silent loss as an unknown key
+    # (#348), and the existing `extensions`-on-SQLite warning sets the precedent.
+    if adapter == "SQLite" && !_is_unset(get(env_block, "url", nothing))
+      @warn "connection.yml: `url:` is ignored on SQLite; set the file path in `database:` instead" key="url" env=settings.app_env
+    end
+
+    cfg = get(env_block, "config", nothing)
+    if cfg isa AbstractDict
+      for (k, v) in cfg
+        k_str = string(k)
+        if k_str in VALID_CONFIG_KEYS
+          if k_str == "log_level"
+            _apply_log_level!(settings, v)
           else
-            did_you_mean = _suggest_name(k_str, VALID_CONFIG_KEYS)
-            if did_you_mean !== nothing
-              @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env did_you_mean=did_you_mean
-            else
-              @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env
-            end
+            setfield!(settings, Symbol(k_str), ((isa(v, String) && startswith(v, ":")) ? Symbol(v[2:end]) : v) )
+          end
+        elseif k_str in VALID_CONNECTION_KEYS
+          # Exact membership only — no `_suggest_name` fallback in this direction, which would
+          # resolve `connections:` to `options` and mislabel an internal-field attempt.
+          @warn "connection.yml: key belongs directly under the environment block, not under `config:`; ignored" key=k_str env=settings.app_env move_to="environment"
+        else
+          did_you_mean = _suggest_name(k_str, VALID_CONFIG_KEYS)
+          if did_you_mean !== nothing
+            @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env did_you_mean=did_you_mean
+          else
+            @warn "connection.yml: unrecognised config key; ignored" key=k_str env=settings.app_env
           end
         end
       end
+    elseif cfg !== nothing
+      @warn "connection.yml: `config:` must be a block of settings; ignored" env=settings.app_env got=typeof(cfg)
+    end
 
-      if ! haskey(db_conn_data[settings.app_env], "options") || ! isa(db_conn_data[settings.app_env]["options"], Dict)
-        db_conn_data[settings.app_env]["options"] = Dict{String,String}()
-      end
+    opts = get(env_block, "options", nothing)
+    if opts isa AbstractDict
+      _warn_unknown_option_keys(opts, settings.app_env)
+    else
+      opts === nothing ||
+        @warn "connection.yml: `options:` must be a block of settings; ignored" env=settings.app_env got=typeof(opts)
+      env_block["options"] = Dict{String,String}()
+    end
   end
 
   haskey(db_conn_data, settings.app_env) && return db_conn_data[settings.app_env]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -36,13 +36,17 @@ import Logging
   mktempdir() do tmpdir
     original_dir = pwd()
     cd(tmpdir) do
-      # Create dummy connection files so load doesn't error or trigger Generator's interactive/long errors
+      # Create dummy connection files so load doesn't error or trigger Generator's interactive/long errors.
+      # `adapter:`/`database:` must sit inside an environment block: written at the top level they
+      # belong to no environment, so `load()` threw `MissingConfigurationError` into the `try` below
+      # and this workload only ever warmed the *failure* path (#348).
       for d in ["db", "db_sch"]
         mkdir(d)
         open(joinpath(d, "connection.yml"), "w") do f
           write(f, """
-          adapter: SQLite
-          database: ":memory:"
+          dev:
+            adapter: SQLite
+            database: ":memory:"
           """)
         end
       end
@@ -50,8 +54,11 @@ import Logging
       @compile_workload begin
         # 0. Precompile Configuration Loading (Mocked environment)
         try
-          Configuration.load()
-          Configuration.load("db_sch")
+          # `env=` explicitly: `_effective_env` lets `ENV["PORMG_ENV"]` outrank the file, so a
+          # maintainer precompiling with PORMG_ENV=test exported would otherwise miss the `dev:`
+          # block and land back on the swallowed-error path this fixture exists to avoid.
+          Configuration.load(; env="dev")
+          Configuration.load("db_sch"; env="dev")
         catch
         end
 
@@ -121,8 +128,15 @@ import Logging
     end
   end
 
-  # Cleanup mock config after precompilation is done
-  delete!(config, "precompile")
+  # Cleanup mock config after precompilation is done. "db"/"db_sch" are registered by the
+  # `Configuration.load` calls above and point at a now-deleted tmpdir, so they must not be
+  # serialized into the cache image alongside their pools.
+  for k in ("precompile", "db", "db_sch")
+    s = get(config, k, nothing)
+    s === nothing && continue
+    s.connections === nothing || close_pool!(s.connections)
+    delete!(config, k)
+  end
 end
 
 # ── Snoop-generated precompile hints ─────────────────────────────────────────

--- a/test/unit/test_configuration_api.jl
+++ b/test/unit/test_configuration_api.jl
@@ -703,3 +703,668 @@ end
         end
     end
 end
+
+# ── #348: unrecognised connection.yml keys outside the `config:` block ────────────────────────
+# #365 covered `config:`; every key directly under an environment block was still dropped in
+# silence. `user:` (libpq's spelling of `username:`) is the flagship case — libpq then falls back
+# to the OS user and the failure surfaces as an unrelated auth error. Misplacement between the two
+# levels gets its own message, because writing `change_data:` at the environment level was
+# previously documented as expected behaviour.
+
+# One filter for the whole warning family — every message carries the prefix on purpose, so the
+# "a valid file emits none of them" guard below cannot be fooled by a reworded message.
+_yml_warns(logs) = filter(l -> l.level == Logging.Warn && occursin("connection.yml:", l.message), logs)
+
+# Index the records (not just their kwargs) by `key=`, so a case can assert on the message too.
+_by_key(warns) = Dict(String(Dict(w.kwargs)[:key]) => w
+                      for w in warns if haskey(Dict(w.kwargs), :key))
+
+_kw(record) = Dict(record.kwargs)
+
+function _write_348_yml(db_dir::String, body::String)
+    mkpath(db_dir)
+    open(joinpath(db_dir, "connection.yml"), "w") do f
+        write(f, body)
+    end
+    return db_dir
+end
+
+function _load_348(db_dir::String)
+    logs, _ = Test.collect_test_logs() do
+        PormG.Configuration.load(db_dir; env="dev")
+    end
+    return _yml_warns(logs)
+end
+
+@testset "unrecognised connection.yml keys emit warnings (#348)" begin
+
+    @testset "other tools' spellings resolve through the alias table" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  user: pormg_user\n" *
+                "  pool: 10\n")
+
+            warns = _load_348(db_dir)
+            by_key = _by_key(warns)
+
+            @test length(warns) == 2
+
+            @test haskey(by_key, "user")
+            @test _kw(by_key["user"])[:env] == "dev"
+            @test _kw(by_key["user"])[:did_you_mean] == "username"
+            @test occursin("unrecognised connection key", by_key["user"].message)
+
+            # The mutation gate for "the alias table is consulted BEFORE `_suggest_name`":
+            # `_levenshtein("pool", "port") == 2` and `2*2 <= 4`, so edit distance alone resolves
+            # `pool:` to `port` — telling the user to rename their pool setting to a TCP port.
+            @test haskey(by_key, "pool")
+            @test _kw(by_key["pool"])[:did_you_mean] == "pool_size"
+            @test _kw(by_key["pool"])[:did_you_mean] != "port"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "a real typo still resolves by edit distance" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  sslmod: require\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test _kw(warns[1])[:did_you_mean] == "sslmode"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "an invented key warns without a suggestion" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  completely_unknown_setting: 1\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("unrecognised connection key", warns[1].message)
+            @test !haskey(_kw(warns[1]), :did_you_mean)
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "a config: key at the environment level says where it belongs" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  change_data: true\n" *
+                "  timezone: 'America/Sao_Paulo'\n")
+
+            warns = _load_348(db_dir)
+            by_key = _by_key(warns)
+
+            @test length(warns) == 2
+            for w in warns
+                @test occursin("belongs under the environment's `config:` block", w.message)
+            end
+
+            # Exact member of VALID_CONFIG_KEYS: misplaced, not misspelled.
+            @test _kw(by_key["change_data"])[:move_to] == "config"
+            @test !haskey(_kw(by_key["change_data"]), :did_you_mean)
+
+            # Misplaced *and* misspelled: the config-key fallback fires only after the environment
+            # block's own vocabulary comes up empty.
+            @test _kw(by_key["timezone"])[:move_to] == "config"
+            @test _kw(by_key["timezone"])[:did_you_mean] == "time_zone"
+
+            # The setting really was discarded — this is the claim the docs used to make.
+            @test PormG.Configuration.get_settings(db_dir).change_data == false
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "an environment key under config: says where it belongs" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  config:\n" *
+                "    change_data: true\n" *
+                "    pool_size: 10\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("belongs directly under the environment block", warns[1].message)
+            @test _kw(warns[1])[:key] == "pool_size"
+            @test _kw(warns[1])[:move_to] == "environment"
+            @test _kw(warns[1])[:env] == "dev"
+
+            # This direction must NOT fall back to `_suggest_name`, so a misplaced key is never
+            # also reported as an unrecognised one.
+            @test isempty(filter(l -> occursin("unrecognised config key", l.message), warns))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "settings outside any environment block are reported" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "adapter: SQLite\n" *
+                "defaultenv: dev\n" *
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n")
+
+            warns = _load_348(db_dir)
+            by_key = _by_key(warns)
+
+            @test length(warns) == 2
+
+            @test occursin("outside any environment block", by_key["adapter"].message)
+            @test _kw(by_key["adapter"])[:move_to] == "environment"
+
+            @test occursin("unrecognised top-level key", by_key["defaultenv"].message)
+            @test _kw(by_key["defaultenv"])[:did_you_mean] == "default_env"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "an empty environment block is not mistaken for a stray key" begin
+        mktempdir() do temp_root
+            # `prod:` with no body parses to `nothing`, not a Dict — it is a block, just an empty
+            # one, and flagging it would fire on ordinary multi-environment files.
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "default_env: dev\n" *
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "prod:\n")
+
+            @test isempty(_load_348(db_dir))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "options: block is validated against its one supported key" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  options:\n" *
+                "    sqlite_split_read_write: true\n")
+
+            @test isempty(_load_348(db_dir))
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  options:\n" *
+                "    foo: 1\n" *
+                "    pool_size: 10\n")
+
+            warns = _load_348(db_dir)
+            by_key = _by_key(warns)
+
+            @test length(warns) == 2
+            @test occursin("unrecognised `options:` key", by_key["foo"].message)
+            @test occursin("does not belong under `options:`", by_key["pool_size"].message)
+            @test _kw(by_key["pool_size"])[:move_to] == "environment"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # A `config:` setting nested under `options:` must be sent to `config:`, not to the
+        # environment block — which would only earn it a second warning telling it to move again.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  options:\n" *
+                "    change_data: true\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test _kw(warns[1])[:key] == "change_data"
+            @test _kw(warns[1])[:move_to] == "config"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # `options:` that is not a mapping was replaced by an empty Dict in silence — the same
+        # asymmetry `config:` used to have.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  options: nope\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("`options:` must be a block of settings", warns[1].message)
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "url: is reported as inert on SQLite" begin
+        # `url:` is read only by the PostgreSQL branch. Under SQLite it was dropped and the pool
+        # fell back to an in-memory database that vanishes at exit — the #348 failure exactly.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  url: 'sqlite:///data.db'\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("`url:` is ignored on SQLite", warns[1].message)
+            @test _kw(warns[1])[:env] == "dev"
+
+            # The silent fallback the warning is about.
+            @test PormG.Configuration.get_settings(db_dir).connections.connection_string == ":memory:"
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # …and it stays quiet on PostgreSQL, where `url:` IS honoured. This is the discriminating
+        # half: without it, deleting the `adapter == "SQLite"` guard leaves the suite green while
+        # every legitimate PostgreSQL `url:` config starts warning.
+        #
+        # `read_db_connection_data` emits the warning without building a pool, so this needs no
+        # live PostgreSQL — `load` would try to construct one.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: PostgreSQL\n" *
+                "  url: 'postgres://user@host/db'\n")
+
+            settings = PormG.Configuration.Settings(app_env="dev", db_def_folder=db_dir)
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.read_db_connection_data(db_dir, settings)
+            end
+            @test isempty(_yml_warns(logs))
+        end
+
+        # A blank `url:` is "not set", on either adapter.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  url: ''\n" *
+                "  database: 'real.sqlite'\n")
+
+            @test isempty(_load_348(db_dir))
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "a blank url: does not discard the PostgreSQL credentials beside it" begin
+        # `url: ''` used to satisfy the pool builder's `!== nothing` gate, producing an EMPTY DSN:
+        # every credential in the block was dropped and libpq fell back to PGHOST/PGUSER or the
+        # local socket as the OS user — the flagship #348 failure, from a config that looks
+        # complete. The validator and the pool builder must agree on what "unset" means.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: PostgreSQL\n" *
+                "  url: ''\n" *
+                "  host: 127.0.0.1\n" *
+                "  port: 5499\n" *
+                "  database: pormg_348\n" *
+                "  username: pormg_user\n" *
+                "  password: pormg_pass\n")
+
+            settings = PormG.Configuration.Settings(app_env="dev", db_def_folder=db_dir)
+            settings.db_config_settings =
+                PormG.Configuration.read_db_connection_data(db_dir, settings)
+
+            # Build only the DSN, not a connection: assert on what the pool would be handed.
+            PormG.Configuration._build_connection_pool!(settings, db_dir)
+            dsn = settings.connections.connection_string
+
+            @test !isempty(dsn)
+            @test occursin("dbname=pormg_348", dsn)
+            @test occursin("user=pormg_user", dsn)
+            @test occursin("host=127.0.0.1", dsn)
+
+            PormG.Configuration.close_pool!(settings.connections)
+        end
+    end
+
+    @testset "a config: block that is not a mapping is reported, not skipped" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  config: true\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("`config:` must be a block of settings", warns[1].message)
+            @test _kw(warns[1])[:env] == "dev"
+
+            @test PormG.Configuration.get_settings(db_dir).change_data == false
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "log_level: values" begin
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  config:\n" *
+                "    log_level: 'verbose'\n")
+
+            warns = _load_348(db_dir)
+
+            @test length(warns) == 1
+            @test occursin("unrecognised `log_level:` value", warns[1].message)
+            @test PormG.Configuration.get_settings(db_dir).log_level == Logging.Debug
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # Substring matching is deliberate and must survive the Dict -> ordered-tuple change.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  config:\n" *
+                "    log_level: 'warning'\n")
+
+            @test isempty(_load_348(db_dir))
+            @test PormG.Configuration.get_settings(db_dir).log_level == Logging.Warn
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # A value containing two level names must resolve deterministically: the matcher walks
+        # LOG_LEVEL_NAMES in order and stops at the FIRST hit. The `Dict` + no-`break` loop this
+        # replaced took the LAST match in an unspecified iteration order.
+        #
+        # `info_warn` is the value that discriminates. It must be `Info` (first in declared order);
+        # last-match-wins yields `Warn`. A value like `debug_or_error` proves nothing — it happens
+        # to come back `Debug` under both.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n" *
+                "  config:\n" *
+                "    log_level: 'info_warn'\n")
+
+            @test isempty(_load_348(db_dir))
+            @test PormG.Configuration.get_settings(db_dir).log_level == Logging.Info
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # Order-independent statement of the same contract, so a reordering of the tuple is caught
+        # even where a two-name value happens to agree.
+        @test first(PormG.Configuration.LOG_LEVEL_NAMES)[1] == "debug"
+        @test [n for (n, _) in PormG.Configuration.LOG_LEVEL_NAMES] ==
+              ["debug", "info", "warn", "error"]
+    end
+
+    @testset "the legacy env: key keeps its own warning and gains no second one" begin
+        # `env:` is inert (#205) and already warns with a migration nudge. The file-level scan must
+        # skip it, or every stale config — including the repo's own db_2/db_sl fixtures — would
+        # also be told `env` is an unrecognised top-level key.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "env: dev\n" *
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  database: \":memory:\"\n")
+
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.load(db_dir; env="dev")
+            end
+
+            @test isempty(filter(l -> occursin("unrecognised top-level key", l.message),
+                                 _yml_warns(logs)))
+            # The #205 warning itself must survive.
+            @test !isempty(filter(l -> l.level == Logging.Warn &&
+                                       occursin("legacy top-level `env:` key", l.message), logs))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "an unusable environment block fails loudly" begin
+        # Missing `adapter:` used to reach `_build_connection_pool!` and raise a bare
+        # KeyError("adapter") several frames from the file that lacked it.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  database: \":memory:\"\n")
+
+            err = try
+                PormG.Configuration.load(db_dir; env="dev"); nothing
+            catch e
+                e
+            end
+            @test err isa PormG.InvalidConfigurationError
+            @test occursin("dev", sprint(showerror, err))
+            @test occursin("adapter", sprint(showerror, err))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "dev:\n" *
+                "  adapter: '  '\n" *
+                "  database: \":memory:\"\n")
+
+            # Assert the message, not just the type: a blank adapter reaches
+            # `_build_connection_pool!` and raises InvalidConfigurationError("Unsupported adapter:")
+            # on its own, so a bare @test_throws stays green with this guard deleted.
+            err = try
+                PormG.Configuration.load(db_dir; env="dev"); nothing
+            catch e
+                e
+            end
+            @test err isa PormG.InvalidConfigurationError
+            @test occursin("has no `adapter:`", sprint(showerror, err))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+
+        # An environment name whose value is a scalar used to die with a raw MethodError from
+        # `haskey(::String, ::String)`.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"), "dev: somestring\n")
+
+            logs, _ = Test.collect_test_logs() do
+                try
+                    PormG.Configuration.load(db_dir; env="dev")
+                catch
+                end
+            end
+
+            err = try
+                PormG.Configuration.load(db_dir; env="dev"); nothing
+            catch e
+                e
+            end
+            @test err isa PormG.InvalidConfigurationError
+            @test occursin("not a block of settings", sprint(showerror, err))
+
+            # …and it must not ALSO be reported as an unknown top-level key. `dev` is a recognised
+            # environment name; the file-level scan cannot tell a malformed block from a stray
+            # setting, so it defers to the precise error above for the active environment.
+            @test isempty(filter(l -> occursin("unrecognised top-level key", l.message),
+                                 _yml_warns(logs)))
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "a fully valid file emits no key warnings at all" begin
+        # The false-positive guard: every member of VALID_CONNECTION_KEYS and VALID_CONFIG_KEYS in
+        # one file. The PostgreSQL-only keys are inert under `adapter: SQLite` — they are read only
+        # in the PG branch of `_build_connection_pool!` — which is what lets one file cover both.
+        mktempdir() do temp_root
+            db_dir = _write_348_yml(joinpath(temp_root, "db"),
+                "default_env: dev\n" *
+                "dev:\n" *
+                "  adapter: SQLite\n" *
+                "  url: ''\n" *
+                "  database: \":memory:\"\n" *
+                "  host: 'pormg348.sqlite'\n" *
+                "  hostaddr: ''\n" *
+                "  port: 5432\n" *
+                "  username: pormg_user\n" *
+                "  password: pormg_pass\n" *
+                "  passfile: ''\n" *
+                "  connect_timeout: 5\n" *
+                "  client_encoding: UTF8\n" *
+                "  sslmode: prefer\n" *
+                "  sslrootcert: ''\n" *
+                "  sslcert: ''\n" *
+                "  sslkey: ''\n" *
+                "  pool_size: 2\n" *
+                "  pool_timeout: 30\n" *
+                "  idle_timeout: 0\n" *
+                "  max_lifetime: 0\n" *
+                "  leak_detection_threshold: 0\n" *
+                "  fail_fast_on_connect: true\n" *
+                "  sqlite_split_read_write: false\n" *
+                "  extensions: []\n" *
+                "  options:\n" *
+                "    sqlite_split_read_write: false\n" *
+                "  config:\n" *
+                "    change_db: true\n" *
+                "    change_data: true\n" *
+                "    django_prefix: myapp\n" *
+                "    time_zone: 'UTC'\n" *
+                "    log_queries: false\n" *
+                "    log_level: 'warn'\n" *
+                "    log_to_file: false\n" *
+                "    model_file: 'custom_models.jl'\n")
+
+            @test isempty(_load_348(db_dir))
+
+            # The guard only means something if the file it approves also still loads correctly.
+            s = PormG.Configuration.get_settings(db_dir)
+            @test s.change_data == true
+            @test s.django_prefix == "myapp"
+            @test s.log_level == Logging.Warn
+
+            _cleanup_configuration_test_keys([db_dir])
+        end
+    end
+
+    @testset "the allowlists and the alias table stay self-consistent" begin
+        conn = Set(PormG.Configuration.VALID_CONNECTION_KEYS)
+
+        # `config:` and `options:` are the nested blocks; both must be allowlisted or the loader
+        # would warn about the very keys it reads.
+        @test "config" in conn
+        @test "options" in conn
+        @test issubset(Set(PormG.Configuration.VALID_OPTION_KEYS), conn)
+
+        # The two levels are disjoint vocabularies — an overlap would make the misplacement
+        # branches unreachable and ambiguous.
+        @test isempty(intersect(conn, Set(PormG.Configuration.VALID_CONFIG_KEYS)))
+
+        # Every alias must point at a key the loader actually reads, and must not shadow one.
+        for (alias, target) in PormG.Configuration.CONNECTION_KEY_ALIASES
+            @test target in conn
+            @test !(alias in conn)
+            @test alias == lowercase(alias)   # looked up case-folded
+        end
+    end
+
+    @testset "register_connection is not touched by the yaml validators" begin
+        mktempdir() do temp_root
+            key = "pormg_348_dynamic"
+            logs, _ = Test.collect_test_logs() do
+                PormG.Configuration.register_connection(key, joinpath(temp_root, "dyn.sqlite");
+                                                        adapter="SQLite")
+            end
+            @test isempty(_yml_warns(logs))
+            PormG.Configuration.unregister_connection(key)
+        end
+    end
+
+    @testset "validators are callable directly, without a file" begin
+        logs, _ = Test.collect_test_logs() do
+            PormG.Configuration._warn_unknown_env_keys(
+                Dict("adapter" => "SQLite", "user" => "x", "pool" => 3), "dev")
+        end
+        warns = _yml_warns(logs)
+        by_key = _by_key(warns)
+
+        @test length(warns) == 2
+        @test _kw(by_key["user"])[:did_you_mean] == "username"
+        @test _kw(by_key["pool"])[:did_you_mean] == "pool_size"
+    end
+
+    @testset "every allowlisted key is documented" begin
+        # The allowlist is now the specification of what `connection.yml` accepts, so a key added
+        # to it without a line in the docs is a key users cannot discover. Before #348 this had
+        # already happened to `url`, `sqlite_split_read_write`, `options`, `hostaddr`, `passfile`,
+        # `connect_timeout`, `client_encoding` and all four `ssl*` keys — none appeared anywhere
+        # in `docs/`.
+        docs_dir = normpath(joinpath(@__DIR__, "..", "..", "docs", "src", "configuration"))
+        @test isdir(docs_dir)
+
+        # `.md` is not pinned to LF in `.gitattributes`, so a Windows checkout yields CRLF (#216).
+        corpus = join([replace(read(joinpath(root, f), String), "\r\n" => "\n")
+                       for (root, _, files) in walkdir(docs_dir)
+                       for f in files if endswith(f, ".md")], "\n")
+
+        # A bare `occursin(k, corpus)` would be green theater: "url" matches any hyperlink, "port"
+        # matches "important", "options" matches ordinary prose. A `"$k:"` arm is barely better —
+        # "port:" is satisfied by "support:". Require the key as a markdown code span, which is how
+        # the reference table and every prose mention spell it.
+        _documented(k) = occursin("`$k`", corpus)
+
+        # Self-check: the matcher must be able to fail, or the loop below proves nothing. The
+        # second decoy is the substring case a looser matcher would wave through.
+        @test !_documented("definitely_not_a_real_key")
+        @test !_documented("por")
+
+        for k in (PormG.Configuration.VALID_CONNECTION_KEYS...,
+                  PormG.Configuration.VALID_CONFIG_KEYS...,
+                  PormG.Configuration.VALID_OPTION_KEYS...)
+            @test _documented(k)
+        end
+    end
+end


### PR DESCRIPTION
Closes #348.

## Context

The `config:` half of #348 was already fixed by #365 (`af8d8889`). What was still live is the residual matching the issue's **title**: every key *directly under an environment block* was read by ad-hoc `haskey`/`get`/`get!` calls in `_build_connection_pool!` and `_configured_extensions`, with no allowlist and no warning.

The flagship case is `user:` instead of `username:` — dropped silently, so libpq falls back to the OS user and the failure surfaces as an unrelated auth error. Same for `pool:` vs `pool_size:`, `sslmod:` silently not enforcing TLS, and `change_data:`/`time_zone:` written at the environment level instead of under `config:` — a trap `docs/src/configuration/connection_yml.md` previously documented as expected behaviour.

## Approach

`VALID_CONNECTION_KEYS` (25 keys), `VALID_OPTION_KEYS`, and a `CONNECTION_KEY_ALIASES` table for spellings borrowed from other tools (libpq `user`/`dbname`, ActiveRecord `pool`, Django `ENGINE`/`NAME`, case-folded). Warn, never throw — consistent with #365 — except where the config is unusable.

All validation runs inside `read_db_connection_data`, **before** `_build_connection_pool!` injects ~14 `nothing` keys via `get!`; validating after it would warn on PormG's own bookkeeping. `register_connection` builds `db_config_settings` from typed kwargs and never enters this path, so it is unaffected by construction.

Two decisions worth knowing, both verified empirically rather than assumed:

- **The alias table is consulted before `_suggest_name`.** `_levenshtein("pool", "port") == 2` and `2*2 <= 4`, so edit distance alone resolves `pool:` to `port` — telling the user to rename their pool setting to a TCP port. A test pins the ordering.
- **The `config:` → environment direction is exact-membership only, with no distance fallback.** `_suggest_name("connections", VALID_CONNECTION_KEYS)` returns `"options"`, which would mislabel an internal-field attempt and change the #365 warning counts. The four #365 testsets are unchanged and are the regression detector for this.

## Adjacent fixes in the same function

All approved in advance; each sat in the lines being rewritten.

| Before | After |
|---|---|
| missing/blank `adapter:` → bare `KeyError("adapter")` several frames away | `InvalidConfigurationError` naming the environment and both adapters |
| environment block that is not a mapping → raw `MethodError` from `haskey(::String, ::String)` | `InvalidConfigurationError` |
| `config:` not a mapping → whole block discarded in silence | warns |
| unrecognised `log_level:` value → silently keeps the default | warns; `LOG_LEVEL_NAMES` replaces a `Dict` literal whose unspecified iteration order plus a missing `break` made a two-name value resolve differently between runs |

## Two things found while implementing

**`src/precompile.jl` wrote a malformed fixture** — `adapter:`/`database:` at the top level, in no environment block. `Configuration.load()` there is wrapped in a bare `try/catch`, so the workload's *"0. Precompile Configuration Loading"* step has only ever warmed the **failure** path. The fixture is fixed, both loads now pass `env="dev"` so an exported `PORMG_ENV` cannot reselect, and the `db`/`db_sch` entries `load` registers are cleaned up alongside the existing `"precompile"` cleanup.

**A blank `url:` produced an empty PostgreSQL DSN.** `_build_connection_pool!` gated on `!== nothing`, so `url: ''` discarded every credential beside it and handed libpq an empty conninfo — falling back to `PGHOST`/`PGUSER` or the local socket as the OS user. That is the flagship #348 failure reached from a config that looks complete. A shared `_is_unset` helper now backs both the validator and the pool builder, so the two halves agree on what "unset" means. Relatedly, `url:` under `adapter: SQLite` is ignored entirely — the pool falls back to an in-memory database that vanishes at exit — and now warns.

## Docs

New **Environment-block Keys** reference — the first documentation anywhere for `url`, `sqlite_split_read_write`, `options`, `hostaddr`, `passfile`, `connect_timeout`, `client_encoding` and the four `ssl*` keys. The admonition that documented the misplacement trap as expected behaviour is rewritten; its "or under a different environment" clause is deliberately **kept**, because that case remains genuinely silent (only the active block is read, so there is nothing to check against).

A drift guard pins every allowlisted key to a markdown code span in `docs/src/configuration/`, so the next key added to the allowlist cannot go undocumented.

## Verification

- Full unit suite **7234/7234**; `#348` testset 173 assertions; `#365` still exactly 27 and `#205` still 17
- Docs build exit 0
- Real `db_2` config load: zero #348-family warnings, DSN correct, reachable; `test_connection_pool.jl` and `test_docs_error_types.jl` slices pass
- `db_sl`: `test_cte.jl` passes

Two independent review rounds. The second found three real defects **in the first round's fixes** — including two cases of green theater in the new tests (a `@test_throws` that stayed green with its guard deleted, and a `log_level` fixture whose value resolved identically under old and new code). Both replaced with discriminating assertions.

## Deliberately not done

- **No `UPGRADING.md` entry.** Everything is additive warnings or a fix to something already broken — the file's rule is "only what *forces* an app edit". The blank-`url:` change is the one arguable case; any app relying on the old behaviour was silently connecting to the wrong database.
- **No `Project.toml` bump** (release trains).
- Left pre-existing: a non-string environment-block key (`5: x`) still dies with a raw `MethodError` from the `Dict{String,Any}` return annotation; and `log_level`/`log_queries`/`log_to_file` are written to `Settings` but never read anywhere in `src/`, so the new "keeping the default" warning names a setting that currently does nothing. Both are follow-up material.

Unrelated observation: the `db_sl` slice `test_row_and_get.jl` fails on a stale fixture — it wants `contract_django_scratch` but `f1.sqlite` still has the pre-#325 `django_contract_scratch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
