### PR TITLE
fix(#388): a ForeignKey target that does not resolve is refused, not guessed

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,80 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## Foreign keys — an unresolved `to` target is refused, not lowercased into a table name (#388)
+
+- **Version**: Unreleased
+- **PormG ref**: #388; `src/Models.jl` (`fk_target_table`), `src/querybuilder/build_joins.jl`,
+  `docs/src/schema_conventions.md`
+- **Severity**: **behavior change (narrow)** — a `ForeignKey`/`OneToOneField` whose `to` names a model
+  that is **not in the models module** now raises instead of referencing/joining a fabricated table.
+  Runtime, not load time: the models file still loads, and the failure happens when the key is
+  rendered. A key whose target *does* resolve is unaffected. Part of the `0.5.x` wave.
+
+### What changed
+
+`to` holds the target's **Julia binding**, not its table name (#360/#386). Three call sites recovered
+a table from an unresolved `to` by **lowercasing it** — which is only the correct inverse while the
+binding happens to be `uppercasefirst(<table>)`. It silently produced a table that does not exist for
+every other shape, and it ignored the target's `db_table` outright:
+
+| live parent table | `to` | old render | now |
+|---|---|---|---|
+| `2fast` | `"Col_2fast"` | `REFERENCES "col_2fast"` | raises |
+| `driver profile` | `"Driver_profile"` | `JOIN "driver_profile"` | raises |
+| `driver` pinned to `db_table = "Legacy_Driver"` | `"Driver"` | `JOIN "driver"` | `JOIN "Legacy_Driver"` |
+
+The rule now is:
+
+> **A foreign key's target must be a model PormG can see. If it is, the table comes off that model
+> (honoring `db_table`). If it is not, PormG raises rather than inventing a table name.**
+
+The runtime path already worked this way — `set_models` raises `ModelDefinitionError` for an
+unresolvable target. This closes the two paths that did not: the migration prelude (which resolves
+best-effort and left a string behind) and the query builder's forward-FK join arms.
+
+Third row of the table is a **fix**, not a break: a `db_table`-pinned parent reached through an
+unresolved `to` used to join the wrong table.
+
+### How to find the calls to migrate
+
+Nothing to grep in *call* sites — the exposure is in **generated models files**. For each one, diff its
+declared bindings against its foreign-key targets; a non-empty difference is a file that will now
+raise:
+
+```julia
+txt   = read("db/automatic_models.jl", String)
+binds = Set(m.captures[1] for m in eachmatch(r"^[ \t]*(\w+)[ \t]*=[ \t]*Models\.Model\("m, txt))
+tgts  = Set(m.captures[2] for m in eachmatch(r"(ForeignKey|OneToOneField)\(\"([^\"]+)\"", txt))
+setdiff(tgts, binds)      # empty == unaffected
+```
+
+The ordinary cause of a non-empty result is an `include_table` / `ignore_table` filter that left an FK
+parent out of the import — not a typo.
+
+### Before → after
+
+```julia
+# before — the parent was filtered out of the import, and the key still "worked" by coincidence
+#          (lowercase("Tb_dia_semana") happens to be the real table `tb_dia_semana`)
+PormG.Migrations.import_models_from_postgres("db_esus",
+  include_table = ["tb_agendado", "tb_cfg_agenda"])      # tb_dia_semana omitted
+# -> Tb_agendado = Models.Model("tb_agendado",
+#      co_dia_semana = Models.ForeignKey("Tb_dia_semana", pk_field="co_dia_semana"))
+#    makemigrations emitted REFERENCES "tb_dia_semana"
+
+# after — add the parent's table to the filter so the key has a model to point at
+PormG.Migrations.import_models_from_postgres("db_esus",
+  include_table = ["tb_agendado", "tb_cfg_agenda", "tb_dia_semana"])
+```
+
+If the parent genuinely lives outside the file, declare a stub for it instead — with `db_table` when
+its table name differs from the model name:
+
+```julia
+Tb_dia_semana = Models.Model("tb_dia_semana", co_dia_semana = Models.IDField())
+```
+
 ## Bulk writes — `columns=` refuses two different source columns for one model field (#380)
 
 - **Version**: Unreleased

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -196,6 +196,23 @@ the binding that table actually gets, not the unusable `"2fast"`.
     older version and your schema has colliding or non-identifier table names, re-run the import
     rather than hand-patching the targets.
 
+Because the target is a **binding**, the target model has to be *in the models module* for the key to
+mean anything. A key whose target is not there — filtered out by `include_table` / `ignore_table`, in
+another schema, or hand-edited — cannot name a table, and PormG says so rather than guessing:
+`set_models` raises `ModelDefinitionError` when the module loads, and `makemigrations` raises the same
+error when it would otherwise have to render the parent into a `REFERENCES` clause.
+
+!!! warning "Why an unresolved target is not derived from its own spelling"
+    Lowercasing the target would look like it works, and for most schemas it does — it is the exact
+    inverse of the sanitizer for any table name that is *already* a legal lowercase identifier. It is
+    wrong for every other one, silently: a table `2fast` binds as `Col_2fast` and would be referenced
+    as `col_2fast`, and `driver profile` binds as `Driver_profile` and would be referenced as
+    `driver_profile` — a table that may well exist and hold someone else's rows. It also cannot see a
+    [`db_table`](#Pinning-an-explicit-table-name-with-db_table), so a pinned parent would be
+    referenced by the wrong name even where the fold was harmless. The fix is to give the key a model
+    to point at: declare the parent (with `db_table` if its table name differs), or widen the
+    `include_table` / `ignore_table` filter and re-import.
+
 ### `django_prefix` interop
 
 A connection may set `django_prefix` in its `connection.yml` `config:` block (default: unset). It

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -890,8 +890,11 @@ function create_table(conn::PormGSQLite, model::PormGModel)
       # Local FK column and referenced parent column both honor db_column (#50).
       local_col = field_db_column(field, string(field_name))
       target_pk = fk_target_column(field)
-      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table.
-      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(fk_target_table(field))\"(\"$target_pk\") ON DELETE $on_delete_str")
+      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table, and is ESCAPED (#388) —
+      # the table being CREATED goes through `_quote_table_ddl` while the table being REFERENCED did
+      # not, so a `db_table` holding a `"` closed the identifier early: a parent pinned to `Ev"il`
+      # rendered `REFERENCES "Ev"il"("id")`, which is malformed SQL and a DDL-injection seam.
+      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(_quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 
@@ -1164,8 +1167,9 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
       on_delete_str = _foreign_key_on_delete_sql(f.on_delete)
       local_col = field_db_column(f, string(f_name))
       target_pk = fk_target_column(f)
-      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table.
-      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(fk_target_table(f))\"(\"$target_pk\") ON DELETE $on_delete_str")
+      # Referenced (parent) TABLE honors db_table (#59) via fk_target_table, escaped as in
+      # `create_table` above (#388).
+      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(_quote_table_ddl(fk_target_table(f; column = f_name, model = model)))\"(\"$target_pk\") ON DELETE $on_delete_str")
     end
   end
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -1094,12 +1094,58 @@ function fk_target_column(field::PormGField)::String
 end
 
 # Referenced (parent) physical TABLE for a ForeignKey (#59) — the table-level sibling of
-# fk_target_column above. A resolved PormGModel target goes through model_table_name (so it
-# honors the target's db_table); a still-unresolved String target falls back to
-# format_model_name, matching fk_target_column's own verbatim-fallback shape for that case.
-function fk_target_table(field::PormGField)::String
+# fk_target_column above. Single-sourced on `_fk_reference_table` (#388) so the DDL renderer and the
+# live-vs-declared field comparison answer "which table does this key point at" the same way:
+# `to_table` when introspection recorded one, else the resolved target's `model_table_name`.
+#
+# #388: a still-unresolved String `.to` now RAISES instead of being lowercased into a table name.
+# `.to` is a Julia BINDING (#360/#386), and the lowercase only ever recovered the table by accident —
+# it inverts `uppercasefirst`, which is what introspection used to write there. It is false for any
+# table whose name is not already a legal identifier: a table `2fast` binds as `Col_2fast` and
+# rendered `REFERENCES "col_2fast"`; `driver profile` binds as `Driver_profile` and rendered
+# `REFERENCES "driver_profile"`. Both name tables that do not exist, emitted into DDL with no warning.
+#
+# Nothing here can recover the real name, so the honest answer is to say so. `set_models` already
+# refuses an unresolvable target exactly this loudly (`resolve_fk_target!`, strict=true); this makes
+# the migration prelude's best-effort path (strict=false) fail at the point of USE rather than hand
+# the database an invented identifier that fails later as a missing relation.
+# `column` / `model` are OPTIONAL diagnostic context, used only to build the refusal message. A field
+# knows its target but not its own name or owner, so without them the error can say *which parent* is
+# missing and nothing else — and the realistic failure is a generated file where one filtered-out
+# parent is referenced by a dozen children, where "which key" is the entire question. Every one of the
+# four call sites has both in scope (`Dialect.create_table`/`alter_field` iterate `model.fields`; the
+# planner's two take `model_name` + `field_name` as parameters), so they all pass them. Keyword rather
+# than positional so any other caller keeps working unchanged.
+function fk_target_table(field::PormGField;
+                         column::Union{AbstractString, Symbol, Nothing} = nothing,
+                         model::Union{AbstractString, Symbol, PormGModel, Nothing} = nothing)::String
+  tbl = _fk_reference_table(field)
+  tbl !== nothing && return tbl
+  # `.to` is safe to read here: `_fk_reference_table` only reaches its `nothing` return after
+  # touching it, so a field without the property has already raised inside it.
+  #
+  # A BLANK `.to` joins the `nothing` arm rather than being interpolated: `ForeignKey("")` is legal to
+  # construct, and quoting it produced "its target  is not a model" — a double space wrapping an empty
+  # ANSI pair, which reads as a rendering bug rather than as the missing target it is. `strip`, not
+  # `isempty`: `ForeignKey(" ")` is just as unresolvable and produced the identical symptom.
   tgt = field.to
-  return tgt isa PormGModel ? model_table_name(tgt) : format_model_name(tgt)
+  unset = tgt === nothing || (tgt isa AbstractString && isempty(strip(tgt)))
+  named = unset ? "is not set" : "\e[31m$(tgt)\e[0m is not a model in the loaded models"
+  where = if column === nothing && model === nothing
+    ""
+  else
+    owner = model isa PormGModel ? model.name : model
+    col_part = column === nothing ? "" : " \e[31m$(column)\e[0m"
+    owner_part = owner === nothing ? "" : " in \e[32m$(owner)\e[0m"
+    " (foreign key$(col_part)$(owner_part))"
+  end
+  throw(ModelDefinitionError(
+    "Cannot determine the table a foreign key references$where: its target $named, so the physical " *
+    "table name is unknown. A `to` string names a Julia model BINDING, not a table, and PormG " *
+    "will not guess a table name from it. Either declare the target model in the models module " *
+    "(giving it db_table=\"…\" when its table name differs from the model name), or — if the file " *
+    "was generated with include_table/ignore_table — add the parent's table to that filter and " *
+    "re-import, so the key has a model to point at."))
 end
 
 # Resolve a string FK/O2O target to its model object within `mod` (#62). Returns the
@@ -1127,11 +1173,18 @@ both model-load lifecycles share — the runtime path (`set_models`) and the mig
 (`_load_current_models` → `_resolve_fk_targets_and_pk!`). Side-effect-free with respect to globals: it
 mutates only `field.to`/`field.pk_field`, never `REGISTERED_MODULES`, `Configuration`, or reverse relations.
 
-`strict=true` (runtime) throws `ArgumentError` on an unresolvable target; `strict=false` (migrations) is
-best-effort — it leaves `field.to` a string, emits a `@debug`, and returns `nothing`, which skips the
-`pk_field` default (so an unresolved field keeps both its string `.to` and a `nothing` `.pk_field`, matching
-the pre-#65 migration behavior). The statement order is load-bearing: the strict throw fires *before* the
-write-back so the message still names the originally-declared target string.
+`strict=true` (runtime) throws [`ModelDefinitionError`](@ref) on an unresolvable target; `strict=false`
+(migrations) is best-effort — it leaves `field.to` a string, emits a `@debug`, and returns `nothing`, which
+skips the `pk_field` default (so an unresolved field keeps both its string `.to` and a `nothing`
+`.pk_field`). The statement order is load-bearing: the strict throw fires *before* the write-back so the
+message still names the originally-declared target string.
+
+The docstring said `ArgumentError` until #388 — it had been wrong since the #231/#239 taxonomy landed, and
+was the last place still promising the retired type for this call. `test_docs_error_type_drift.jl` cannot
+catch it: the function is not `public`, so `api.md` never renders this docstring.
+
+An unresolved `.to` is no longer usable downstream: `fk_target_table` refuses to derive a physical table
+from a binding (#388), so `strict=false` defers the failure to the point of use rather than suppressing it.
 
 `field` is left untyped because `sForeignKey`/`sOneToOneField` are defined later in the load order (in
 `models/fields.jl`); both call sites already guard with `field isa sForeignKey || field isa sOneToOneField`,

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -183,7 +183,10 @@ function _add_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite
     local_col = Models.field_db_column(new_field, string(field_name))
     on_delete_sql = hasfield(typeof(new_field), :on_delete) ? Dialect._foreign_key_on_delete_sql(new_field.on_delete) : nothing
     _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
-    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(fk_target_table(new_field))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+    # `_quote_table_ddl` on the referenced table (#388): `add_foreign_key` interpolates
+    # `ref_table_name` verbatim — every identifier it receives is pre-quoted HERE — so an embedded
+    # `"` in a parent's `db_table` would close the identifier early and corrupt the ALTER.
+    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(new_field; column = field_name, model = model_name)))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
   end
   return nothing
 end
@@ -201,7 +204,8 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
       local_col = Models.field_db_column(field, string(field_name))
       on_delete_sql = hasfield(typeof(field), :on_delete) ? Dialect._foreign_key_on_delete_sql(field.on_delete) : nothing
       _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
-      Dialect.add_foreign_key(conn, model_table_name(model), "\"$constraint_name\"", "\"$local_col\"",  "\"$(fk_target_table(field))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+      # Referenced table escaped as in `_add_fk_constraint_in_alteration` above (#388).
+      Dialect.add_foreign_key(conn, model_table_name(model), "\"$constraint_name\"", "\"$local_col\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
     # For SQLite, FKs are added in CREATE TABLE, so if we are adding a field to an existing table, 
     # we might need recreation if it's a FK.
     end
@@ -999,9 +1003,22 @@ end
 
 # Resolve each code model's FK/O2O targets against `models_module` (write-back) and default a
 # missing `pk_field`, by delegating each field to the shared `Models.resolve_fk_target!` (#65).
-# Best-effort (strict=false): an unresolvable string target is left as-is (e.g. a cross-module
-# reference whose verbatim fallback is already correct) with a `@debug`, never breaking the run.
+# Best-effort (strict=false): an unresolvable string target is left as-is with a `@debug` rather
+# than aborting the whole load, so a diff can still be computed for every OTHER model in the file.
 # The runtime path's strict throw lives in `set_models`, so typos surface loudly there first.
+#
+# #388 changed what "left as-is" costs. This comment used to justify the tolerance by saying the
+# unresolved string's "verbatim fallback is already correct" and that it "never breaks the run" —
+# both are now false. There is no fallback: `fk_target_table` refuses an unresolved target, because
+# `.to` is a Julia BINDING and the lowercase that used to stand in for a table name was only ever
+# right by accident. So the run does break, deliberately, at the point where the parent would have
+# been rendered into a `REFERENCES` clause.
+#
+# What is NOT a reason to defer: making the failure narrower. It is not narrower — `makemigrations`
+# puts no `try` around `get_migration_plan` (the guarded call in both arms is `convert_schema_to_models`),
+# so the throw aborts the whole run exactly as a `strict=true` throw here would. The reason to defer
+# is the one above: most models never reach a `REFERENCES` clause at all, so an unresolved target on a
+# model with no pending DDL costs nothing, and the diff for every other model still gets computed.
 function _resolve_fk_targets_and_pk!(current_models::Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}, models_module::Module)::Nothing
   for (_, entry) in current_models
     model = entry[:model]

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -245,6 +245,44 @@ function _reverse_join_table(reverse_model::PormGModel, logical_name::AbstractSt
   return django !== nothing ? string(django, lowercase(logical_name)) : lowercase(logical_name)
 end
 
+# FORWARD FK/O2O join target whose `.to` is still a STRING (#388). `.to` names the target's Julia
+# BINDING (#360/#386), never its table, so the only correct move is to resolve the binding in the
+# owning models module and read the table off the model — which is exactly what the resolved-`.to`
+# arm beside each call site already does, and what the next-hop lookup does one line later.
+#
+# Both call sites used to `lowercase` the binding into a table name instead. That inverts
+# `uppercasefirst`, which is the right inverse only while the binding IS `uppercasefirst(<table>)`:
+# a table `2fast` binds as `Col_2fast` and joined `col_2fast`, `driver profile` binds as
+# `Driver_profile` and joined `driver_profile`. Neither table exists. It also ignored `db_table`
+# outright, so a parent pinned to an explicit table joined the wrong one even when the guess would
+# otherwise have inverted cleanly.
+#
+# The `instruct.django` arm went with it, deliberately. That prefix fallback is documented as the
+# spelling for a REVERSE-join target carrying no `db_table` (`docs/src/schema_conventions.md` →
+# *`django_prefix` interop*), and the resolved-model arm this now joins has never applied it — so the
+# arm only fired when a key happened to reach the String branch, which rendered ONE foreign key as
+# two different tables depending on whether `set_models` had resolved its target yet.
+#
+# Raises rather than returning `nothing`: an unresolvable binding cannot produce a join at all. What
+# changes here is the ERROR, not whether there is one — the old code always failed too, just as a
+# bare `UndefVarError` from a `getfield`: at this hop when the path had exactly two segments, and
+# one iteration later in the `while` loop (`new_object = getfield(…)`) when it had more. Both name a
+# Julia symbol rather than the field path the user wrote, which is the part worth fixing.
+#
+# The genuinely SILENT case was never the unresolvable binding — it was a binding that DOES resolve
+# but whose table is not `lowercase(binding)`, which produced a perfectly well-formed `JOIN` against
+# the wrong table. Not necessarily a MISSING one: `Driver_Profile` folds to `driver_profile`, which on
+# PostgreSQL is a second, real table that may exist and hold someone else's rows — a query that
+# returns results, all of them wrong. That is the case the two mixed-case join testsets pin.
+function _forward_join_model(to::AbstractString, mod::Module, owner::PormGModel, column::AbstractString)::PormGModel
+  model = Models._resolve_target_model(to, mod)
+  model isa PormGModel && return model
+  throw(QueryBuildError(
+    "Invalid field path: the foreign key \e[31m$(column)\e[0m in \e[32m$(owner.name)\e[0m targets " *
+    "\e[31m$(to)\e[0m, which is not a model binding in \e[32m$(mod)\e[0m. A ForeignKey `to` string " *
+    "names a Julia model binding, not a table, so there is no table to join."))
+end
+
 # Shared helper used at the four sites in `_build_row_join` where a many-to-many
 # (forward or reverse) hop must be expanded into the through-table + related-table
 # join pair. Returns the alias of the related-table join, the row dict for that
@@ -306,6 +344,15 @@ end
 
 function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bool=true)
   vector = copy(field)
+  # The `String` member is UNREACHABLE as of #388, and deliberately left in place. Every one of the
+  # nine assignments below now stores a resolved model — `cte_model`, `_apply_many_to_many_branch`'s
+  # `foreign_model` (×4), `first_model`/`next_model` (the forward arms), and `reverse_model` (×2) —
+  # so narrowing this to `Union{PormGModel, Nothing}` would make that invariant enforced rather than
+  # merely true. It is not narrowed here because the annotation would then `convert` on assignment,
+  # turning any path this audit missed from a working query into a `TypeError`. The unit suite does
+  # reach these branches (`test_cte_ergonomics.jl`, `test_many_to_many.jl`), but not all four M2M call
+  # sites, and this change is not authorized to run the integration suite that would. Narrow it in a
+  # change that can; until then the `isa PormGModel` tests downstream stay.
   foreign_table_name::Union{String, PormGModel, Nothing} = nothing
   foreing_table_module::Module = instruct.object.model._module::Module
   row_join = sizehint!(Dict{String, Union{String, Vector{FilterType}}}(), 8)
@@ -425,16 +472,18 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
     first_field = _get_join_field(instruct.object, join_path) !== nothing ? _get_join_field(instruct.object, join_path) : instruct.object.model.fields[first_column]
     # @pormg_debug
     row_join["how"] = _determine_join_type(first_field, second_fild_name= size(vector, 1) > 1 ? vector[2] : nothing)
-    foreign_table_name = first_field.to
-    if foreign_table_name === nothing
+    first_target = first_field.to
+    first_target === nothing &&
       throw(QueryBuildError("Invalid field path: the column $(first_column) does not have a foreign key"))
-    elseif isa(foreign_table_name, PormGModel)
-      row_join["b"] = Models.model_table_name(foreign_table_name)
-      size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
-    else
-      row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
-      size(vector, 1) == 2 && (last_field = getfield(foreing_table_module, foreign_table_name |> Symbol).fields[vector[2]])
-    end
+    # #388: the two arms are ONE arm now. A String `.to` is the target's binding, so resolving it
+    # yields the same model a `set_models`-resolved `.to` already holds, and the table comes off that
+    # model either way. Carrying the model forward (matching the reverse branch below, #343) also
+    # spares the next hop and `_solve_field` from repeating the binding lookup.
+    first_model = first_target isa PormGModel ? first_target :
+      _forward_join_model(first_target, foreing_table_module, instruct.object.model, first_column)
+    row_join["b"] = Models.model_table_name(first_model)
+    size(vector, 1) == 2 && (last_field = first_model.fields[vector[2]])
+    foreign_table_name = first_model
     # @pormg_debug
     row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
     # Local FK column and referenced parent column both honor db_column (#50).
@@ -539,18 +588,20 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       !hasfield(typeof(first_field), :to) && throw(QueryBuildError("Invalid field path: the column $(first_column) is a field from $(new_object.name), but it does not have a foreign key"))
       row_join["a"] = prev_b
       row_join["alias_a"] = tb_alias      
-      row_join["how"] = _determine_join_type(new_object.fields[first_column], previus_how=prev_how, second_fild_name= size(vector, 1) > 1 ? vector[2] : nothing)
-      foreign_table_name = new_object.fields[first_column].to
-      if foreign_table_name === nothing
+      # `first_field`, not a second `new_object.fields[first_column]` lookup — same object, and it is
+      # the one the `hasfield(:to)` guard above already vetted and `fk_target_column` reads below.
+      row_join["how"] = _determine_join_type(first_field, previus_how=prev_how, second_fild_name= size(vector, 1) > 1 ? vector[2] : nothing)
+      next_target = first_field.to
+      if next_target === nothing
         # #197: this used to blame `vector[2]`, but the FK-less column is `first_column`.
         throw(QueryBuildError("Invalid field path: the column $(first_column) in $(new_object.name) does not have a foreign key target"))
-      elseif isa(foreign_table_name, PormGModel)
-        row_join["b"] = Models.model_table_name(foreign_table_name)
-        size(vector, 1) == 2 && (last_field = foreign_table_name.fields[vector[2]])
-      else
-        row_join["b"] = instruct.django !== nothing ? string(instruct.django,  foreign_table_name |> lowercase) : foreign_table_name |> lowercase
-        size(vector, 1) == 2 && (last_field = getfield(foreing_table_module, foreign_table_name |> Symbol).fields[vector[2]])
       end
+      # #388: same single arm as the first hop above — see `_forward_join_model`.
+      next_model = next_target isa PormGModel ? next_target :
+        _forward_join_model(next_target, foreing_table_module, new_object, first_column)
+      row_join["b"] = Models.model_table_name(next_model)
+      size(vector, 1) == 2 && (last_field = next_model.fields[vector[2]])
+      foreign_table_name = next_model
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias) # TODO chage by row_join and test the speed
       # Local FK column and referenced parent column both honor db_column (#50).
       row_join["key_b"] = Models.fk_target_column(first_field)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ end
     @testset "Mixed-case Model Binding in Reverse Joins (#343)" include("unit/test_reverse_join_mixed_case_binding.jl")
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "db_table Authoritative (#59)" include("unit/test_db_table.jl")
+    @testset "Unresolved ForeignKey Target Is Never Guessed (#388)" include("unit/test_fk_unresolved_target.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
     @testset "JSON Path Lookups (#27)" include("unit/test_json_lookups.jl")

--- a/test/unit/test_db_table.jl
+++ b/test/unit/test_db_table.jl
@@ -186,11 +186,51 @@ DbtPlain.connect_key = "db_table_mock"
     @test occursin("REFERENCES \"Dbt_Driver_Scratch\"(\"id\")", child_ddl)
     @test !occursin("REFERENCES \"dbt_driver_scratch\"", child_ddl)
 
-    # An UNRESOLVED (String) target keeps the pre-existing format_model_name fallback — that is the
-    # introspection/pre-set_models shape, where there is no model object to read a db_table off.
+    # An UNRESOLVED (String) target REFUSES rather than falling back (#388). This assertion used to
+    # read `== "some_model"`, the `format_model_name` lowercase — which is exactly the fabrication
+    # #388 removed: `.to` names a Julia BINDING, and the only reason lowercasing it ever produced a
+    # table was that it inverts the `uppercasefirst` introspection used to write there. There is no
+    # model object here to read a `db_table` off, so there is no honest answer to give.
     strfk = Model("dbt_strfk_scratch",
       id = IDField(), other = ForeignKey("Some_Model", pk_field = "id", on_delete = "CASCADE"))
-    @test fk_target_table(strfk.fields["other"]) == "some_model"
+    @test_throws PormG.ModelDefinitionError fk_target_table(strfk.fields["other"])
+    err = try; fk_target_table(strfk.fields["other"]); nothing; catch e; e end
+    @test occursin("Some_Model", err.msg)          # names the target it could not resolve
+    @test !occursin("some_model", err.msg)         # and never the invented table name
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # A `db_table` holding a double quote must not escape its identifier in a REFERENCES clause (#388).
+  #
+  # The table being CREATED has gone through `_quote_table_ddl` since #59; the table being REFERENCED
+  # had not. So the two halves of the same statement disagreed, and a parent pinned to `Ev"il`
+  # rendered `REFERENCES "Ev"il"("id")` — the identifier closes at the embedded quote, leaving `il`
+  # as stray SQL. Malformed at best, and a DDL-injection seam through a value the schema author
+  # controls. #388 made `db_table` authoritative on one more path, which is what surfaced it.
+  #
+  # Both engines, because they reach the clause through different renderers: SQLite writes the FK
+  # inline in `create_table`, PostgreSQL through the planner's `add_foreign_key` (whose caller
+  # pre-quotes every identifier, so the escape has to happen at the call site there).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "an embedded quote in a referenced db_table is escaped, not closed (#388)" begin
+    evil_parent = Model("dbt_evil_parent_scratch", db_table = "Ev\"il", id = IDField())
+    evil_child  = Model("dbt_evil_child_scratch",
+      id = IDField(), pid = ForeignKey(evil_parent, pk_field = "id", on_delete = "CASCADE"))
+
+    sl_ddl = PormG.Dialect.create_table(MockSQLiteDbTable(), evil_child)
+    @test occursin("REFERENCES \"Ev\"\"il\"", sl_ddl)   # doubled — the identifier stays one token
+    @test !occursin("REFERENCES \"Ev\"il\"", sl_ddl)    # the broken rendering must be gone
+
+    # The CREATE side already escaped; assert both halves now agree rather than only the new one.
+    parent_ddl = PormG.Dialect.create_table(MockSQLiteDbTable(), evil_parent)
+    @test occursin("CREATE TABLE IF NOT EXISTS \"Ev\"\"il\"", parent_ddl)
+
+    # PostgreSQL's path: the planner pre-quotes, so `add_foreign_key` receives it already escaped.
+    pg_fk = PormG.Dialect.add_foreign_key(MockPostgresDbTable(), "dbt_evil_child_scratch",
+      "\"c_fk\"", "\"pid\"",
+      "\"$(PormG.Dialect._quote_table_ddl(fk_target_table(evil_child.fields["pid"])))\"", "\"id\"")
+    @test occursin("REFERENCES \"Ev\"\"il\"", pg_fk)
+    @test !occursin("REFERENCES \"Ev\"il\"", pg_fk)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -242,6 +242,22 @@ const DOCERR_CASES = [
                 columns = ["c1" => "status", "c2" => "status"], show_query = :dict)
         end,
     ),
+    (
+        # The page's claim is about `makemigrations`, which needs a database. This pins it one layer
+        # down, at a DDL renderer that reaches the same throw with no connection.
+        #
+        # SQLite specifically, and that is not arbitrary: `create_table(::PormGPostgres, …)` renders
+        # columns only and never calls `fk_target_table`, so the PG arm of this call would assert
+        # nothing. PG reaches the throw through the planner's `add_foreign_key` paths instead, which
+        # `test_fk_unresolved_target.jl` covers. The throw itself lives in `fk_target_table` and is
+        # engine-agnostic, so one engine is enough to pin the TYPE — which is all this table claims.
+        "schema_conventions.md — a foreign key whose target is not in the models module raises (#388)",
+        ModelDefinitionError,
+        () -> PormG.Dialect.create_table(DocErrMockSQLite(),
+            Model("docerr_orphan_child_probe",
+                id       = IDField(),
+                parentid = ForeignKey("Docerr_Never_Declared", pk_field = "id"))),
+    ),
 ]
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_fk_unresolved_target.jl
+++ b/test/unit/test_fk_unresolved_target.jl
@@ -1,0 +1,281 @@
+"""
+#388: an unresolved `ForeignKey.to` is never lowercased into a physical table name.
+
+`.to` holds a Julia **binding**, not a table. Three call sites recovered the table by LOWERCASING it,
+which is only the right inverse while the binding is exactly `uppercasefirst(<table>)`. #360/#386
+made `.to` the model's real binding, which the lowercase cannot invert — so the guess started
+fabricating names that no table answers to:
+
+  | live table       | `.to` after #386 | old render                      |
+  |------------------|------------------|---------------------------------|
+  | `2fast`          | `Col_2fast`      | `REFERENCES "col_2fast"`      ✗ |
+  | `driver profile` | `Driver_profile` | `REFERENCES "driver_profile"` ✗ |
+
+Two layers, one defect. `Models.fk_target_table` feeds the DDL (`Dialect.create_table`,
+`planner.add_foreign_key`); `_build_row_join`'s forward-FK arms feed the `JOIN`. Both now resolve the
+binding, or refuse.
+
+Why the join assertions are `!occursin` on the FABRICATION and not only `occursin` on the truth: a
+parent whose name needs sanitizing is the only shape that separates the two answers. On an
+already-legal lowercase name (`driver`) the old lowercase and the new resolution agree, so an
+assertion built on one would stay green through a full revert. Every join assertion below therefore
+uses a parent the lowercase gets WRONG — a spaced name, or a `db_table`-pinned one.
+
+DB-free: mock connections render SQL through `inspect_query` / `Dialect`, no socket.
+"""
+# julia --project=. test/unit/test_fk_unresolved_target.jl
+
+using Test
+using PormG
+using PormG.Models: Model, IDField, CharField, IntegerField, ForeignKey, fk_target_table
+using PormG.QueryBuilder: inspect_query
+
+struct MockPgFkUnres <: PormG.PormGPostgres end
+struct MockSlFkUnres <: PormG.PormGSQLite end
+PormG.config["fk_unres_mock"] = PormG.Configuration.Settings(
+  connections = MockPgFkUnres(),
+  change_data = true,
+)
+
+# One models module for the whole file. `_module`/`connect_key` are wired by hand rather than through
+# `set_models`, which would try to LOAD a connection folder off disk — and, more to the point, would
+# RESOLVE every `.to` and so hide the very branch under test.
+const FKU_MOD = Module(:FkUnresScratch)
+Base.eval(FKU_MOD, :(using PormG))
+
+function fku_register!(binding::Symbol, model)
+  model._module = FKU_MOD
+  model.connect_key = "fk_unres_mock"
+  Base.eval(FKU_MOD, :(const $binding = $model))
+  return model
+end
+
+@testset "#388 · an unresolved ForeignKey target is never guessed into a table" begin
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # 1. DDL — `fk_target_table` refuses instead of fabricating.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  @testset "fk_target_table refuses an unresolved String target" begin
+    # `Col_2fast` is the binding a table literally named `2fast` receives: `uppercasefirst` cannot
+    # make a leading digit legal, so the sanitizer prefixes it. Lowercasing that binding yields
+    # `col_2fast` — a table that does not exist, which used to reach the database inside a
+    # `REFERENCES` clause with no warning at any layer.
+    digit_fk = ForeignKey("Col_2fast", pk_field = "id", on_delete = "CASCADE")
+    @test_throws PormG.ModelDefinitionError fk_target_table(digit_fk)
+
+    err = try; fk_target_table(digit_fk); nothing; catch e; e end
+    @test occursin("Col_2fast", err.msg)        # names the target it could not resolve …
+    @test !occursin("col_2fast", err.msg)       # … and never the name it used to invent
+    # The message has to point at the realistic cause. The ordinary way to reach this is a generated
+    # file whose parent was filtered out of the import, not a typo.
+    @test occursin("include_table", err.msg)
+    @test occursin("ignore_table", err.msg)
+
+    # A space is the other shape `uppercasefirst` cannot invert: `driver profile` binds as
+    # `Driver_profile`, whose lowercase is `driver_profile` — a DIFFERENT table that may well also
+    # exist in the same schema, which is what made this silent rather than merely wrong.
+    spaced_fk = ForeignKey("Driver_profile", pk_field = "id")
+    @test_throws PormG.ModelDefinitionError fk_target_table(spaced_fk)
+
+    # An EMPTY target is refused by the same seam rather than throwing something incidental — and
+    # reports as "is not set" rather than interpolating nothing between two spaces. `ForeignKey("")`
+    # sets `.to == ""`, NOT `nothing`, so this is the empty-string arm; the `nothing` arm is the
+    # assertion below it, reachable only post-construction since the constructor requires a target.
+    @test_throws PormG.ModelDefinitionError fk_target_table(ForeignKey(""))
+    empty_err = try; fk_target_table(ForeignKey("")); nothing; catch e; e end
+    @test occursin("is not set", empty_err.msg)
+    @test !occursin("target  is", empty_err.msg)     # no double space where the name would go
+
+    nil_fk = ForeignKey("Fku_placeholder"); nil_fk.to = nothing
+    @test_throws PormG.ModelDefinitionError fk_target_table(nil_fk)
+    nil_err = try; fk_target_table(nil_fk); nothing; catch e; e end
+    @test occursin("is not set", nil_err.msg)
+
+    # Whitespace-only is as unresolvable as empty and must read the same way, not as a blank gap.
+    blank_err = try; fk_target_table(ForeignKey(" ")); nothing; catch e; e end
+    @test occursin("is not set", blank_err.msg)
+
+    # The message names WHICH key when the caller can say. A field knows its target but not its own
+    # name or owner, so without this the error is "target X is missing" for a parent that a dozen
+    # children may reference — and every DDL call site has both in scope, so they all pass them.
+    ctx_err = try
+      fk_target_table(digit_fk; column = "co_dia_semana", model = "tb_agendado"); nothing
+    catch e; e end
+    @test occursin("co_dia_semana", ctx_err.msg)
+    @test occursin("tb_agendado", ctx_err.msg)
+    # …and stays well-formed when the caller cannot: no empty parenthetical, no dangling "in".
+    @test !occursin("(foreign key)", err.msg)
+    @test !occursin(" in )", err.msg)
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # 2. DDL positive control — a key that CAN name its table still renders, on both backends.
+  #    This is the assertion that goes red if the refusal over-corrects into rejecting valid keys.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  @testset "a resolvable target still renders REFERENCES" begin
+    # Plain parent: no db_table, so the table is the logical name, verbatim.
+    plain_parent = Model("fku_driver_scratch", id = IDField(), surname = CharField())
+    # Pinned parent: db_table differs from the logical name, and must WIN. Before #388 the String
+    # branch ignored db_table entirely, so a pinned parent was referenced by the wrong name even
+    # when the lowercase guess would otherwise have inverted cleanly.
+    # NOTE (#394): this spaced name renders fine in DDL but the query builder would REFUSE it —
+    # `SAFE_IDENTIFIER_PATTERN` rejects spaces while `_quote_table_ddl` does not, so PormG will
+    # migrate a table it cannot then join. That split predates #388 and is tracked separately; the
+    # name is kept here deliberately, because the DDL half is what this testset asserts and a space
+    # is the sharpest proof that `db_table` reaches the `REFERENCES` clause verbatim.
+    pinned_parent = Model("fku_pinned_scratch", db_table = "Fku Pinned Table",
+                          id = IDField(), surname = CharField())
+
+    child = Model("fku_result_scratch",
+      id       = IDField(),
+      points   = IntegerField(),
+      plainid  = ForeignKey(plain_parent, pk_field = "id", on_delete = "CASCADE"),
+      pinnedid = ForeignKey(pinned_parent, pk_field = "id", on_delete = "CASCADE"),
+    )
+
+    @test fk_target_table(child.fields["plainid"])  == "fku_driver_scratch"
+    @test fk_target_table(child.fields["pinnedid"]) == "Fku Pinned Table"
+
+    # SQLite carries FKs inline in CREATE TABLE, so the created table and both referenced ones are
+    # rendered by a single call — this asserts they agree as ONE string.
+    # The DDL renderers pass `column`/`model` through, so a refusal raised from inside `create_table`
+    # names the offending key rather than just the missing parent.
+    ddl_err = try
+      PormG.Dialect.create_table(MockSlFkUnres(),
+        Model("fku_ddl_ctx_scratch", id = IDField(),
+              co_dia_semana = ForeignKey("Fku_Filtered_Parent", pk_field = "id")))
+      nothing
+    catch e; e end
+    @test ddl_err isa PormG.ModelDefinitionError
+    @test occursin("co_dia_semana", ddl_err.msg)
+    @test occursin("fku_ddl_ctx_scratch", ddl_err.msg)
+
+    ddl = PormG.Dialect.create_table(MockSlFkUnres(), child)
+    @test occursin("REFERENCES \"fku_driver_scratch\"(\"id\")", ddl)
+    @test occursin("REFERENCES \"Fku Pinned Table\"(\"id\")", ddl)
+    @test !occursin("REFERENCES \"fku_pinned_scratch\"", ddl)   # the logical name never reaches DDL
+
+    # PostgreSQL does NOT carry foreign keys in CREATE TABLE — `create_table(::PormGPostgres, …)`
+    # renders columns only and never calls `fk_target_table` at all. (Measured: on an unresolved FK
+    # it returns DDL without raising, while the SQLite call on the SAME model raises.) So an
+    # `occursin("CREATE TABLE", create_table(pg, …))` assertion here would constrain nothing
+    # whatsoever — it passes before the fix, after it, and if the refusal over-corrected into
+    # rejecting valid keys. It was exactly that, and this replaces it.
+    #
+    # PG's real `fk_target_table` call sites are the planner's ALTER paths (`_add_constrains`,
+    # `_add_fk_constraint_in_alteration`), both of which render through `add_foreign_key`. That is
+    # the seam to assert, and it is where a fabricated parent name would have reached a PG database.
+    pg_fk = PormG.Dialect.add_foreign_key(MockPgFkUnres(), "fku_result_scratch",
+      "\"fku_pinned_fk\"", "\"pinnedid\"",
+      "\"$(fk_target_table(child.fields["pinnedid"]))\"", "\"id\"")
+    @test occursin("REFERENCES \"Fku Pinned Table\"", pg_fk)
+    @test !occursin("fku_pinned_scratch", pg_fk)          # the logical name never reaches PG DDL
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # 3. JOIN — hop 1 of `_build_row_join`. A String `.to` resolves to the model and reads the table
+  #    off it, so `db_table` wins and a sanitized binding is not folded into a fictional table.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  @testset "first-hop join resolves the binding instead of lowercasing it" begin
+    # Fixture shapes are constrained here in a way the DDL testset above is not: the query builder
+    # runs every table through `SAFE_IDENTIFIER_PATTERN` (`sanitization.jl`), which rejects a space
+    # outright — so `driver profile`, the sharpest illustration of the defect, cannot reach a JOIN
+    # at all and would test that guard rather than this fix. MIXED CASE is the legal-identifier
+    # shape with the same property: the fold is not an identity, so the old lowercase and the new
+    # resolution give DIFFERENT answers and the assertions below can tell them apart.
+    #
+    # Pinned parent: binding `Fku_pinned` -> lowercase `fku_pinned`, but the table is
+    # `Fku_Pinned_Physical`. The old branch ignored `db_table` entirely, so it joined a table that
+    # does not exist even though the fold itself was clean.
+    fku_register!(:Fku_pinned,
+      Model("fku_pinned_logical", db_table = "Fku_Pinned_Physical",
+            id = IDField(), code = CharField()))
+    # Mixed-case LOGICAL name via the Dict arity — the introspection-exempt path (#300/#59), where
+    # the name is read from a live database and must survive verbatim. Binding `Fku_Mixed_Parent`
+    # folds to `fku_mixed_parent`, which is a different table on PostgreSQL.
+    fku_register!(:Fku_Mixed_Parent,
+      Model("Fku_Mixed_Parent", Dict{String, PormG.PormGField}(
+        "id" => IDField(), "surname" => CharField())))
+
+    # `.to` stays a STRING on purpose — that is the unresolved shape. Both keys are declared by
+    # binding name, exactly as a generated models file spells them.
+    child = fku_register!(:Fku_lap,
+      Model("fku_lap_scratch",
+        id       = IDField(),
+        millis   = IntegerField(),
+        mixedid  = ForeignKey("Fku_Mixed_Parent", pk_field = "id", on_delete = "CASCADE"),
+        pinnedid = ForeignKey("Fku_pinned",       pk_field = "id", on_delete = "CASCADE"),
+      ))
+    @test child.fields["mixedid"].to isa String   # guard: the branch under test is really taken
+
+    sql = inspect_query(child.objects.values("millis", "mixedid__surname"))[:sql_text]
+    @test occursin("\"Fku_Mixed_Parent\"", sql)    # the real table …
+    @test !occursin("fku_mixed_parent", sql)       # … and never the folded fabrication
+
+    pin_sql = inspect_query(child.objects.values("millis", "pinnedid__code"))[:sql_text]
+    @test occursin("\"Fku_Pinned_Physical\"", pin_sql)   # db_table wins on the String branch too
+    @test !occursin("fku_pinned", pin_sql)               # neither the folded binding nor the logical name
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # 4. JOIN — hop 2+. `_build_row_join` renders the second and later hops in a separate `while`
+  #    loop with its own copy of the branch, which is why #388 counted three sites and not two.
+  #    A test that only walked one hop would leave that copy uncovered.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  @testset "multi-hop join resolves every hop" begin
+    # Same mixed-case shape as above, one hop further out. The grandparent is `db_table`-pinned so
+    # hop 2 also proves the pin is honored, which the old branch dropped on the floor.
+    fku_register!(:Fku_Team_Deep,
+      Model("fku_team_deep_logical", db_table = "Fku_Team_Deep_TBL",
+            id = IDField(), team_name = CharField()))
+    fku_register!(:Fku_Driver_Deep,
+      Model("Fku_Driver_Deep", Dict{String, PormG.PormGField}(
+        "id" => IDField(), "surname" => CharField(),
+        "teamid" => ForeignKey("Fku_Team_Deep", pk_field = "id", on_delete = "CASCADE"))))
+    child = fku_register!(:Fku_deep_lap,
+      Model("fku_deep_lap_scratch", id = IDField(), millis = IntegerField(),
+            driverid = ForeignKey("Fku_Driver_Deep", pk_field = "id", on_delete = "CASCADE")))
+
+    sql = inspect_query(child.objects.values("millis", "driverid__teamid__team_name"))[:sql_text]
+    @test occursin("\"Fku_Driver_Deep\"", sql)    # hop 1
+    @test occursin("\"Fku_Team_Deep_TBL\"", sql)  # hop 2 — the second copy of the branch
+    @test !occursin("fku_driver_deep", sql)       # the folded binding, hop 1
+    @test !occursin("fku_team_deep", sql)         # the folded binding / logical name, hop 2
+  end
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # 5. JOIN — an unresolvable binding raises a PormG error rather than leaking `UndefVarError`.
+  #
+  #    Scope, stated honestly: the old code failed here too. It just failed as a bare
+  #    `UndefVarError` out of a `getfield`, naming a Julia symbol instead of the field path the user
+  #    wrote. So what these assertions pin is the ERROR TYPE and its message, not the existence of
+  #    an error — the type is what a caller can `catch`, and `UndefVarError` is not in the taxonomy.
+  #    (An earlier version of this comment claimed a one-segment path used to emit silently wrong
+  #    SQL. It does not: the `while` loop's own `getfield` catches the >2-segment case one iteration
+  #    later, and a 1-segment path builds no join at all. The genuinely silent case is a binding
+  #    that RESOLVES but whose table is not its lowercase — testsets 3 and 4 above.)
+  #
+  #    Both entry points are covered because they reach the branch differently: `values(...)` walks
+  #    the projection, `filter(...)` walks the filter path.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  @testset "an unresolvable binding raises QueryBuildError, not UndefVarError" begin
+    orphan = fku_register!(:Fku_orphan,
+      Model("fku_orphan_scratch", id = IDField(), value = IntegerField(),
+            ghostid = ForeignKey("Fku_Never_Declared", pk_field = "id", on_delete = "CASCADE")))
+
+    @test_throws PormG.QueryBuildError inspect_query(
+      orphan.objects.values("value", "ghostid__whatever"))
+
+    err = try
+      inspect_query(orphan.objects.values("value", "ghostid__whatever")); nothing
+    catch e; e end
+    @test occursin("Fku_Never_Declared", err.msg)
+    @test !occursin("fku_never_declared", err.msg)   # the fabrication is never offered as a table
+
+    # The same refusal reached through `filter` rather than `values`. Not a different code path in
+    # `_build_row_join` — `"ghostid__id"` is still a two-segment path — but a different way in, and
+    # the two entry points have diverged before.
+    @test_throws PormG.QueryBuildError inspect_query(
+      orphan.objects.filter("ghostid__id" => 1).values("value"))
+  end
+end

--- a/test/unit/test_model_name_case.jl
+++ b/test/unit/test_model_name_case.jl
@@ -152,8 +152,7 @@ NameCaseDriver.connect_key = "model_name_case_mock"
 
   # ─────────────────────────────────────────────────────────────────────────────
   # The DECOUPLING that closed the underscore split at its root (#317). `format_model_name` no
-  # longer inherits the field-name hatch, so it rewrites nothing but case — and an unresolved
-  # String FK target renders the SAME identifier `create_table` writes. Before, these disagreed.
+  # longer inherits the field-name hatch, so it rewrites nothing but case.
   # ─────────────────────────────────────────────────────────────────────────────
   @testset "format_model_name is a pure case fold (#317)" begin
     @test Models.format_model_name("_Order")  == "_order"    # was: "order" — the split
@@ -161,10 +160,19 @@ NameCaseDriver.connect_key = "model_name_case_mock"
     @test Models.format_model_name("a__b")    == "a__b"      # was: ModelDefinitionError
     @test Models.format_model_name("Driver")  == "driver"    # the fold itself is unchanged
 
-    # The property that matters: an FK pointing at an unresolved `_`-prefixed target references the
-    # table that name denotes, not a stripped variant of it.
+    # #317's own FK claim is RETIRED here, not merely re-asserted (#388). It used to read
+    # `fk_target_table(fk) == "_fk317_parent"` — "an FK pointing at an unresolved `_`-prefixed
+    # target references the table that name denotes". That property depended on `.to` holding the
+    # table name, which #360/#386 ended: `.to` is now the target's Julia BINDING, and lowercasing a
+    # binding back into a table only works while the binding is exactly `uppercasefirst(<table>)`.
+    # `_Fk317_Parent` happens to satisfy that; `Col_2fast` and `Driver_profile` do not, and used to
+    # render tables that do not exist. So the honest property is that it refuses.
+    #
+    # `format_model_name` itself is untouched by that — it is still the pure fold asserted above,
+    # and still the right function for a LOGICAL-name comparison. It simply no longer has any
+    # business deriving a physical table.
     fk = Models.ForeignKey("_Fk317_Parent", pk_field = "id")
-    @test Models.fk_target_table(fk) == "_fk317_parent"
+    @test_throws PormG.ModelDefinitionError Models.fk_target_table(fk)
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_schema_conventions.jl
+++ b/test/unit/test_schema_conventions.jl
@@ -20,9 +20,18 @@ using PormG.Models
 struct MockPGConv <: PormG.PormGPostgres end
 struct MockSLConv <: PormG.PormGSQLite end
 
+# The FK parent, as a MODEL rather than a bare `"driver"` string (#388). `fk_target_table` renders the
+# parent's physical table off the resolved target and refuses an unresolved one — `.to` is a Julia
+# BINDING, not a table, so lowercasing it into one was a guess that happened to be right only for a
+# name already spelled like a legal lowercase identifier. These testsets are about the FK COLUMN and
+# the `ON DELETE` mapping; the target just has to be real, and passing the model makes it so without
+# needing a models module. The rendered table is `"driver"` either way, so every assertion below is
+# unchanged.
+const CONV_DRIVER = Models.Model("driver", id = Models.IDField())
+
 # Render a model whose single FK carries the given keyword args, for on_delete assertions.
 _fk_ddl(; fk_kw...) = PormG.Dialect.create_table(MockSLConv(),
-    Models.Model("ratings", id = Models.IDField(), driver = Models.ForeignKey("driver"; fk_kw...)))
+    Models.Model("ratings", id = Models.IDField(), driver = Models.ForeignKey(CONV_DRIVER; fk_kw...)))
 
 @testset "Schema Conventions Freeze (#33)" begin
 
@@ -61,10 +70,12 @@ _fk_ddl(; fk_kw...) = PormG.Dialect.create_table(MockSLConv(),
     # importer's job, not native schema generation).
     @testset "FK column is the field name verbatim (no _id suffix)" begin
         ddl = PormG.Dialect.create_table(MockSLConv(),
-            Models.Model("result", resultid = Models.IDField(), driverid = Models.ForeignKey("driver")))
+            Models.Model("result", resultid = Models.IDField(),
+                         driverid = Models.ForeignKey(CONV_DRIVER)))   # model target, see #388 above
         @test occursin("\"driverid\"", ddl)     # the column equals the field name
         @test !occursin("driverid_id", ddl)     # no Django-style _id suffix
         @test !occursin("\"driver_id\"", ddl)   # not silently transformed
+        @test occursin("REFERENCES \"driver\"", ddl)   # …and the parent table is still `driver`
     end
 
     # Default on_delete is NO ACTION; the documented mapping is frozen (note PROTECT→RESTRICT and


### PR DESCRIPTION
Closes #388

## The defect

`ForeignKey.to` holds a Julia **binding**, not a physical table. Three sites recovered a table by
**lowercasing** an unresolved `.to`, which only inverts `uppercasefirst` — right by accident, and wrong
since #386 (#360) made `.to` the model's real binding.

| live parent table | `.to` after #386 | old render |
|---|---|---|
| `2fast` | `Col_2fast` | `REFERENCES "col_2fast"` ❌ |
| `driver profile` | `Driver_profile` | `JOIN "driver_profile"` ❌ |
| `driver` pinned to `db_table = "Legacy_Driver"` | `Driver` | `JOIN "driver"` ❌ |

The third row is the one worth pausing on: the fold was *clean* there, and the join was still wrong,
because the fallback ignored `db_table` entirely. And a folded name is not always a *missing* table —
`Driver_Profile` folds to `driver_profile`, which on PostgreSQL can be a second, real table holding
someone else's rows. That is a query returning results, all of them wrong.

## The decision

**Refuse to guess**, rather than emitting a `to_table` breadcrumb into generated model files. The
breadcrumb would have added a public kwarg to every introspected FK *and* turned `to_table` into
persisted state that can go stale and silently outrank a correctly-resolved target.

## What changed

**`fk_target_table`** ([`src/Models.jl`](../blob/fix/388-fk-target-table/src/Models.jl)) is now
single-sourced on `_fk_reference_table` — the honest primitive #386 already added — and raises
`ModelDefinitionError` when neither a `to_table` nor a resolved target can name the table. The message
names the realistic cause (an `include_table`/`ignore_table` filter that left the parent out of a
generated file) and, through new optional `column`/`model` kwargs that all four call sites pass, *which
key* tripped it. Without those the error can only say which parent is missing — and the realistic
failure is one filtered-out parent referenced by a dozen children.

**Both `build_joins` forward-FK arms** resolve the binding through the owning models module instead.
The two arms collapse into one, because a resolved String `.to` yields the same model a
`set_models`-resolved `.to` already holds. `db_table` is honored, and the resolved model is carried
forward exactly as #343 already did for the reverse branch — which also removes two redundant binding
lookups. These sites never needed the design decision: the line *immediately after* each already did
`getfield(module, Symbol(.to))`.

**The forward `instruct.django` arm is dropped.** `schema_conventions.md` documents that prefix
fallback as **reverse**-join only, and the resolved-model arm has never applied it — so it fired only
when a key happened to reach the String branch, rendering one foreign key as two different tables
depending on whether `set_models` had run yet. `_reverse_join_table` keeps its own arm untouched.

## Scope widened once, deliberately

Review surfaced that `fk_target_table`'s result was interpolated into `REFERENCES` **without**
`_quote_table_ddl`, while the table being *created* has been escaped since #59. A `db_table` holding a
`"` closed the identifier early:

```sql
FOREIGN KEY ("pid") REFERENCES "Ev"il"("id") ON DELETE NO ACTION
```

Broken SQL, and a DDL-injection seam through a value the schema author controls. Pre-existing, but this
PR makes `db_table` authoritative on one more path, so it is escaped here at all four sites with a
two-engine regression test. Confirmed by measurement, not inference.

## Verification

| check | result |
|---|---|
| full unit suite | **7360 / 7360** |
| new `test_fk_unresolved_target.jl` | 39 / 39 |
| **mutation gate** — same file with `src/` reverted | 8 pass / 15 fail / 16 error |
| guards: `test_docs_error_types` · `..._drift` | green (a `DOCERR_CASES` entry is owed and added) |
| `esus_back` offline golden-SQL suite, `origin/main` vs this branch | **byte-identical SQL** |

The downstream check is the load-bearing one. `esus_back` is a real consuming app whose offline suite
exists to catch exactly this; I audited all 1524 of its FK/O2O declarations (283 + 13 distinct targets
across the two *imported* modules, all resolving), then ran the suite both ways and diffed. The only
differences are precompile noise, timings, and the RNG seed.

That suite has **13 failures that are pre-existing on `origin/main`** — `@yyyy_mm` now rendering a
sargable half-open range instead of `to_char(...)` (#352), plus a widened parameter element type. They
are identical on both sides. Worth flagging on its own: that suite is PormG's own downstream guard and
its expectations have drifted.

## Not done, and why

- **#394** — a `db_table` the DDL accepts can be *rejected* by the query builder
  (`SAFE_IDENTIFIER_PATTERN` refuses spaces and leading digits, `_quote_table_ddl` does not), so PormG
  will migrate a schema it can never query. Pre-existing, same family as #59/#300, filed separately
  because the real question is whether the query-side injection guard should accept an already-quoted
  identifier — a query-builder design call, not an FK one.
- **`_reverse_join_table`'s own `lowercase(rel.model_name)` fold** — same defect class, outside this
  issue's three named sites, and unverified. Noted here rather than fixed.
- **Narrowing `foreign_table_name` to `Union{PormGModel, Nothing}`** — all nine assignments now store a
  model, so the `String` member is unreachable. Declined: the annotation would `convert` on assignment,
  turning any path this audit missed into a `TypeError`, and this change is not authorized to run the
  integration suite that would exercise every CTE/M2M branch. The invariant is documented at the
  declaration instead.
- **`src/Dialect.jl:16` imports `format_model_name` with zero uses** — already orphaned before this
  diff, left alone.

## Review

Reviewed by an independent reader over two rounds. The second round is the one that earned its keep: it
found that a *fix from the first round* had introduced a false claim — a comment asserting that
deferring the throw "keeps the failure specific to the key that caused it." Both halves are false, and I
verified both: `get_migration_plan` sits outside the only `try`, so the whole run aborts either way, and
the deferred message was measurably *less* specific than the strict path's. That is what prompted the
`column`/`model` kwargs above.

Every finding was reproduced independently before being acted on. One was declined with the reasoning
recorded in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
