### PR TITLE
fix(#391): pin Base.have_color so the #380 ANSI assertion is launch-independent

### DIFF
--- a/test/unit/test_bulk_update_column_scope.jl
+++ b/test/unit/test_bulk_update_column_scope.jl
@@ -796,7 +796,16 @@ end
                 # the guard lives in the shared _prepare_bulk_df!, so a regression could hit
                 # one path only if a caller ever stopped routing through it.
                 @testset "$op_name" begin
+                    # `Base.have_color` is PINNED for the call, not just for the assertion: the
+                    # subtype constructor bakes the color decision into `msg` at construction time
+                    # (`_emsg`, `src/Kernel.jl`), so by the time the error is caught the escapes are
+                    # already in or already out. Unpinned, the ANSI assertion below silently depended
+                    # on how Julia was launched — it passed under a bare `julia` and failed under
+                    # `julia --color=yes`, which is exactly how CI runs the suite. Same idiom, and
+                    # the same reason, as `_with_have_color` in test_error_message_ansi.jl.
+                    _saved_have_color = Base.have_color
                     err = try
+                        Base.eval(Base, :(have_color = false))
                         bulk_op(
                             Metric.objects, df_conflict,
                             columns    = ["c1" => "weight", "c2" => "weight"],
@@ -805,6 +814,8 @@ end
                         nothing
                     catch e
                         e
+                    finally
+                        Base.eval(Base, :(have_color = $_saved_have_color))
                     end
                     @test err isa PormG.QueryBuildError
                     msg = sprint(showerror, err)
@@ -814,6 +825,10 @@ end
                     @test occursin("mapped from two different columns", msg)
                     # The message must name the operation it came from, and must render clean
                     # off-TTY — QueryBuildError's constructor runs _emsg, so no raw ANSI leaks.
+                    # Meaningful only because the construction above ran with color pinned OFF:
+                    # with color ON, `_emsg` is the identity, so this would pass even for a
+                    # constructor that never called it (the tautology test_error_message_ansi.jl
+                    # documents).
                     @test occursin("Error in $(op_name),", msg)
                     @test !occursin("\e[", msg)
                 end


### PR DESCRIPTION
## Summary

CI has been **red on `main` since #380 merged** (`7e1630bc`), and every branch opened since inherited
it — #348 (PR #385) and #360 (PR #386) both failed on a baseline they did not cause. Three assertions
fail, all at `test/unit/test_bulk_update_column_scope.jl:818`, for `bulk_update` / `bulk_insert` /
`bulk_copy`:

```
Expression: !(occursin("\e[", msg))
 Evaluated: !(occursin("\e[", "Error in bulk_update, the field \e[4m\e[31mweight\e[0m is mapped
            from two different columns in columns=: …"))
```

**This is a test defect, not a defect in the error message.** PormG decides error colorization at
**construction** time: every `PormGError` subtype constructor runs `_emsg(msg)` (`src/exceptions.jl`),
whose default is `color = (Base.have_color === true)` (`src/Kernel.jl`). That is the documented,
intended design.

Because the decision reads `Base.have_color`, it follows how Julia was **launched** — and
`julia-actions/julia-runtest` invokes the suite as `julia --color=yes …`. On CI, `_emsg` is therefore
the identity, the escapes stay in `msg`, and `sprint(showerror, err)` reproduces them faithfully.
Locally, a bare `julia --project=. test/runtests.jl` has color off, `_emsg` strips, and the assertion
passes. The test was launch-dependent, and nothing in the documented local recipe reproduces the CI
flag — so it was invisible locally by construction.

`test/unit/test_error_message_ansi.jl` already established the fix for exactly this, and states the
reason in its own comment — *"this lets the end-to-end assertions below exercise both the strip and
keep paths deterministically regardless of how the test process was launched"*. Every ANSI assertion
in that file is wrapped in its `_with_have_color` pin. Line 818 was the **only** ANSI assertion in the
suite without one, verified by grep across `test/`.

Two details the fix depends on:

- **The pin covers the call, not just the assertion.** The escapes are baked into `msg` when the
  exception is constructed, so by the time it is caught the decision is already made. Pinning only
  around the `@test` would change nothing.
- **It also makes the assertion meaningful.** With color ON, `_emsg` is the identity, so
  `!occursin("\e[", …)` would pass even for a constructor that never called `_emsg` at all — the
  tautology `test_error_message_ansi.jl` calls out explicitly. Pinned OFF, it genuinely tests that the
  constructor routed through `_emsg`.

## Test plan

- [x] Reproduced the failure on clean `main` (`a7255f33`) with `julia --color=yes` — the same three
      failures, so it is not specific to CI's OS or to any open branch.
- [x] Confirmed via CI history that the `fix/380-columns-duplicate-target` branch (`1f0e5b7a`) itself
      failed **before** either later branch existed; last green CI was `320fba88` (#347 merge).
- [x] `julia --color=yes --project=. test/runtests.jl` — **7298 pass, 0 fail** (this is how CI runs it).
- [x] `julia --color=no --project=. test/unit/test_bulk_update_column_scope.jl` — green, so the fix is
      genuinely launch-independent rather than flipped to the other launch mode.
- [x] Test-only change: one file, 15 added lines, no `src/` edit.

## Deliberately not done

- **No change to `_emsg` or the error taxonomy.** Construction-time colorization is documented and
  covered by `test_error_message_ansi.jl`; changing it would be a broad behavioral change to every
  `PormGError`, and the reported failure does not call for it.
- **No change to `.github/instructions/general.instructions.md`.** #391 lists adding `--color=yes` to
  the documented verification commands so the local recipe matches CI — a real gap, since the current
  *"Local green ≠ CI green"* note only warns about `Manifest.toml` resolution. Left off this PR
  because instruction edits are not committed unless asked; tracked on the issue.
- **`_with_have_color` not promoted to a shared test helper.** Worth doing so the next ANSI assertion
  has an obvious thing to reach for, but it touches two test files for no behavioral gain here.
  Tracked on the issue.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)
