### PR TITLE
fix(#364): derive from_/to_ join columns for a self-referential ManyToManyField

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -942,6 +942,8 @@ Team_member_settings = Models.Model(
 
 When `through` is not supplied, PormG migrations synthesize a join table with two foreign keys and a composite unique index. The relation can be traversed in filters and projections with the same double-underscore syntax used by `ForeignKey` joins.
 
+The field may also target the model that declares it (pass the model name as a string). Both join columns are then prefixed `from_` / `to_`, since one table cannot carry the same column twice — see [Self-Referential Relationships](many_to_many.md#Self-Referential-Relationships).
+
 ```julia
 Driver_collection = Models.Model("driver_collections",
     id = Models.IDField(),

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -43,6 +43,111 @@ This is essential for multi-hop joins and reverse-lookups. Without it, PormG def
 
 ---
 
+## Self-Referential Relationships
+
+A `ManyToManyField` may point at the model that declares it — drivers who were teammates, circuits
+that succeed one another, constructors that share an engine supplier. Reference the model **by
+string**, since its own binding does not exist yet at the point the field is written:
+
+```julia
+M2m_teammate_scratch = Models.Model("m2m_teammate_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of")
+)
+```
+
+Both ends of this relation are the same model, so the usual `<model>_<pk>` column rule would name
+them identically — and one table cannot carry the same column twice. PormG therefore prefixes the
+two ends, exactly as Django does:
+
+| | Normal relation | Self-referential relation |
+|---|---|---|
+| Owner end | `<owner model>_<pk>` | `from_<model>_<pk>` |
+| Target end | `<target model>_<pk>` | `to_<model>_<pk>` |
+
+So `m2m_teammate_scratch_teammates` is created with `from_m2m_teammate_scratch_id` and
+`to_m2m_teammate_scratch_id`. With the conventional `id` primary key this is byte-identical to
+Django's `from_<model>_id` / `to_<model>_id`; a model keyed on something else keeps that key's name
+in the stem, matching the column PormG's own migrations create.
+
+Everything else behaves exactly like any other many-to-many — the manager, the `__` traversal, and
+the reverse accessor:
+
+```julia
+senna = M.M2m_teammate_scratch.objects.get("driverref" => "senna")
+
+M.M2m_teammate_scratch.teammates(senna[:id]).add(prost_id, berger_id)
+
+# Forward: which drivers list prost as a teammate?
+teammates_of_prost = M.M2m_teammate_scratch.objects.filter(
+    "teammates__driverref" => "prost"
+).values("driverref").list()
+
+# Reverse, through related_name: which drivers is senna listed as a teammate of?
+listed_with_senna = M.M2m_teammate_scratch.objects.filter(
+    "teammate_of__driverref" => "senna"
+).values("driverref").list()
+```
+
+The forward query joins out on `from_…` and back on `to_…`; the reverse swaps them. Both traverse
+the same base table twice, which PormG resolves with distinct aliases:
+
+```sql
+SELECT "Tb"."driverref" as "driverref"
+FROM "m2m_teammate_scratch" as "Tb"
+  INNER JOIN "m2m_teammate_scratch_teammates" AS "Tb_1" ON "Tb"."id" = "Tb_1"."from_m2m_teammate_scratch_id"
+  INNER JOIN "m2m_teammate_scratch" AS "Tb_2" ON "Tb_1"."to_m2m_teammate_scratch_id" = "Tb_2"."id"
+WHERE "Tb_2"."driverref" = $1
+```
+
+!!! warning "The relation is directional — there is no `symmetrical=`"
+    Django's `ManyToManyField('self')` defaults to `symmetrical=True`, which makes `add` write the
+    link both ways and suppresses the reverse accessor. **PormG has no equivalent**: a link is
+    stored in one direction only, so `senna.teammates.add(prost)` does *not* make senna appear in
+    prost's `teammates`. If you want a symmetric relationship, add both directions yourself.
+
+    That is also why `related_name` is worth setting here. The forward and reverse accessors land on
+    the *same* model, so the default reverse name — the bare model name — reads like a foreign key
+    rather than the other end of the link.
+
+    **It must differ from every field name on that model**, the relation's own field included.
+    `teammates = ManyToManyField("…", related_name="teammates")` is the tempting spelling for a link
+    you think of as symmetric, and it would leave the reverse end permanently shadowed by the
+    forward one. PormG rejects it with a `ModelDefinitionError` rather than letting the two collapse
+    into one accessor.
+
+!!! warning "A self-`ForeignKey` and a self-`ManyToManyField` on one model need an explicit `related_name`"
+    Both derive the *same* default reverse accessor — the model's own name — and the two
+    registration paths disagree about what to do when they collide: depending on the order the
+    model's fields happen to be iterated, you either get a `ModelDefinitionError` naming the model
+    twice and neither field, or the many-to-many reverse accessor is silently discarded
+    ([#396](https://github.com/PingoLee/PormG.jl/issues/396)).
+
+    Give at least one of them an explicit `related_name` and the ambiguity disappears:
+
+    ```julia
+    M2m_teammate_scratch = Models.Model("m2m_teammate_scratch",
+      id = Models.IDField(),
+      driverref = Models.CharField(unique=true),
+      mentor = Models.ForeignKey("M2m_teammate_scratch", null=true, related_name="mentees"),
+      teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of")
+    )
+    ```
+
+!!! note "An explicit `through=` needs its ends named"
+    On a self-relation PormG cannot infer which of the through model's two foreign keys is the
+    source and which is the target — both point at the same model. It refuses rather than guessing;
+    pin `source_field` and `target_field` to the through model's own field names, the same way
+    Django requires `through_fields`:
+
+    ```julia
+    rivals = Models.ManyToManyField("M2m_racer_scratch", through="M2m_rivalry_scratch",
+                                    source_field="challenger", target_field="defender")
+    ```
+
+---
+
 ## Explicit Through Tables
 
 Sometimes you need to store extra data *on the relationship itself*. For example, you might want to know not just *which* team a driver races for, but *what year* they joined.

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -129,7 +129,13 @@ exactly as it always has, so no existing schema changes and nothing needs re-mig
 
     On the auto-derived path the join **columns** follow the logical name too (`<model>_<pk field>`),
     which is why they are
-    unaffected by a `db_table` pin. Against a Django-owned schema that closes most of the gap but not
+    unaffected by a `db_table` pin. **One exception**: when the field points at its own model, both
+    ends would derive the same string, and one table cannot carry the same column twice — so a
+    self-referential relation is spelled `from_<model>_<pk field>` / `to_<model>_<pk field>` instead
+    (#364), matching Django's rule for that case. With the conventional `id` primary key the two
+    agree byte for byte; see
+    [Self-Referential Relationships](many_to_many.md#Self-Referential-Relationships).
+    Against a Django-owned schema that closes most of the gap but not
     all of it: Django's through table is `<the owning model's table>_<field>`, so the table needs the
     pin the importer applies, while the columns line up on their own — *provided the primary key is
     named `id`*. Django always spells its m2m columns `<model_name>_id`; PormG uses the target's

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -2791,8 +2791,11 @@ function _many_to_many_table_name(source_model::PormGModel, field_name::String, 
   return format_model_name("$(source_name)_$(field_name)")
 end
 
-function _many_to_many_column_name(model::PormGModel, pk_field::String)::String
-  return format_fild_name("$(format_model_name(model.name))_$(pk_field)")
+# `prefix` exists for the SELF-REFERENTIAL case (#364) and is empty everywhere else. It prefixes the
+# whole derived name rather than being spliced in, so `from_`/`to_` land where Django puts them and
+# the stem stays byte-identical to the ordinary derivation.
+function _many_to_many_column_name(model::PormGModel, pk_field::String; prefix::String = "")::String
+  return format_fild_name("$(prefix)$(format_model_name(model.name))_$(pk_field)")
 end
 
 function _infer_through_field(through_model::PormGModel, target_model::PormGModel, role::String)::String
@@ -2830,8 +2833,30 @@ function _relation_from_many_to_many(
   # verbatim when the field pins one, and the synthesized name otherwise (#59/#345).
   through_table_name = _many_to_many_table_name(owner_model, field_name, field, settings)
   through_resolved = nothing
-  owner_column = field.source_field === nothing ? _many_to_many_column_name(owner_model, owner_pk) : field.source_field
-  related_column = field.target_field === nothing ? _many_to_many_column_name(related_model, related_pk) : field.target_field
+  # #364: a SELF-referential relation derives the same string for both ends, because both ends are
+  # the same model. That is not a cosmetic clash — `synthesize_many_to_many_through_models` builds
+  # the through model from a `Dict{Symbol, Any}` keyed on these two names, so the duplicate key
+  # resolves last-wins and the join table is created with ONE endpoint column instead of two.
+  # Silently: no error, and a table that cannot represent the relation it exists for.
+  #
+  # Django's rule for this case differs from its normal one for exactly that reason — one table
+  # cannot carry the same column twice — so it names the ends `from_<model>_id` / `to_<model>_id`.
+  # PormG keeps its own `<model>_<pk>` stem rather than Django's hardcoded `_id`, so a model keyed on
+  # `codigo` gets `from_driver_codigo`; for the usual `id` pk the two spellings coincide.
+  #
+  # Gated on NEITHER side being pinned, not per-side. `ManyToManyField("Driver", source_field =
+  # "mentor_id")` on a self-relation already yields the valid pair `mentor_id` / `driver_id` today —
+  # deriving `to_driver_id` for the unpinned half would rewrite a working schema. Explicit wins here
+  # as it does everywhere else; the residue (a pin that collides with the derived half) is caught by
+  # the guard below rather than by silently overriding what the user wrote.
+  self_relation = field.through === nothing && _same_model_reference(owner_model, related_model)
+  if self_relation && field.source_field === nothing && field.target_field === nothing
+    owner_column = _many_to_many_column_name(owner_model, owner_pk; prefix = "from_")
+    related_column = _many_to_many_column_name(related_model, related_pk; prefix = "to_")
+  else
+    owner_column = field.source_field === nothing ? _many_to_many_column_name(owner_model, owner_pk) : field.source_field
+    related_column = field.target_field === nothing ? _many_to_many_column_name(related_model, related_pk) : field.target_field
+  end
 
   if field.through !== nothing
     through_model = if field.through isa PormGModel
@@ -2858,6 +2883,16 @@ function _relation_from_many_to_many(
     owner_pk = owner_fk.pk_field === nothing ? owner_pk : String(owner_fk.pk_field)
     related_pk = related_fk.pk_field === nothing ? related_pk : String(related_fk.pk_field)
   end
+
+  # #364, fail-closed. Everything downstream — the synthesized through model's field `Dict`, the
+  # unique index, both join legs, the manager mutators — assumes these two name DIFFERENT columns.
+  # The derivation above can no longer produce a pair that violates it, so what is left is what a
+  # user wrote: both sides pinned to one name, or one side pinned to the string the other derives.
+  # Placed after the `through` block so it covers the explicit path too, where `source_field` /
+  # `target_field` bypass `_infer_through_field` entirely.
+  owner_column == related_column && throw(ModelDefinitionError(
+    "ManyToManyField $(owner_model.name).$(field_name) resolves both join columns to \e[31m$(owner_column)\e[0m; " *
+    "one join table cannot carry the same column twice. Set source_field and target_field to distinct names."))
 
   inverse_accessor = field.related_name === nothing ? get_model_name(owner_model, settings, false) : field.related_name
   return ManyToManyRelation(
@@ -2926,6 +2961,28 @@ function _register_many_to_many_relation!(_module::Module, settings::PormGSettin
   _cache_many_to_many_relation!(model, field_name, relation)
 
   reverse_accessor = relation.inverse_accessor
+  # #364: on a SELF-relation both accessors land on the SAME model but in two DIFFERENT dicts — the
+  # forward one in `model.cache["many_to_many"]` (written just above), the reverse one in
+  # `related_objects` — so the `haskey` check below is blind to a collision between them. And the
+  # readers resolve the cache FIRST (`has_many_to_many_accessor` / `get_many_to_many_relation`), so
+  # an equal name leaves the reverse relation permanently shadowed by the forward one. That is not a
+  # dead accessor: the manager's `_m2m_query` filters on `inverse_accessor`, so every `.all()` would
+  # traverse the join table backwards and silently answer the opposite question.
+  #
+  # Checked against `model.fields` rather than just `field_name` because the join builder resolves a
+  # field before a reverse accessor (`_build_row_join`), so ANY field name shadows it the same way.
+  # A non-self relation cannot reach this — its two accessors live on different models, which is why
+  # the `haskey` guard alone was sufficient before a self-relation could be built at all.
+  if _same_model_reference(related_model, model) && haskey(model.fields, reverse_accessor)
+    # The default accessor is the bare model name, so this fires on models that never wrote a
+    # `related_name` at all — say where the name came from rather than pointing at an option the
+    # user cannot find in their own source.
+    origin = field.related_name === nothing ? " (derived from the model name, because related_name is unset)" : ""
+    throw(ModelDefinitionError(
+      "ManyToManyField $(model.name).$(field_name) is self-referential, so its reverse accessor " *
+      "\e[31m$(reverse_accessor)\e[0m$(origin) collides with a field of the same name on that model " *
+      "and would be silently unreachable. Give the reverse end a distinct related_name."))
+  end
   haskey(related_model.related_objects, reverse_accessor) && throw(ModelDefinitionError("The related_name $(reverse_accessor) in the model $(model.name) is already defined"))
   related_model.related_objects[reverse_accessor] = _reverse_many_to_many_relation(relation, reverse_accessor)
   field.related_name === nothing && (field.related_name = reverse_accessor)

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -1240,7 +1240,14 @@ A self-referential M2M is the one case where Django does not use `<class>_id` at
 cannot carry the same column twice, so it names the ends `from_<class>_id` / `to_<class>_id`. That
 case was unreachable before #346 — `ManyToManyField("self")` died at `set_models` — so resolving
 `"self"` without this would have traded a loud failure for a join table with one column doing two
-jobs. (The same defect for hand-written models is #364.)
+jobs.
+
+The same defect for hand-written models was #364, now fixed in `_relation_from_many_to_many`, which
+derives `from_<model>_<pk>` / `to_<model>_<pk>` for a self-relation. This pin is therefore no longer
+load-bearing for an `id`-keyed model — the two derivations agree byte for byte — but it is still
+required for any other primary key, because Django hardcodes `_id` where PormG carries the pk field
+name. Pinning both ends here also routes the field down the explicit branch, which is what keeps the
+importer's output independent of PormG's own derivation.
 """
 function _pin_m2m_join_columns!(index::_DjangoClassIndex)
   by_binding = Dict{String, _DjangoClass}()

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -383,6 +383,23 @@ M2m_driver_default_reverse_scratch = Models.Model("m2m_driver_default_reverse_sc
   partners = Models.ManyToManyField(M2m_brand_scratch),
 )
 
+# #364 — SELF-referential ManyToManyField: both ends of the relation resolve to THIS model, so the
+# join columns take Django's `from_`/`to_` spelling (`from_m2m_teammate_scratch_id` /
+# `to_m2m_teammate_scratch_id`) instead of the same `<model>_<pk>` string twice. Mirrors the Django
+# importer fixture's `racing.Driver.teammates` (#346), which reaches the same shape by pinning.
+#
+# The target is a STRING on purpose: a model cannot reference its own binding before it exists, so
+# the string is the only way to write this by hand — and it is resolved at `set_models`.
+#
+# `related_name` is set because the reverse accessor lands on this same model alongside the forward
+# one; the default would be the bare model name, which reads as a foreign key rather than the other
+# end of a teammate link. PormG has no Django `symmetrical=`, so the relation is DIRECTIONAL.
+M2m_teammate_scratch = Models.Model("m2m_teammate_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of"),
+)
+
 # Case-preservation (#57) fixtures — DELIBERATELY mixed-case COLUMNS (driverRef,
 # foreName, parentRef, lapTime) to prove PormG creates and queries genuinely
 # mixed-case columns on a live DB. These are capability fixtures, NOT the house

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -381,6 +381,23 @@ M2m_driver_default_reverse_scratch = Models.Model("m2m_driver_default_reverse_sc
   partners = Models.ManyToManyField(M2m_brand_scratch),
 )
 
+# #364 — SELF-referential ManyToManyField: both ends of the relation resolve to THIS model, so the
+# join columns take Django's `from_`/`to_` spelling (`from_m2m_teammate_scratch_id` /
+# `to_m2m_teammate_scratch_id`) instead of the same `<model>_<pk>` string twice. Mirrors the Django
+# importer fixture's `racing.Driver.teammates` (#346), which reaches the same shape by pinning.
+#
+# The target is a STRING on purpose: a model cannot reference its own binding before it exists, so
+# the string is the only way to write this by hand — and it is resolved at `set_models`.
+#
+# `related_name` is set because the reverse accessor lands on this same model alongside the forward
+# one; the default would be the bare model name, which reads as a foreign key rather than the other
+# end of a teammate link. PormG has no Django `symmetrical=`, so the relation is DIRECTIONAL.
+M2m_teammate_scratch = Models.Model("m2m_teammate_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of"),
+)
+
 # Case-preservation (#57) fixtures — DELIBERATELY mixed-case COLUMNS (driverRef,
 # foreName, parentRef, lapTime) to prove PormG creates and queries genuinely
 # mixed-case columns on a live DB. These are capability fixtures, NOT the house

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -46,10 +46,30 @@ const _M2M_SCRATCH_TABLES = (
     "m2m_squad_dbtable_scratch",
     "m2m_tester_dbtable_scratch",
     "m2m_enrolment_join_tbl",
+    # #364, self-referential M2M. Both the owner table and its auto-generated join table are listed.
+    "m2m_teammate_scratch",
+    "m2m_teammate_scratch_teammates",
+)
+
+# Tables whose SHAPE also has to be checked, not just their existence.
+#
+# `table_exists` answers existence only, so it cannot see the #364 failure mode: a database migrated
+# against the pre-fix tree has `m2m_teammate_scratch_teammates` — it just has ONE endpoint column
+# instead of two, because the duplicate `Dict` key collapsed. That table passes the existence sweep,
+# so `makemigrations` never fires and the run dies further down with a confusing "no such column".
+# Listing the required columns here makes the stale-schema case self-heal exactly like the
+# missing-table case.
+const _M2M_SCRATCH_TABLE_COLUMNS = Dict(
+    "m2m_teammate_scratch_teammates" => ["from_m2m_teammate_scratch_id", "to_m2m_teammate_scratch_id"],
 )
 
 function _m2m_scratch_table_exists(pool, table_name::String)::Bool
-    return Base.invokelatest(table_exists, pool, table_name)
+    Base.invokelatest(table_exists, pool, table_name) || return false
+    required = get(_M2M_SCRATCH_TABLE_COLUMNS, table_name, nothing)
+    required === nothing && return true
+    # Present but the WRONG SHAPE counts as missing, so the migration path below runs (#364).
+    have = Base.invokelatest(column_names, pool, table_name)
+    return all(c -> c in have, required)
 end
 
 function _ensure_m2m_scratch_schema!()
@@ -537,6 +557,99 @@ end
     M.M2m_sponsor_scratch.objects.delete(allow_delete_all=true)
     M.M2m_brand_scratch.objects.delete(allow_delete_all=true)
     M.M2m_driver_default_reverse_scratch.objects.delete(allow_delete_all=true)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #364: a SELF-referential ManyToManyField, end to end.
+#
+# Both ends of the relation resolve to one model, so the join columns used to derive the same string
+# twice. The damage was structural rather than cosmetic: the through model is built from a
+# `Dict{Symbol, Any}` keyed on those two names, so the duplicate key collapsed last-wins and the
+# migration created `m2m_teammate_scratch_teammates` with `id` plus ONE endpoint column. Every
+# assertion below is unreachable on that schema — the join has no second column to land on.
+#
+# What only this layer can prove: that the two `from_`/`to_` columns are real columns in a real
+# table, that a row can be written through one end and read back from the other, and that traversing
+# FORWARD and traversing BACK return different drivers. The unit suite renders the SQL; it cannot
+# tell you the database accepted it.
+#
+# The relation is DIRECTIONAL — PormG has no Django `symmetrical=` — so `senna → prost` does not
+# imply `prost → senna`. The asymmetry assertions below are the point, not an oversight.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Many-to-Many: self-referential relation (#364)" begin
+    # Inside the `try` so a failure here still runs the cleanup below.
+    try
+        M.M2m_teammate_scratch.objects.delete(allow_delete_all=true)
+
+        senna = M.M2m_teammate_scratch.objects.create("driverref" => "senna")
+        prost = M.M2m_teammate_scratch.objects.create("driverref" => "prost")
+        berger = M.M2m_teammate_scratch.objects.create("driverref" => "berger")
+
+        # The relation records two DIFFERENT columns. Stated first because everything after it is
+        # meaningless if this regresses — and on the bug the run would fail here rather than in a
+        # confusing place downstream.
+        rel = Models.get_many_to_many_relation(M.M2m_teammate_scratch, "teammates")
+        @test rel.owner_column == "from_m2m_teammate_scratch_id"
+        @test rel.related_column == "to_m2m_teammate_scratch_id"
+        @test rel.through_table == "m2m_teammate_scratch_teammates"
+
+        # Both are real columns on the real table — the assertion that fails on the collapsed
+        # two-column schema even if the relation metadata were somehow right.
+        cols = Base.invokelatest(column_names, PormG.config[PORMG_DB_FOLDER].connections,
+                                 "m2m_teammate_scratch_teammates")
+        @test "from_m2m_teammate_scratch_id" in cols
+        @test "to_m2m_teammate_scratch_id" in cols
+
+        # --- Writing through the manager ---------------------------------------------------------
+        senna_mgr = M.M2m_teammate_scratch.teammates(senna)
+        @test senna_mgr.add(prost, berger) === nothing
+        @test Set([row[:driverref] for row in senna_mgr.all().list()]) == Set(["prost", "berger"])
+
+        # Idempotent re-add (PostgreSQL: WHERE NOT EXISTS; SQLite: INSERT OR IGNORE) — this is what
+        # the composite unique index over the two columns backs. On the collapsed schema the index
+        # covered one column twice, which capped each driver at a single teammate.
+        @test senna_mgr.add(prost) === nothing
+        @test length(senna_mgr.all().list()) == 2
+
+        # --- The relation is directional ---------------------------------------------------------
+        # senna → prost was written; prost → senna was not. Same table, opposite columns.
+        prost_mgr = M.M2m_teammate_scratch.teammates(prost)
+        @test isempty(prost_mgr.all().list())
+
+        # --- Forward traversal: who has prost as a teammate? --------------------------------------
+        forward = M.M2m_teammate_scratch.objects
+        forward.filter("teammates__driverref" => "prost")
+        forward.values("driverref")
+        forward_rows = forward.list()
+        @test length(forward_rows) == 1
+        @test forward_rows[1][:driverref] == "senna"
+
+        # --- Reverse traversal via related_name: whose teammate is senna? -------------------------
+        # The same physical rows read from the other end. That this returns a DIFFERENT driver than
+        # the forward query is the end-to-end proof the two join columns are distinct: with one
+        # column doing both jobs the two directions cannot disagree.
+        reverse = M.M2m_teammate_scratch.objects
+        reverse.filter("teammate_of__driverref" => "senna")
+        reverse.values("driverref")
+        reverse_rows = reverse.list()
+        @test Set([row[:driverref] for row in reverse_rows]) == Set(["prost", "berger"])
+        @test forward_rows[1][:driverref] ∉ [row[:driverref] for row in reverse_rows]
+
+        # --- set / remove / clear on a self-relation ----------------------------------------------
+        diff = senna_mgr.set(berger)
+        @test diff.added == 0
+        @test diff.removed == 1
+        @test [row[:driverref] for row in senna_mgr.all().list()] == ["berger"]
+
+        @test senna_mgr.remove(berger) === nothing
+        @test isempty(senna_mgr.all().list())
+
+        @test senna_mgr.add(prost, berger) === nothing
+        @test senna_mgr.clear() === nothing
+        @test isempty(senna_mgr.all().list())
+    finally
+        M.M2m_teammate_scratch.objects.delete(allow_delete_all=true)
+    end
 end
 
 @testset "Many-to-Many advanced: read-only guard" begin

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -793,3 +793,329 @@ end
   source_sql = join(values(plan[:racing_driver]), "\n")
   @test !occursin("\"teams\"", source_sql)
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #364 fixture: SELF-referential ManyToManyFields.
+#
+# Both ends of the relation resolve to one model, which is the case where PormG's ordinary
+# `<model>_<pk>` derivation produces the SAME string twice. Registered through `set_models` so the
+# join-rendering testset below has a real `_module` to resolve bindings against — the derivation
+# testsets call `_relation_from_many_to_many` directly and do not need it.
+#
+# `Teammate` carries the default `id` primary key (the Django-identical case) and `Rival` a `codigo`
+# one, so both spellings the fix has to produce are fixtured.
+# ─────────────────────────────────────────────────────────────────────────────
+module ManyToManySelfModels
+import PormG
+import PormG.Models
+
+Teammate = Models.Model("teammate",
+  id = Models.IDField(),
+  driverref = Models.CharField(),
+  teammates = Models.ManyToManyField("Teammate", related_name="teammate_of"),
+)
+
+Rival = Models.Model("rival",
+  codigo = Models.CharField(primary_key=true),
+  rivals = Models.ManyToManyField("Rival", related_name="rival_of"),
+)
+
+PormG.Models.set_models(@__MODULE__, "m2m_mock")
+end
+
+const M2MSELF = ManyToManySelfModels
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364): a self-referential relation derives `from_`/`to_`-prefixed join columns.
+# Both ends resolve to the same model, so the plain `<model>_<pk>` rule derives one string twice and
+# the join table ends up with a single endpoint column. Django prefixes the ends for exactly this
+# reason; PormG keeps its own `<model>_<pk>` STEM rather than Django's hardcoded `_id`, so the two
+# agree whenever the primary key is `id` and diverge intentionally when it is not.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a self-referential ManyToManyField derives from_/to_ join columns (#364)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  # --- The plain `id` case: byte-identical to Django's from_driver_id / to_driver_id -------------
+  driver = Models.Model("driver", id = Models.IDField(), surname = Models.CharField())
+  field = Models.ManyToManyField("Driver")
+  rel = Models._relation_from_many_to_many(driver, "Driver", "teammates", field, driver, "Driver", settings)
+
+  @test rel.owner_column == "from_driver_id"
+  @test rel.related_column == "to_driver_id"
+  # The property that actually matters, stated directly rather than implied by the two above.
+  @test rel.owner_column != rel.related_column
+  # The through TABLE name never carried the collision and is untouched by any of this.
+  @test rel.through_table == "driver_teammates"
+
+  # --- A non-`id` primary key keeps PormG's stem ------------------------------------------------
+  # Django would spell both ends `_id` regardless; PormG addresses the column its own migration
+  # planner creates, which follows the pk field name.
+  codigo = Models.Model("piloto", codigo = Models.CharField(primary_key=true))
+  codigo_rel = Models._relation_from_many_to_many(
+    codigo, "Piloto", "parceiros", Models.ManyToManyField("Piloto"), codigo, "Piloto", settings)
+  @test codigo_rel.owner_column == "from_piloto_codigo"
+  @test codigo_rel.related_column == "to_piloto_codigo"
+
+  # --- Explicit pins still win, on both sides ---------------------------------------------------
+  pinned = Models.ManyToManyField("Driver", source_field="left_id", target_field="right_id")
+  pinned_rel = Models._relation_from_many_to_many(driver, "Driver", "teammates", pinned, driver, "Driver", settings)
+  @test pinned_rel.owner_column == "left_id"
+  @test pinned_rel.related_column == "right_id"
+
+  # --- Pinning ONE side leaves the other on the plain derivation ---------------------------------
+  # Deliberate, and the reason the branch is gated on "neither pinned" rather than applied per side:
+  # `source_field = "mentor_id"` already yields the valid pair mentor_id / driver_id today, and
+  # deriving `to_driver_id` for the unpinned half would rewrite a schema that works.
+  half = Models.ManyToManyField("Driver", source_field="mentor_id")
+  half_rel = Models._relation_from_many_to_many(driver, "Driver", "teammates", half, driver, "Driver", settings)
+  @test half_rel.owner_column == "mentor_id"
+  @test half_rel.related_column == "driver_id"
+
+  # --- A NON-self relation is completely unaffected ---------------------------------------------
+  # The guard against "fixing" this by prefixing every m2m column.
+  sponsor = Models.Model("sponsor", id = Models.IDField())
+  plain_rel = Models._relation_from_many_to_many(
+    driver, "Driver", "sponsors", Models.ManyToManyField(sponsor), sponsor, "Sponsor", settings)
+  @test plain_rel.owner_column == "driver_id"
+  @test plain_rel.related_column == "sponsor_id"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364): the synthesized through table carries THREE columns, not two.
+# This is the assertion that catches the real damage. `synthesize_many_to_many_through_models` builds
+# the through model from a `Dict{Symbol, Any}` keyed on the two join column names, so when they were
+# equal the duplicate key resolved last-wins and the table was planned with `id` plus ONE endpoint —
+# silently, with a unique index over the same column twice. Counting the fields is what fails on the
+# bug; asserting the two names alone would not, because the Dict collapse happens downstream of them.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a self-referential ManyToManyField synthesizes a three-column through table (#364)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  current_schema = Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}(
+    :teammate => Dict{Symbol, Union{Bool, PormGModel}}(:model => M2MSELF.Teammate, :exist => false),
+  )
+
+  expanded = Models.synthesize_many_to_many_through_models(current_schema, settings)
+  @test haskey(expanded, :teammate_teammates)
+
+  through = expanded[:teammate_teammates][:model]
+  # `id` + BOTH endpoints. On the bug this was ["id", "teammate_id"] — length 2.
+  @test length(through.fields) == 3
+  @test sort(collect(keys(through.fields))) == ["from_teammate_id", "id", "to_teammate_id"]
+
+  # The unique index names both columns, so it is a real composite constraint rather than the same
+  # column repeated (which capped each row at a single link).
+  auto = through.cache["many_to_many_auto"]
+  @test auto["owner_column"] == "from_teammate_id"
+  @test auto["related_column"] == "to_teammate_id"
+  @test auto["unique_index"] == "teammate_teammates_from_teammate_id_to_teammate_id_uniq"
+
+  # And it reaches the emitted DDL, not just the cache.
+  plan = Migrations.get_migration_plan(PormGModel[], current_schema, M2MMockPostgres(), settings, interactive=false)
+  through_sql = join(values(plan[:teammate_teammates]), "\n")
+  @test occursin("CREATE TABLE", through_sql)
+  @test occursin("from_teammate_id", through_sql)
+  @test occursin("to_teammate_id", through_sql)
+  @test occursin("CREATE UNIQUE INDEX", through_sql)
+  # The source table gains no column of its own for the relation.
+  @test !occursin("\"teammates\"", join(values(plan[:teammate]), "\n"))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364): two join columns resolving to one name is refused, not planned.
+# The derivation can no longer produce a colliding pair on its own, so what reaches this guard is
+# what a user wrote — both sides pinned to one name, or one side pinned to the string the other
+# derives. Fail-closed: every downstream consumer (the through model's field Dict, the unique index,
+# both join legs, the manager mutators) assumes the two name different columns.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a ManyToManyField whose ends resolve to one column is refused (#364)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+  driver = Models.Model("driver", id = Models.IDField())
+
+  # Both sides pinned to the same name.
+  both = Models.ManyToManyField("Driver", source_field="link_id", target_field="link_id")
+  err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "teammates", both, driver, "Driver", settings)
+  @test occursin("link_id", err.value.msg)
+  @test occursin("source_field", err.value.msg)
+
+  # One side pinned to exactly what the other derives — the residue the "neither pinned" gate leaves.
+  # The cause is asserted, not just the type: `ModelDefinitionError` is this file's catch-all (some
+  # two dozen throw sites in `Models.jl`), so a future validator firing earlier on the same input
+  # would keep a type-only assertion green with THIS guard deleted.
+  collide = Models.ManyToManyField("Driver", source_field="driver_id")
+  collide_err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "teammates", collide, driver, "Driver", settings)
+  @test occursin("cannot carry the same column twice", collide_err.value.msg)
+
+  # The guard sits AFTER the `through` block, so the explicit path is covered too — there
+  # `source_field`/`target_field` bypass `_infer_through_field` entirely.
+  target = Models.Model("team", id = Models.IDField())
+  through_model = Models.Model("membership",
+    id = Models.IDField(),
+    driver = Models.ForeignKey(driver, on_delete=Models.CASCADE),
+    team = Models.ForeignKey(target, on_delete=Models.CASCADE),
+  )
+  # `through_model.fields["driver"]` exists, so nothing else on this path can throw — which is
+  # exactly why the cause is asserted: a DIFFERENT future error is what would masquerade here.
+  through_collide = Models.ManyToManyField(target, through=through_model,
+                                           source_field="driver", target_field="driver")
+  through_err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "teams", through_collide, target, "Team", settings)
+  @test occursin("cannot carry the same column twice", through_err.value.msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364): on a self-relation the reverse accessor may not collide with a field.
+# The two accessors for a self-relation land on ONE model but in two different dicts — the forward in
+# `model.cache["many_to_many"]`, the reverse in `related_objects` — so the pre-existing duplicate
+# `related_name` check cannot see a collision between them. Since every reader resolves the cache (and
+# the join builder resolves `fields`) FIRST, an equal name leaves the reverse relation permanently
+# shadowed, and the manager then traverses the join table backwards while reporting no error at all.
+# Same silent-collapse class as the column bug this issue is about, one dict over.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a self-referential ManyToMany refuses a reverse accessor that shadows a field (#364)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  # `related_name` equal to the m2m field's OWN name — the natural spelling for a relation a user
+  # thinks of as symmetric, and the one the docs steer toward by recommending `related_name`.
+  shadow_module = Module(:M2MShadowSelf)
+  Core.eval(shadow_module, :(import PormG; import PormG.Models))
+  Core.eval(shadow_module, :(Teammate = Models.Model("teammate_shadow",
+    id = Models.IDField(),
+    driverref = Models.CharField(),
+    teammates = Models.ManyToManyField("Teammate", related_name="teammates"),
+  )))
+  shadow = Core.eval(shadow_module, :(Teammate))
+  err = @test_throws PormG.ModelDefinitionError Models._register_many_to_many_relation!(
+    shadow_module, settings, shadow, "teammates", shadow.fields["teammates"])
+  @test occursin("self-referential", err.value.msg)
+  @test occursin("related_name", err.value.msg)
+
+  # Any OTHER field name shadows it identically, because the join builder resolves a field before a
+  # reverse accessor — so the guard checks `model.fields`, not just the m2m field's own name.
+  other_module = Module(:M2MShadowOther)
+  Core.eval(other_module, :(import PormG; import PormG.Models))
+  Core.eval(other_module, :(Teammate = Models.Model("teammate_shadow2",
+    id = Models.IDField(),
+    driverref = Models.CharField(),
+    teammates = Models.ManyToManyField("Teammate", related_name="driverref"),
+  )))
+  other = Core.eval(other_module, :(Teammate))
+  other_err = @test_throws PormG.ModelDefinitionError Models._register_many_to_many_relation!(
+    other_module, settings, other, "teammates", other.fields["teammates"])
+  # This case covers the WIDENED half of the guard, so it is the one where a masquerading
+  # `ModelDefinitionError` from somewhere else would hide the most. Assert the cause.
+  @test occursin("collides with a field", other_err.value.msg)
+
+  # A DISTINCT related_name registers both ends, and they stay distinguishable. This is the
+  # assertion that keeps the guard from being over-broad.
+  @test Models.get_many_to_many_relation(M2MSELF.Teammate, "teammates").reverse == false
+  @test M2MSELF.Teammate.related_objects["teammate_of"].reverse == true
+
+  # A NON-self relation is untouched: its two accessors land on DIFFERENT models, so a related_name
+  # matching a field on the OWNER is not a collision at all.
+  #
+  # `chassis` exists on the owner and NOT on the target, deliberately. The reverse accessor is
+  # installed on the TARGET, so a name that also exists there would be a genuine shadow — the same
+  # failure this guard closes, one model over — and asserting success on it would pin a broken
+  # configuration as correct. That cross-model half is pre-existing and out of this issue's scope
+  # (the correct general check is `haskey(related_model.fields, …)`, equivalent to the shipped
+  # `haskey(model.fields, …)` only under the self gate); this fixture must not bless it either way.
+  sponsor = Models.Model("shadow_sponsor", id = Models.IDField(), name = Models.CharField())
+  cross_module = Module(:M2MShadowCross)
+  Core.eval(cross_module, :(import PormG; import PormG.Models))
+  Core.eval(cross_module, :(Sponsor = $sponsor))
+  Core.eval(cross_module, :(Racer = Models.Model("shadow_racer",
+    id = Models.IDField(),
+    chassis = Models.CharField(),
+    sponsors = Models.ManyToManyField(Sponsor, related_name="chassis"),
+  )))
+  racer = Core.eval(cross_module, :(Racer))
+  @test !haskey(sponsor.fields, "chassis")   # precondition: not a shadow on the target either
+  @test Models._register_many_to_many_relation!(
+    cross_module, settings, racer, "sponsors", racer.fields["sponsors"]) === nothing
+  # And the reverse accessor it installed is genuinely reachable.
+  @test sponsor.related_objects["chassis"] isa Models.ManyToManyRelation
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364): a self-relation renders a correct self-join in BOTH directions.
+# Asserting the two column names differ passes for any two distinct strings — it cannot tell whether
+# the join builder puts them on the right legs. This renders the SQL instead: the base table appears
+# twice under DIFFERENT aliases with the through table between them, the forward direction leaves on
+# `from_` and arrives on `to_`, and the reverse direction swaps exactly those two.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a self-referential ManyToMany renders a correct self-join both ways (#364)" begin
+  # --- Forward: the field's own accessor ---------------------------------------------------------
+  forward = M2MSELF.Teammate.objects
+  forward.filter("teammates__driverref" => "senna")
+  forward.values("driverref")
+  forward_sql = inspect_query(forward)[:sql_text]
+
+  @test occursin("FROM \"teammate\" as \"Tb\"", forward_sql)
+  @test occursin("\"teammate_teammates\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"from_teammate_id\"", forward_sql)
+  @test occursin("\"teammate\" AS \"Tb_2\" ON \"Tb_1\".\"to_teammate_id\" = \"Tb_2\".\"id\"", forward_sql)
+
+  # --- Reverse: the related_name accessor, which must mirror the two legs ------------------------
+  reverse = M2MSELF.Teammate.objects
+  reverse.filter("teammate_of__driverref" => "prost")
+  reverse.values("driverref")
+  reverse_sql = inspect_query(reverse)[:sql_text]
+
+  @test occursin("\"teammate_teammates\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"to_teammate_id\"", reverse_sql)
+  @test occursin("\"teammate\" AS \"Tb_2\" ON \"Tb_1\".\"from_teammate_id\" = \"Tb_2\".\"id\"", reverse_sql)
+
+  # The two directions are genuinely different queries — on the bug both legs referenced one column,
+  # so traversing forward and traversing back were indistinguishable.
+  @test forward_sql != reverse_sql
+
+  # --- The relation is registered on ONE model, forward and reverse both -------------------------
+  fwd_rel = Models.get_many_to_many_relation(M2MSELF.Teammate, "teammates")
+  rev_rel = M2MSELF.Teammate.related_objects["teammate_of"]
+  @test fwd_rel.owner_column == "from_teammate_id"
+  @test fwd_rel.related_column == "to_teammate_id"
+  @test rev_rel isa Models.ManyToManyRelation
+  @test rev_rel.reverse
+  # The reverse relation swaps the two ends; the through table is the same one read backwards.
+  @test rev_rel.owner_column == fwd_rel.related_column
+  @test rev_rel.related_column == fwd_rel.owner_column
+  @test rev_rel.through_table == fwd_rel.through_table
+
+  # --- The non-`id` primary key fixture reaches the same place ----------------------------------
+  rival_rel = Models.get_many_to_many_relation(M2MSELF.Rival, "rivals")
+  @test rival_rel.owner_column == "from_rival_codigo"
+  @test rival_rel.related_column == "to_rival_codigo"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ManyToManyField (#364, adjacent): an explicit `through=` on a self-relation still fails LOUDLY.
+# Nothing here changed, and pinning it says so. `_infer_through_field` scans the through model for
+# foreign keys to the target; on a self-relation both sides find the same TWO, so it refuses rather
+# than guessing which end is which. That matches Django, which requires `through_fields` in exactly
+# this case, and the message names the escape hatch.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an explicit through= on a self-relation demands explicit source/target fields (#364)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  driver = Models.Model("racer", id = Models.IDField(), surname = Models.CharField())
+  rivalry = Models.Model("rivalry",
+    id = Models.IDField(),
+    challenger = Models.ForeignKey(driver, on_delete=Models.CASCADE),
+    defender = Models.ForeignKey(driver, on_delete=Models.CASCADE),
+  )
+
+  err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Racer", "rivals", Models.ManyToManyField(driver, through=rivalry), driver, "Racer", settings)
+  @test occursin("multiple foreign keys", err.value.msg)
+  @test occursin("source_field", err.value.msg)
+
+  # And pinning both ends resolves it — the through model's own FK field names become the columns.
+  resolved = Models._relation_from_many_to_many(
+    driver, "Racer", "rivals",
+    Models.ManyToManyField(driver, through=rivalry, source_field="challenger", target_field="defender"),
+    driver, "Racer", settings)
+  @test resolved.owner_column == "challenger"
+  @test resolved.related_column == "defender"
+  @test resolved.through_table == "rivalry"
+end


### PR DESCRIPTION
Closes #364.

## The problem, and why it was worse than reported

Both ends of a self-referential `ManyToManyField` resolve to the same model, so `_many_to_many_column_name` derived the identical `<model>_<pk>` string twice. The issue predicted "one column doing two jobs". What actually happened is a silent collapse:

```
rel.owner_column   = "driver_id"
rel.related_column = "driver_id"

synthesize_many_to_many_through_models →
  through fields : ["driver_id", "id"]     ← TWO columns, not three
  unique_index   : "driver_teammates_driver_id_driver_id_uniq"
```

`synthesize_many_to_many_through_models` builds the through model from a `Dict{Symbol, Any}` keyed on those two names, so the duplicate key resolved last-wins. A self-M2M migrated to a join table that structurally cannot store the relation — no error, no warning — and the unique index over one column repeated capped each row at a single link.

## The fix

**`_relation_from_many_to_many`** derives `from_<model>_<pk>` / `to_<model>_<pk>` for a self-relation, matching Django's rule for the case while keeping PormG's own `<model>_<pk>` stem rather than Django's hardcoded `_id`. With the conventional `id` primary key the two spellings coincide; a model keyed on `codigo` gets `from_piloto_codigo`, which is the column PormG's own migrations create.

Gated on **neither** side being pinned rather than applied per side. `ManyToManyField("Driver", source_field="mentor_id")` on a self-relation already yields the valid pair `mentor_id` / `driver_id` today, and deriving `to_driver_id` for the unpinned half would rewrite a schema that works. Explicit wins here as everywhere else.

**A fail-closed guard** then refuses any pair that still resolves equal — both sides pinned to one name, or one side pinned to the string the other derives. Placed after the `through` block so it covers the explicit path, where `source_field` / `target_field` bypass `_infer_through_field` entirely.

## A second instance of the same defect class, found in review

On a self-relation the forward accessor lives in `model.cache["many_to_many"]` and the reverse in `related_objects` — two dicts on one model — so the pre-existing duplicate-`related_name` check was blind to a collision *between* them. Because the readers resolve the cache first (and the join builder resolves fields before reverse accessors), `related_name="teammates"` registered cleanly and left the reverse end permanently shadowed. Not merely a dead accessor: the manager's `_m2m_query` filters on `inverse_accessor`, so every `.all()` traversed the join table backwards and silently answered the opposite question.

`_register_many_to_many_relation!` now refuses it, checked against `model.fields` rather than just the field's own name, since any field name shadows identically. Non-self relations are unaffected — their two accessors land on different models.

## Deliberately not done

**The ForeignKey reverse-accessor collision at `Models.jl:651`.** The `related_name === nothing` arm assigns unguarded while its three siblings check, so a self-`ForeignKey` next to a self-`ManyToManyField` — both defaulting to the model's own name — collides depending on `Dict` iteration order: 6/10 runs threw, 4/10 silently discarded the M2M reverse accessor.

Pre-existing, not enabled by this PR: registration already behaved this way on `main`; what changed is that the M2M half now produces a working table, so the shape is worth writing. Fixing it alters `ForeignKey` behavior for model shapes that exist in downstream apps today and needs its own audit. Filed as #396 (`bug`, `pre-publish`) and documented in `docs/src/many_to_many.md` so the trap is at least a stated one.

**Explicit `through=` on a self-relation** still raises `"has multiple foreign keys to X; set source_field explicitly"`. That is correct and matches Django's `through_fields` requirement — pinned with a regression test rather than changed.

**The >63-byte unique-index name.** PostgreSQL truncates `m2m_teammate_scratch_teammates_..._uniq` (91 chars) with a `NOTICE`. Inert: `_add_many_to_many_auto_constraints` runs only from `_add_new_table`, so the index is created once with the table and never re-compared against introspection. Already the status quo — the existing `m2m_driver_endorsement_scratch` index is 101 chars in the passing suite.

**No `UPGRADING.md` entry and no `Project.toml` bump.** A self-M2M could not produce a working schema at all, so nothing forces a consuming-app source edit, and the "neither pinned" gate preserves every configuration that works today. Additive → documented in `docs/`, not in the rollout log.

## Verification

| | Result |
|---|---|
| Unit suite | **7370 / 7370** |
| Guard tests (`test_docs_error_type_drift`, `test_docs_error_types`) | green |
| Mutation check | new tests fail on the unfixed tree (`length(through.fields)` → 2, not 3) |
| Integration slice, `db_sl` | all 12 testsets; #364 testset 22 assertions |
| Integration slice, `db_2` (PostgreSQL) | all 12 testsets; #364 testset 22 assertions |
| Doc examples | both new blocks executed against live `f1.sqlite` |
| Docs build | clean; all cross-page anchors resolve |

Tests span both layers, as the bug does. The unit testsets pin the derivation, the three-column synthesis (the assertion that actually fails on the bug — the two column names alone would not, since the `Dict` collapse happens downstream of them), the guard, the shadowing refusal, and the rendered forward/reverse join SQL. The integration testset reads the live column list and proves that traversing forward and traversing back return *different* drivers — which with one column doing both jobs is impossible.

`_ensure_m2m_scratch_schema!` was also made shape-aware: `table_exists` is existence-only, so a database migrated against the pre-fix tree would have kept its stale two-column join table and died later on "no such column". It now self-heals like the missing-table case.

## Review

Two independent review rounds by a fresh reader. Round one surfaced the shadowing bug above. Round two found a real defect in the new tests — the "non-self relations are untouched" case used a `related_name` that also matched a field on the *target* model, so it asserted success on a silently broken configuration. Both were reproduced before being acted on; both are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
