### PR TITLE
fix(#370): resolve a cross-app base through the importing module's imports

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -227,17 +227,59 @@ ImportBatch = Models.Model("importbatch", db_table = "imports_importbatch",
     only resolves after the whole module body has run.
 
 Importing the apps together also merges an **abstract base declared in another app** — the shared
-`core.models.TimeStampedModel` shape — and resolves a `TextChoices` enumeration the same way. Each
-app's own classes win, so a name two apps both declare resolves locally, as it does in Django.
+`core.models.TimeStampedModel` shape — and resolves a `TextChoices` enumeration the same way.
 
-!!! warning "A base name is matched across apps, whether or not that app imported it ([#370](https://github.com/PingoLee/PormG.jl/issues/370))"
-    The importer reads `models.py` files, not their `import` statements, so a base is matched by
-    **name** across the whole project. If one app inherits `BaseReport` from a third-party library and
-    an unrelated app happens to declare a concrete `BaseReport` of its own, the first is read as
-    multi-table inheritance and **not imported** — so adding an app to the list can remove a table
-    belonging to another app. It is always reported with a `# PormG:` marker, never silent. Importing
-    that app on its own is the workaround until
-    [#370](https://github.com/PingoLee/PormG.jl/issues/370) settles how narrow the lookup should be.
+**A class from another app has to be imported, exactly as Python requires.** Each app's own classes
+win, so a name two apps both declare resolves locally, as it does in Django; anything else is looked
+up through that `models.py`'s own `from … import …` lines:
+
+```python
+# imports/models.py
+from core.models import TimeStampedModel        # <- this line is what makes the merge happen
+
+class ImportBatch(TimeStampedModel):
+    note = models.CharField(max_length=40)
+```
+
+Without the import the base is reported as unresolved and the model keeps only its own columns —
+which is also what Python would do, since the name would not be defined. The lookup accepts the
+spellings a real project uses: an alias (`import TimeStampedModel as TSM`), a star import, a
+re-export through another app, and a nested package (`from apps.core.models import …`).
+
+A module path names an app when the app's own name is followed by its **models module** —
+`core.models`, `core.models.base` — or by nothing at all, the package re-exporting through its
+`__init__.py` (`from core import …`). The name matched is the app's label **or** its package
+directory, because Django's `AppConfig.label` is frequently not the directory name:
+`"crm" => "server/customers/models.py"` resolves `from customers.models import …` as well as
+`from crm.models import …`.
+
+Anything written **in front** of that name has to be where the app actually lives. A project laid
+out as `apps/core/` resolves `from apps.core.models import …`; the same import against an app at
+`server/core/` does not, and neither does `from wagtail.core.models import Page` — Wagtail is not
+your `core` app, however much the path looks alike. `from core.forms import Pedido` is refused too:
+a sibling module is not the models module.
+
+A **single** leading dot is this app's own package and never names another app, so `from .core.models
+import …` stays local; **two or more** ascend, so `apps/{core,shop}/` can write
+`from ..core.models import …` and have it resolve.
+
+!!! note "Pass a path, spelled from your Python import root"
+    The package directory can only be read from a **path**, and only as deeply as you spell it. An
+    app handed over as source text (`"crm" => read("customers/models.py", String)`) is known by its
+    label alone, so neither `from customers.models import …` nor any qualified spelling reaches it.
+    Equally, an app passed as `"core/models.py"` cannot match `from apps.core.models import …` even
+    when Python roots it under `apps/` — pass `"apps/core/models.py"`. Either way the failure is an
+    unresolved base with a marker, never a wrong match.
+
+!!! note "Why the import line matters — a table used to disappear ([#370](https://github.com/PingoLee/PormG.jl/issues/370))"
+    Matching bases by **name** alone meant a base one app inherited from a third-party library
+    resolved against an unrelated app's class of the same name. If that class was concrete, the
+    child was read as multi-table inheritance and **not imported** — so adding an app to the list
+    removed a table belonging to another app, which Python's per-module namespaces make impossible.
+    Resolution now follows the `import` statements, so a name imported from outside the app set can
+    no longer collide with an app's class. When a base is left unresolved and another app *does*
+    declare that name, the marker says so and names the app — and says whether the module failed to
+    import it or imported it from somewhere else entirely, because those want different fixes.
 
 A `django_prefix` on the connection is **rejected** here rather than ignored. It is one value for the
 whole connection, and relationship accessor names strip it — so `racing_circuit` would become
@@ -538,8 +580,26 @@ Relatorio = Models.Model("relatorio",
   titulo = Models.CharField(max_length=80))
 ```
 
-Importing the defining app alongside this one resolves it — see
+Importing the defining app alongside this one resolves it — provided this `models.py` really does
+`from core.models import TimeStampedModel`, which is what the lookup follows. See
 [Importing a multi-app project](@ref).
+
+**A class with no resolvable base and no column of its own is reported, not skipped quietly.** Every
+field it might have lives in a base the importer cannot see, so there is no evidence either way and
+it produces no table — but saying nothing is how a real model disappears without a trace. The marker
+names the module the base was imported from, which is usually all it takes to tell the two apart:
+
+```julia
+# PormG: class 'MeuManager' inherits 'InheritanceManager', imported from 'model_utils.managers',
+#   which nothing in this import defines, and declares no field of its own — not imported. …
+# PormG: class 'Pedido' inherits 'TimeStampedModel', imported from 'core.models', which nothing in
+#   this import defines, and declares no field of its own — not imported. …
+```
+
+The first is a library and nothing is missing; the second says which app to add to the call. A base
+with no `import` line at all says that instead. A **dotted** base (`forms.Form`,
+`serializers.Serializer`) stays silent: it names a module, so it is a helper by construction, and
+the namespace is the same discriminator that keeps a `ModelForm` out of the schema.
 
 Dropping the model instead would be the worse trade: a table that silently disappears is harder to
 notice than one that is present and annotated.
@@ -573,6 +633,14 @@ ImportBatch = Models.Model("importbatch",
 or declared on an **abstract base** the model inherits. Lookup is scoped in that order, so two models
 may each nest a `Status` with different members and each resolves to its own. A nested enum can also
 be addressed through its owner (`ImportBatch.Status.choices`), as Django allows.
+
+A module-level enum in **another app** follows the same rule as a base: it resolves only when this
+`models.py` imports it — alias, star import and re-export included, exactly as for a base. Matching
+by name alone handed a model another app's enumeration with no marker anywhere — the wrong `choices`
+and `default` in the schema and nothing in the file to show it (#370).
+
+A **nested** enum belongs to its owning class in its own app, so two apps may each declare a `Base`
+with its own nested `Status` and a child of either resolves to the right one.
 
 | Reference | Result |
 |---|---|

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -624,6 +624,82 @@ function _lift_meta!(cls::PyClass)
   return cls
 end
 
+"""
+    _PyImports
+
+The module-level `from … import …` bindings of one `models.py`.
+
+`names` maps a name as it appears in a base list to `(module path, origin name)`, so
+`from core.models import TimeStampedModel as TSM` records
+`"TSM" => ("core.models", "TimeStampedModel")`. `stars` holds the module paths of
+`from … import *`, which binds names no parser can enumerate without reading that module.
+
+Read for ONE purpose: deciding whether a base name this app does not define may resolve against
+another app's class (#370). A name the module never imported is not in scope in Python either, so
+resolving it across apps invents an inheritance edge the project does not have — and when the other
+app's class is concrete, that edge is read as multi-table inheritance and costs a whole table.
+"""
+struct _PyImports
+  names::Dict{String, Tuple{String, String}}
+  stars::Vector{String}
+end
+
+# `from <module> import <rest>`. The module may carry leading dots (a relative import) or be
+# nothing but dots (`from . import models`), which is why it is `[.\w]+` and not a dotted name.
+const _FROM_IMPORT_RE = r"^from\s+([.\w]+)\s+import\s+(.+)$"
+
+"""
+    _py_imports(stmts) -> _PyImports
+
+The module-level `from … import …` bindings of a parsed `models.py`.
+
+Only `indent == 0` statements count: an import inside `if TYPE_CHECKING:` or a `try/except
+ImportError` is not an unconditional module-level binding, and a base arriving that way is reported
+as unresolved rather than guessed at.
+
+Plain `import x.y [as z]` is deliberately NOT recorded. It binds a MODULE, so the base it enables is
+written dotted (`class Foo(x.y.Base)`) — and a dotted token has never matched the bare-name class
+index (`_class_bases` keeps the token verbatim), so honouring it here would resolve nothing.
+Supporting it means teaching base resolution about dotted tokens first; until then leaving it out is
+neither a regression nor a gap this function could close on its own.
+"""
+function _py_imports(stmts::Vector{PyStmt})::_PyImports
+  names = Dict{String, Tuple{String, String}}()
+  stars = String[]
+  for s in stmts
+    s.indent == 0 || continue
+    m = match(_FROM_IMPORT_RE, s.text)
+    m === nothing && continue
+    mod = String(m.captures[1])
+    rest = strip(String(m.captures[2]))
+    # `_py_logical_lines` folds a wrapped `from m import (\n  A,\n  B,\n)` into ONE statement, so
+    # the brackets arrive inline. Stripping them here is what makes the parenthesised form — the
+    # spelling every formatter produces once the list is long — behave like the flat one.
+    if startswith(rest, "(")
+      rest = strip(rest[nextind(rest, firstindex(rest)):end])
+      endswith(rest, ")") && (rest = strip(rest[firstindex(rest):prevind(rest, lastindex(rest))]))
+    end
+    if rest == "*"
+      mod in stars || push!(stars, mod)
+      continue
+    end
+    for item in split(rest, ',')
+      t = strip(item)
+      isempty(t) && continue                        # the trailing comma of a parenthesised list
+      parts = split(t, r"\s+as\s+")
+      origin = String(strip(parts[1]))
+      local_name = length(parts) > 1 ? String(strip(parts[end])) : origin
+      (isempty(origin) || isempty(local_name)) && continue
+      # LAST binding wins, because that is what Python does: a second `from b import X` rebinds the
+      # name the first bound. The opposite of the first-wins rule the class index uses, and
+      # deliberately so — that rule is about PRECEDENCE between apps, this one about rebinding
+      # inside one module.
+      names[local_name] = (mod, origin)
+    end
+  end
+  return _PyImports(names, stars)
+end
+
 
 #═══════════════════════════════════════════════════════════════════════════════
 # SECTION: The Django import engine — one or many apps (#346)
@@ -1516,7 +1592,20 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       # standalone comment in the generated module. That is the #70 convention applied one level up:
       # the artifact itself shows what is missing, instead of the gap living only in a console warning
       # the reader of the file will never see.
-      if ci.kind === :not_a_model || ci.kind === :abstract
+      if ci.kind === :not_a_model && ci.ancestry_lost
+        # NOT silent, unlike its neighbours below. Every base is unresolvable and the body declares
+        # no column, so this is either a helper or a model whose every field lives in a base the
+        # importer cannot see — and nothing in the source separates the two. Skipping was the right
+        # call and saying nothing was not: a real model then left no trace anywhere.
+        @warn "import: class skipped — no resolvable base and no field of its own" class=class_name bases=join(ci.unresolved, ", ")
+        push!(Instructions, "# PormG: class '$(class_name)' inherits " *
+                            join(("'$(b)'" for b in ci.unresolved), ", ") *
+                            _bound_module_note(graph, ci.unresolved) *
+                            ", and declares no field of its own — not imported. If it is a model, " *
+                            "its columns all come from that base: " * _resolve_base_advice(app.label) *
+                            _declaring_apps_hint(graph, [(b, graph.self) for b in ci.unresolved]))
+        continue
+      elseif ci.kind === :not_a_model || ci.kind === :abstract
         continue                       # a QuerySet/Manager/Form/enum/helper, or a base — silent
       end
 
@@ -1555,18 +1644,19 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       # marker on, so its gap would otherwise reach the file unannounced.
       unresolved_bases = _inherited_unresolved(graph, class)
       if !isempty(unresolved_bases)
-        for b in unresolved_bases
+        for (b, _) in unresolved_bases
           @warn "import: base class is not defined in this file; any fields it declares are missing from the imported model" class=class_name base=b
         end
         push!(markers, "# PormG: model '$(class_name)' inherits " *
-                       join(("'$(b)'" for b in unresolved_bases), ", ") *
+                       join(("'$(b)'" for (b, _) in unresolved_bases), ", ") *
                        ", not defined in " *
                        (app.label === nothing ? "this file" : "any app of this import") *
                        " — any fields declared there are MISSING below. Add them by hand, or " *
                        (app.label === nothing ?
                          "pass every app of the project as \"<app_label>\" => \"<models.py>\" pairs " *
                          "so a base in another app is merged." :
-                         "add the app that defines them to the pair list."))
+                         "add the app that defines them to the pair list.") *
+                       _declaring_apps_hint(graph, unresolved_bases))
       end
 
       # Django would hand this model its abstract base's `db_table`, giving every child of that base
@@ -2052,7 +2142,7 @@ function import_models_from_django(
     "that call instead."))
 
   labels = Set{String}()
-  staged = Tuple{String, Vector{PyClass}}[]
+  staged = _AppScope[]
   for pair in apps
     label = strip(String(first(pair)))
     isempty(label) && throw(InvalidMigrationError(
@@ -2083,20 +2173,21 @@ function import_models_from_django(
         "the path to that app's models.py, or its source text — and source text contains newlines, " *
         "so this is a path that does not exist."))
     end
-    push!(staged, (label, _py_classes(_py_logical_lines(_django_source_text(source)))))
+    # The PATH is kept, not just its contents: it carries the app's package directory name, which is
+    # the second key a Python module path may name this app by. Django's `AppConfig.label` is often
+    # not the package directory (`server/core/models.py` imported as `from server.core.models import
+    # …` while the label is `core`), so keeping both is what stops a legitimate import from reading
+    # as third-party. Source text handed over inline has no path, and then the label is all there is.
+    push!(staged, _app_scope(label, occursin('\n', source) ? nothing : source,
+                             _py_logical_lines(_django_source_text(source))))
   end
 
   # Classification is deferred until every app is parsed, so each app's bases and enum references
-  # resolve against the WHOLE project — its own classes first, then the rest in the order given.
-  # A shared abstract base in a `core` app is the shape that needs it; see
-  # `_django_graph_from_classes`.
-  parsed = _DjangoApp[_DjangoApp(label,
-                        _django_graph_from_classes(classes,
-                          # Own app first, then every other app in the order they were listed. Kept
-                          # as GROUPS so both the class index and the enum scopes resolve first-wins
-                          # with the same precedence.
-                          vcat([classes], [g for (l, g) in staged if l != label])))
-                      for (label, classes) in staged]
+  # resolve against the WHOLE project — its own classes first, then whatever this app's `models.py`
+  # actually imports from the others. A shared abstract base in a `core` app is the shape that needs
+  # it; see `_django_graph_from_scopes`.
+  parsed = _DjangoApp[_DjangoApp(sc.label, _django_graph_from_scopes(staged, i))
+                      for (i, sc) in enumerate(staged)]
 
   # An app that contributes no table is legal (a Django app can declare no models) but it is never
   # what you meant when the other apps reference it, so it is reported per app rather than only in
@@ -2191,19 +2282,28 @@ What the importer decided about one `class` in the source.
   Both put a schema on disk that does not match the database, so neither is emitted.
 - `:not_a_model` — a QuerySet, Manager, Form, enum or plain helper. Skipped silently.
 
-`unresolved` holds bases that name nothing in this file (`from core.models import TimeStampedModel`).
-The class is still imported — dropping it would re-create the vanishing-model bug — but it carries a
-marker saying whose fields are missing. Importing several apps together (#346) resolves these.
+`unresolved` holds bases that name nothing this module can see (`from core.models import
+TimeStampedModel` without that app in the run, or a base from a third-party library). The class is
+still imported — dropping it would re-create the vanishing-model bug — but it carries a marker
+saying whose fields are missing. Importing several apps together (#346) resolves these, provided
+this module actually imports the name (#370).
+
+`ancestry_lost` marks the ONE `:not_a_model` that is not a helper: a class whose entire base list is
+unresolvable and which declares no column of its own, so nothing distinguishes it from a plain
+`class Foo(SomeMixin)`. It is recorded at the point the decision is made rather than recomputed by
+the reporter, because rederiving it there means two predicates that have to agree — and the reporter
+would have to guess whether `:not_a_model` came from a blacklisted base, a `Meta.model`, or this.
 """
 struct _ClassInfo
   kind::Symbol
   bases::Vector{String}
   parents::Vector{String}              # in-file ABSTRACT bases whose fields this class inherits
-  unresolved::Vector{String}           # bases this file does not define
+  unresolved::Vector{String}           # bases nothing in scope defines
   mti_parent::Union{String, Nothing}
   meta::Dict{String, String}
   is_auth_user::Bool
   proxy::Bool
+  ancestry_lost::Bool
 end
 
 # A class this importer emits a `Models.Model(...)` for. A proxy is `:concrete` in every other
@@ -2277,9 +2377,202 @@ end
 # `abstract = True` / `proxy = True`, read off the raw right-hand side.
 _meta_is_true(raw::AbstractString)::Bool = parse_value(raw) === true
 
-function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, PyClass},
-                          visiting::Set{String}, cls::PyClass)::_ClassInfo
-  haskey(info, cls.name) && return info[cls.name]
+"""
+    _AppScope
+
+One app's contribution to an import run: its `label`, the `keys` a Python module path may name it
+by, its own `classes` in source order, the `own` name→class table (first-wins), and its
+[`_PyImports`](@ref).
+
+`keys` is EMPTY for the single-app arity. That is not a detail — it is what makes the one-app path
+provably unchanged by #370: with no key, no module path can ever match an app, so import and star
+resolution cannot fire and `_resolve_base` degenerates to a lookup in `own`, exactly the
+`haskey(index, b)` the flat index used to perform.
+"""
+struct _AppScope
+  label::String
+  keys::Vector{String}
+  pkg_path::Vector{String}             # lowercased package chain of this app's models.py; see below
+  classes::Vector{PyClass}
+  own::Dict{String, PyClass}
+  imports::_PyImports
+end
+
+# The package chain leading to this app's models module: `server/core/models.py` and
+# `server/core/models/__init__.py` both give `["server", "core"]`. Empty when the app was handed over
+# as source text, which has no location to compare against.
+#
+# Absolute leading components (a temp dir, a checkout root) are harmless because the only thing that
+# ever reads this is a SUFFIX comparison — how a Python import spells the path depends on where
+# `sys.path` is rooted, and only the tail is knowable.
+function _app_pkg_path(path::Union{Nothing, AbstractString})::Vector{String}
+  path === nothing && return String[]
+  d = dirname(String(path))
+  lowercase(basename(d)) == "models" && (d = dirname(d))
+  comps = [lowercase(c) for c in split(replace(d, '\\' => '/'), '/') if !isempty(c)]
+  return comps
+end
+
+# Django's `AppConfig.label` is frequently not the package directory name, so the directory is
+# carried as a SECOND key rather than as a replacement: whichever of the two an import spells, it
+# resolves.
+_app_package_key(path::Union{Nothing, AbstractString})::Union{Nothing, String} =
+  (p = _app_pkg_path(path); isempty(p) ? nothing : p[end])
+
+function _app_scope(label::AbstractString, path::Union{Nothing, AbstractString},
+                    stmts::Vector{PyStmt})::_AppScope
+  classes = _py_classes(stmts)
+  own = Dict{String, PyClass}()
+  for c in classes
+    haskey(own, c.name) || (own[c.name] = c)   # first-wins; a module-level redefinition is pathological
+  end
+  keys = String[]
+  pkg = String[]
+  if !isempty(label)
+    push!(keys, lowercase(label))
+    pkg = _app_pkg_path(path)
+    d = isempty(pkg) ? nothing : pkg[end]
+    (d === nothing || d in keys) || push!(keys, d)
+  end
+  return _AppScope(String(label), keys, pkg, classes, own, _py_imports(stmts))
+end
+
+"""
+    _app_for_module(scopes, mod) -> Union{Int, Nothing}
+
+The app in `scopes` that a Python module path names, or `nothing`.
+
+A component `c` names an app when `c` is one of that app's keys (its label or its package directory)
+**and** the app's models module follows — `core.models`, `core.models.base` — or nothing follows,
+which is the app package re-exporting through its `__init__.py` (`from core import …`). Components
+are scanned RIGHT TO LEFT, because a nested app package is ordinary and a left-to-right first match
+would stop at `apps`/`server` and resolve nothing.
+
+**Anything in front of the key must be where the app actually lives.** That is the load-bearing
+half, and matching the key plus a `models` tail alone is not enough: `from wagtail.core.models
+import Page` — the canonical Wagtail import — has a key `core` followed by `models`, so a project
+with a `core` app read a third-party base as its own and refused the child as multi-table
+inheritance. #370 verbatim, one module name over. So `comps[1:i]` must be a SUFFIX of the app's
+`pkg_path`; `apps.core.models` resolves for an app at `apps/core/`, and `wagtail.core.models` for
+the same app does not. A key at position 1 needs no prefix to agree with, which is what keeps the
+plain `core.models` spelling working — and what makes an app handed over as SOURCE TEXT (no path,
+so no `pkg_path`) reachable only by that plain spelling.
+
+`from core.forms import Pedido` is refused by the same rule: a sibling module is not the models
+module, and binding a form to a model would be the same defect one file over.
+
+The prefix check is deliberately NOT total: position 1 has nothing in front of it, so a *top-level*
+distribution whose package name equals an app key (`from core.models import X` where `core` is a
+third-party package) still resolves. Closing that would take the plain `<label>.models` spelling
+with it, and that is the spelling an app handed over as source text can only be reached by.
+
+`pkg_path` is read from the path the CALLER passed, not from an importable root, so how deeply the
+path is spelled decides which qualified spellings match: an app passed as `"core/models.py"` cannot
+match `apps.core.models` even when Python roots it there. It degrades to an unresolved base with a
+marker, never to a wrong match.
+
+**A SINGLE leading dot names this app's own package and can never name another app.** `from .base
+import X` is `base.py` next to this `models.py`, and `from .core.models import X` is an internal
+`core/` subpackage — both leave components that are perfectly ordinary app labels once the dot is
+stripped, and reading them as another app is #370 again. **Two or more dots ascend** to a parent
+package, which is exactly how a project laid out as `apps/{core,shop}/` writes a genuine cross-app
+import (`from ..core.models import TimeStampedModel`), so those do resolve.
+"""
+function _app_for_module(scopes::Vector{_AppScope}, mod::AbstractString)::Union{Int, Nothing}
+  dots = something(findfirst(!isequal('.'), mod), lastindex(mod) + 1) - 1
+  dots == 1 && return nothing                          # this app's own package — never another app
+  comps = [lowercase(c) for c in split(mod, '.') if !isempty(c)]
+  isempty(comps) && return nothing
+  for i in length(comps):-1:1
+    # Either the app's models module follows the key, or nothing does (the package re-export).
+    (get(comps, i + 1, "") == "models" || i == length(comps)) || continue
+    key = comps[i]
+    for (j, sc) in enumerate(scopes)
+      key in sc.keys || continue
+      # Position 1 has nothing in front of it to disagree with. Anything deeper must match where the
+      # app's models.py actually sits, or a vendor package sharing the app's name resolves into it.
+      (i == 1 || (length(sc.pkg_path) >= i && sc.pkg_path[end - i + 1:end] == comps[1:i])) || continue
+      return j
+    end
+  end
+  return nothing
+end
+
+"""
+    _resolve_base(scopes, from_idx, token) -> Union{Tuple{Int, PyClass}, Nothing}
+
+The class a base token names, as seen from app `from_idx`, with the app that owns it.
+
+The app's OWN classes win — Django's rule for an unqualified reference, and the precedence #346
+documents. Everything else has to be imported: a name this `models.py` never bound is not in scope
+in Python, so resolving it against another app would invent an inheritance edge the project does not
+have (#370).
+"""
+_resolve_base(scopes::Vector{_AppScope}, from_idx::Int, token::AbstractString) =
+  haskey(scopes[from_idx].own, token) ? (from_idx, scopes[from_idx].own[token]) :
+    _resolve_imported(scopes, from_idx, String(token), Set{Tuple{Int, String}}())
+
+# `seen` is keyed by (app, NAME), not by app. The token changes across a re-export hop — an app
+# reached for `Foo` may still have to be asked about `Bar` — so an app-keyed set makes a second,
+# valid branch of the star-import loop below return `nothing` purely because an earlier branch had
+# already visited that app for a different name. That made the result depend on the ORDER of two
+# `from … import *` lines.
+function _resolve_imported(scopes::Vector{_AppScope}, idx::Int, token::String,
+                           seen::Set{Tuple{Int, String}})::Union{Tuple{Int, PyClass}, Nothing}
+  (idx, token) in seen && return nothing
+  push!(seen, (idx, token))
+  imp = scopes[idx].imports
+  entry = get(imp.names, token, nothing)
+  if entry !== nothing
+    (mod, origin) = entry
+    a = _app_for_module(scopes, mod)
+    # The name is BOUND, and bound to something outside the app set — a third-party base. Stopping
+    # here rather than falling through to the star imports is the #370 fix itself.
+    a === nothing && return nothing
+    haskey(scopes[a].own, origin) && return (a, scopes[a].own[origin])
+    # A re-export façade: `reports` imports from `access`, which imported it from `core`. Common
+    # enough in projects with a "base app" that not following it would be a fresh silent loss.
+    return _resolve_imported(scopes, a, origin, seen)
+  end
+  for mod in imp.stars
+    a = _app_for_module(scopes, mod)
+    a === nothing && continue
+    haskey(scopes[a].own, token) && return (a, scopes[a].own[token])
+    r = _resolve_imported(scopes, a, token, seen)
+    r === nothing || return r
+  end
+  return nothing
+end
+
+"""
+    _ClassifyState
+
+The working tables of one classification run, all keyed by `(app index, class name)`.
+
+Keying by app is not bookkeeping. A bare class name is ambiguous the moment two apps declare one —
+which `_build_class_index`'s whole collision machinery exists because they DO — and both tables here
+are consulted across app boundaries as the walk follows a base into the app that defines it.
+`visiting` in particular reported a false inheritance cycle: `core.Bar(Foo)` reached from `L.Foo`
+found `"Foo"` already in a bare-name set, refused `core.Bar`, poisoned `L.Foo`, and dropped the
+model in silence.
+
+`resolved` records the edge each `(app, token)` pair took, so the projection that builds the public
+graph can follow exactly the chain classification followed.
+"""
+struct _ClassifyState
+  scopes::Vector{_AppScope}
+  info::Dict{Tuple{Int, String}, _ClassInfo}
+  visiting::Set{Tuple{Int, String}}
+  resolved::Dict{Tuple{Int, String}, Tuple{Int, PyClass}}
+end
+
+_ClassifyState(scopes::Vector{_AppScope}) =
+  _ClassifyState(scopes, Dict{Tuple{Int, String}, _ClassInfo}(), Set{Tuple{Int, String}}(),
+                 Dict{Tuple{Int, String}, Tuple{Int, PyClass}}())
+
+function _classify_class!(st::_ClassifyState, app::Int, cls::PyClass)::_ClassInfo
+  key = (app, cls.name)
+  haskey(st.info, key) && return st.info[key]
 
   meta = _parse_meta_options(cls.meta)
   bases = _class_bases(cls)
@@ -2289,8 +2582,8 @@ function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, Py
 
   # An inheritance CYCLE is malformed Python. Refuse the class rather than recurse forever; not
   # memoized, because the in-progress outer call owns the entry for this name.
-  if cls.name in visiting
-    return _ClassInfo(:not_a_model, bases, String[], String[], nothing, meta, is_auth, proxy)
+  if key in st.visiting
+    return _ClassInfo(:not_a_model, bases, String[], String[], nothing, meta, is_auth, proxy, false)
   end
 
   is_root = is_auth || any(b -> b in _MODEL_ROOT_BASES, bases)
@@ -2313,18 +2606,28 @@ function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, Py
   # Bases are resolved even when one of them is blacklisted, because a blacklisted base no longer
   # decides the outcome on its own — see the `kind` selection below.
   #
-  # `haskey(index, b)` is tested BEFORE `_NON_MODEL_BASES`, and that ordering is the whole fix for a
+  # A RESOLVED base is tested BEFORE `_NON_MODEL_BASES`, and that ordering is the whole fix for a
   # real silent loss: `Manager`, `Choices` and `Enum` are perfectly good model names — a Manager in
   # an HR schema is a person — and dismissing such a base by NAME made the class invisible as an
   # ancestor. Its children then resolved no parent, fell through to `non_model`, and were dropped
-  # without a word, taking the base's columns with them. A definition in this file always outranks
-  # a name on a list.
-  push!(visiting, cls.name)
+  # without a word, taking the base's columns with them. A definition always outranks a name on a
+  # list — and now that resolution is import-aware, it is only the definition this module can
+  # actually SEE, so `class Foo(Manager)` in an app that wrote `from django.db.models import
+  # Manager` correctly falls to the blacklist instead of borrowing another app's `Manager` class.
+  push!(st.visiting, key)
   try
     for b in bases
       (b in _MODEL_ROOT_BASES || b in _AUTH_USER_BASES) && continue
-      if haskey(index, b)
-        pk = _classify_class!(info, index, visiting, index[b]).kind
+      r = _resolve_base(st.scopes, app, b)
+      if r !== nothing
+        (bapp, bcls) = r
+        st.resolved[(app, b)] = r
+        # Recursion carries the RESOLVED app, never the importing one. A base's own bases are names
+        # in ITS module, so classifying `core.Auditavel` in the importing app's namespace loses
+        # `TimeStampedModel`, makes `Auditavel` field-less and therefore `:not_a_model`, poisons the
+        # child — and the child is then dropped with no marker at all, which is strictly worse than
+        # the defect this change exists to remove.
+        pk = _classify_class!(st, bapp, bcls).kind
         if pk === :abstract
           push!(parents, b)
         elseif pk === :concrete || pk === :mti
@@ -2336,7 +2639,7 @@ function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, Py
           poisoned = true
         end
       elseif b in _NON_MODEL_BASES
-        # A known non-model NAME that this file does not define. Already reflected in `non_model`;
+        # A known non-model NAME that nothing in scope defines. Already reflected in `non_model`;
         # it is not an unresolved ancestor, so it must not be marked as one.
         continue
       else
@@ -2344,7 +2647,7 @@ function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, Py
       end
     end
   finally
-    delete!(visiting, cls.name)
+    delete!(st.visiting, key)
   end
 
   kind = if describes_a_model || isempty(bases)
@@ -2378,8 +2681,30 @@ function _classify_class!(info::Dict{String, _ClassInfo}, index::Dict{String, Py
     :not_a_model
   end
 
-  ci = _ClassInfo(kind, bases, parents, unresolved, mti_parent, meta, is_auth, proxy)
-  info[cls.name] = ci
+  # Reached the final `else` with bases nothing could resolve: every column this class has lives in a
+  # base the importer cannot see, so there is no evidence either way and it is skipped. Recorded so
+  # the reporter can say so — skipping it in silence is how a real model disappears without a trace.
+  #
+  # Restricted to BARE base names, using the same discriminator `_declares_fields` uses one screen
+  # down: a namespace is the one piece of information already in the source. `forms.Form` and
+  # `serializers.Serializer` are dotted, so they name a module this file never had and a dotted token
+  # could not have resolved anyway — those are helpers, definitively, and marking them would be pure
+  # noise on every `models.py` that also holds a ModelForm. A BARE `CustomUser` is the ambiguous one:
+  # it is exactly what an `import` would have bound, which is what makes it worth a line.
+  #
+  # Deliberately NOT narrowed further by "the name was imported from a module naming no app". That
+  # test cannot tell a third-party library from an app of this project the caller simply did not
+  # pass — and those are the same string. Worse, the single-app arity has no app keys at all, so the
+  # test is true for EVERY explicitly-imported base there and the marker never fired for the case it
+  # exists for. The module name goes into the message instead: naming `model_utils.managers` lets a
+  # reader dismiss a library in one glance, and naming `core.models` tells them which pair is
+  # missing. A comment too many is recoverable; a model that vanished silently is not.
+  ancestry_lost = kind === :not_a_model && !isempty(unresolved) &&
+                  !describes_a_model && !non_model && !poisoned &&
+                  all(b -> !occursin('.', b), unresolved)
+
+  ci = _ClassInfo(kind, bases, parents, unresolved, mti_parent, meta, is_auth, proxy, ancestry_lost)
+  st.info[key] = ci
   return ci
 end
 
@@ -2393,84 +2718,137 @@ Deliberately silent: classification emits no warnings, so `parse_class` can be c
 without side effects. The importer reads `info` and does the reporting.
 """
 function _django_class_graph(model_py_string::AbstractString)
-  classes = _py_classes(_py_logical_lines(model_py_string))
-  return _django_graph_from_classes(classes, [classes])
+  stmts = _py_logical_lines(model_py_string)
+  # No label and therefore no module keys: `_app_for_module` can never match, so import resolution
+  # is inert and this path behaves exactly as it did when the index was one flat name→class table.
+  return _django_graph_from_scopes([_app_scope("", nothing, stmts)], 1)
 end
 
 """
-    _django_graph_from_classes(classes, scope_classes) -> NamedTuple
+    _django_graph_from_scopes(scopes, self) -> NamedTuple
 
-Classify `classes`, resolving their bases and enum references against `scope_classes`.
+Classify `scopes[self]`'s classes, resolving their bases and enum references across `scopes`.
 
-The two arguments differ only for a multi-app project (#346), where `scope_classes` is EVERY app's
-classes (this app's first) while `classes` stays this app's own. That is what lets
+`scopes` holds every app of the import run (#346); `self` says which one this graph is for. That is
+what lets
 
 ```python
 # core/models.py                       # imports/models.py
-class TimeStampedModel(models.Model):  class ImportBatch(TimeStampedModel):
-    class Meta: abstract = True            note = models.CharField(max_length=40)
+class TimeStampedModel(models.Model):  from core.models import TimeStampedModel
+    class Meta: abstract = True        class ImportBatch(TimeStampedModel):
+                                           note = models.CharField(max_length=40)
 ```
 
 merge — a shared abstract base in a `core` app is one of the commonest shapes in a real Django
 project, and importing the apps separately is exactly what `_inherited_unresolved`'s marker has been
 telling people to stop doing since #341 ("import the app that defines them together with this one").
-Before this, importing them together changed nothing: the graph was built per file, so the base was
-still "not defined in this file" and the child silently lost its columns.
 
-This app's own definitions come first, so a class name that two apps both declare resolves to the
-LOCAL one — Django's rule for an unqualified reference, and the same precedence
-`_lookup_class_ref` applies to relation targets.
+**Resolution follows the `import` statements, not the name (#370).** An app's own classes win, as
+Django resolves an unqualified reference; anything else must have been imported by that module.
+Matching purely by name meant a base one app inherited from a third-party library resolved against
+an unrelated app's class of the same name — and when that class was concrete, the child was refused
+as multi-table inheritance and its table vanished from the generated file. Adding an app to the
+import removed a table from another app, which Python's per-module namespaces make impossible.
 
-Cross-app inheritance keeps Django's semantics rather than gaining new ones: an abstract base merges
-its fields, and a CONCRETE base in another app is still multi-table inheritance and still refused.
+Cross-app inheritance still keeps Django's semantics rather than gaining new ones: an abstract base
+merges its fields, and a CONCRETE base in another app — genuinely imported — is still multi-table
+inheritance and still refused.
 
-The lookup is by NAME, and this file reads `models.py` rather than its `import` statements — so a base
-one app inherits from a library resolves against an unrelated app's class of the same name, and is
-then refused as MTI. Reported with a marker, never silent, and tracked as #370, which is where the
-decision belongs: parse the imports, restrict the cross-app scope to abstract bases, or accept it.
-`info` stays per app because it is keyed by class name, and two apps may legitimately declare the
-same one.
+`index` and `info` describe **this app's own classes only**, name-keyed, which is what every caller
+reading them by class name expects. The ancestor walkers cannot use a bare name (two apps may
+declare one), so they read `byapp` and `resolved` instead: `byapp[(app, name)]` is the classified
+info of any class the walk reached, and `resolved[(app, token)]` is the edge a base token took.
 """
-function _django_graph_from_classes(classes::Vector{PyClass}, scope_groups::Vector{Vector{PyClass}})
-  index = Dict{String, PyClass}()
-  for group in scope_groups, c in group
-    # First definition wins; within one file a name redefined at module level is pathological
-    # Python, and across files this is what makes the local app outrank the rest of the project.
-    haskey(index, c.name) || (index[c.name] = c)
-  end
-  info = Dict{String, _ClassInfo}()
-  visiting = Set{String}()
+function _django_graph_from_scopes(scopes::Vector{_AppScope}, self::Int)
+  st = _ClassifyState(scopes)
+  classes = scopes[self].classes
   for c in classes
-    _classify_class!(info, index, visiting, c)
+    _classify_class!(st, self, c)
   end
-  # Enums follow the same scope as bases — and the same PRECEDENCE, which is why the groups arrive
-  # separately instead of pre-flattened. `_collect_enums` is last-wins within a file (`out[c.name] =`
-  # overwrites), so merging a flat "own classes, then every app" vector let the LAST-listed app's
-  # `Status` overwrite everyone's, including the app that declares its own — silently handing a model
-  # another app's enumeration, and then reporting its own member as "not a member of Status".
-  # Collected per group and merged first-wins, so precedence matches `index` exactly.
-  enums = Dict{String, Dict{String, _PyEnum}}()
-  for group in scope_groups
-    _merge_enum_scopes!(enums, _collect_enums(group))
-  end
-  return (classes = classes, index = index, info = info, enums = enums)
-end
 
-# Merge `from` into `into` keeping whatever `into` already has, at BOTH levels: the scope key (a
-# class name, or `""` for module scope) and the enum name inside it. Two apps can each declare an
-# enum of the same name in the same scope, and the earlier group — the local app — must win.
-#
-# Parameters are untyped on purpose: `_PyEnum` is declared further down this file, and a signature
-# is evaluated at DEFINITION time, so naming it here is an `UndefVarError` at load. Same forward
-# reference that keeps `_is_emitted` untyped at its call sites.
-function _merge_enum_scopes!(into, from)
-  for (scope, members) in from
-    dest = get!(into, scope, valtype(into)())
-    for (name, e) in members
-      haskey(dest, name) || (dest[name] = e)
+  # Own classes, source order, first-wins — the invariant `_build_class_index` relies on when it
+  # indexes `graph.index[e.class]` without a guard.
+  index = Dict{String, PyClass}()
+  info = Dict{String, _ClassInfo}()
+  for c in classes
+    haskey(index, c.name) && continue
+    index[c.name] = c
+    info[c.name] = st.info[(self, c.name)]
+  end
+
+  # Enum scope, keyed by `(app, scope)` — a class name, or `""` for module level.
+  #
+  # The app half is not bookkeeping. Keyed by bare scope name, two apps that each declare a `Base`
+  # with a nested `Situacao` collapse into one entry, and `core.Base`'s own field silently takes
+  # `shop.Base`'s members — a wrong enumeration in the schema with no marker anywhere. The base
+  # resolved perfectly; only the scope table could not tell the two classes apart. `_enum_scopes`
+  # hands back the `(app, name)` pairs it already resolved, so the lookup asks the right app.
+  #
+  # The MODULE scope of THIS app is the one place anything crosses: a top-level
+  # `class Status(models.TextChoices)` referenced as `choices=Status.choices` is a Python name
+  # lookup, so it is gated exactly like a base (#370). Every other app's module scope stays its own
+  # and is reached only as an ancestor's, below.
+  per_app = [_collect_enums(sc.classes) for sc in scopes]
+  enums = Dict{Tuple{Int, String}, Dict{String, _PyEnum}}()
+  for (i, t) in enumerate(per_app), (scope, members) in t
+    enums[(i, scope)] = members
+  end
+  mod_scope = Dict{String, _PyEnum}()
+  own_mod = get(per_app[self], "", nothing)
+  own_mod === nothing || merge!(mod_scope, own_mod)      # own declarations always win
+  for local_name in keys(scopes[self].imports.names)
+    haskey(mod_scope, local_name) && continue
+    e = _resolve_enum(scopes, per_app, self, local_name, Set{Tuple{Int, String}}())
+    e === nothing || (mod_scope[local_name] = e)
+  end
+  # A star import cannot be enumerated, so it contributes the other app's own module-level names.
+  # Not its re-exports: those have no name here to ask about, and inventing the closure of every
+  # star-imported app's imports would bind names the source never mentions.
+  for mod in scopes[self].imports.stars
+    a = _app_for_module(scopes, mod)
+    (a === nothing || a == self) && continue
+    src = get(per_app[a], "", nothing)
+    src === nothing && continue
+    for (n, e) in src
+      haskey(mod_scope, n) || (mod_scope[n] = e)
     end
   end
-  return into
+  enums[(self, "")] = mod_scope
+
+  return (classes = classes, index = index, info = info, enums = enums,
+          scopes = scopes, self = self, byapp = st.info, resolved = st.resolved)
+end
+
+# The base resolver's walk, for a module-level enumeration instead of a class: own declarations, then
+# named imports, following a re-export façade exactly as `_resolve_imported` does.
+#
+# Kept as a second function rather than one generic because the tables differ — `own` versus the `""`
+# scope of `_collect_enums` — but the RULES must not drift. They did in the first cut of #370: a base
+# behind `shop → access → core` resolved and the enum behind the same façade did not, and the marker
+# then told the reader to import a module they had already imported.
+function _resolve_enum(scopes::Vector{_AppScope}, per_app, idx::Int, token::String,
+                       seen::Set{Tuple{Int, String}})
+  (idx, token) in seen && return nothing
+  push!(seen, (idx, token))
+  imp = scopes[idx].imports
+  entry = get(imp.names, token, nothing)
+  if entry !== nothing
+    (mod, origin) = entry
+    a = _app_for_module(scopes, mod)
+    a === nothing && return nothing          # bound to something outside the app set
+    src = get(per_app[a], "", nothing)
+    src !== nothing && haskey(src, origin) && return src[origin]
+    return _resolve_enum(scopes, per_app, a, origin, seen)
+  end
+  for mod in imp.stars
+    a = _app_for_module(scopes, mod)
+    a === nothing && continue
+    src = get(per_app[a], "", nothing)
+    src !== nothing && haskey(src, token) && return src[token]
+    r = _resolve_enum(scopes, per_app, a, token, seen)
+    r === nothing || return r
+  end
+  return nothing
 end
 
 # ── Django `TextChoices` / `IntegerChoices` (#342) ───────────────────────────────────────────────
@@ -2659,44 +3037,81 @@ function _collect_nested_enums!(into::Dict{String, _PyEnum}, cls::PyClass, prefi
 end
 
 """
-    _enum_scopes(graph, cls) -> Vector{String}
+    _enum_scopes(graph, cls) -> Vector{Tuple{Int, String}}
 
-The scopes an enum reference inside `cls` may name, in precedence order: the class itself, then its
-ABSTRACT BASES (nearest first), then module level (`""`).
+The scopes an enum reference inside `cls` may name, as `(app, scope)` in precedence order: the class
+itself, then its ABSTRACT BASES (nearest first), then module level — this app's first, then that of
+each app an ancestor came from.
 
 The abstract-base step is not optional. `_inherited_statements` merges a base's field statements
 into the child and processes them under the CHILD's name, so a base declaring both
 `class Status(TextChoices)` and a field using it hands the child a reference that is nowhere in the
 child's own scope — which this importer then reported as "not defined in this file" while it sat
 three lines above. An abstract base with an enumerated status column is mainstream Django.
+
+The ancestor's module scope is in the list for the same reason one step further out: a base in
+`core` may reference a MODULE-level `Status` that `core` declares, and once that statement has been
+merged into a child in another app, nothing in the child's own scopes can see it.
+
+Every entry carries the app it belongs to. Two apps may each declare a `Base` with a nested
+`Situacao`, and a scope list of bare names cannot say which one a merged statement meant.
+
+!!! warning "Known imprecision — the list is per CLASS, not per statement"
+    `_inherited_statements` merges an ancestor's statements into the child and they are all
+    processed under one scope list, so the ancestor-module tail is reachable from the child's OWN
+    statements too, and this app's module scope outranks the ancestor's even for a statement that
+    came out of the ancestor's body — where Python would resolve in the ancestor's module.
+
+    Both are narrower than what preceded them: the enum table used to be one flat, app-blind
+    dictionary, so every app's module scope was reachable from everywhere. Closing them properly
+    means tagging each merged statement with the app it came from and resolving per statement, which
+    is a change to the field pipeline rather than to this list.
 """
-function _enum_scopes(graph, cls::PyClass)::Vector{String}
-  out = String[cls.name]
-  seen = Set{String}()
-  function walk(name::AbstractString)
-    info = get(graph.info, String(name), nothing)
-    info === nothing && return
-    for b in info.parents
-      b in seen && continue
-      push!(seen, b)
-      push!(out, b)
-      walk(b)
+function _enum_scopes(graph, cls::PyClass)::Vector{Tuple{Int, String}}
+  out = Tuple{Int, String}[(graph.self, cls.name)]
+  ancestor_apps = Int[]
+  seen = Set{Tuple{Int, String}}()
+  function walk(a::Int, c::PyClass)
+    key = (a, c.name)
+    key in seen && return
+    push!(seen, key)
+    ci = get(graph.byapp, key, nothing)
+    ci === nothing && return
+    for b in ci.parents
+      r = get(graph.resolved, (a, b), nothing)
+      r === nothing && continue
+      (pa, pc) = r
+      (pa, pc.name) in seen && continue
+      # The scope key is the ancestor's OWN name, because that is how `_collect_enums` keys a class
+      # scope — not the token the child referred to it by, which an `as` alias makes a different
+      # string entirely.
+      push!(out, (pa, pc.name))
+      pa == graph.self || pa in ancestor_apps || push!(ancestor_apps, pa)
+      walk(pa, pc)
     end
     return
   end
-  walk(cls.name)
-  push!(out, "")
+  walk(graph.self, cls)
+  push!(out, (graph.self, ""))                 # this app's module scope outranks any borrowed one
+  for a in ancestor_apps
+    push!(out, (a, ""))
+  end
   return out
 end
 
 """
     _lookup_enum(enums, scopes, ref) -> Union{_PyEnum, Nothing}
 
-Resolve an enum NAME against an ordered list of scopes. First match wins, so a nested enum shadows a
-module-level one of the same name — Python's own rule. A qualified `Owner.Status` is accepted last,
-since Django permits addressing a nested enum through its owner.
+Resolve an enum NAME against an ordered list of `(app, scope)` keys. First match wins, so a nested
+enum shadows a module-level one of the same name — Python's own rule. A qualified `Owner.Status` is
+accepted last, since Django permits addressing a nested enum through its owner.
+
+The qualified form is tried against the apps already in `scopes` and no others: `Owner` is a name in
+one of those modules, so widening the search to every app would resolve it in a module the source
+cannot see — the flat-table defect one level down.
 """
-function _lookup_enum(enums, scopes::Vector{String}, ref::AbstractString)::Union{_PyEnum, Nothing}
+function _lookup_enum(enums, scopes::Vector{Tuple{Int, String}},
+                      ref::AbstractString)::Union{_PyEnum, Nothing}
   for s in scopes
     scope = get(enums, s, nothing)
     scope === nothing && continue
@@ -2704,10 +3119,13 @@ function _lookup_enum(enums, scopes::Vector{String}, ref::AbstractString)::Union
   end
   idx = findlast('.', ref)
   if idx !== nothing
-    owner = ref[firstindex(ref):prevind(ref, idx)]
+    owner = String(ref[firstindex(ref):prevind(ref, idx)])
     inner = ref[nextind(ref, idx):end]
-    scope = get(enums, String(owner), nothing)
-    scope === nothing || (haskey(scope, inner) && return scope[inner])
+    for (a, _) in scopes
+      scope = get(enums, (a, owner), nothing)
+      scope === nothing && continue
+      haskey(scope, inner) && return scope[inner]
+    end
   end
   return nothing
 end
@@ -2722,38 +3140,52 @@ before the class's own body is the whole merge: `process_class_fields!` writes i
 Bases are walked in **reverse** declaration order, because Python resolves `class C(A, B)` left to
 right — A must win, so A's statements have to be written last.
 """
+# ── Walking the abstract-ancestor chain ──────────────────────────────────────────────────────────
+# Every helper below follows `_ClassInfo.parents`, and none of them can do it with a bare class
+# name. `graph.info` describes THIS app's own classes; a parent token is a name in the CHILD's
+# module, two apps may each declare a `Base`, and an `as` alias makes the token differ from the
+# class's own name. So they read `graph.resolved[(app, token)]` — the edge classification actually
+# took — and `graph.byapp[(app, name)]`, which covers every class the walk reached, in any app.
+
 function _inherited_statements(graph, cls::PyClass)::Vector{PyStmt}
   out = PyStmt[]
-  seen = Set{String}()
-  function walk(c::PyClass)
-    ci = get(graph.info, c.name, nothing)
+  seen = Set{Tuple{Int, String}}()
+  function walk(a::Int, c::PyClass)
+    ci = get(graph.byapp, (a, c.name), nothing)
     ci === nothing && return
     for b in Iterators.reverse(ci.parents)
-      b in seen && continue
-      push!(seen, b)
-      p = get(graph.index, b, nothing)
-      p === nothing && continue
-      walk(p)
-      append!(out, p.body)
+      r = get(graph.resolved, (a, b), nothing)
+      r === nothing && continue
+      (pa, pc) = r
+      (pa, pc.name) in seen && continue
+      push!(seen, (pa, pc.name))
+      walk(pa, pc)
+      append!(out, pc.body)
     end
     return
   end
-  walk(cls)
+  walk(graph.self, cls)
   return out
 end
 
 # Django's `AbstractUser` columns reach a class through an abstract base too:
 # `class BaseUser(AbstractUser): class Meta: abstract = True` then `class User(BaseUser)`.
 function _inherits_auth_user(graph, cls::PyClass)::Bool
-  ci = get(graph.info, cls.name, nothing)
-  ci === nothing && return false
-  ci.is_auth_user && return true
-  for b in ci.parents
-    p = get(graph.index, b, nothing)
-    p === nothing && continue
-    _inherits_auth_user(graph, p) && return true
+  function walk(a::Int, c::PyClass, seen::Set{Tuple{Int, String}})::Bool
+    key = (a, c.name)
+    key in seen && return false
+    push!(seen, key)
+    ci = get(graph.byapp, key, nothing)
+    ci === nothing && return false
+    ci.is_auth_user && return true
+    for b in ci.parents
+      r = get(graph.resolved, (a, b), nothing)
+      r === nothing && continue
+      walk(r[1], r[2], seen) && return true
+    end
+    return false
   end
-  return false
+  return walk(graph.self, cls, Set{Tuple{Int, String}}())
 end
 
 """
@@ -2778,16 +3210,18 @@ const _META_KEYS_NOT_INHERITED = ("abstract", "db_table")
 
 function _effective_meta(graph, cls::PyClass)::Dict{String, String}
   b = _inherited_meta_base(graph, cls)
-  b === nothing && return graph.info[cls.name].meta
-  pm = graph.info[b].meta
+  b === nothing && return graph.byapp[(graph.self, cls.name)].meta
+  pm = graph.byapp[(b[1], b[2].name)].meta
   return Dict{String, String}(k => v for (k, v) in pm if !(k in _META_KEYS_NOT_INHERITED))
 end
 
 """
-    _inherited_meta_base(graph, cls) -> Union{String, Nothing}
+    _inherited_meta_base(graph, cls) -> Union{Tuple{Int, PyClass}, Nothing}
 
-The abstract base whose `Meta` Django installs on `cls`: the nearest ancestor declaring a `Meta`
-block at all. `nothing` when `cls` declares its own, or when no ancestor has one.
+The abstract base whose `Meta` Django installs on `cls`, as `(owning app, class)`: the nearest
+ancestor declaring a `Meta` block at all. `nothing` when `cls` declares its own, or when no ancestor
+has one. The owning app travels with the class because a bare name cannot address it — see the
+ancestor-walk note above.
 
 One walk, used by BOTH consumers — `_effective_meta` and the withheld-`db_table` report. They used
 to walk separately and disagree: the reporter climbed the whole chain while `_effective_meta`
@@ -2797,54 +3231,148 @@ would never have inherited it (Django resolves `Meta` to one class, not a merge 
 Gated on whether a Meta BLOCK was declared, not on whether it yielded options: `class Meta:`
 carrying only a docstring is still a declaration, and Django does not inherit past one.
 """
-function _inherited_meta_base(graph, cls::PyClass)::Union{String, Nothing}
+function _inherited_meta_base(graph, cls::PyClass)::Union{Tuple{Int, PyClass}, Nothing}
   isempty(cls.meta) || return nothing
-  seen = Set{String}()
-  function walk(c::PyClass)::Union{String, Nothing}
-    ci = get(graph.info, c.name, nothing)
+  seen = Set{Tuple{Int, String}}()
+  function walk(a::Int, c::PyClass)::Union{Tuple{Int, PyClass}, Nothing}
+    ci = get(graph.byapp, (a, c.name), nothing)
     ci === nothing && return nothing
     for b in ci.parents
-      b in seen && continue
-      push!(seen, b)
-      p = get(graph.index, b, nothing)
-      p === nothing && continue
-      isempty(p.meta) || return b
-      r = walk(p)
-      r === nothing || return r
+      r = get(graph.resolved, (a, b), nothing)
+      r === nothing && continue
+      (pa, pc) = r
+      (pa, pc.name) in seen && continue
+      push!(seen, (pa, pc.name))
+      isempty(pc.meta) || return (pa, pc)
+      w = walk(pa, pc)
+      w === nothing || return w
     end
     return nothing
   end
-  return walk(cls)
+  return walk(graph.self, cls)
 end
 
 """
-    _inherited_unresolved(graph, cls) -> Vector{String}
+    _inherited_unresolved(graph, cls) -> Vector{Tuple{String, Int}}
 
-Bases that neither `cls` nor any of its abstract ancestors could resolve.
+Bases that neither `cls` nor any of its abstract ancestors could resolve, each with the index of the
+app whose `models.py` actually declares the class carrying that base.
 
 An abstract base with its own unresolvable base (`class Auditavel(TimeStampedModel)` with
 `abstract = True`) loses columns exactly as the child would, but the base emits nothing — so without
 walking the chain its gap reaches the generated file with no marker at all.
+
+The owning app travels with the token because the walk crosses apps: an unresolved base found on
+`core.Auditavel` while emitting `shop.Pedido` needs its `import` line in **`core`**, and advice
+pointing at `shop` would be advice that cannot work.
 """
-function _inherited_unresolved(graph, cls::PyClass)::Vector{String}
-  out = String[]
-  seen = Set{String}()
-  function walk(c::PyClass)
-    ci = get(graph.info, c.name, nothing)
+function _inherited_unresolved(graph, cls::PyClass)::Vector{Tuple{String, Int}}
+  out = Tuple{String, Int}[]
+  seen = Set{Tuple{Int, String}}()
+  function walk(a::Int, c::PyClass)
+    ci = get(graph.byapp, (a, c.name), nothing)
     ci === nothing && return
     for b in ci.unresolved
-      b in out || push!(out, b)
+      any(t -> first(t) == b, out) || push!(out, (b, a))
     end
     for b in ci.parents
-      b in seen && continue
-      push!(seen, b)
-      p = get(graph.index, b, nothing)
-      p === nothing || walk(p)
+      r = get(graph.resolved, (a, b), nothing)
+      r === nothing && continue
+      (pa, pc) = r
+      (pa, pc.name) in seen && continue
+      push!(seen, (pa, pc.name))
+      walk(pa, pc)
     end
     return
   end
-  walk(cls)
+  walk(graph.self, cls)
   return out
+end
+
+# The fix to suggest for a base nothing in the run defines, in the vocabulary of the arity in use.
+# Conditional on purpose: the same marker covers a base from a third-party library, where there is
+# no app to add and nothing to do, and an unconditional "add the app" would be advice that cannot be
+# followed.
+_resolve_base_advice(label)::String =
+  label === nothing ?
+    "if that module is an app of this project, pass every app as \"<app_label>\" => " *
+    "\"<models.py>\" pairs so a base in another app is merged." :
+    "if that module is an app of this project, add it to the pair list."
+
+"""
+    _bound_module_note(graph, bases) -> String
+
+`", imported from 'model_utils.managers'"` when the module bound these names from somewhere the
+import table records, or a phrase saying nothing in the run defines them.
+
+This is what replaced *suppressing* the skip marker for a name bound outside the app set. The two
+things that test conflates — a third-party library, and an app of this project the caller did not
+pass — are the same string, and the caller is the only one who can tell them apart. Printing the
+module lets them: `model_utils.managers` is dismissed at a glance, `core.models` says which pair is
+missing.
+"""
+function _bound_module_note(graph, bases::Vector{String})::String
+  mods = String[]
+  for b in bases
+    entry = get(graph.scopes[graph.self].imports.names, b, nothing)
+    entry === nothing && continue
+    entry[1] in mods || push!(mods, entry[1])
+  end
+  isempty(mods) && return ", which nothing in this import defines and this models.py does not import"
+  return ", imported from " * join(("'$(m)'" for m in mods), ", ") *
+         ", which nothing in this import defines"
+end
+
+"""
+    _declaring_apps_hint(graph, bases) -> String
+
+A sentence naming the other apps of this run that DECLARE a class of one of these names, or `""`.
+
+Since #370 a base resolves across apps only when the module imported it, so two very different
+situations would otherwise print the same marker: a base nothing in the project defines, and a base
+another app defines but this one never imported. The fixes differ — one wants a pair added to the
+call, the other an `import` line in the source — and only naming the app tells them apart. This is
+the part of the issue's "improve the marker" option worth keeping once the lookup itself is fixed.
+
+It states only what the import table can back, because the two shapes want different advice and a
+guess told users something false in testing:
+
+- the name was never imported → the fix is an `import` line;
+- the name WAS imported, from a module outside the app set (`from library.base import BaseReport`)
+  → there is nothing to fix, and the useful thing to say is that the two are simply different
+  classes. This is #370's own shape, and "does not import it" would have been a plain lie.
+
+A star import can bind the name invisibly, so nothing is claimed there at all. And `bases` carries
+the app that declares the class holding the base — for an inherited gap that is an ancestor's app,
+not the one being emitted, and advice naming the wrong module cannot work.
+"""
+function _declaring_apps_hint(graph, bases::Vector{Tuple{String, Int}})::String
+  parts = String[]
+  for (b, owner) in bases
+    apps = String[]
+    for (i, sc) in enumerate(graph.scopes)
+      (i == owner || isempty(sc.label)) && continue
+      haskey(sc.own, b) && push!(apps, sc.label)
+    end
+    isempty(apps) && continue
+    sc = graph.scopes[owner]
+    where = isempty(sc.label) ? "this file" : "app '$(sc.label)'"
+    declared = "'$(b)' is declared by app" * (length(apps) == 1 ? " " : "s ") *
+               join(("'$(a)'" for a in apps), ", ")
+    entry = get(sc.imports.names, b, nothing)
+    if entry !== nothing && _app_for_module(graph.scopes, entry[1]) === nothing
+      # NOT "so they are different classes" — they may well be the same one. A qualified path can
+      # fail to match an app that was handed over as SOURCE TEXT, because there is no location to
+      # check the prefix against, and asserting difference there is simply false.
+      push!(parts, declared * ", but $(where) imports it from '$(entry[1])', which this import " *
+                   "could not match to any app — so they were not treated as the same class. If " *
+                   "they are, pass that app by PATH so its package can be matched")
+    elseif entry === nothing && isempty(sc.imports.stars)
+      push!(parts, declared * ", but $(where) does not import it — add the import if that is what " *
+                   "you meant")
+    end
+  end
+  return isempty(parts) ? "" : " Note: " * join(parts, "; ") * "."
 end
 
 # An abstract base declaring `db_table` is a Django footgun the importer refuses to reproduce (see
@@ -2853,7 +3381,7 @@ end
 function _abstract_db_table_base(graph, cls::PyClass)::Union{String, Nothing}
   b = _inherited_meta_base(graph, cls)
   b === nothing && return nothing
-  return haskey(graph.info[b].meta, "db_table") ? b : nothing
+  return haskey(graph.byapp[(b[1], b[2].name)].meta, "db_table") ? b[2].name : nothing
 end
 
 """
@@ -2949,7 +3477,7 @@ function _match_field_statement(text::AbstractString)
   return (name = lhs, type = String(m.captures[1]), args = args)
 end
 
-function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[], enums = Dict{String, Dict{String, _PyEnum}}(), enum_scopes::Vector{String} = String[String(class_name), ""])
+function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt}, class_name::AbstractString, is_auth_user::Bool, has_primary_key::Base.RefValue{Bool}, autofields_ignore::Vector{String}, parameters_ignore::Vector{String}, markers::Vector{String} = String[], enums = Dict{Tuple{Int, String}, Dict{String, _PyEnum}}(), enum_scopes::Vector{Tuple{Int, String}} = Tuple{Int, String}[(1, String(class_name)), (1, "")])
   # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
   # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
   # class reaching `AbstractUser` through an abstract base both qualify — an equality test on the
@@ -3098,9 +3626,9 @@ function django_field_type(field_type::AbstractString)::String
 end
 
 function parse_field_args(args_str::AbstractString, field_type::AbstractString, parameters_ignore::Vector{String};
-                         enums = Dict{String, Dict{String, _PyEnum}}(),
+                         enums = Dict{Tuple{Int, String}, Dict{String, _PyEnum}}(),
                          class_name::AbstractString = "",
-                         enum_scopes::Vector{String} = String[String(class_name), ""],
+                         enum_scopes::Vector{Tuple{Int, String}} = Tuple{Int, String}[(1, String(class_name)), (1, "")],
                          field_name::AbstractString = "",
                          markers::Vector{String} = String[])
   # This function parses field arguments handling nested parentheses and commas
@@ -3244,7 +3772,7 @@ Resolve a Django enum reference in a field option.
 Returns the resolved value, `_ENUM_NOT_A_REFERENCE` when `value` is not one, or `_ENUM_DROP` to mean
 "drop this option" (already warned and marked).
 """
-function _resolve_enum_reference(value::AbstractString, enums, enum_scopes::Vector{String},
+function _resolve_enum_reference(value::AbstractString, enums, enum_scopes::Vector{Tuple{Int, String}},
                                  class_name::AbstractString,
                                  field_name::AbstractString, key::AbstractString,
                                  markers::Vector{String},

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -165,8 +165,16 @@ class SupportedThing(models.Model):
         generated = read(generated_path, String)
         @test occursin("SupportedThing = Models.Model(\"supportedthing\"", generated)
         @test occursin("label = Models.CharField(max_length=50)", generated)
+        # `PlainHelper(object)` is a helper by its base list, so it leaves no trace at all.
         @test !occursin("PlainHelper", generated)
-        @test !occursin("ProxyUser", generated)
+        # `ProxyUser(CustomUser)` is NOT the same case, and used to be treated as though it were.
+        # Its only base is unresolvable and its body is `pass`, so every column it might have lives
+        # somewhere the importer cannot see — which is equally the shape of a real model and of a
+        # helper. It is still not emitted as a table, but dropping it in silence is how a genuine
+        # model disappears without a trace, so it now says so (#370).
+        @test !occursin("ProxyUser = Models.Model", generated)
+        @test occursin("# PormG: class 'ProxyUser' inherits 'CustomUser'", generated)
+        @test occursin("declares no field of its own", generated)
     finally
         cleanup_import_test!(config_key, db_dir_existed)
     end

--- a/test/unit/test_import_django_project.jl
+++ b/test/unit/test_import_django_project.jl
@@ -1053,8 +1053,12 @@ class TimeStampedModel(models.Model):
 class Circuit(models.Model):
     name = models.CharField(max_length=120)
 """
+    # The `from core.models import …` line is not decoration: since #370 a base resolves across apps
+    # only when this module actually imported it, which is also the only spelling Python would run —
+    # without it `TimeStampedModel` is an undefined name and Django raises at import time.
     downstream = """
 from django.db import models
+from core.models import TimeStampedModel
 
 class ImportBatch(TimeStampedModel):
     note = models.CharField(max_length=40)
@@ -1098,6 +1102,7 @@ class Venda(models.Model):
 """
     child = """
 from django.db import models
+from core.models import Venda
 
 class Pedido(Venda):
     obs = models.CharField(max_length=40)
@@ -1385,8 +1390,11 @@ class Status(models.TextChoices):
     DRAFT = "d", "Draft"
     SENT = "s", "Sent"
 """
+    # As with a cross-app base, the import line is what puts `Status` in this module's namespace —
+    # and since #370 that is what the importer resolves on, rather than the bare name.
     consumer = """
 from django.db import models
+from core.models import Status
 
 class Batch(models.Model):
     situacao = models.CharField(max_length=1, choices=Status.choices, default=Status.DRAFT)
@@ -1845,5 +1853,825 @@ class Pessoa(models.Model):
         @test occursin("core.Pessoa", msg)
     finally
         cleanup_project_test!(config_key, db_dir_existed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#370): a base resolves across apps only when the module imported it.
+#
+# #346 resolved every app's bases against every app's classes, by NAME. That is what merges a shared
+# `core.models.TimeStampedModel` — and it is also how a base an app inherits from a THIRD-PARTY
+# library resolved against an unrelated app's class of the same name. When that class was concrete
+# the child was refused as multi-table inheritance and its table vanished from the generated file:
+# adding an app to the import REMOVED a table belonging to another app, which Python's per-module
+# namespaces make impossible.
+#
+# The rule is now Python's own — an app's own classes win, and anything else must have been imported.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@testset "a base from a third-party library does not collide with another app's class (#370)" begin
+    # `reports` inherits BaseReport from a library. `billing` happens to declare a CONCRETE class of
+    # the same name and knows nothing about `reports`. Before #370 the two were the same name and so
+    # the same class, and `Relatorio` was refused as multi-table inheritance and dropped.
+    reports = """
+from django.db import models
+from library.base import BaseReport
+
+class Relatorio(BaseReport):
+    titulo = models.CharField(max_length=80)
+"""
+    billing = """
+from django.db import models
+
+class BaseReport(models.Model):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["reports" => reports, "billing" => billing];
+                                             output_file = "crossapp_thirdparty.jl")
+    try
+        # The table is HERE. This assertion is the issue.
+        @test occursin("Relatorio = Models.Model(\"relatorio\", db_table = \"reports_relatorio\"", generated)
+        @test occursin("titulo = Models.CharField(max_length=80)", generated)
+        # ...and it is not refused for inheritance it never had.
+        @test !occursin("Django multi-table inheritance", generated)
+        # `billing`'s own class is untouched by any of this.
+        @test occursin("BaseReport = Models.Model(\"basereport\", db_table = \"billing_basereport\"", generated)
+        # The marker still reports the missing columns, and now says why the same-named class next
+        # door was not used — and says it accurately. `reports` DOES import `BaseReport`; claiming
+        # it does not would be a plain lie, and the useful fact is where it imports it from.
+        @test occursin("'BaseReport' is declared by app 'billing', but app 'reports' imports it " *
+                       "from 'library.base', which this import could not match to any app — so " *
+                       "they were not treated as the same class", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # The invariant behind the issue title: adding an app must never REMOVE a table.
+    alone, key2, existed2 = import_project(["reports" => reports];
+                                           output_file = "alone_thirdparty.jl")
+    try
+        @test occursin("Relatorio = Models.Model(", alone)
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+end
+
+@testset "an imported base still merges, and a concrete one is still refused (#370)" begin
+    core = """
+from django.db import models
+
+class TimeStampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+class Venda(models.Model):
+    total = models.IntegerField()
+"""
+    good = """
+from django.db import models
+from core.models import TimeStampedModel
+
+class Pedido(TimeStampedModel):
+    obs = models.CharField(max_length=40)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => good];
+                                             output_file = "gate_merge.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated)
+        @test !occursin("not defined in", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # A CONCRETE base, genuinely imported, is still multi-table inheritance and still refused —
+    # gating the lookup must not cost the refusal that keeps a wrong primary key off the disk.
+    mti = """
+from django.db import models
+from core.models import Venda
+
+class Pedido(Venda):
+    obs = models.CharField(max_length=40)
+"""
+    generated2, key2, existed2 = import_project(["core" => core, "shop" => mti];
+                                                output_file = "gate_mti.jl")
+    try
+        @test occursin("Django multi-table inheritance", generated2)
+        @test !occursin("Pedido = Models.Model", generated2)
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # The same abstract base, NOT imported: no merge, and the columns are reported missing rather
+    # than silently taken from a class this module cannot see.
+    ungated = """
+from django.db import models
+
+class Pedido(TimeStampedModel):
+    obs = models.CharField(max_length=40)
+"""
+    generated3, key3, existed3 = import_project(["core" => core, "shop" => ungated];
+                                                output_file = "gate_ungated.jl")
+    try
+        @test !occursin("created_at", generated3)
+        @test occursin("not defined in any app of this import", generated3)
+        # Here the module really did NOT import it, so that is what the hint says.
+        @test occursin("'TimeStampedModel' is declared by app 'core', but app 'shop' does not " *
+                       "import it — add the import if that is what you meant", generated3)
+        # The table itself survives — a missing base never costs a table.
+        @test occursin("Pedido = Models.Model(", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+end
+
+@testset "a base's own bases resolve in ITS app, not the importing one (#370)" begin
+    # Two-hop abstract chain. `shop` imports only `Auditavel`, whose own base exists solely in
+    # `core`. Resolving that in the IMPORTING app's namespace loses it, which makes `Auditavel`
+    # field-less and therefore not-a-model, which poisons `Pedido` — and `Pedido` is then dropped
+    # with no marker at all. Strictly worse than the defect #370 set out to remove.
+    core = """
+from django.db import models
+
+class TimeStampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+class Auditavel(TimeStampedModel):
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Auditavel
+
+class Pedido(Auditavel):
+    obs = models.CharField(max_length=40)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "twohop.jl")
+    try
+        @test occursin("Pedido = Models.Model(", generated)
+        # The grandparent's column arrives through a base that declares none of its own.
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated)
+        @test occursin("obs = Models.CharField(max_length=40)", generated)
+        @test !occursin("not defined in", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a class name two apps share does not fabricate an inheritance cycle (#370)" begin
+    # Fails before this change. `core.Bar` reaches its base `Foo` while `l.Foo` is mid-classification
+    # and a BARE-NAME `visiting` set reads that as a cycle: `core.Bar` is refused, which poisons
+    # `l.Foo`, which is dropped in silence. The two `Foo`s are different classes in different
+    # modules, and only a name-keyed table could confuse them.
+    core = """
+from django.db import models
+
+class Foo(models.Model):
+    a = models.IntegerField()
+
+    class Meta:
+        abstract = True
+
+class Bar(Foo):
+    shared = models.CharField(max_length=10)
+
+    class Meta:
+        abstract = True
+"""
+    l = """
+from django.db import models
+from core.models import Bar
+
+class Foo(Bar):
+    b = models.IntegerField()
+"""
+    generated, key, existed = import_project(["core" => core, "l" => l];
+                                             output_file = "false_cycle.jl")
+    try
+        # On `main`, classifying `l.Foo` marks the bare name "Foo" as in-progress; the walk into
+        # `core.Bar` then resolves ITS base `Foo` through an own-app-first flat index straight back
+        # to `l.Foo`, reads that as a cycle, and drops the model without a word. Here it is emitted.
+        @test occursin("Foo = Models.Model(\"foo\", db_table = \"l_foo\"", generated)
+        # And it carries the whole chain: its own column, `core.Bar`'s, and `core.Foo`'s.
+        @test occursin("b = Models.IntegerField()", generated)
+        @test occursin("shared = Models.CharField(max_length=10)", generated)
+        @test occursin("a = Models.IntegerField()", generated)
+        # Both `core` classes are abstract, so neither emits a table of its own.
+        @test !occursin("core_foo", generated)
+        @test !occursin("Bar = Models.Model", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "an alias, a star import and a re-export all resolve a base (#370)" begin
+    core = """
+from django.db import models
+
+class TimeStampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+"""
+    # `from core.models import X as Y` — the base is spelled by its LOCAL name.
+    aliased = """
+from django.db import models
+from core.models import TimeStampedModel as TSM
+
+class Pedido(TSM):
+    obs = models.CharField(max_length=40)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => aliased];
+                                             output_file = "alias.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated)
+        @test !occursin("not defined in", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # `from core.models import *` binds names no parser can enumerate, so the whole app comes into
+    # scope rather than none of it.
+    starred = """
+from django.db import models
+from core.models import *
+
+class Pedido(TimeStampedModel):
+    obs = models.CharField(max_length=40)
+"""
+    generated2, key2, existed2 = import_project(["core" => core, "shop" => starred];
+                                                output_file = "star.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated2)
+        @test !occursin("not defined in", generated2)
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # A re-export façade: `shop` imports from `access`, which imported it from `core` and declares no
+    # such class of its own. Stopping at `access` would be a fresh silent loss.
+    access = """
+from django.db import models
+from core.models import TimeStampedModel
+
+class Perfil(TimeStampedModel):
+    nome = models.CharField(max_length=20)
+"""
+    downstream = """
+from django.db import models
+from access.models import TimeStampedModel
+
+class Pedido(TimeStampedModel):
+    obs = models.CharField(max_length=40)
+"""
+    generated3, key3, existed3 = import_project(["core" => core, "access" => access,
+                                                 "shop" => downstream];
+                                                output_file = "reexport.jl")
+    try
+        @test occursin("Pedido = Models.Model(", generated3)
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated3)
+        @test !occursin("not defined in", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+end
+
+@testset "a module path names an app by label or by package directory (#370)" begin
+    # `Page` is here so the vendor-path sub-test below can actually FAIL when the rule is wrong.
+    # Without a concrete class of that name in `core`, `from wagtail.core.models import Page` leaves
+    # `Page` unresolved either way, `Artigo` is emitted either way, and the assertion passes whether
+    # or not the module path was matched — a test that cannot see the bug it was written for.
+    core = """
+from django.db import models
+
+class TimeStampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+class Pedido(models.Model):
+    total = models.IntegerField()
+
+class Page(models.Model):
+    slug = models.CharField(max_length=30)
+"""
+    # A nested app package. A LEFT-to-right first-component match would stop at `apps` and resolve
+    # nothing, which is why the scan runs right to left — but what makes `apps` acceptable here is
+    # that the app's models.py really does live under `apps/`, so a PATH is required.
+    nest_root = mktempdir()
+    mkpath(joinpath(nest_root, "apps", "core"))
+    write(joinpath(nest_root, "apps", "core", "models.py"), core)
+    nested = """
+from django.db import models
+from apps.core.models import TimeStampedModel
+
+class Nota(TimeStampedModel):
+    texto = models.CharField(max_length=20)
+"""
+    generated, key, existed = import_project(
+        ["core" => joinpath(nest_root, "apps", "core", "models.py"), "shop" => nested];
+        output_file = "nested_pkg.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated)
+        @test !occursin("not defined in", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # The same app package re-exporting through its `__init__.py`, still qualified by `apps`.
+    pkg_nested = """
+from django.db import models
+from apps.core import TimeStampedModel
+
+class Nota(TimeStampedModel):
+    texto = models.CharField(max_length=20)
+"""
+    generated5, key5, existed5 = import_project(
+        ["core" => joinpath(nest_root, "apps", "core", "models.py"), "shop" => pkg_nested];
+        output_file = "nested_pkg_init.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated5)
+        @test !occursin("not defined in", generated5)
+    finally
+        cleanup_project_test!(key5, existed5)
+    end
+
+    # A THIRD-PARTY package whose own layout happens to contain the app's name followed by `models`.
+    # `wagtail.core.models` is the canonical Wagtail import, and matching "an app key with `models`
+    # after it" anywhere in the path read it as this project's `core` — #370 all over again. What
+    # rejects it is that `wagtail` is not where `core/models.py` actually lives.
+    vendor = """
+from django.db import models
+from wagtail.core.models import Page
+
+class Artigo(Page):
+    corpo = models.CharField(max_length=100)
+"""
+    generated6, key6, existed6 = import_project(
+        ["core" => joinpath(nest_root, "apps", "core", "models.py"), "cms" => vendor];
+        output_file = "vendor_models_tail.jl")
+    try
+        @test occursin("Artigo = Models.Model(\"artigo\", db_table = \"cms_artigo\"", generated6)
+        @test occursin("corpo = Models.CharField(max_length=100)", generated6)
+        @test !occursin("Django multi-table inheritance", generated6)
+    finally
+        cleanup_project_test!(key6, existed6)
+        rm(nest_root; recursive = true, force = true)
+    end
+
+    # A SIBLING module of the same app is not its models module. `core/forms.py` may perfectly well
+    # declare its own `Pedido`, and binding that to the model `core/models.py` declares would be
+    # #370 one module over.
+    from_forms = """
+from django.db import models
+from core.forms import Pedido
+
+class Recibo(Pedido):
+    valor = models.IntegerField()
+"""
+    generated2, key2, existed2 = import_project(["core" => core, "shop" => from_forms];
+                                                output_file = "sibling_module.jl")
+    try
+        @test !occursin("Django multi-table inheritance", generated2)
+        @test occursin("Recibo = Models.Model(", generated2)
+        @test occursin("not defined in any app of this import", generated2)
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # The label is often NOT the package directory — Django's `AppConfig.label` frequently differs.
+    # A pair given as a PATH carries the directory as a second key, so an import spelling the package
+    # name resolves even though the label differs.
+    dir_root = mktempdir()
+    mkpath(joinpath(dir_root, "customers"))
+    write(joinpath(dir_root, "customers", "models.py"), core)
+    by_package = """
+from django.db import models
+from customers.models import TimeStampedModel
+
+class Nota(TimeStampedModel):
+    texto = models.CharField(max_length=20)
+"""
+    generated3, key3, existed3 = import_project(["crm" => joinpath(dir_root, "customers", "models.py"),
+                                                 "shop" => by_package];
+                                                output_file = "label_vs_dir.jl")
+    try
+        @test occursin("created_at = Models.DateTimeField(auto_now_add=true)", generated3)
+        @test !occursin("not defined in", generated3)
+        # The label still drives the table prefix; only the LOOKUP accepts either spelling.
+        @test occursin("db_table = \"crm_pedido\"", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+        rm(dir_root; recursive = true, force = true)
+    end
+end
+
+@testset "a class with no resolvable base and no field of its own is not dropped in silence (#370)" begin
+    # Every column this class might have lives in a base the importer cannot see, so there is no
+    # evidence either way and it is skipped — but skipping it without a word is exactly how a real
+    # model disappears leaving no trace. A DOTTED base is a different case and stays silent: it names
+    # a module, so it is a helper by construction.
+    src = """
+from django.db import models
+
+class Perfil(CustomUser):
+    pass
+
+class ContatoForm(forms.Form):
+    pass
+
+class Real(models.Model):
+    nome = models.CharField(max_length=10)
+"""
+    generated, key, existed = import_project(["app" => src]; output_file = "silent_drop.jl")
+    try
+        @test occursin("Real = Models.Model(", generated)
+        @test !occursin("Perfil = Models.Model", generated)
+        @test occursin("# PormG: class 'Perfil' inherits 'CustomUser'", generated)
+        @test occursin("declares no field of its own", generated)
+        # A `forms.Form` helper produces no noise — the namespace already settles what it is.
+        @test !occursin("ContatoForm", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a module-level enum crosses apps only when imported (#370)" begin
+    core = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+    SENT = "s", "Sent"
+"""
+    # `shop` never imports `Status` and declares no enum of its own. Before #370 it silently received
+    # `core`'s enumeration — no marker anywhere, and the wrong choices reached the schema.
+    shop = """
+from django.db import models
+
+class Batch(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_ungated.jl")
+    try
+        @test !occursin("(\"d\", \"Draft\")", generated)
+        @test occursin("Batch = Models.Model(", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # Imported, so it resolves — including through an alias.
+    shop2 = """
+from django.db import models
+from core.models import Status as S
+
+class Batch(models.Model):
+    situacao = models.CharField(max_length=1, choices=S.choices, default=S.DRAFT)
+"""
+    generated2, key2, existed2 = import_project(["core" => core, "shop" => shop2];
+                                                output_file = "enum_gated.jl")
+    try
+        @test occursin("choices=((\"d\", \"Draft\"), (\"s\", \"Sent\"))", generated2)
+        @test occursin("default=\"d\"", generated2)
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # An app declaring its OWN `Status` keeps it, whatever another app imported into scope.
+    shop3 = """
+from django.db import models
+from core.models import Status
+
+class Batch(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+class Status(models.TextChoices):
+    OPEN = "o", "Open"
+"""
+    generated3, key3, existed3 = import_project(["core" => core, "shop" => shop3];
+                                                output_file = "enum_local_wins.jl")
+    try
+        @test occursin("(\"o\", \"Open\")", generated3)
+        @test !occursin("(\"d\", \"Draft\")", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+end
+
+@testset "a cross-app AbstractUser chain resolves only when imported (#370)" begin
+    # `settings.AUTH_USER_MODEL` auto-detection walks the abstract chain to find the single
+    # AbstractUser subclass. If gating broke that walk the reference would stop resolving — the one
+    # regression shape that turns a working import into a FAILING one rather than a marked one.
+    core = """
+from django.contrib.auth.models import AbstractUser
+
+class BaseUser(AbstractUser):
+    class Meta:
+        abstract = True
+"""
+    access = """
+from django.db import models
+from core.models import BaseUser
+
+class User(BaseUser):
+    matricula = models.CharField(max_length=20)
+"""
+    racing = """
+from django.conf import settings
+from django.db import models
+
+class Race(models.Model):
+    reported_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+"""
+    generated, key, existed = import_project(["core" => core, "access" => access,
+                                              "racing" => racing];
+                                             output_file = "auth_chain.jl")
+    try
+        # The AbstractUser columns reached `User` through the imported abstract base...
+        @test occursin("username = Models.CharField", generated)
+        # ...so AUTH_USER_MODEL found its single candidate and the FK resolves to it.
+        @test occursin("reported_by_id = Models.ForeignKey(\"User\"", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a module path matches an app only where the app's models module follows (#370)" begin
+    # The first cut of #370 accepted a match on the LAST component of any path, which let a
+    # third-party module resolve into an app whose label happened to equal that component — the
+    # original defect, one module name over. Every case here failed that way.
+    core = """
+from django.db import models
+
+class Page(models.Model):
+    slug = models.CharField(max_length=30)
+
+class Perfil(models.Model):
+    apelido = models.CharField(max_length=30)
+"""
+    # `wagtail.core` ends in `core`, and `core` is a real app in this run.
+    cms = """
+from django.db import models
+from wagtail.core import Page
+
+class Artigo(Page):
+    corpo = models.CharField(max_length=100)
+"""
+    generated, key, existed = import_project(["core" => core, "cms" => cms];
+                                             output_file = "thirdparty_tail.jl")
+    try
+        @test occursin("Artigo = Models.Model(\"artigo\", db_table = \"cms_artigo\"", generated)
+        @test occursin("corpo = Models.CharField(max_length=100)", generated)
+        @test !occursin("Django multi-table inheritance", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # A SINGLE-dot import names a submodule of the app doing the importing. Stripping the dot leaves
+    # `core`, a perfectly ordinary app label — so one dot must never be read as naming another app,
+    # with or without a `models` tail.
+    for (name, line) in (("dot_pkg", "from .core import Perfil"),
+                         ("dot_models", "from .core.models import Perfil"))
+        shop = """
+from django.db import models
+$(line)
+
+class Conta(Perfil):
+    saldo = models.IntegerField()
+"""
+        generated2, key2, existed2 = import_project(["core" => core, "shop" => shop];
+                                                    output_file = "relative_$(name).jl")
+        try
+            @test occursin("Conta = Models.Model(\"conta\", db_table = \"shop_conta\"", generated2)
+            @test !occursin("Django multi-table inheritance", generated2)
+        finally
+            cleanup_project_test!(key2, existed2)
+        end
+    end
+
+    # TWO dots ascend to the parent package, which is how a project laid out as `apps/{core,shop}/`
+    # spells a genuine cross-app import. That one must resolve.
+    ascending = """
+from django.db import models
+from ..core.models import Perfil
+
+class Conta(Perfil):
+    saldo = models.IntegerField()
+"""
+    generated4, key4, existed4 = import_project(["core" => core, "shop" => ascending];
+                                                output_file = "relative_ascend.jl")
+    try
+        # Genuinely imported and genuinely concrete, so this IS multi-table inheritance.
+        @test occursin("Django multi-table inheritance", generated4)
+    finally
+        cleanup_project_test!(key4, existed4)
+    end
+
+    # The one absolute single-component form IS the app package, re-exporting through `__init__.py`.
+    pkg = """
+from django.db import models
+from core import Perfil
+
+class Conta(Perfil):
+    saldo = models.IntegerField()
+"""
+    generated3, key3, existed3 = import_project(["core" => core, "shop" => pkg];
+                                                output_file = "bare_package.jl")
+    try
+        # Genuinely imported and genuinely concrete, so this one IS multi-table inheritance.
+        @test occursin("Django multi-table inheritance", generated3)
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+end
+
+@testset "two apps declaring the same class name keep their own nested enums (#370)" begin
+    # The base resolved correctly here from the very first cut; it was the ENUM scope table that was
+    # still flat and name-keyed, so `core.Base`'s own field silently took `shop.Base`'s members.
+    # Nothing in the generated file said so — the same silent-wrong-schema class as #370 itself.
+    core = """
+from django.db import models
+
+class Base(models.Model):
+    class Situacao(models.TextChoices):
+        ATIVO = "A", "Ativo"
+
+    situacao = models.CharField(max_length=1, choices=Situacao.choices)
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base as CoreBase
+
+class Base(models.Model):
+    class Situacao(models.TextChoices):
+        OUTRO = "O", "Outro"
+
+    class Meta:
+        abstract = True
+
+class Pedido(CoreBase):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_class_scope.jl")
+    try
+        # `Pedido` inherits `core.Base`, so its `situacao` must carry CORE's members.
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"A\", \"Ativo\"),))",
+                       generated)
+        @test !occursin("\"Outro\"", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a module-level enum resolves through a re-export, as a base does (#370)" begin
+    # Base resolution followed a re-export façade from the start; enum resolution did not, so an
+    # identically-shaped project resolved the base and dropped the enumeration — with a marker
+    # telling the reader to import a module they had already imported.
+    core = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+"""
+    access = """
+from django.db import models
+from core.models import Status
+"""
+    shop = """
+from django.db import models
+from access.models import Status
+
+class Batch(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices, default=Status.DRAFT)
+"""
+    generated, key, existed = import_project(["core" => core, "access" => access, "shop" => shop];
+                                             output_file = "enum_reexport.jl")
+    try
+        @test occursin("choices=((\"d\", \"Draft\"),)", generated)
+        @test occursin("default=\"d\"", generated)
+        @test !occursin("which this file does not define", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "star-import order does not decide whether a base resolves (#370)" begin
+    # `seen` guarding the re-export walk was keyed by APP, not by (app, name). An app already
+    # visited for one token then answered `nothing` for a different token, so which of two
+    # `from … import *` lines came first decided whether the base resolved at all.
+    y = """
+from django.db import models
+
+class Foo(models.Model):
+    ycol = models.IntegerField()
+
+    class Meta:
+        abstract = True
+
+class Bar(models.Model):
+    bcol = models.IntegerField()
+
+    class Meta:
+        abstract = True
+"""
+    x = """
+from django.db import models
+from y.models import Foo, Bar
+"""
+    b = """
+from django.db import models
+from x.models import *
+"""
+    c = """
+from django.db import models
+from x.models import Bar as Foo
+"""
+    for (label, first, second) in (("c_then_b", "c", "b"), ("b_then_c", "b", "c"))
+        a = """
+from django.db import models
+from $(first).models import *
+from $(second).models import *
+
+class Conta(Foo):
+    own = models.IntegerField()
+"""
+        generated, key, existed = import_project(["y" => y, "x" => x, "b" => b, "c" => c,
+                                                  "a" => a];
+                                                 output_file = "star_order_$(label).jl")
+        try
+            # Whichever order the two star imports appear in, `Foo` resolves and its column arrives.
+            @test occursin("Conta = Models.Model(", generated)
+            @test !occursin("not defined in any app of this import", generated)
+        finally
+            cleanup_project_test!(key, existed)
+        end
+    end
+end
+
+@testset "a skipped no-field class names the module its base came from (#370)" begin
+    # `ancestry_lost` exists for a class that MIGHT be a model whose columns all live in a base the
+    # importer cannot see. "The base came from a module naming no app" does NOT settle that: a
+    # third-party library and an app the caller forgot to pass are the same string — and in the
+    # single-app arity there are no app keys at all, so that test is true for every imported base
+    # and the marker would never fire for the case it exists for. The module goes in the message.
+    src = """
+from django.db import models
+from model_utils.managers import InheritanceManager
+
+class MeuManager(InheritanceManager):
+    pass
+
+class Perfil(CustomUser):
+    pass
+
+class Real(models.Model):
+    nome = models.CharField(max_length=10)
+"""
+    generated, key, existed = import_project(["app" => src]; output_file = "thirdparty_helper.jl")
+    try
+        @test occursin("Real = Models.Model(", generated)
+        # Named, so a reader dismisses the library in one glance...
+        @test occursin("# PormG: class 'MeuManager' inherits 'InheritanceManager', imported from " *
+                       "'model_utils.managers', which nothing in this import defines", generated)
+        # ...and a base with no import line at all says exactly that instead.
+        @test occursin("# PormG: class 'Perfil' inherits 'CustomUser', which nothing in this " *
+                       "import defines and this models.py does not import", generated)
+        @test !occursin("Perfil = Models.Model", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+
+    # The single-app arity is where this matters most, and where the discarded guard disabled it
+    # outright: an app whose base lives in a sibling app the caller did not pass.
+    single = """
+from django.db import models
+from core.models import TimeStampedModel
+
+class Pedido(TimeStampedModel):
+    pass
+
+class Outro(models.Model):
+    nome = models.CharField(max_length=10)
+"""
+    generated2, key2, existed2 = import_one_app(single; output_file = "single_ancestry_lost.jl")
+    try
+        @test occursin("# PormG: class 'Pedido' inherits 'TimeStampedModel', imported from " *
+                       "'core.models', which nothing in this import defines", generated2)
+        @test occursin("\"<app_label>\" => \"<models.py>\" pairs", generated2)
+    finally
+        cleanup_project_test!(key2, existed2)
     end
 end


### PR DESCRIPTION
Closes #370.

Multi-app import (#346) resolved every app's base classes against **every** app's classes, by **name**. That is what merges a shared `core.models.TimeStampedModel` — and it is also how a base one app inherits from a third-party library resolved against an unrelated app's class of the same name. When that class was concrete the child was refused as multi-table inheritance and its table **vanished** from the generated file: adding an app to the import removed a table belonging to another app, which Python's per-module namespaces make impossible.

Issue option 2 — parse the imports — was chosen over the cheaper two. Option 3 (abstract-only cross-app scope) would have stopped refusing a *genuine* cross-app `class Pedido(billing.Venda)` and emitted a table with the wrong primary key, which is the schema-contradicts-database outcome the MTI refusal exists to prevent.

## What changed

**Resolution follows the `import` statements.** `_py_logical_lines` already emitted them and `_py_classes` discarded them one call later, so `_py_imports` reads the table that was being thrown away — aliases, parenthesised lists, star imports, re-export façades. An app's own classes still win, as Django resolves an unqualified reference.

**A module path must agree with where the app lives.** A component names an app when the app's models module follows its label or package directory (or nothing follows — the `__init__.py` re-export) **and** whatever precedes it is a suffix of that app's package path. Both halves matter: `from wagtail.core.models import Page` is the canonical Wagtail import and has a key followed by `models`, so without the prefix check a project with a `core` app reproduced the defect verbatim. One leading dot is the app's own package and never names another app; two or more ascend, which is how `apps/{core,shop}/` spells a real cross-app import.

**Classification is keyed `(app, name)`, and recursion carries the RESOLVED app.** A base's own bases are names in *its* module. Resolving them in the importing app's namespace made an abstract base field-less, therefore not-a-model, which poisoned the child — dropped with **no marker at all**, strictly worse than the defect being fixed.

**Two live bugs fixed on the way**, both reproduced against `main`:
- the bare-name `visiting` set read `core.Bar(Foo)` reached from `L.Foo` as an inheritance cycle and lost *every* model in the file;
- an un-imported module-level enum silently supplied another app's `choices`/`default`.

**Enums** are gated the same way and the table is keyed `(app, scope)` — app-blind class scopes let two apps that each declare a `Base` with a nested `Situacao` collapse into one entry.

**Diagnostics.** A class with no resolvable base and no column of its own used to be skipped in complete silence; it now says so and names the module the base came from, which separates a third-party mixin from a missing pair. The unresolved-base marker names another app declaring that name and states only what the import table backs.

## Tests

Three `models.py` fixtures in the #346 suite declared a cross-app base or enum without importing it — invalid Python that raises `NameError` in Django. They gained the import line they always needed.

Fourteen new testsets. Mutation-checked against the unmodified `main` checkout: #370 itself (`Relatorio` gone), the false inheritance cycle (**no file emitted at all**), and the silent enum leak all confirmed broken there.

- Full unit suite: **7504 / 7504**
- Docs build: exit 0
- Module-path matching: 25 cases across four project layouts

## Deliberately not done

- **No `UPGRADING.md` entry, no version bump.** #346 is inside `## Unreleased`, so this refines behaviour that has never shipped, and it forces no consuming-app source edit.
- **No integration tests.** The Django importer has zero integration coverage — it reads `.py` text and writes a `.jl` file, touching no DDL path and no driver round-trip.
- **`import x.y as z`** is not recorded: a dotted base token never matched the bare-name class index either, so honouring it would resolve nothing.
- **Conditional imports** (`if TYPE_CHECKING:`, `try/except ImportError`) are not module-level bindings; the base is reported unresolved instead.
- **Enum scope is per class, not per statement** — a merged base statement resolves module-level enums in the child's app first. Pre-existing (the old table was one flat app-blind dictionary, so every app's module scope was reachable from everywhere) and narrowed here to ancestor apps. Closing it means tagging merged statements with their origin app in `_inherited_statements`; follow-up issue to come.

## Reviewer notes

Three independent review rounds; each found something real, including two rounds where a test of mine was green over a live bug. `src/migrations/importers.jl` is also being edited on `fix/369-abstractuser-double-pk`, and this diff restructures the classification core — whichever lands second will need a non-trivial merge there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
