### PR TITLE
fix(#369): a declared primary key suppresses Django's implicit id

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -626,8 +626,40 @@ field and its source line; it is never dropped silently.
 
 ### Automatic Additions
 
-- **Primary Key**: If no primary key is defined, `id = Models.IDField()` is automatically added
-- **AbstractUser**: For models inheriting from `AbstractUser`, additional fields like `date_joined` are added
+- **Primary Key**: If no primary key is defined, `id = Models.IDField()` is automatically added.
+  Declaring any field `primary_key=True` **suppresses** it, as in Django — including a field named
+  `id` itself, which then keeps its declared type
+- **AbstractUser**: For models inheriting from `AbstractUser`, additional fields like `date_joined` are added.
+  `id` is **not** one of them: `AbstractUser` inherits Django's implicit `id` from `models.Model`
+  rather than owning it, so a user model keyed on its own field — `matricula = CharField(primary_key=True)`
+  on a legacy table — has that one key and no `id`, like any other model
+
+!!! warning "Not every field type can be a primary key in PormG"
+    `primary_key=True` is honoured on exactly six types: `IDField`, `AutoField`, `CharField`,
+    `UUIDField`, `ForeignKey` and `OneToOneField`.
+
+    `DecimalField` and `FloatField` reject it deliberately (precision-comparison risk) and **raise**,
+    which stops the import — re-declare that column as a `CharField` key in Django, or exclude it.
+
+    On every other type it is silently **dropped** at construction, so
+    `codigo = models.IntegerField(primary_key=True)` imports as a plain `IntegerField` and the model
+    ends up with **no** primary key at all.
+
+    The importer does **not** paper over that with a synthetic `id`: the Django table has no such
+    column, and naming one would break every query that expands the field list. It emits a `# PormG:`
+    marker above the model and a warning naming the field, so the gap is visible in the artifact.
+
+    **Fix it — do not ship it.** A model with no primary key is not merely limited:
+
+    - a `ManyToManyField` pointing at it makes the **whole generated file fail to load**
+      (`ModelDefinitionError: … requires the target model to define a single primary key`), taking
+      every other model in the file with it;
+    - a `ForeignKey` pointing at it **loads and is silently wrong** — the key is rendered as
+      `pk_field="id"`, naming a column the table does not have;
+    - `save()` and the migration planner have nothing to key on.
+
+    Re-declare the key by hand as `Models.CharField(primary_key=true, …)` or
+    `Models.UUIDField(primary_key=true)`, matching the real column.
 
 !!! note "Django-import conventions differ from native PormG"
     The importer deliberately matches **Django's** schema conventions, not PormG's: it auto-adds an
@@ -645,7 +677,7 @@ field and its source line; it is never dropped silently.
 | | |
 |---|---|
 | **Imported** | Fields (including definitions wrapped across lines), `ForeignKey` / `OneToOneField` / `ManyToManyField` — including `"self"`, `"<app_label>.<Class>"` and `settings.AUTH_USER_MODEL` targets, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints`, `Meta.indexes`, `Meta.index_together` (the last three: see the whitelists above), abstract-base inheritance, `AbstractUser` auth columns, `TextChoices` / `IntegerChoices` enumerations |
-| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them |
+| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them. A `primary_key=True` on a field type PormG cannot key on — the column survives, the key does not, and no `id` is substituted; the model is then unusable by relations until you re-declare the key (see the warning above) |
 | **Reported and skipped** | `Meta.ordering` and every other option with no PormG equivalent; a `UniqueConstraint` or an `Index` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`) |
 | **Not supported** | Field types PormG does not implement — these raise, naming the field and class, rather than importing something wrong. Model methods, managers, signals and validators are Python and have no PormG counterpart |
 

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -1254,15 +1254,19 @@ function _pin_m2m_join_columns!(index::_DjangoClassIndex)
   for e in index.entries
     e.model === nothing || (by_binding[e.binding] = e)
   end
-  # `get_model_pk_field` THROWS when a model carries more than one primary key, and a model can:
-  # `process_class_fields!` injects an `id` for every `AbstractUser` subclass, so a legacy user table
-  # that also declares `matricula = CharField(primary_key=True)` has two (#369). Calling it eagerly for every
-  # entry turned that into a raw `ModelDefinitionError` that aborted the WHOLE import — no file, no
-  # marker, every other model lost — for a project that has no ManyToManyField anywhere, on both
-  # arities. So it is called lazily, only for models that actually own an auto-derived M2M, and a
-  # throw skips the pin rather than the import: the field keeps PormG's own derivation, exactly as
-  # before this pass existed. The two-primary-key model is broken either way (it is refused at
-  # `set_models`); that is not this pass's to fix or to escalate.
+  # `get_model_pk_field` THROWS when a model carries more than one primary key, and a model still
+  # can: a class that declares `primary_key=True` on two fields outright builds without complaint —
+  # nothing counts primary keys at declaration — so the throw stays reachable from any models.py.
+  # `set_models` raises it only for a model that OWNS a ManyToManyField (relation wiring reads the
+  # key); otherwise the model registers cleanly and throws at the first read. (The commonest source
+  # used to be an `AbstractUser` subclass with a key of its own, which this importer handed a second,
+  # injected `id`; that is fixed at the root in `_import_django_apps` — #369.)
+  # Calling it eagerly for every entry turned the throw into a raw `ModelDefinitionError` that
+  # aborted the WHOLE import — no file, no marker, every other model lost — for a project that has
+  # no ManyToManyField anywhere, on both arities. So it is called lazily, only for models that
+  # actually own an auto-derived M2M, and a throw skips the pin rather than the import: the field
+  # keeps PormG's own derivation, exactly as before this pass existed. The two-primary-key model is
+  # broken either way; that is not this pass's to fix or to escalate.
   pk_cache = Dict{_DjangoClass, Union{Nothing, String}}()
   function pk_name(e)
     get!(pk_cache, e) do
@@ -1382,8 +1386,9 @@ end
 # propose DROPPING it. `db_index` is the same story one severity down.
 function _degraded_relation_column(field, owner::_DjangoClass, field_key::String)
   # A relation that is also the PRIMARY KEY has nowhere to degrade to: `BigIntegerField` cannot be
-  # one (it hardcodes `primary_key = false`), and `has_primary_key` was decided before this pass, so
-  # no `id` is synthesized to replace it. Degrading would emit a model with NO primary key — which
+  # one (it hardcodes `primary_key = false`), and the implicit `id` was already decided in
+  # `_import_django_apps` before this pass runs, so none is synthesized to replace it — this field
+  # still counted as the key when that ran. Degrading would emit a model with NO primary key — which
   # breaks `save()`, every ManyToManyField touching it, and the migration planner, none of them where
   # a reader would look. Erroring is the honest outcome even under `strict_relations = false`.
   if field.primary_key
@@ -1587,14 +1592,53 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
 
       # Initialize fields_dict
       fields_dict = Dict{Symbol, Any}()
-      has_primary_key = Ref(false)  # Flag to check if a primary key exists
 
       # Process fields separately
-      process_class_fields!(fields_dict, class_content, class_name, _inherits_auth_user(graph, class), has_primary_key, autofields_ignore, parameters_ignore, markers, graph.enums, _enum_scopes(graph, class))
+      declared_pk = process_class_fields!(fields_dict, class_content, class_name, _inherits_auth_user(graph, class), autofields_ignore, parameters_ignore, markers, graph.enums, _enum_scopes(graph, class))
 
-      # Insert IDField if no primary key is defined
-      if !has_primary_key[]
+      # Django's implicit `id`, added only when nothing claimed the key — DERIVED, per field, from
+      # what was built and from what the models.py declared, never tracked with a class-wide flag
+      # (#369). Such a flag desynchronized from `fields_dict` in both directions: the `AbstractUser`
+      # branch set it before a single field had been read, so a user table declaring its own key got
+      # a SECOND primary key; and it stayed set when a class overrode a `primary_key=True` field
+      # inherited from an abstract base with a plain one — legal Django — leaving a model with no key
+      # and no `id` either.
+      #
+      # BOTH readings are needed, and they disagree in opposite directions:
+      #   - the built field alone misses `codigo = models.IntegerField(primary_key=True)`, because
+      #     most PormG field types refuse `primary_key` and construct with `false` — and injecting
+      #     `id` there would name a column the Django table does not have;
+      #   - the declaration alone misses `codigo = models.AutoField()`, which declares nothing but
+      #     builds a field that IS the key, because PormG's `AutoField` defaults `primary_key = true`.
+      # `get_model_pk_field`, which reads this model downstream, sees only the first.
+      built_pk = any(f -> f.primary_key, values(fields_dict))
+      if !built_pk && isempty(declared_pk)
           fields_dict[:id] = Models.IDField()
+      end
+
+      # Declared keys that did NOT survive into a built one — the field type refused `primary_key`
+      # and the column came through plain. Tested per declaration rather than as "no key was built",
+      # because a class can lose one key and still have another: PormG then keys the model on a
+      # different column from the one Django keys its table on, and that disagreement is exactly as
+      # worth reporting as having no key at all.
+      lost_pk = sort(String[String(k) for k in declared_pk
+                            if !(haskey(fields_dict, k) && fields_dict[k].primary_key)])
+      if !isempty(lost_pk)
+        @warn "import: a declared primary key is a field type PormG cannot key on; the column is imported without it" class=class_name fields=join(lost_pk, ", ") model_still_has_a_key=built_pk
+        push!(markers, "# PormG: '$(class_name)' declares its primary key on " *
+                       join(("'$(f)'" for f in lost_pk), ", ") *
+                       " — a field type PormG cannot make a primary key (only IDField, AutoField, " *
+                       "CharField, UUIDField, ForeignKey and OneToOneField can), so the column is " *
+                       "imported WITHOUT it. " *
+                       (built_pk ?
+                          "Another field on this model is a primary key, so PormG keys it on that " *
+                          "one while Django keys the table on the column above — they disagree." :
+                          "This model therefore has NO primary key. No `id` was substituted, " *
+                          "because Django's table has no such column — but that leaves the model " *
+                          "unusable by anything that needs a key: a ManyToManyField pointing at it " *
+                          "makes the WHOLE generated file fail to load, and a ForeignKey pointing " *
+                          "at it loads and is silently wrong.") *
+                       " Re-declare the key by hand as a CharField/UUIDField primary key.")
       end
 
       # Rewrite every relation target to the BINDING of the model it names, before the model is
@@ -2949,14 +2993,23 @@ function _match_field_statement(text::AbstractString)
   return (name = lhs, type = String(m.captures[1]), args = args)
 end
 
-function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[], enums = Dict{String, Dict{String, _PyEnum}}(), enum_scopes::Vector{String} = String[String(class_name), ""])
+function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[], enums = Dict{String, Dict{String, _PyEnum}}(), enum_scopes::Vector{String} = String[String(class_name), ""])
   # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
   # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
   # class reaching `AbstractUser` through an abstract base both qualify — an equality test on the
   # whole base list matched neither.
+  #
+  # `id` is deliberately NOT one of them (#369). `AbstractUser` INHERITS Django's implicit `id`
+  # from `models.Model` rather than owning it, so a declared `primary_key=True` suppresses it here
+  # exactly as on any other model — and the caller already applies that rule to every class it
+  # emits. Injecting one here instead claimed the key before a single field had been read, so a
+  # legacy user table keyed on `matricula` came out with TWO primary keys and could never load.
+  # Do not re-add it.
+  #
+  # Returns the field keys whose surviving declaration said `primary_key=True` — see the loop.
+  declared_pk = Set{Symbol}()
+
   if is_auth_user
-      has_primary_key[] = true
-      fields_dict[:id] = Models.IDField()
       fields_dict[:password] = Models.CharField()
       fields_dict[:last_login] = Models.DateTimeField()
       fields_dict[:is_superuser] = Models.BooleanField()
@@ -3003,31 +3056,47 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
                                               field_name = field_name, markers = markers)
 
     # An IGNORED field type contributes no column, so it cannot be the primary key either. Tested
-    # BEFORE `has_primary_key` for that reason (#346): the other order let
+    # BEFORE the primary-key bookkeeping below for that reason (#346): the other order let
     # `autofields_ignore = [… "CharField"]` claim the PK from a `CharField(primary_key=True)` and
     # then drop it, so the synthetic `id` was suppressed and the model came out with NO fields at
     # all. `_import_django_apps` then skipped it silently — while the class index had already handed
     # it a binding, so every ForeignKey to it named a binding the generated file never defined.
     field_type in autofields_ignore && continue
 
-    # Check for primary key
-    if haskey(options, :primary_key) && options[:primary_key] == true
-        has_primary_key[] = true
+    # The key this statement writes, computed up front so the bookkeeping below can name it without
+    # restating the ForeignKey `_id` rule.
+    field_key = field_type in ["ForeignKey", "OneToOneField"] ? Symbol("$(field_name)_id") :
+                                                                Symbol(field_name)
+
+    # Whether DJANGO called this field the primary key — recorded beside the built field because it
+    # cannot be read back off it (#369). Most PormG field types do not accept `primary_key` at all:
+    # `_common_kwargs` warns "Unexpected parameter" and constructs with `primary_key = false`, so a
+    # legacy table keyed on `codigo = models.IntegerField(primary_key=True)` yields a field that
+    # denies being the key. Deciding the implicit `id` from the built fields ALONE would then invent
+    # an `id` column the Django table has not got. Mirrors `fields_dict`'s last-write-wins, so a
+    # child overriding an inherited key with a plain field drops the claim along with the value.
+    #
+    # A ManyToManyField is excluded outright: it contributes no column, `sManyToManyField` hardcodes
+    # `primary_key = false`, and Django rejects the combination anyway — so recording one would
+    # report a lost column that never was a column.
+    if field_type != "ManyToManyField" && get(options, :primary_key, false) == true
+      push!(declared_pk, field_key)
+    else
+      delete!(declared_pk, field_key)
     end
 
     # Instantiate the field
     try
       # println(field_type)
       if field_type in ["ForeignKey", "OneToOneField"]
-        # Add "_id" suffix for foreign keys
-        field_key = Symbol("$(field_name)_id")
+        # `field_key` already carries the "_id" suffix foreign keys take.
         # println(related_model, " ", related_model |> typeof)
         _normalize_django_set_default!(options, field_name)
         fields_dict[field_key] = getfield(Models, Symbol(field_type))(related_model; options...)
       elseif field_type == "ManyToManyField"
-        fields_dict[Symbol(field_name)] = Models.ManyToManyField(related_model; options...)
+        fields_dict[field_key] = Models.ManyToManyField(related_model; options...)
       else
-        fields_dict[Symbol(field_name)] = getfield(Models, Symbol(field_type))(; options...)
+        fields_dict[field_key] = getfield(Models, Symbol(field_type))(; options...)
       end
     catch e
       @pormg_debug
@@ -3053,11 +3122,11 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
         retry_options = filter(kv -> !(kv.first in (:choices, :default)), options)
         recovered = try
           if field_type in ["ForeignKey", "OneToOneField"]
-            fields_dict[Symbol("$(field_name)_id")] = getfield(Models, Symbol(field_type))(related_model; retry_options...)
+            fields_dict[field_key] = getfield(Models, Symbol(field_type))(related_model; retry_options...)
           elseif field_type == "ManyToManyField"
-            fields_dict[Symbol(field_name)] = Models.ManyToManyField(related_model; retry_options...)
+            fields_dict[field_key] = Models.ManyToManyField(related_model; retry_options...)
           else
-            fields_dict[Symbol(field_name)] = getfield(Models, Symbol(field_type))(; retry_options...)
+            fields_dict[field_key] = getfield(Models, Symbol(field_type))(; retry_options...)
           end
           true
         catch e2
@@ -3089,7 +3158,7 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     end
   end
 
-  return nothing
+  return declared_pk
 
 end
 

--- a/test/unit/test_import_django_project.jl
+++ b/test/unit/test_import_django_project.jl
@@ -285,8 +285,9 @@ class Circuit(models.Model):
     end
 
     # Django's shared-primary-key pattern pointed outside the import. There is nowhere to degrade to:
-    # the fallback column type cannot be a primary key, and `has_primary_key` was already decided, so
-    # no `id` is synthesized to replace it — the model would come out with NO primary key, which
+    # the fallback column type cannot be a primary key, and the implicit `id` was already decided —
+    # this field still counted as the key then — so none is synthesized to replace it. The model
+    # would come out with NO primary key, which
     # breaks `save()`, every M2M touching it, and the planner. A hard error even when
     # `strict_relations` is off.
     pk_relation = """
@@ -1405,19 +1406,24 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 # Django Importer (#346): a model with two primary keys must not take the import down
 #
-# `get_model_pk_field` THROWS on more than one primary key, and a model can have two:
-# `process_class_fields!` injects an `id` for every AbstractUser subclass, so a legacy user table
-# keyed on `matricula` has both. Reading the primary key eagerly for every entry — to decide
-# ManyToMany join columns — turned that into a raw ModelDefinitionError that aborted the WHOLE
-# import, on a project with no ManyToManyField at all, on BOTH arities.
+# `get_model_pk_field` THROWS on more than one primary key, and nothing counts primary keys when the
+# model is declared — so a class declaring `primary_key=True` on two fields builds a malformed model
+# that reaches the throw later (at `set_models` if it owns a ManyToManyField, whose relation wiring
+# reads the key; otherwise at the first query or `save()`). Reading the primary key eagerly for every
+# entry — to decide ManyToMany join columns — turned that into a raw ModelDefinitionError that
+# aborted the WHOLE import, on a project with no ManyToManyField at all, on BOTH arities.
+#
+# The original fixture for this was an AbstractUser subclass with its own key, which the importer
+# handed a second, injected `id`. That is fixed at the root (#369, below), so this now uses a class
+# that is two-key on its own terms — otherwise the containment property loses its only coverage.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "a two-primary-key model does not abort the import (#346)" begin
     source = """
-from django.contrib.auth.models import AbstractUser
 from django.db import models
 
-class User(AbstractUser):
-    matricula = models.CharField(max_length=20, primary_key=True)
+class Thing(models.Model):
+    a = models.CharField(max_length=5, primary_key=True)
+    b = models.CharField(max_length=5, primary_key=True)
 
 class Circuit(models.Model):
     name = models.CharField(max_length=40)
@@ -1426,10 +1432,17 @@ class Circuit(models.Model):
                                                            output_file = "two_pk.jl")
     try
         # Every OTHER model survives — that is the property, and it is ALL this asserts. The two-PK
-        # model itself is malformed and is refused later at `set_models`, exactly as it was before
-        # this pass existed; the injected-`id`-plus-declared-PK defect behind it is #369.
+        # model itself is malformed and blows up at the first thing that reads its key, exactly as it
+        # did before this pass existed. Declaring it does not refuse it — nothing counts primary keys
+        # there — and for this `Thing`, which owns no relation, `set_models` does not either; the
+        # throw waits for a query or a `save()`. (The `with_m2m` variant below is the shape that DOES
+        # fail at `set_models`, because relation wiring reads the key.)
         @test occursin("Circuit = Models.Model(\"circuit\", db_table = \"access_circuit\"", generated)
-        @test occursin("User = Models.Model(\"user\", db_table = \"access_user\"", generated)
+        @test occursin("Thing = Models.Model(\"thing\", db_table = \"access_thing\"", generated)
+        # Both declared keys are emitted verbatim: the importer reports what the models.py says, it
+        # does not silently pick a winner.
+        @test occursin("a = Models.CharField(primary_key=true, max_length=5)", generated)
+        @test occursin("b = Models.CharField(primary_key=true, max_length=5)", generated)
     finally
         cleanup_project_test!(config_key, db_dir_existed)
     end
@@ -1452,15 +1465,15 @@ class Circuit(models.Model):
     # unreadable primary key means "do not know", and pinning on a guess would write a column name
     # into the artifact with nothing behind it.
     with_m2m = """
-from django.contrib.auth.models import AbstractUser
 from django.db import models
 
 class Circuit(models.Model):
     name = models.CharField(max_length=40)
 
-class User(AbstractUser):
-    matricula = models.CharField(max_length=20, primary_key=True)
-    circuits = models.ManyToManyField(Circuit)
+class Thing(models.Model):
+    a = models.CharField(max_length=5, primary_key=True)
+    b = models.CharField(max_length=5, primary_key=True)
+    others = models.ManyToManyField(Circuit)
 """
     config_key3, existed3 = project_config!()
     try
@@ -1471,10 +1484,265 @@ class User(AbstractUser):
         end
         @test occursin("Circuit = Models.Model(\"circuit\"", generated)
         # The join TABLE still pins (it needs no primary key); the columns do not.
-        @test occursin("circuits = Models.ManyToManyField(\"Circuit\", db_table=\"access_user_circuits\")", generated)
+        @test occursin("others = Models.ManyToManyField(\"Circuit\", db_table=\"access_thing_others\")", generated)
         @test !occursin("source_field=", generated)
     finally
         cleanup_project_test!(config_key3, existed3)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#369): a declared primary key suppresses Django's implicit `id`
+#
+# `AbstractUser` INHERITS `id` from `models.Model` rather than owning it, so declaring any
+# `primary_key=True` field suppresses it — exactly as on any other model. The importer instead
+# injected an `id` for every AbstractUser subclass before reading a single field, so a legacy user
+# table keyed on `matricula` came out with TWO primary keys and was unusable: `get_model_pk_field`
+# refuses more than one, and `save()`, every ManyToManyField touching the model, the relation wiring
+# and the migration planner all go through it. The failure is deferred, not immediate — the model is
+# built and registered without complaint, then throws at the first read.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an AbstractUser subclass with its own primary key has exactly one (#369)" begin
+    own_pk = """
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+class User(AbstractUser):
+    matricula = models.CharField(max_length=20, primary_key=True)
+"""
+    generated, config_key, db_dir_existed = import_project(["access" => own_pk];
+                                                           output_file = "auth_own_pk.jl")
+    try
+        @test occursin("matricula = Models.CharField(primary_key=true, max_length=20)", generated)
+        # The implicit `id` is GONE, not merely shadowed. `User` is the only model in this file, so
+        # a bare search for the field is unambiguous.
+        @test !occursin("Models.IDField()", generated)
+        # The other ten auth columns are untouched — only `id` was ever wrong.
+        @test occursin("date_joined = Models.DateTimeField()", generated)
+        @test occursin("username = Models.CharField()", generated)
+
+        # The property the old #346 test deliberately did not assert: the model LOADS. Before this
+        # fix `get_model_pk_field` threw ModelDefinitionError here, naming `matricula, id`.
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        user = Core.eval(sandbox, :(auth_own_pk.User))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, user) == :matricula
+        @test !haskey(user.fields, "id")
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # An AbstractUser subclass that declares NO key still gets Django's implicit `id` — the fix
+    # removes the unconditional injection, not the implicit key itself.
+    no_pk = """
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+class User(AbstractUser):
+    apelido = models.CharField(max_length=20)
+"""
+    generated2, key2, existed2 = import_project(["access" => no_pk];
+                                                 output_file = "auth_no_pk.jl")
+    try
+        @test occursin("id = Models.IDField()", generated2)
+        sandbox2 = Module()
+        Core.eval(sandbox2, Meta.parse(generated2))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox2, :(auth_no_pk.User))) == :id
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # The class declares `id` ITSELF. This was already correct — the declared field overwrote the
+    # injected one and there was exactly one key — and it has to stay correct: the declared type
+    # must survive, not be replaced by an IDField.
+    declared_id = """
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+class User(AbstractUser):
+    id = models.UUIDField(primary_key=True)
+"""
+    generated3, key3, existed3 = import_project(["access" => declared_id];
+                                                 output_file = "auth_declared_id.jl")
+    try
+        @test occursin("id = Models.UUIDField(primary_key=true)", generated3)
+        @test !occursin("Models.IDField()", generated3)
+        sandbox3 = Module()
+        Core.eval(sandbox3, Meta.parse(generated3))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox3, :(auth_declared_id.User))) == :id
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#369): an inherited primary key overridden by a non-key field
+#
+# Django permits overriding a field inherited from an ABSTRACT base. The importer merges such a base
+# by statement concatenation (ancestors first, last write wins), so the base's `primary_key=True`
+# statement ran and the child's plain redeclaration replaced the value. A boolean flag recorded the
+# base's claim and was never unset, so the model came out with NO key and no implicit `id` either —
+# the same flag-versus-dict desync as the AbstractUser injection, in the other direction. The claim
+# is now recorded per field and retracted when the field is rewritten, so an override drops it along
+# with the value; nothing survives that the final field set does not agree with.
+#
+# The base here is a plain `models.Model`, deliberately: on an AbstractUser base the unconditional
+# `id` injection masked this outcome, so that shape produces identical output before and after the
+# fix and would prove nothing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an overridden inherited primary key falls back to the implicit id (#369)" begin
+    source = """
+from django.db import models
+
+class Base(models.Model):
+    codigo = models.CharField(max_length=10, primary_key=True)
+
+    class Meta:
+        abstract = True
+
+class Thing(Base):
+    codigo = models.CharField(max_length=10)
+"""
+    generated, config_key, db_dir_existed = import_project(["access" => source];
+                                                           output_file = "abstract_pk_override.jl")
+    try
+        # The child's redeclaration wins, and it is not a key...
+        @test occursin("codigo = Models.CharField(max_length=10)", generated)
+        @test !occursin("codigo = Models.CharField(primary_key=true", generated)
+        # ...so nothing claims the key and Django's implicit `id` is what the model gets. Before the
+        # fix this model was emitted with `codigo` as its ONLY field and no primary key anywhere.
+        @test occursin("id = Models.IDField()", generated)
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox, :(abstract_pk_override.Thing))) == :id
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#369): a legacy-keyed user table now pins its ManyToMany join column
+#
+# `_pin_m2m_join_columns!` exists for exactly this shape — Django hardcodes `<class>_id` for the join
+# column while PormG derives it from the primary-key field name, so a model keyed on anything but
+# `id` needs the pin. It could never reach that shape for an AbstractUser subclass: the model had two
+# keys, `get_model_pk_field` threw, and the pass caught it and left the columns derived. With one key
+# the pin fires, which is the visible downstream half of this fix.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a ManyToMany owned by a legacy-keyed user table pins source_field (#369)" begin
+    source = """
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+class Circuit(models.Model):
+    name = models.CharField(max_length=40)
+
+class User(AbstractUser):
+    matricula = models.CharField(max_length=20, primary_key=True)
+    circuits = models.ManyToManyField(Circuit)
+"""
+    config_key, db_dir_existed = project_config!()
+    try
+        # No warning at all now — the primary key is readable, so nothing is "left derived". Asserts
+        # the ABSENCE of the `cannot read the primary key` warn this fixture used to produce.
+        generated = @test_logs min_level=Logging.Warn begin
+            import_models_from_django(["access" => source]; db = config_key,
+                                      file = "auth_pk_m2m.jl", force_replace = true)
+            read(joinpath(config_key, "auth_pk_m2m.jl"), String)
+        end
+        # Django names the join column from the CLASS (`user_id`), not from the key field
+        # (`matricula_id`), which is why the pin is needed at all.
+        @test occursin("circuits = Models.ManyToManyField(\"Circuit\", db_table=\"access_user_circuits\", source_field=\"user_id\")",
+                       generated)
+        # `Circuit` is keyed on `id` and its binding matches its class name, so its end needs no pin.
+        @test !occursin("target_field=", generated)
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#369): "did anything claim the key" has to be asked TWICE
+#
+# The built field and the Django declaration each miss a case the other catches, in opposite
+# directions, so deciding the implicit `id` from either one alone is wrong:
+#
+#   - `IntegerField(primary_key=True)` DECLARES the key, but PormG's IntegerField does not accept
+#     `primary_key` and constructs with `false`. Reading the built fields alone concludes "no key"
+#     and adds an `id` — naming a column the Django table has not got, which breaks every query that
+#     expands the field list. This is a legacy-schema shape, not a hypothetical.
+#   - `AutoField()` DECLARES nothing, but PormG's AutoField defaults `primary_key = true`. Reading
+#     the declarations alone concludes "no key" and adds an `id` beside it — two primary keys, the
+#     very defect #369 is about.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a primary key PormG cannot express is reported, never replaced by an id (#369)" begin
+    unkeyable = """
+from django.db import models
+
+class Municipio(models.Model):
+    codigo = models.IntegerField(primary_key=True)
+    nome = models.CharField(max_length=40)
+"""
+    generated, config_key, db_dir_existed = import_project(["access" => unkeyable];
+                                                           output_file = "unkeyable_pk.jl")
+    try
+        @test occursin("codigo = Models.IntegerField()", generated)
+        # NO phantom `id`. `access_municipio` is keyed on `codigo` and has no `id` column.
+        @test !occursin("Models.IDField()", generated)
+        # ...and the artifact states the gap rather than shipping a silently key-less model.
+        @test occursin("# PormG: 'Municipio' declares its primary key on 'codigo'", generated)
+        @test occursin("This model therefore has NO primary key", generated)
+
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox, :(unkeyable_pk.Municipio))) === nothing
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # A ManyToManyField is never a candidate: it contributes no column, so reporting a "lost" key on
+    # one would name a column that never existed — and the model still needs its implicit `id`.
+    m2m_pk = """
+from django.db import models
+
+class Circuit(models.Model):
+    name = models.CharField(max_length=40)
+
+class Thing(models.Model):
+    others = models.ManyToManyField(Circuit, primary_key=True)
+"""
+    generated3, key3, existed3 = import_project(["access" => m2m_pk]; output_file = "m2m_pk.jl")
+    try
+        @test occursin("id = Models.IDField()", generated3)
+        @test !occursin("declares its primary key", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+
+    # The mirror case. `AutoField()` must NOT also receive an `id`, and must not be reported as
+    # unkeyable either — the built field is a perfectly good primary key.
+    auto = """
+from django.db import models
+
+class Thing(models.Model):
+    codigo = models.AutoField()
+    nome = models.CharField(max_length=40)
+"""
+    generated2, key2, existed2 = import_project(["access" => auto]; output_file = "auto_pk.jl")
+    try
+        @test occursin("codigo = Models.AutoField()", generated2)
+        @test !occursin("Models.IDField()", generated2)
+        @test !occursin("# PormG:", generated2)
+        sandbox2 = Module()
+        Core.eval(sandbox2, Meta.parse(generated2))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox2, :(auto_pk.Thing))) == :codigo
+    finally
+        cleanup_project_test!(key2, existed2)
     end
 end
 


### PR DESCRIPTION
Closes #369

An `AbstractUser` subclass that declared its own primary key was imported with **two** — `process_class_fields!` injected `id = Models.IDField()` for every such class before reading a single field. `get_model_pk_field` refuses more than one, so the generated model could never load.

## Root cause

`has_primary_key`, a class-wide `Ref{Bool}` standing in for a question the field dict can answer. It desynced in **both** directions:

- the `AbstractUser` branch set it before any field had been read — the reported bug;
- it stayed set when a class overrode a `primary_key=True` field inherited from an abstract base with a plain one (legal Django), leaving a model with no key **and** no `id`. The auth branch's injected `id` happened to mask that, so fixing only #369 would have exposed it.

## The change

The flag is deleted. The implicit `id` is decided from two per-field readings, because each misses a case the other catches:

| reading | misses |
|---|---|
| the built field (`f.primary_key`) | `codigo = models.IntegerField(primary_key=True)` — 18 of 26 PormG field types silently refuse `primary_key` and construct with `false`. Injecting `id` there names a column the Django table has not got. |
| the Django declaration | `codigo = models.AutoField()` — declares nothing, but PormG's `AutoField` defaults `primary_key = true`. Injecting `id` beside it gives two keys. |

`process_class_fields!` returns the field keys whose *surviving* declaration claimed the key — push/delete mirrors `fields_dict`'s last-write-wins, so an override retracts the claim — and the caller injects `id` only when neither reading finds one.

Where PormG cannot express the declared key, **no `id` is substituted** and a `# PormG:` marker states the gap and what it costs. A key-less model is not a soft degrade: an M2M pointing at it makes the whole generated file fail to load, and an FK pointing at it loads silently wrong.

## Downstream effect

`_pin_m2m_join_columns!` can now read a legacy-keyed user table's key, so its join column pins to `source_field="user_id"` instead of being left derived — the legacy-schema case that function's docstring exists for. Its `try`/`catch` stays: a class declaring `primary_key=True` on two fields outright still reaches the throw, and the #346 containment test is repointed at exactly that shape so the catch keeps its coverage.

## Verification

- Every new testset was **mutation-checked** against the unfixed source. One draft passed before *and* after — an `AbstractUser` abstract base masked the bug — and was repointed at a plain `models.Model` base where it actually bites.
- Full unit suite **7452/7452**, exit 0.
- Two review passes (independent + delta). The first caught a genuine regression in this branch: an early version produced a phantom `id` for `IntegerField(primary_key=True)`. The second caught an over-correction claiming `set_models` never counts primary keys — measured: it throws for a two-pk model that **owns** a ManyToManyField, accepts one with no relations.

## Deliberately not done

- **No `UPGRADING.md` entry, no `Project.toml` bump** — additive/fix-only. Every model whose output changes was unloadable or already schema-unfaithful before.
- **No docs build run.** The docs change is prose in an existing file using an admonition pattern already present; instantiating the docs env dirties `docs/Project.toml` with a line-endings diff.
- **No integration run** — the diff is confined to the Django importer, which the integration suite does not exercise.
- **The `id`-clobber follow-up stays deferred**, by prior decision. It got marginally worse in one shape: `class User(AbstractUser): id = models.UUIDField()` (a declared, non-key field named `id`) now has its column replaced by `IDField()`, where the auth branch used to protect it by accident. Django rejects that shape itself (`models.E004`), and the proper fix is the deferred item, so scope was held.
- **`BigAutoField` / `SmallAutoField` do not exist in PormG at all** — Django 3.2+'s `DEFAULT_AUTO_FIELD`. An explicit `id = models.BigAutoField(primary_key=True)` aborts the import with `UndefVarError`. Pre-existing and unrelated to #369; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
