### PR TITLE
fix(#376): a CTE's columns are its projection aliases, not the source db_column

### DIFF
--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -252,6 +252,29 @@ The `.with()` method:
 2. Creates a `LEFT JOIN stats ON result.driverid = stats.driverid`.
 3. Makes `stats__total_results` available for selection via `values()`.
 
+!!! note "A CTE's columns are its projection aliases"
+    A CTE is a **derived table**: the only columns it exposes are the names its `values()` call
+    produces. That matters when a projected field declares
+    [`db_column`](../fields.md#Database-Column-Mapping) — the physical name is consumed *inside*
+    the `WITH` body, so the outer query names the **field**, never the column.
+
+    Suppose `Race` declared `name = Models.CharField(db_column = "race_name")`:
+
+    ```julia
+    # The CTE body renders `"race_name" AS "name"` — `name` is the column it exposes.
+    races_91 = M.Race.objects.filter("year" => 1991).values("raceid", "name")
+
+    q = M.Result.objects
+    q.with("r91" => races_91, join_field="raceid" => "raceid")
+    q.filter("r91__name" => "Brazilian Grand Prix")   # → the CTE's "name" column, not "race_name"
+    q.values("resultid", "race" => "r91__name")
+    ```
+
+    Give the projection a custom alias (`values("rname" => "name")`) and *that* becomes the outer
+    name (`r91__rname`). The `join_field` follows the same split: its **second** element names a
+    CTE column and is a field name, while the first names a real column on the main table and does
+    resolve through `db_column`.
+
 ---
 
 ## Correlating a CTE with `F()` (no `join_field`)

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -434,6 +434,16 @@ Two consequences worth noting:
       ([#64](https://github.com/PingoLee/PormG.jl/issues/64)). The one surface that is **not**
       configurable is the **auto-generated ManyToMany through-table column names** (`<model>_<pk>`).
 
+  !!! note "A CTE exposes aliases, not columns"
+      A CTE (or any `values()`-projected subquery) is a **derived table**: its columns are the
+      projection *aliases*, because the physical name is consumed inside the `WITH` body
+      (`"product_sku" AS "sku"`). So an outer reference to a CTE-projected field names the **field**
+      (or its custom alias), not the `db_column`
+      ([#376](https://github.com/PingoLee/PormG.jl/issues/376)) — the column-side half of the
+      join-key rule above. Fields on real tables reached *through* the CTE are unaffected and still
+      resolve their own `db_column`. See
+      [Subqueries and CTEs](read/subqueries_and_ctes.md#Basic-CTE-with-JOIN).
+
 !!! note "Imported models differ"
     The Django importer appends `_id` to a `ForeignKey`/`OneToOneField` field and points it at the
     referenced `id` — e.g. Django's `category = ForeignKey(...)` becomes a `category_id` column —

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -1076,6 +1076,38 @@ function field_db_column(field::PormGField, name::AbstractString)::String
 end
 field_db_column(field::PormGField, name::Symbol)::String = field_db_column(field, String(name))
 
+# The same field as a DERIVED table exposes it (#376). A CTE (or any `values()`-projected
+# subquery) has no physical columns of its own: its columns ARE the projection ALIASES, because
+# the physical name is consumed INSIDE the body (`"Tb"."product_sku" as "sku"`). A field object
+# reused to TYPE such a column must therefore stop claiming the base table's `db_column`, or the
+# outer query references `"ev"."product_sku"` — a column the CTE does not expose, which both
+# backends reject at execution. Clearing the slot makes `field_db_column` fall back to the name it
+# is asked about, and at every CTE call site that name IS the alias. This is the column-side half
+# of the rule #64 already applies to the CTE side of a `join_field` key.
+#
+# COPY, never mutate: `_build_cte_custom_model` reuses the REAL model's field objects verbatim, and
+# a model is live shared schema state — `Base.deepcopy_internal(::Model_Type, …)` shares it on
+# purpose. Mutating here would rename the base table's column for every other query.
+#
+# Rebuilt through the struct's DEFAULT POSITIONAL CONSTRUCTOR rather than `setfield!`, because
+# `sIDField` is an IMMUTABLE struct while the other 25 field types are mutable — this is the one
+# form that works for both, and `id` appears in nearly every CTE projection. No field struct
+# declares an inner constructor, so `T(fields...)` exists for all of them; if one ever does, the
+# structural guard in `test/unit/test_db_column.jl` fails.
+#
+# A type with no `db_column` slot (`sManyToManyField`) and a field that declares none both return
+# the IDENTICAL object, so the common path allocates nothing and renders byte-identically. The
+# emptiness guard mirrors `field_db_column`'s own test, so `db_column = ""` — already a no-op
+# there — is not copied either.
+function field_without_db_column(field::PormGField)::PormGField
+  T = typeof(field)
+  idx = findfirst(==(:db_column), fieldnames(T))
+  idx === nothing && return field
+  dbc = getfield(field, idx)
+  (dbc isa AbstractString && !isempty(dbc)) || return field
+  return T((i == idx ? nothing : getfield(field, i) for i in 1:fieldcount(T))...)
+end
+
 # `model_table_name` / `model_has_db_table` (#59) — the table-level mirror of `field_db_column`
 # above — live in `Kernel` and are imported at the top of this module, because layer-2
 # `Configuration` needs them and is included before `Models`. See Kernel.jl for the definitions.

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -1129,6 +1129,16 @@ function _resolve_bucket_column(raw_field::String, instruc::SQLInstruction)
   # carry the base DateField and genuinely produce a date; and every OTHER function — `ToChar`
   # included, which is what would actually produce a "1991-10" text column — is rejected outright
   # when the CTE model is built. So the DATE gate is as trustworthy here as anywhere else.
+  #
+  # #376: the drift guard below still MATCHES on a CTE path. It matched before the fix too — both
+  # sides read the SAME field object, so they agreed on the physical name and the rewrite was
+  # applied to a column the CTE does not expose. What changed is WHICH name they agree on: the CTE
+  # model's fields now carry no db_column (`Models.field_without_db_column`, applied in
+  # `_build_cte_custom_model`), so `field_db_column(f_meta, <alias>)` and the rendered column both
+  # answer the projection ALIAS. Resolving the alias at the REFERENCE site instead would have left
+  # `f_meta` claiming the physical name while the render answered the alias — failing this guard
+  # closed and silently dropping the #352/#373 rewrite for every CTE date-bucket filter, with no
+  # other symptom. That is why the fix belongs at construction.
   column_sql = _get_select_query(raw_field, instruc)
   f_meta = get(instruc.tab_field_cache, raw_field, nothing)
   f_meta === nothing && return (nothing, "")

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -450,6 +450,9 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       # the values() projection ALIASES (`"pk_code" AS "code"`), so the join references the
       # alias "code", not the physical column. Only the main-table side (key_a above) is a
       # real physical column and is db_column-resolved.
+      # #376 generalized this from the KEY to every CTE COLUMN, by stripping db_column from the CTE
+      # model's fields at construction. So this literal is now also what `Models.model_column(
+      # cte_model, cte_table_key)` would answer — kept literal because it needs no lookup.
       row_join["key_b"] = cte_table_key
     end
 
@@ -603,7 +606,10 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       size(vector, 1) == 2 && (last_field = next_model.fields[vector[2]])
       foreign_table_name = next_model
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias) # TODO chage by row_join and test the speed
-      # Local FK column and referenced parent column both honor db_column (#50).
+      # Local FK column and referenced parent column both honor db_column (#50). When `new_object`
+      # is a CTE model this stays correct WITHOUT a branch (#376): its fields carry no db_column, so
+      # `key_a` resolves to the projection alias the CTE actually exposes, while `key_b` reads the
+      # REAL target model and keeps its physical column — the two halves of the same contract.
       row_join["key_b"] = Models.fk_target_column(first_field)
       row_join["key_a"] = Models.field_db_column(first_field, first_column)
     elseif haskey(new_object.related_objects, vector[1])

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -605,7 +605,31 @@ function _build_cte_custom_model(cte::CTEDict, instruct::SQLInstruction)
     # fields[value_part.field] = _set_field_from_sql_function(value_part.field, value_part._as, instruct)
     key_new = value_part.custom_as !== nothing ? value_part.custom_as : value_part._as
     try
-      fields[key_new] = _set_field_from_sql_function(value_part.field, value_part._as, instruct)
+      # #376: `key_new` is the alias `_query_select` renders for this column, and a CTE's columns
+      # ARE its aliases — the physical name is consumed inside the body. So the field object that
+      # TYPES this column must not carry the SOURCE table's db_column, or every outer reference
+      # (`_solve_field`'s terminal column, the deep-path join key, the JSON-lookup base column, and
+      # the #373 bucket-column drift guard) names a column the CTE does not expose. Fixing it HERE
+      # rather than at those four reference sites is what keeps them branch-free — see
+      # `Models.field_without_db_column` for the full reasoning.
+      #
+      # It rests on every CTE column having an alias `key_new` agrees with. Two ways a body could
+      # render bare physical names, and neither reaches this loop:
+      #   - `values("*")` — `_set_field_from_sql_function` raises UnknownFieldError on the field `*`.
+      #   - no `.values()` at all — the body renders `SELECT *`, but `values` is then empty, so this
+      #     loop produces a model with ZERO fields and every outer reference fails closed with
+      #     UnknownFieldError. Fail-closed, not wrong SQL.
+      # If a `SELECT "R1".*` projection is ever allowed inside a CTE it must be excluded from this
+      # call, not folded into it.
+      #
+      # The `key_new` == rendered-alias correspondence does have one PRE-EXISTING hole, unrelated to
+      # db_column and not introduced here: two `values()` entries sharing an `_as` collapse onto ONE
+      # rendered ALIAS — `get_select_query` reuses the cached SQLField for the second entry, so the
+      # body emits two columns under the same name — while this loop still registers both names. So
+      # `values("id", "sku", "code" => "sku")` puts `code` on the model though the body emits `sku`
+      # twice and no `code` at all. It reproduces identically with no db_column anywhere.
+      fields[key_new] = Models.field_without_db_column(
+        _set_field_from_sql_function(value_part.field, value_part._as, instruct))
       push!(selected_field_names, key_new)
     catch e
       @pormg_debug false

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -328,14 +328,99 @@ end
 
         main = M.Db_column_pk_scratch.objects
         main.with("rpk_cte" => cte, join_field="code" => "code", join_type="INNER")
-        main.values("code", "lbl" => "rpk_cte__label")
+        # #376: `rpk_cte__code` is the half this testset used to miss. `label` has no db_column, so
+        # projecting only it never exercised the CTE COLUMN rule; `code` does (→ "pk_code"), and
+        # before #376 the outer query asked the CTE for "pk_code" — a column it does not expose.
+        main.values("code", "cte_code" => "rpk_cte__code", "lbl" => "rpk_cte__label")
         rows = main.list()
         @test length(rows) == 1                 # INNER join keeps only the matched code (700)
         @test rows[1][:code] == 700
+        @test rows[1][:cte_code] == 700         # the CTE's own projection of the renamed PK
         @test rows[1][:lbl] == "CT"
     finally
         M.Db_column_pk_child_scratch.objects.delete(allow_delete_all=true)
         M.Db_column_pk_strchild_scratch.objects.delete(allow_delete_all=true)
         M.Db_column_pk_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# #376: a CTE PROJECTS a db_column-mapped field, and the outer query references it. A CTE is a
+# derived table whose columns are the values() projection ALIASES, so the reference must name
+# "sku" — the physical "product_sku" is consumed inside the WITH body and is not visible outside.
+# Executed rather than merely rendered: the pre-#376 failure was at execution time
+# (`column R1_1.product_sku does not exist` / `no such column`), which SQL-shape asserts miss.
+@testset "db_column: CTE-projected column is referenced by its alias (#376)" begin
+    # Clear children before the parent (CASCADE) so this testset is order-independent, matching
+    # the convention of the FK testsets above.
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        M.Db_column_scratch.objects.create("sku" => "CTE-A", "name" => "Alpha")
+        M.Db_column_scratch.objects.create("sku" => "CTE-B", "name" => "Beta")
+
+        # The CTE projects `sku` (physical "product_sku") plus the join key `id` (no db_column, so
+        # the join key itself is unaffected — this isolates the COLUMN rule from the #64 KEY rule).
+        cte = M.Db_column_scratch.objects
+        cte.filter("name" => "Alpha")
+        cte.values("id", "sku")
+
+        # filter + values on the CTE-reached column, in one query.
+        main = M.Db_column_scratch.objects
+        main.with("ev" => cte, join_field="id" => "id", join_type="INNER")
+        main.filter("ev__sku" => "CTE-A")
+        main.values("name", "s" => "ev__sku")
+        rows = main.list()
+        @test length(rows) == 1
+        @test rows[1][:name] == "Alpha"
+        @test rows[1][:s] == "CTE-A"          # the CTE's projection, keyed by the FIELD name
+
+        # order_by on a CTE-reached db_column field that is neither projected nor filtered, so it
+        # is resolved here for the first time: `get_order_query` reuses `instruc.cache` when the
+        # same path was already resolved, and the filter runs first — hence `name` (no db_column)
+        # is the filtered column and `sku` the ordered one. The filter also exists to emit the
+        # JOIN: a CTE column referenced ONLY by order_by registers the alias without emitting one
+        # (a separate, pre-#376 defect that also hits plain FK paths on models with no db_column),
+        # and this testset must not depend on it. Built as a FRESH CTE object: a `.with` source is
+        # shared state, and reusing one across queries is what the #43 coverage exists to police.
+        cte2 = M.Db_column_scratch.objects
+        cte2.values("id", "sku", "name")
+
+        ordered = M.Db_column_scratch.objects
+        ordered.with("ev2" => cte2, join_field="id" => "id", join_type="INNER")
+        ordered.filter("ev2__name" => "Alpha")
+        ordered.values("name")
+        ordered.order_by("ev2__sku")
+        ord_rows = ordered.list()
+        @test length(ord_rows) == 1           # executes at all — the pre-#376 failure mode
+        @test ord_rows[1][:name] == "Alpha"
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    end
+end
+
+# #376 sibling: a CTE projects a FOREIGN KEY (physical "parent_fk") and the outer query TRAVERSES
+# it. The join out of the CTE keys on the alias "parent"; the joined REAL table still resolves its
+# own db_column ("product_sku"). Both halves of the contract in one executed query.
+@testset "db_column: traversing a CTE-projected ForeignKey (#376)" begin
+    M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+    M.Db_column_scratch.objects.delete(allow_delete_all=true)
+    try
+        parent = M.Db_column_scratch.objects.create("sku" => "FKP", "name" => "Parent")
+        M.Db_column_child_scratch.objects.create("parent" => parent[:id], "note" => "kid")
+
+        cte = M.Db_column_child_scratch.objects
+        cte.values("id", "parent")
+
+        main = M.Db_column_child_scratch.objects
+        main.with("ev" => cte, join_field="id" => "id", join_type="INNER")
+        main.values("note", "s" => "ev__parent__sku")
+        rows = main.list()
+        @test length(rows) == 1
+        @test rows[1][:note] == "kid"
+        @test rows[1][:s] == "FKP"            # reached through the CTE's aliased FK column
+    finally
+        M.Db_column_child_scratch.objects.delete(allow_delete_all=true)
+        M.Db_column_scratch.objects.delete(allow_delete_all=true)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ end
     @testset "Unresolved ForeignKey Target Is Never Guessed (#388)" include("unit/test_fk_unresolved_target.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
+    @testset "CTE Columns Are Projection Aliases (#376)" include("unit/test_cte_db_column.jl")
     @testset "JSON Path Lookups (#27)" include("unit/test_json_lookups.jl")
     @testset "JSON Containment Operators (#27)" include("unit/test_json_operators.jl")
     @testset "Field Validation and Operations" include("unit/test_field_validation_and_operations.jl")

--- a/test/unit/test_cte_db_column.jl
+++ b/test/unit/test_cte_db_column.jl
@@ -1,0 +1,386 @@
+"""
+Unit coverage for #376: a CTE's columns are its `values()` projection ALIASES, never the source
+model's `db_column`.
+
+A CTE (or any projected subquery) is a DERIVED table. The physical column name is consumed INSIDE
+the body — `SELECT "Tb"."product_sku" as "sku"` — and the only name it exposes to the outer query
+is `sku`. Before #376 the synthesized CTE model stored the SOURCE model's field objects verbatim,
+`db_column` and all, so every outer reference resolved through `Models.field_db_column` and named a
+column the CTE does not have (`column R1_1.product_sku does not exist` / `no such column`).
+
+The fix strips `db_column` at CTE-model construction (`Models.field_without_db_column`, applied in
+`_build_cte_custom_model`), so the model stops misdescribing itself and THREE reference sites become
+correct with no CTE branch in any of them:
+  - the terminal column of every dotted path (`filter` / `values` / `order_by` / annotate / `F()`),
+  - the deep-path join key when a CTE projects a ForeignKey and the path continues,
+  - the JSON-lookup base column when a CTE projects a JSONField.
+
+It also keeps #373's sargable date-bucket rewrite landing on the right column. That rewrite is gated
+by a drift guard which recomputes `field_db_column` from the cached terminal field and refuses to
+fire unless it matches the rendered column. Pre-#376 the guard matched — both sides read the same
+field object — and the rewrite fired onto the nonexistent physical column. Stripping at construction
+keeps them matching, now on the alias. Resolving the alias at the REFERENCE site instead would have
+made them disagree, failing the guard closed and silently dropping the rewrite; the `#373` testset
+below is what discriminates between the two fixes.
+
+All assertions render via mock PostgreSQL/SQLite connections — no live database.
+
+Sibling coverage:
+  - `test_db_column.jl` → the `field_without_db_column` helper itself, and the #50 base contract.
+  - `test_alignment_sqlite.jl` → the #64 CTE/M2M join-KEY half of the same rule.
+  - `test_cte_ergonomics.jl` → CTE join shapes (#44), no db_column involved.
+  - `test/integration/test_db_column_db.jl` → the same queries executed on both backends.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+# Dedicated mock connections + config key so this file cannot contaminate (or be contaminated by)
+# other unit files sharing Main in runtests.jl. Only the connection TYPE matters — dispatch selects
+# SQLite `?`/`json_extract` vs PostgreSQL `$N`/`#>>` rendering.
+struct CteDbColMockSQLite <: PormG.PormGSQLite end
+struct CteDbColMockPostgres <: PormG.PormGPostgres end
+const _CDC_SL = CteDbColMockSQLite()
+const _CDC_PG = CteDbColMockPostgres()
+# ORDER BY renders NULL placement via a library-version probe (#75); pin a modern version so
+# order_by works on the mock without a live driver (same pattern as test_alignment_sqlite.jl).
+PormG.backend_sqlite_version(::CteDbColMockSQLite) = 3045000
+
+PormG.config["cte_dbcol_mock"] = PormG.Configuration.Settings(
+  connections = _CDC_PG, change_data = true, db_def_folder = "cte_dbcol_mock",
+)
+
+# Inline fixtures in their own module: `set_models` is REQUIRED here (not a style choice), because
+# `_build_row_join` reads `instruct.object.model._module::Module` — a bare `Model(...)` leaves
+# `_module === nothing` and TypeErrors the moment a join renders.
+module CteDbColModels
+import PormG
+import PormG.Models
+
+# Every mapped field's PHYSICAL name differs from its FIELD name, so any assertion that sees a
+# physical name outside the CTE body is a real failure and not a naming coincidence.
+Cdc_parent = Models.Model("cdc_parent",
+  id   = Models.IDField(),
+  sku  = Models.CharField(db_column = "product_sku"),
+  seen = Models.DateField(db_column = "seen_on", null = true),
+  meta = Models.JSONField(db_column = "meta_json", null = true),
+  name = Models.CharField(null = true),
+)
+
+Cdc_child = Models.Model("cdc_child",
+  id     = Models.IDField(),
+  parent = Models.ForeignKey(Cdc_parent, db_column = "parent_fk", on_delete = "CASCADE", null = true),
+  note   = Models.CharField(null = true),
+)
+
+# Control model: no db_column anywhere. A CTE over this must render exactly as it did pre-#376 —
+# the fix has to be a strict no-op when nothing is renamed.
+Cdc_plain = Models.Model("cdc_plain",
+  id   = Models.IDField(),
+  sku  = Models.CharField(),
+  note = Models.CharField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "cte_dbcol_mock")
+end
+
+const CDC = CteDbColModels
+import PormG.QueryBuilder: inspect_query
+
+# Count occurrences of a physical column name in the rendered SQL. The contract is positional as
+# well as textual: a physical name may appear EXACTLY ONCE (inside the CTE body's `as` projection)
+# and never again, so a plain `occursin` would not catch a leak into the outer query. `count` over a
+# literal String, not a Regex — a needle carrying regex syntax would otherwise silently change what
+# is matched. Prefixed like the mocks above: `runtests.jl` includes ~50 files into one `Main`.
+_cdc_hits(sql::AbstractString, needle::AbstractString) = count(needle, sql)
+
+# The `sku` CTE reused across cases: SELECT "Tb"."product_sku" as "sku" FROM cdc_parent.
+_cdc_sku_cte() = (c = CDC.Cdc_parent.objects; c.values("id", "sku"); c)
+
+@testset "CTE columns are projection aliases, not db_column (#376)" begin
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: filter on a CTE-projected db_column field
+  # `.with("ev" => cte).filter("ev__sku" => …)` must render `"R1_1"."sku"` — the alias the CTE
+  # exposes. Pre-#376 it rendered `"R1_1"."product_sku"`, which no backend can resolve.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "filter on a CTE-projected db_column field uses the alias" begin
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => _cdc_sku_cte(), join_field = "id" => "id")
+    q.filter("ev__sku" => "ABC")
+    q.values("id")
+
+    insp = inspect_query(q)
+    sql = insp[:sql_text]
+
+    # The outer predicate names the ALIAS ...
+    @test occursin("\"R1_1\".\"sku\" = \$1", sql)
+    # ... and the physical name appears exactly once, in the CTE BODY's projection — nowhere else.
+    @test occursin("\"Tb\".\"product_sku\" as \"sku\"", sql)
+    @test _cdc_hits(sql, "product_sku") == 1
+    @test insp[:parameters] == ["ABC"]
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: cross-dialect parity on SQLite
+  # The bug is a column-NAME defect, not a rendering one, so the alias contract must hold
+  # identically under `?` placeholders.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "SQLite renders the same alias contract" begin
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => _cdc_sku_cte(), join_field = "id" => "id")
+    q.filter("ev__sku" => "ABC")
+    q.values("id")
+
+    sql = inspect_query(q; connection = _CDC_SL)[:sql_text]
+    @test occursin("\"R1_1\".\"sku\" = ?", sql)
+    @test _cdc_hits(sql, "product_sku") == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: values() / SELECT on a CTE-projected db_column field
+  # The select path funnels through the same terminal resolution as filter; asserting it separately
+  # is what the issue's acceptance list asks for (filter / values / order_by each covered).
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "values() projects the CTE alias" begin
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => _cdc_sku_cte(), join_field = "id" => "id")
+    q.values("name", "s" => "ev__sku")
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"R1_1\".\"sku\" as \"s\"", sql)
+    @test _cdc_hits(sql, "product_sku") == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: order_by() on a CTE-projected db_column field
+  # ORDER BY must resolve the CTE column FRESHLY, so the ordered column is deliberately neither
+  # projected nor filtered: `get_order_query` reuses `instruc.cache` when the same path was already
+  # resolved (build_query.jl:138), and `get_filter_query` runs first — so filtering `ev__seen` here
+  # would silently test the filter's selector instead. `ev__sku` is filtered only to emit the JOIN:
+  # a CTE column referenced ONLY by order_by registers the alias without emitting one, a separate
+  # pre-#376 defect that also hits plain FK paths (`order_by("fk__col")`) on models with no
+  # db_column at all — this file must not depend on it, so the join is asserted too.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "order_by() sorts on the CTE alias" begin
+    cte = CDC.Cdc_parent.objects
+    cte.values("id", "sku", "seen")
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.filter("ev__sku" => "ABC")     # emits the join, and caches "ev__sku" — NOT "ev__seen"
+    q.values("id")
+    q.order_by("ev__seen")           # ... so this path is resolved here for the first time
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("JOIN \"ev\" AS \"R1_1\" ON \"R1\".\"id\" = \"R1_1\".\"id\"", sql)
+    @test occursin(r"ORDER BY\s+\"R1_1\"\.\"seen\" ASC", sql)
+    @test _cdc_hits(sql, "seen_on") == 1     # physical name only in the CTE body
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: a CUSTOM projection alias is what the outer query must name
+  # `values("psku" => "sku")` makes the CTE expose `psku`. This is the sharpest form of the bug:
+  # pre-#376 the outer query rendered `"R1_1"."product_sku"` — a name that appears NOWHERE in the
+  # emitted statement, since the body aliased the column to `psku`.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a custom projection alias is the outer name" begin
+    cte = CDC.Cdc_parent.objects
+    cte.values("id", "psku" => "sku")
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.filter("ev__psku" => "ABC")
+    q.values("id")
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"Tb\".\"product_sku\" as \"psku\"", sql)   # the body aliases to psku ...
+    @test occursin("\"R1_1\".\"psku\" = \$1", sql)              # ... so the outer query names psku
+    @test _cdc_hits(sql, "product_sku") == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # CTE reference: a ForeignKey projected in a CTE, referenced terminally
+  # An FK field carries `db_column` for its LOCAL column ("parent_fk"). Projected into a CTE it is
+  # exposed as `parent`, so an outer reference to it is the alias like any other column.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a projected ForeignKey is referenced by its alias" begin
+    cte = CDC.Cdc_child.objects
+    cte.values("id", "parent")
+
+    q = CDC.Cdc_child.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.values("note", "p" => "ev__parent")
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"R1_1\".\"parent\" as \"p\"", sql)
+    @test _cdc_hits(sql, "parent_fk") == 1                          # only the CTE body's projection
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Sibling site: a projected ForeignKey TRAVERSED further (the deep-path join key)
+  # `ev__parent__sku` builds a second join FROM the CTE alias. Its `key_a` is a CTE column and must
+  # be the alias; `key_b` and the terminal column belong to the REAL target table and must keep
+  # their physical names — both halves of the contract asserted in one query.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "traversing a projected ForeignKey joins on the alias" begin
+    cte = CDC.Cdc_child.objects
+    cte.values("id", "parent")
+
+    q = CDC.Cdc_child.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.values("note", "s" => "ev__parent__sku")
+
+    sql = inspect_query(q)[:sql_text]
+    # The join OUT of the CTE keys on the alias the CTE exposes ...
+    @test occursin("\"R1_1\".\"parent\" = \"R1_2\".\"id\"", sql)
+    @test !occursin("\"R1_1\".\"parent_fk\"", sql)
+    # ... while the joined REAL table still resolves its own db_column (#50 is not weakened).
+    @test occursin("\"R1_2\".\"product_sku\" as \"s\"", sql)
+    @test _cdc_hits(sql, "parent_fk") == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Sibling site: a projected JSONField extracted through
+  # A non-terminal JSONField is a value EXTRACTION on the joined alias (#27). The base column it
+  # extracts from is a CTE column, so it too must be the alias, not "meta_json".
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a projected JSONField extracts from the alias" begin
+    cte = CDC.Cdc_parent.objects
+    cte.values("id", "meta")
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.filter("ev__meta__driver" => "senna")
+    q.values("id")
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"R1_1\".\"meta\"", sql)      # extraction targets the alias
+    @test _cdc_hits(sql, "meta_json") == 1            # physical name only in the CTE body
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #373 crossover: the sargable date-bucket rewrite lands on the CTE's alias
+  # `_checked_bucket_column` refuses the rewrite unless the cached terminal field's resolved column
+  # matches the rendered one. That matched BEFORE #376 as well — both sides read the same field
+  # object, agreed on the physical name, and the rewrite fired onto a column the CTE does not
+  # expose. What changed is WHICH name they agree on. Resolving the alias at the reference site
+  # instead would have made them disagree, failing the guard closed and silently dropping the #352
+  # rewrite; so this testset discriminates between the two candidate fixes, not fix vs. no-fix.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "sargable date-bucket rewrite survives a CTE (#373)" begin
+    cte = CDC.Cdc_parent.objects
+    cte.values("id", "seen")
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.filter("ev__seen__@yyyy_mm__@lte" => "1991-10")
+    q.values("id")
+
+    insp = inspect_query(q)
+    sql = insp[:sql_text]
+    # Rewritten to a half-open range on the raw column — no to_char wrapper ...
+    @test !occursin("to_char", lowercase(sql))
+    # ... asserted on the FULL predicate, never a bare "<" (which also matches "<=").
+    @test occursin(" < \$1", sql) && !occursin(" <= \$1", sql)
+    @test insp[:parameters] == ["1991-11-01"]     # @lte "1991-10" → strictly before 1991-11-01
+    # And it ranges on the CTE's alias column, not the physical name.
+    @test occursin("\"R1_1\".\"seen\"", sql)
+    @test _cdc_hits(sql, "seen_on") == 1
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Premise guard: a CTE body never exposes bare PHYSICAL names
+  # The fix assumes every CTE column has an alias `key_new` agrees with. Two shapes could break
+  # that by rendering `SELECT *`, and BOTH are pinned here because the src comment now relies on
+  # both: `values("*")` is rejected outright, and a CTE with no `.values()` at all renders `*` in
+  # the body but yields a ZERO-field model, so every outer reference fails closed. The second is
+  # the drift path that matters — `_subquery_projection_labels` already defaults an empty `values`
+  # to `model.field_names` for SUBqueries, and doing that "helpfully" here would hand the CTE model
+  # FIELD names while the body emits PHYSICAL ones: #376 reintroduced silently, suite still green.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a CTE body cannot expose physical names (premise guard)" begin
+    # (a) values("*") is rejected when the CTE model is built.
+    star = CDC.Cdc_parent.objects
+    star.values("*")
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => star, join_field = "id" => "id")
+    q.values("id")
+
+    # Asserted on the CAUSE, not just the type: UnknownFieldError is raised from ~8 sites across
+    # build_joins.jl/ctes.jl, so a type-only check would stay green if this query later failed for
+    # an unrelated reason and stopped guarding the premise at all.
+    err = try inspect_query(q); nothing catch e; e end
+    @test err isa PormG.UnknownFieldError
+    err isa PormG.UnknownFieldError &&
+      @test occursin("_set_field_from_sql_function", PormG.error_message(err))
+
+    # (b) No `.values()` at all: the body renders `SELECT *`, but the CTE model has no fields, so
+    # referencing ANY column of it fails closed rather than resolving to a physical name.
+    bare = CDC.Cdc_parent.objects        # deliberately no .values()
+
+    q2 = CDC.Cdc_parent.objects
+    q2.with("ev" => bare, join_field = "id" => "id")
+    q2.values("id", "s" => "ev__sku")
+
+    err2 = try inspect_query(q2); nothing catch e; e end
+    @test err2 isa PormG.UnknownFieldError
+    # The trailing empty "available fields:" list IS the mechanism: zero fields on the CTE model.
+    # If an empty `values` ever defaulted to the model's field names, this list would be populated
+    # and the reference would resolve — to a name the `SELECT *` body does not expose.
+    err2 isa PormG.UnknownFieldError &&
+      @test endswith(PormG.error_message(err2), "available fields: ")
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # The worst form: a collision that returned WRONG DATA rather than erroring
+  # When the CTE aliases some OTHER field to the physical name (`"product_sku" => "name"`), the
+  # pre-#376 resolution of `ev__sku` to `"R1_1"."product_sku"` named a column that DOES exist on
+  # the CTE — carrying `name`'s values. No backend error, no failed query: silently wrong rows.
+  # Every other case in this file fails loudly; this one is why the fix is a correctness fix and
+  # not merely a "query used to error" fix.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a colliding alias returned wrong data, not an error" begin
+    cte = CDC.Cdc_parent.objects
+    cte.values("sku", "product_sku" => "name")   # exposes "sku" (=sku) AND "product_sku" (=name)
+
+    q = CDC.Cdc_parent.objects
+    q.with("ev" => cte, join_field = "sku" => "sku")
+    q.values("id", "x" => "ev__sku")
+
+    sql = inspect_query(q)[:sql_text]
+    # The CTE really does expose a "product_sku" column carrying `name` — without this the rest of
+    # the testset would pass vacuously if the body ever stopped emitting that projection.
+    @test occursin("\"Tb\".\"name\" as \"product_sku\"", sql)
+    # The outer projection reads the CTE's `sku` column ...
+    @test occursin("\"R1_1\".\"sku\" as \"x\"", sql)
+    # ... and NOT its `product_sku` column, which here holds `name` — the silent-wrong-data path.
+    @test !occursin("\"R1_1\".\"product_sku\"", sql)
+    # The main-table side of the join key is a real physical column and still resolves (#64).
+    @test occursin("\"R1\".\"product_sku\" = \"R1_1\".\"sku\"", sql)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Control: a CTE over a model with NO db_column is untouched
+  # `field_without_db_column` returns the identical object when there is nothing to strip, so the
+  # overwhelmingly common case must render exactly as before — this guards against the fix
+  # "fixing" queries that were already correct.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a db_column-free CTE renders unchanged" begin
+    cte = CDC.Cdc_plain.objects
+    cte.values("id", "sku")
+
+    q = CDC.Cdc_plain.objects
+    q.with("ev" => cte, join_field = "id" => "id")
+    q.filter("ev__sku" => "ABC")
+    q.values("id", "s" => "ev__sku")
+
+    sql = inspect_query(q)[:sql_text]
+    @test occursin("\"Tb\".\"sku\" as \"sku\"", sql)     # body: column == field name
+    @test occursin("\"R1_1\".\"sku\" = \$1", sql)        # outer filter
+    @test occursin("\"R1_1\".\"sku\" as \"s\"", sql)     # outer projection
+  end
+
+end

--- a/test/unit/test_db_column.jl
+++ b/test/unit/test_db_column.jl
@@ -17,6 +17,7 @@ using PormG.Models: Model, CharField, IDField, IntegerField, ForeignKey, OneToOn
                     field_db_column, fk_target_column, model_column, model_has_db_column,
                     are_model_fields_equal
 using PormG.QueryBuilder: inspect_query, Count
+using InteractiveUtils: subtypes   # #376: walk every field TYPE, not a hand-maintained list
 
 # Dedicated mock connections — uniquely named so they never clash with other unit files'
 # mock structs when runtests.jl includes them into the same module.
@@ -100,6 +101,75 @@ Entry.connect_key = "default"
     @test model_column(Product, "not_a_field") == "not_a_field"   # verbatim fallback
     @test model_has_db_column(Product)
     @test !model_has_db_column(Model("nocol_scratch", id=IDField(), name=CharField()))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # field_without_db_column (#376): the same field as a DERIVED table exposes it.
+  # A CTE's columns are its `values()` projection ALIASES, so the field object that TYPES a CTE
+  # column must stop claiming the base table's physical name. Two guards: a STRUCTURAL one over
+  # every field type (the rebuild goes through the default positional constructor, which only
+  # exists while no field struct declares an inner one), and a BEHAVIORAL round-trip.
+  # Rendering coverage for the CTE itself lives in `test_cte_db_column.jl`.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "field_without_db_column strips the physical name (#376)" begin
+
+    # Structural: the helper rebuilds `T(getfield(f, 1), …)`, so every concrete field type must
+    # still be a plain struct with only Julia's two AUTO-GENERATED constructors (the `::Any` one
+    # and the field-typed one). An inner constructor would sit in front of the rebuild and could
+    # normalize, reorder or reject the arguments — silently changing what the CTE model holds.
+    #
+    # Counting methods, NOT `hasmethod(T, Tuple{fieldtypes(T)...})`: the auto-generated `::Any`
+    # constructor makes that true for ANY same-arity tuple (measured: it also accepts N `Int`s),
+    # so it detects nothing except an arity change. `SQLOrder` in `querybuilder/types.jl` shows a
+    # same-arity inner constructor is a shape this repo actually uses.
+    concrete = filter(isconcretetype, subtypes(PormG.PormGField))
+    @test length(concrete) == 26                        # fails loudly when a field type is added —
+    for T in concrete                                   # exactly when this helper wants re-reading
+      @test length(methods(T)) == 2                     # no inner constructor in front of the rebuild
+    end
+    # Every field type carries a `db_column` slot except ManyToMany, which adds no physical column
+    # to the owning table at all. A NEW slot-less type would make the helper a silent no-op there.
+    @test [T for T in concrete if !(:db_column in fieldnames(T))] == [PormG.Models.sManyToManyField]
+
+    # Behavioral: a renamed field is rebuilt as the SAME type with db_column cleared and every
+    # other slot preserved — checked field-by-field, so a constructor-argument-order slip (which
+    # would silently swap two same-typed slots) cannot pass.
+    renamed = CharField(db_column = "product_sku", null = true, max_length = 42)
+    stripped = PormG.Models.field_without_db_column(renamed)
+    @test typeof(stripped) === typeof(renamed)
+    @test stripped.db_column === nothing
+    @test field_db_column(stripped, "sku") == "sku"     # ... so it now answers the ALIAS
+    for f in fieldnames(typeof(renamed))
+      f === :db_column && continue
+      @test getfield(stripped, f) === getfield(renamed, f)
+    end
+
+    # sIDField is the one IMMUTABLE field struct — the reason the helper rebuilds instead of
+    # mutating, since `id` appears in nearly every CTE projection.
+    @test !ismutabletype(PormG.Models.sIDField)
+    stripped_id = PormG.Models.field_without_db_column(IDField(db_column = "pk_code"))
+    @test stripped_id isa PormG.Models.sIDField && stripped_id.db_column === nothing
+
+    # A ForeignKey keeps its resolved target BY REFERENCE — the copy must not deep-copy the model
+    # graph, or `fk_target_column` would read a detached parent.
+    fk = ForeignKey(DriverRef, pk_field = "code", db_column = "drv")
+    fk_stripped = PormG.Models.field_without_db_column(fk)
+    @test fk_stripped.db_column === nothing
+    @test fk_stripped.to === DriverRef                    # same model object, not a copy
+    @test fk_target_column(fk_stripped) == "driver_code"  # parent's own db_column still resolves
+
+    # JSONField: the base column of a `payload__key` extraction goes through the same helper.
+    json_stripped = PormG.Models.field_without_db_column(PormG.Models.JSONField(db_column = "meta_json", null = true))
+    @test json_stripped.db_column === nothing
+
+    # No-op cases return the IDENTICAL object — this is what makes the fix allocate nothing and
+    # render byte-identically for the overwhelmingly common db_column-free model.
+    plain = CharField(null = true)
+    @test PormG.Models.field_without_db_column(plain) === plain
+    empty_dbc = CharField(db_column = "")                 # already a no-op for field_db_column
+    @test PormG.Models.field_without_db_column(empty_dbc) === empty_dbc
+    m2m = PormG.Models.ManyToManyField(DriverRef)          # no db_column slot at all
+    @test PormG.Models.field_without_db_column(m2m) === m2m
   end
 
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #376.

## The bug

The synthesized CTE model stored the **source** model's field objects verbatim — `_set_field_from_sql_function` returns `instruct.object.model.fields[field]`, the same object, not a copy — keyed by the projection alias. So the model claimed a `db_column` the derived table does not have.

A CTE is a derived table: the physical name is consumed *inside* the body (`"Tb"."product_sku" as "sku"`), and `sku` is the only column it exposes. Every outer reference resolved through `Models.field_db_column` and named a column that is not there.

## The fix

Strip `db_column` at CTE-model construction rather than special-casing the reference sites. The model stops misdescribing itself, and **three** defect sites become correct with no CTE branch in any of them:

| Site | Path | Before | After |
|---|---|---|---|
| `build_joins.jl:677` | terminal column — `filter`/`values`/`order_by`/annotate/`F()`/UPDATE SET | `"R1_1"."product_sku"` | `"R1_1"."sku"` |
| `build_joins.jl:608` | CTE projects an FK, path continues (`ev__parent__sku`) | `ON "R1_1"."parent_fk" = …` | `ON "R1_1"."parent" = …` |
| `build_joins.jl:338` | CTE projects a JSONField (`ev__meta__key`) | extracts from `"meta_json"` | extracts from `"meta"` |

The whole functional change is one new `Models` helper plus one wrapped call; the rest of the `src/` diff is comments.

## This is a correctness fix, not just an error fix

The issue frames the symptom as a hard backend error. It also has a **silent wrong-data** form: when the CTE aliases some *other* field to the physical name, the old resolution named a column that **does** exist on the CTE and carries the wrong field's data.

```julia
cte.values("sku", "product_sku" => "name")   # exposes "sku" (=sku) AND "product_sku" (=name)
q.with("ev" => cte, join_field = "sku" => "sku").values("x" => "ev__sku")
# pre-fix → "R1_1"."product_sku"  — resolves fine, returns `name`'s values
```

## Why not the fix the issue suggested

The issue proposes resolving the alias at the terminal-column site. That breaks #373. `_checked_bucket_column` recomputes `field_db_column` from the cached terminal field and refuses the sargable date-bucket rewrite unless it matches the rendered column. Resolving at the reference site leaves that metadata claiming the physical name, so the guard fails closed and every CTE date-bucket filter silently loses the #352 rewrite — no test failure, just a slow plan. Stripping at construction keeps both sides agreeing, on the alias.

`field_without_db_column` **copies** (field objects are shared live schema state) and rebuilds through the struct's default positional constructor, because `sIDField` is the one immutable field struct and `id` appears in nearly every CTE projection. A field with no `db_column` — or a type with no such slot (`sManyToManyField`) — returns the **identical** object, so the common path allocates nothing and renders byte-identically.

## Scope widened deliberately

The `:608` (FK-through-CTE) and `:338` (JSON-through-CTE) siblings are **not** in the issue's task list. The same one-line change fixes them, so they are covered rather than left free to regress. Widened on the maintainer's explicit say-so.

## Verification

- **Unit**: 7542/7542, exit 0. New `test/unit/test_cte_db_column.jl` — 38 assertions; with the fix neutralized, **21 fail** (survivors are the controls).
- **Integration (SQLite / `db_sl`)**: `test_db_column_db.jl` and `test_cte.jl` fully green.
- Guard files unchanged-green: `test_sargable_date_range.jl`, `test_cte_ergonomics.jl`, `test_json_lookups.jl`, `test_alignment_sqlite.jl`, `test_db_column.jl`.
- Two independent review passes (initial + delta re-review); every finding fixed or explicitly declined below.

## Deliberately NOT done

- **PostgreSQL integration was not run** — `db_2` was in use by another session. The issue's acceptance list asks for both engines; this is the one item outstanding. The rendering is dialect-independent and `db_sl` executes the same queries.
- **The JSON sibling has unit coverage only.** No integration model declares a `JSONField` *with* a `db_column`, and adding one would touch `models.jl` → DDL → a full `test_migration_bootstrap.jl` run.
- **No `UPGRADING.md` entry, no `Project.toml` bump.** The file's rule is "only what *forces* a consuming-app source edit". Every manifestation was a hard error or silently wrong data, and the one plausible workaround (aliasing the projection to the physical name) renders byte-identically before and after — so no app source edit is forced.
- **The duplicate-`values()`-alias collision is documented, not fixed.** Two entries sharing an `_as` collapse onto one rendered alias while both names land on the CTE model. Pre-existing, reproduces with no `db_column` anywhere, and refusing duplicates is a behavior change beyond this issue. Recorded in a comment at the one site that can see it; follow-up issue to come.

## Follow-ups found while working this

Two pre-existing defects, both out of scope, both to be filed:

1. **`ORDER BY` on a join path that is neither filtered nor projected emits an unjoined alias.** Not CTE-specific and not `db_column`-specific — `M.Chi.objects.values("note").order_by("parent__sku")` renders `ORDER BY "Tb_1"."sku"` with no `JOIN`. Root cause: `build_row_join_sql_text` runs at `build_query.jl:448`, before `get_order_query` at `:450`, so a join first discovered during ORDER BY resolution is never rendered. Both `order_by` tests here filter a *different* CTE column so they neither depend on nor mask it.
2. The duplicate-`_as` collision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
