### PR TITLE
fix(#377): a through= model's FK db_column is the join column

### DIFF
--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -976,7 +976,7 @@ manager.set([senna_id])          # returns (added=X, removed=Y)
 driver_rows = manager.all().values("surname", "nationality").list()
 ```
 
-Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table — including its `db_table`, if it declares one, which then names the join table in every query and mutator. The field-level `db_table` below applies to the auto-generated table only and is ignored when `through` is given.
+Use `through=Existing_model` when the relationship table has extra fields, such as the season when a driver was added to a collection. In that case PormG treats the through model as a normal model and does not auto-generate a join table — including its `db_table`, if it declares one, which then names the join table in every query and mutator, and its two foreign keys' `db_column`, which name the join **columns** (#377). The field-level `db_table` below applies to the auto-generated table only and is ignored when `through` is given.
 
 !!! warning
     **Django-Style Strict Mutators**: If the custom `through` model contains any extra fields beyond the relationship foreign keys, direct manager mutator operations (`add`, `remove`, `clear`, and `set`) will raise a `QueryBuildError`. Create or delete custom through model objects directly using the through model's objects manager instead.

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -146,6 +146,17 @@ WHERE "Tb_2"."driverref" = $1
                                     source_field="challenger", target_field="defender")
     ```
 
+    With an explicit `through=`, each is a **field name** on that model, never a column: PormG
+    resolves it to the field's `db_column` on its way into the SQL, exactly as it does for an
+    inferred end. A pin that names no field of the through model — or names one that is not a
+    foreign key to the side it stands for — raises `ModelDefinitionError` and lists the foreign keys
+    it could have named ([#377](https://github.com/PingoLee/PormG.jl/issues/377)). Same two checks
+    Django runs on `through_fields`.
+
+    (On the *auto-generated* join table these two options name the join **columns** directly — there
+    is no through model to hold a field. See
+    [Foreign-key columns](schema_conventions.md#Foreign-key-columns).)
+
 ---
 
 ## Explicit Through Tables
@@ -206,6 +217,37 @@ This pattern matches Django exactly and keeps your model definitions clean and r
     and `drivers__driverref`, and in the manager mutators for a through model that permits them.
     The `db_table` option on the `ManyToManyField` itself names the *auto-generated* join table only;
     with an explicit `through=` there is no generated table to name, so that option is ignored.
+
+!!! note "The through model's `db_column`s are the join columns"
+    The column-axis half of the same rule. A through model's two foreign keys are ordinary fields, so
+    each may map to a differently-named column with
+    [`db_column`](fields.md#Database-Column-Mapping), and PormG addresses the column —
+    not the field name — in every join and every mutator
+    ([#377](https://github.com/PingoLee/PormG.jl/issues/377)):
+
+    ```julia
+    M2m_membership_scratch = Models.Model("m2m_membership_scratch",
+      db_table = "racing_membership",
+      id = Models.IDField(),
+      driver_id = Models.ForeignKey(M2m_driver_explicit_scratch, db_column="drv", on_delete=Models.CASCADE),
+      team_id = Models.ForeignKey(M2m_team_scratch, db_column="tm", on_delete=Models.CASCADE),
+      joined_year = Models.IntegerField()
+    )
+    ```
+
+    ```sql
+    INNER JOIN "racing_membership" AS "Tb_1" ON "Tb"."id" = "Tb_1"."drv"
+    INNER JOIN "m2m_team_scratch" AS "Tb_2" ON "Tb_1"."tm" = "Tb_2"."id"
+    ```
+
+    The fields are spelled `driver_id` / `team_id` here only to match an existing schema that names
+    its columns that way — the same interop choice described under
+    [Foreign-key columns](schema_conventions.md#Foreign-key-columns), and what the Django importer
+    emits. `db_column` works exactly the same on the `driver` / `team` spelling used above.
+    Either way you keep querying by the **field** name —
+    `driver_id`, not `drv` — as everywhere else; only the rendered column changes. This matches
+    Django, which reads the through foreign key's `column` (`db_column` when set) for the join and
+    its `name` for `through_fields`.
 
 ### Relationship Mutator Limitations on Custom Through Tables
 

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -146,8 +146,11 @@ exactly as it always has, so no existing schema changes and nothing needs re-mig
     table **is** that model's table — its own `db_table` if it declares one — so the field-level
     `db_table` has nothing left to name and is ignored. Same rule as Django, and the same rule the
     Django importer already assumes when it declines to pin a `db_table` on a `through=` field. The
-    join columns are then the through model's own FK fields, so `source_field` / `target_field` is
-    again the pin to reach for when those field names differ from the physical columns.
+    join columns are then the through model's own foreign keys, resolved through their `db_column`
+    like any other field (#377) — so a through model written against a legacy schema needs no pin at
+    all. `source_field` / `target_field` remain the way to say **which** foreign key is which end,
+    for a through model that has two pointing at the same model; each takes the field name, and its
+    column is resolved from it. Same contract as Django's `through_fields`.
 
 ### Generated files: colliding bindings and names are disambiguated
 
@@ -427,12 +430,22 @@ Two consequences worth noting:
   not `pk_field` is spelled out — string targets are resolved to the model object once, up front
   ([#62](https://github.com/PingoLee/PormG.jl/issues/62)).
 
-  !!! note "Limitation: ManyToMany through-table column names"
+  !!! note "`db_column` and the ManyToMany join columns"
       `db_column` is honored across the whole stack — CRUD (create/get/update, bulk, sequence sync),
-      FK constraints and joins (model-instance or string targets, a renamed parent PK), **and**
-      ManyToMany / CTE join keys when a participating model's primary key uses `db_column`
-      ([#64](https://github.com/PingoLee/PormG.jl/issues/64)). The one surface that is **not**
-      configurable is the **auto-generated ManyToMany through-table column names** (`<model>_<pk>`).
+      FK constraints and joins (model-instance or string targets, a renamed parent PK), ManyToMany /
+      CTE join keys when a participating model's primary key uses `db_column`
+      ([#64](https://github.com/PingoLee/PormG.jl/issues/64)), **and** the join columns of an
+      explicit `through=` model, which are that model's own foreign keys and resolve their
+      `db_column` like any other field
+      ([#377](https://github.com/PingoLee/PormG.jl/issues/377)).
+
+      The **auto-generated** join columns are the one place `db_column` has nothing to say, because
+      there is no field to hang it on — PormG both creates that table and names its columns
+      `<model>_<pk>`. They are still overridable, by `source_field` / `target_field` on the
+      `ManyToManyField`, which name those columns **directly** on this path; that is how the Django
+      importer pins Django's `<class>_id` spelling (see above). With an explicit `through=` the same
+      two options name **fields** on the through model instead, and the column is resolved from the
+      field.
 
   !!! note "A CTE exposes aliases, not columns"
       A CTE (or any `values()`-projected subquery) is a **derived table**: its columns are the

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -116,11 +116,34 @@ end
   owner_model::String
   owner_binding::String
   owner_pk::String
+  # The two join-key axes, split (#377). `*_column` is the PHYSICAL column on the join table — the
+  # only thing a renderer wants, and the only one of the pair that ever reaches SQL. `*_field` is the
+  # through model's FIELD name, i.e. a key into `through_model.fields`.
+  #
+  # They used to be one slot that meant both. `_infer_through_field` returns a field name, which
+  # equals the column exactly when that field declares no `db_column` — so on an explicit `through=`
+  # a `db_column` (what every Django import writes for a legacy schema) made every join and every
+  # mutator address a column that does not exist, while `QueryBuilder._m2m_has_extra_fields`, which
+  # compares against `keys(through_model.fields)`, was the lone reader that wanted the field name and
+  # got it by luck. Resolving into the single slot would have repaired the SQL and broken that guard
+  # in the same commit — the mirror image of the trap #363 fell into on the table axis.
+  #
+  # Django keeps this same split, and for the same reason: `ManyToManyField.contribute_to_class`
+  # binds `m2m_column_name` to the through FK's `column` (`db_column or attname`) and
+  # `m2m_field_name` to its `name`.
+  #
+  # On the AUTO path the two hold the same string by construction, not by coincidence:
+  # `synthesize_many_to_many_through_models` builds that join table FROM these names, so there is no
+  # `db_column` to resolve and nothing downstream can shift. Both are REQUIRED rather than defaulted,
+  # for the reason `through_model_resolved` is: a default would let a future constructor mean "no
+  # db_column" by omission, which is the fail-open shape this split exists to close.
   owner_column::String
+  owner_field::String
   related_model::String
   related_binding::String
   related_pk::String
   related_column::String
+  related_field::String
   inverse_accessor::String
   reverse::Bool = false
   # #65: resolved model objects for the two sides, populated wherever a relation is built
@@ -2883,6 +2906,71 @@ function _many_to_many_column_name(model::PormGModel, pk_field::String; prefix::
   return format_fild_name("$(prefix)$(format_model_name(model.name))_$(pk_field)")
 end
 
+# Could this through-model field serve as the join key for the end that points at `target_model`
+# (#377)? Used by the PIN path only — `_infer_through_field` below deliberately asks a STRICTER
+# question, and the difference between the two is the point of having both.
+#
+# LENIENT on an unresolved reference, and that is load-bearing rather than sloppy. A `String` `.to`
+# holds the target's Julia BINDING, not its table or logical name (#360/#386), and recovering a model
+# from it by case-fold is only the correct inverse while the binding happens to be
+# `uppercasefirst(model.name)` — the exact flaw #388 closed elsewhere. `Driver = Model("drivers", ...)`
+# breaks it, and that is this repo's own house idiom. Worse, whether a through model's foreign keys
+# are still strings HERE depends on where its binding sorts in the single registration loop of
+# `set_models`, so a strict test would accept or refuse the same models file across a rename.
+#
+# Refusing would also point fail-closed in the wrong direction: `_infer_through_field` ALREADY fails
+# on that shape, and pinning is the documented rescue for exactly that (`docs/src/many_to_many.md`).
+# So verify what can be verified and take the human's word otherwise. The E338 half still fires, and
+# it is the half that catches the common slip — a `db_column` written where a field name belongs.
+_through_fk_for(f, target_model::PormGModel)::Bool =
+  (f isa sForeignKey || f isa sOneToOneField) &&
+  (!(f.to isa PormGModel) || _same_model_reference(f.to, target_model))
+
+# Is `pin` a usable `source_field` / `target_field` for the end that points at `target_model` (#377)?
+#
+# Two conditions, and they are the two Django checks for `through_fields`: the pin must name a FIELD
+# on the through model (`fields.E338`), and that field must be a foreign key TO the model this end
+# stands for (`fields.E339`). Checking only the first is not enough — the two ends of a through model
+# are usually both foreign keys, so a pin that names the wrong one passes a mere existence test and
+# builds a relation whose join keys are swapped: SQL that executes and returns the wrong rows.
+_is_through_pin_for(through_model::PormGModel, pin::String, target_model::PormGModel)::Bool =
+  haskey(through_model.fields, pin) && _through_fk_for(through_model.fields[pin], target_model)
+
+# Composes the refusal for a pin `_is_through_pin_for` rejected; the CALL SITE throws it, per the
+# funnel convention in `.github/skills/pormg-querybuilder-internals`. It separates the two rejection
+# reasons because the remedies differ — a name that is not a field at all is usually a `db_column`
+# written where a field name belongs, while a name that IS a field but points elsewhere is usually
+# the two ends written the wrong way round. Lists the foreign keys that would have worked, because
+# the pin exists precisely for the case where a human has to choose between several.
+#
+# The two models are KEYWORDS on purpose: `target_model` and `owner_model` are the same object on the
+# source arm, so transposing two adjacent positionals would compile, run, and quietly name the wrong
+# model on the target arm — with the suggestion list to match, and no test able to see it.
+function _through_pin_invalid(through_model::PormGModel, pin::String, field_name::String, option::String;
+                              target_model::PormGModel, owner_model::PormGModel)::ModelDefinitionError
+  # The SAME predicate that rejected the pin, so the suggestion can never contradict the refusal —
+  # in particular it cannot claim "no foreign key at all" about a key the check would have accepted.
+  usable = sort!([String(n) for (n, f) in through_model.fields if _through_fk_for(f, target_model)])
+  reason = if !haskey(through_model.fields, pin)
+    "is not a field of the through model $(through_model.name). Pin the FIELD name, not the " *
+    "db_column — the column is resolved from the field"
+  else
+    "is a field of the through model $(through_model.name) but not a foreign key to " *
+    "$(target_model.name), which is the side $(option) names"
+  end
+  usable_msg = isempty(usable) ?
+    "That through model has no foreign key to $(target_model.name) at all" :
+    "Foreign keys to $(target_model.name): $(join(usable, ", "))"
+  return ModelDefinitionError(
+    "ManyToManyField $(owner_model.name).$(field_name) pins $(option) = \e[31m$(pin)\e[0m, which " *
+    "$(reason). $(usable_msg).")
+end
+
+# NOTE the deliberate asymmetry with `_through_fk_for` above: inference uses the STRICT comparison,
+# and must. It is choosing among candidates, so counting an unresolved reference as a match would make
+# every foreign key on the through model a candidate and then either pick the wrong one or report a
+# spurious ambiguity. A pin has no such problem — the human already chose — which is why the pin
+# path is allowed to be lenient, and is the documented rescue when this function cannot decide (#377).
 function _infer_through_field(through_model::PormGModel, target_model::PormGModel, role::String)::String
   matches = String[]
   for (field_name, field) in through_model.fields
@@ -2942,6 +3030,13 @@ function _relation_from_many_to_many(
     owner_column = field.source_field === nothing ? _many_to_many_column_name(owner_model, owner_pk) : field.source_field
     related_column = field.target_field === nothing ? _many_to_many_column_name(related_model, related_pk) : field.target_field
   end
+  # #377: on the AUTO path the field name and the physical column are the same string by
+  # construction — `synthesize_many_to_many_through_models` builds the join table FROM these very
+  # names, so there is no user-declared `db_column` anywhere to diverge from. Seeded (rather than
+  # defaulted on the struct) so the slot is written on every path exactly once; the `through` branch
+  # below overwrites all four.
+  owner_field = owner_column
+  related_field = related_column
 
   if field.through !== nothing
     through_model = if field.through isa PormGModel
@@ -2961,12 +3056,39 @@ function _relation_from_many_to_many(
     # The model itself is recorded below, so nothing has to recover it from this string.
     through_table_name = model_table_name(through_model)
     through_resolved = through_model
-    owner_column = field.source_field === nothing ? _infer_through_field(through_model, owner_model, "source") : field.source_field
-    related_column = field.target_field === nothing ? _infer_through_field(through_model, related_model, "target") : field.target_field
-    owner_fk = through_model.fields[owner_column]
-    related_fk = through_model.fields[related_column]
+    # FIELD names, both arms (#377). That is what `_infer_through_field` returns, and what
+    # `source_field` / `target_field` are documented to take — the same contract as Django's
+    # `through_fields`, which `_get_m2m_attr` matches against the through FK's `name`.
+    owner_field = field.source_field === nothing ? _infer_through_field(through_model, owner_model, "source") : field.source_field
+    related_field = field.target_field === nothing ? _infer_through_field(through_model, related_model, "target") : field.target_field
+    # A bad pin used to die in the `getindex` below with a bare `KeyError` — or, when it named a
+    # non-FK field, one line further on with a `FieldError` about `.pk_field` — naming neither model
+    # nor field, and in neither case a `PormGError`. A pin naming the WRONG foreign key did not fail
+    # at all: it built a relation with the join keys swapped. Pinning the COLUMN name is also now the
+    # likeliest slip, because it was the documented workaround for #377 before this commit removed
+    # the need for it. Django refuses all three as system checks (`fields.E338`/`E339`); this is that
+    # rule, raised where models are defined.
+    #
+    # Inferred names cannot reach it — `_infer_through_field` returns a key it just read off
+    # `through_model.fields` after testing the very same predicate — so it fires only on a pin.
+    _is_through_pin_for(through_model, owner_field, owner_model) || throw(_through_pin_invalid(
+      through_model, owner_field, field_name, "source_field";
+      target_model = owner_model, owner_model = owner_model))
+    _is_through_pin_for(through_model, related_field, related_model) || throw(_through_pin_invalid(
+      through_model, related_field, field_name, "target_field";
+      target_model = related_model, owner_model = owner_model))
+    owner_fk = through_model.fields[owner_field]
+    related_fk = through_model.fields[related_field]
     owner_pk = owner_fk.pk_field === nothing ? owner_pk : String(owner_fk.pk_field)
     related_pk = related_fk.pk_field === nothing ? related_pk : String(related_fk.pk_field)
+    # #377: the through side's PHYSICAL columns, resolved ONCE — the column-axis mirror of the
+    # `model_table_name` call above. The eight sites that render these (both through-side join keys
+    # in `_insert_many_to_many_joins`, the four manager mutators, and the `_m2m_current_ids`
+    # read-back) all want the column and none of them can see the through model, so resolving here
+    # is what keeps them correct without teaching each one to re-resolve. `model_column` is a strict
+    # no-op when the field declares no `db_column`, which is why the common case is untouched.
+    owner_column = model_column(through_model, owner_field)
+    related_column = model_column(through_model, related_field)
   end
 
   # #364, fail-closed. Everything downstream — the synthesized through model's field `Dict`, the
@@ -2975,9 +3097,20 @@ function _relation_from_many_to_many(
   # user wrote: both sides pinned to one name, or one side pinned to the string the other derives.
   # Placed after the `through` block so it covers the explicit path too, where `source_field` /
   # `target_field` bypass `_infer_through_field` entirely.
+  #
+  # #377 widened what this catches without moving it: on the explicit path these are now the RESOLVED
+  # columns, so two DISTINCT through fields that both pin the same `db_column` are refused here as
+  # well. That is the condition the message always described — one join table cannot carry the same
+  # column twice — and it was previously invisible, because the comparison saw field names.
+  # The remedy depends on WHICH way the pair collided (#377). Two different fields landing on one
+  # column is a `db_column` clash and no amount of re-pinning fixes it — saying "set them to distinct
+  # names" there sends the reader to the one thing that is already true.
   owner_column == related_column && throw(ModelDefinitionError(
     "ManyToManyField $(owner_model.name).$(field_name) resolves both join columns to \e[31m$(owner_column)\e[0m; " *
-    "one join table cannot carry the same column twice. Set source_field and target_field to distinct names."))
+    "one join table cannot carry the same column twice. " *
+    (owner_field == related_field ?
+      "Set source_field and target_field to distinct names." :
+      "The fields $(owner_field) and $(related_field) both map to that column — give one of them a distinct db_column.")))
 
   inverse_accessor = field.related_name === nothing ? get_model_name(owner_model, settings, false) : field.related_name
   return ManyToManyRelation(
@@ -2987,10 +3120,12 @@ function _relation_from_many_to_many(
     owner_binding=owner_binding,
     owner_pk=owner_pk,
     owner_column=owner_column,
+    owner_field=owner_field,
     related_model=related_model.name,
     related_binding=related_binding,
     related_pk=related_pk,
     related_column=related_column,
+    related_field=related_field,
     inverse_accessor=inverse_accessor,
     reverse=false,
     # #65: persist the already-resolved model objects (both sides arrive here resolved from either
@@ -3010,10 +3145,16 @@ function _reverse_many_to_many_relation(relation::ManyToManyRelation, reverse_ac
     owner_binding=relation.related_binding,
     owner_pk=relation.related_pk,
     owner_column=relation.related_column,
+    # Swapped with its column (#377), not carried: `*_field` names ONE SIDE's foreign key on the
+    # through model, so it follows that side across the flip exactly as `*_column` does. Contrast
+    # `through_model_resolved` below, which is deliberately not swapped because the join table is
+    # not a side.
+    owner_field=relation.related_field,
     related_model=relation.owner_model,
     related_binding=relation.owner_binding,
     related_pk=relation.owner_pk,
     related_column=relation.owner_column,
+    related_field=relation.owner_field,
     inverse_accessor=relation.field_name,
     reverse=true,
     # #65: swap the resolved sides to match the swapped string fields above.

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -491,8 +491,12 @@ table with two foreign keys and a composite unique index.
 - `through::Union{String, PormGModel, Nothing} = nothing`: explicit through model; skips auto table synthesis.
 - `related_name::Union{String, Nothing} = nothing`: reverse accessor on the target model.
 - `db_table::Union{String, Nothing} = nothing`: auto-through table name override. Ignored when `through` is given — the join table is then the through model's own table (its `db_table` if it declares one).
-- `source_field::Union{String, Nothing} = nothing`: through-table column pointing to the source model.
-- `target_field::Union{String, Nothing} = nothing`: through-table column pointing to the target model.
+- `source_field::Union{String, Nothing} = nothing`: the join key pointing at the source model. With an explicit `through`, it names a **field** on that model and the physical column is resolved from the field's `db_column` (#377); on the auto-synthesized table it names the column directly, since PormG creates it.
+- `target_field::Union{String, Nothing} = nothing`: the same, for the target model.
+
+Both pins exist to disambiguate **which** foreign key is which end — required when the through model
+has two pointing at the same model, as on a self-relation. A `through` model whose foreign keys simply
+map to differently-named columns needs no pin: `db_column` is resolved on its own.
 """
 function ManyToManyField(to::Union{String, PormGModel}; kwargs...)
   accepted = Set([

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -178,19 +178,18 @@ function _insert_many_to_many_joins(
   # its physical column via the owning model's db_column. `model_column` is a strict no-op when the
   # PK has no db_column.
   #
-  # The through-table columns (owner_column / related_column) go in as-is, and that is a narrower
-  # claim than it used to be. On the AUTO path they are names PormG generated for a table PormG
-  # created, so there is nothing to resolve. On an explicit `through=` they come from
-  # `Models._infer_through_field`, which returns the FIELD NAME on a user's model — equal to the
-  # physical column exactly when that field declares no `db_column`.
+  # The through-table columns (owner_column / related_column) go in as-is, and since #377 that is a
+  # claim about the SLOT, not a bet about the model. Both are resolved to physical columns once, at
+  # registration, exactly as `through_table` is one line below: on the AUTO path they are names PormG
+  # generated for a table PormG created, and on an explicit `through=` they are
+  # `Models.model_column(through_model, <the FK field name>)`.
   #
-  # Django's default convention satisfies that (`driver` imports as the field `driver_id`, which is
-  # also Django's column), which is why an ordinary import joins correctly. A `db_column=` written in
-  # the Django source does NOT: the importer splats it onto the field it builds
-  # (`process_class_fields!`), so the field is `driver_id` while the column is whatever was pinned.
-  # The shape is origin-independent — hand-written models reach it the same way. That column axis is
-  # the unfixed sibling of #363, which settled the TABLE axis only; `source_field` / `target_field`
-  # on the ManyToManyField bypass `_infer_through_field` and are the escape hatch today.
+  # Before that they were the through model's FIELD NAME, rendered raw — equal to the physical column
+  # exactly when the field declared no `db_column`. Django's default convention satisfies that
+  # (`driver` imports as the field `driver_id`, which is also Django's column), which is why an
+  # ordinary import joined correctly and the bug survived; a `db_column=` written in the Django source
+  # did not, because the importer splats it onto the field it builds (`process_class_fields!`). The
+  # shape was origin-independent — hand-written models reached it the same way.
   _module = instruct.object.model._module::Module
   owner_model = _resolve_m2m_side_model(_module, relation.owner_binding, relation.owner_model, relation.field_name)
   related_model = _resolve_m2m_side_model(_module, relation.related_binding, relation.related_model, relation.field_name)

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -103,8 +103,12 @@ function _m2m_has_extra_fields(manager::ManyToManyManager)::Bool
   through_model = manager.relation.through_model_resolved
   through_model === nothing && return false
 
-  owner_col = manager.relation.owner_column
-  related_col = manager.relation.related_column
+  # The FIELD names, not the columns (#377). This is the one reader of the pair that asks a question
+  # about the through MODEL's shape rather than about SQL, so it takes the field slot while the four
+  # mutators below take the column slot. Reading `*_column` here would report a through model whose
+  # foreign keys declare a `db_column` as carrying two extra fields, and lock its mutators.
+  owner_col = manager.relation.owner_field
+  related_col = manager.relation.related_field
 
   for field_name in keys(through_model.fields)
     clean_name = strip(field_name, '"')

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -371,6 +371,40 @@ M2m_enrolment_dbtable_scratch = Models.Model("m2m_enrolment_dbtable_scratch",
   squad = Models.ForeignKey(M2m_squad_dbtable_scratch, on_delete=Models.CASCADE),
 )
 
+# Explicit through whose foreign keys declare a `db_column` (#377) — the COLUMN-axis sibling of the
+# `db_table` fixture above. The relation rendered the through model's FIELD name as the join column,
+# which equals the physical column only while no `db_column` is declared; that was true of every
+# `through=` fixture in this file, which is why #377 outlived #363.
+#
+# `db_table` is pinned here TOO, on purpose: that is the shape a Django import of a legacy schema
+# produces (an app label AND `db_column=` on the FKs), and carrying both proves the two axes are
+# independent rather than one accidentally covering the other.
+#
+# The field names carry Django's `_id` suffix because that is what `process_class_fields!` emits, and
+# the columns are DIFFERENT STRINGS, not case variants — SQLite compares identifiers
+# case-insensitively, so a case-only difference could not tell a fixed tree from a broken one.
+#
+# FK-only on purpose: the mutators are then permitted, so the raw-SQL write path
+# (`INSERT`/`DELETE ... FROM <through table>`, plus the `SELECT <related column>` read-back behind
+# `set`) is exercised alongside the join path.
+M2m_crew_dbcol_scratch = Models.Model("m2m_crew_dbcol_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(unique=true)
+)
+
+M2m_mechanic_dbcol_scratch = Models.Model("m2m_mechanic_dbcol_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  crews = Models.ManyToManyField(M2m_crew_dbcol_scratch, through="M2m_crewslot_dbcol_scratch", related_name="mechanics")
+)
+
+M2m_crewslot_dbcol_scratch = Models.Model("m2m_crewslot_dbcol_scratch",
+  db_table = "m2m_crewslot_join_tbl",
+  id = Models.IDField(),
+  mechanic_id = Models.ForeignKey(M2m_mechanic_dbcol_scratch, db_column="mech_ref", on_delete=Models.CASCADE),
+  crew_id = Models.ForeignKey(M2m_crew_dbcol_scratch, db_column="crew_ref", on_delete=Models.CASCADE),
+)
+
 # Default reverse accessor (no related_name): target uses owner model name lowercase.
 M2m_brand_scratch = Models.Model("m2m_brand_scratch",
   id = Models.IDField(),

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -369,6 +369,40 @@ M2m_enrolment_dbtable_scratch = Models.Model("m2m_enrolment_dbtable_scratch",
   squad = Models.ForeignKey(M2m_squad_dbtable_scratch, on_delete=Models.CASCADE),
 )
 
+# Explicit through whose foreign keys declare a `db_column` (#377) — the COLUMN-axis sibling of the
+# `db_table` fixture above. The relation rendered the through model's FIELD name as the join column,
+# which equals the physical column only while no `db_column` is declared; that was true of every
+# `through=` fixture in this file, which is why #377 outlived #363.
+#
+# `db_table` is pinned here TOO, on purpose: that is the shape a Django import of a legacy schema
+# produces (an app label AND `db_column=` on the FKs), and carrying both proves the two axes are
+# independent rather than one accidentally covering the other.
+#
+# The field names carry Django's `_id` suffix because that is what `process_class_fields!` emits, and
+# the columns are DIFFERENT STRINGS, not case variants — SQLite compares identifiers
+# case-insensitively, so a case-only difference could not tell a fixed tree from a broken one.
+#
+# FK-only on purpose: the mutators are then permitted, so the raw-SQL write path
+# (`INSERT`/`DELETE ... FROM <through table>`, plus the `SELECT <related column>` read-back behind
+# `set`) is exercised alongside the join path.
+M2m_crew_dbcol_scratch = Models.Model("m2m_crew_dbcol_scratch",
+  id = Models.IDField(),
+  name = Models.CharField(unique=true)
+)
+
+M2m_mechanic_dbcol_scratch = Models.Model("m2m_mechanic_dbcol_scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(unique=true),
+  crews = Models.ManyToManyField(M2m_crew_dbcol_scratch, through="M2m_crewslot_dbcol_scratch", related_name="mechanics")
+)
+
+M2m_crewslot_dbcol_scratch = Models.Model("m2m_crewslot_dbcol_scratch",
+  db_table = "m2m_crewslot_join_tbl",
+  id = Models.IDField(),
+  mechanic_id = Models.ForeignKey(M2m_mechanic_dbcol_scratch, db_column="mech_ref", on_delete=Models.CASCADE),
+  crew_id = Models.ForeignKey(M2m_crew_dbcol_scratch, db_column="crew_ref", on_delete=Models.CASCADE),
+)
+
 # Default reverse accessor (no related_name): target uses owner model name lowercase.
 M2m_brand_scratch = Models.Model("m2m_brand_scratch",
   id = Models.IDField(),

--- a/test/integration/test_many_to_many.jl
+++ b/test/integration/test_many_to_many.jl
@@ -49,6 +49,11 @@ const _M2M_SCRATCH_TABLES = (
     # #364, self-referential M2M. Both the owner table and its auto-generated join table are listed.
     "m2m_teammate_scratch",
     "m2m_teammate_scratch_teammates",
+    # #377. Same rule as #363 above — the through model is listed by its PHYSICAL name, since that
+    # is what `table_exists` asks the database for.
+    "m2m_crew_dbcol_scratch",
+    "m2m_mechanic_dbcol_scratch",
+    "m2m_crewslot_join_tbl",
 )
 
 # Tables whose SHAPE also has to be checked, not just their existence.
@@ -61,6 +66,11 @@ const _M2M_SCRATCH_TABLES = (
 # missing-table case.
 const _M2M_SCRATCH_TABLE_COLUMNS = Dict(
     "m2m_teammate_scratch_teammates" => ["from_m2m_teammate_scratch_id", "to_m2m_teammate_scratch_id"],
+    # #377. Existence alone cannot see the failure mode here either: a database migrated against a
+    # pre-fix tree has `m2m_crewslot_join_tbl` — it just spells the two endpoint columns after the
+    # FIELD names (`mechanic_id`/`crew_id`) instead of their `db_column`. That table passes the
+    # existence sweep, so `makemigrations` never fires and the run dies later on "no such column".
+    "m2m_crewslot_join_tbl" => ["mech_ref", "crew_ref"],
 )
 
 function _m2m_scratch_table_exists(pool, table_name::String)::Bool
@@ -469,6 +479,78 @@ end
     M.M2m_enrolment_dbtable_scratch.objects.delete(allow_delete_all=true)
     M.M2m_tester_dbtable_scratch.objects.delete(allow_delete_all=true)
     M.M2m_squad_dbtable_scratch.objects.delete(allow_delete_all=true)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #377: an explicit `through=` model whose foreign keys declare a `db_column`.
+#
+# The relation used to record the through model's FIELD name and render it as a column, so every
+# join and every mutator addressed `mechanic_id`/`crew_id` while the real columns are
+# `mech_ref`/`crew_ref`. Both engines answer that with "no such column" — this is the layer that
+# proves the SQL reaches something real, which no rendered-string assertion can.
+#
+# Exercised here and nowhere else: the raw-SQL write path. `add`/`remove`/`clear`/`set` interpolate
+# the column names straight into INSERT/DELETE and never go through the join builder, and `set`
+# additionally reads the SELECTed column back out of the result frame by that same name — three
+# independent consumers of the slot the fix changed.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Many-to-Many: explicit through model whose FKs declare db_column (#377)" begin
+    M.M2m_crewslot_dbcol_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_mechanic_dbcol_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_crew_dbcol_scratch.objects.delete(allow_delete_all=true)
+
+    # Preconditions. Without them every assertion below passes vacuously against a fixture whose
+    # field names and columns agree — the condition under which #377 is invisible.
+    @test PormG.Models.model_column(M.M2m_crewslot_dbcol_scratch, "mechanic_id") == "mech_ref"
+    @test PormG.Models.model_column(M.M2m_crewslot_dbcol_scratch, "crew_id") == "crew_ref"
+    # ...and the physical table really carries the renamed columns and not the field names, which is
+    # what makes the pre-fix SQL a hard database error rather than a silently different answer.
+    slot_cols = Base.invokelatest(column_names, PormG.config[PORMG_DB_FOLDER].connections,
+                                  "m2m_crewslot_join_tbl")
+    @test "mech_ref" in slot_cols
+    @test "crew_ref" in slot_cols
+    @test !("mechanic_id" in slot_cols)
+    @test !("crew_id" in slot_cols)
+
+    mech = M.M2m_mechanic_dbcol_scratch.objects.create("driverref" => "chapman")
+    crew_a = M.M2m_crew_dbcol_scratch.objects.create("name" => "Lotus")
+    crew_b = M.M2m_crew_dbcol_scratch.objects.create("name" => "March")
+
+    manager = M.M2m_mechanic_dbcol_scratch.crews(mech)
+
+    # WRITE path — INSERT naming the physical columns.
+    @test manager.add(crew_a, crew_b) === nothing
+    @test Set([row[:name] for row in manager.all().list()]) == Set(["Lotus", "March"])
+
+    # The rows really landed, queried through the through model in its own right. Note the filter
+    # names the FIELD (`mechanic_id`) while the stored column is `mech_ref` — the ordinary #50
+    # contract, here on the same model whose columns the m2m path also has to resolve.
+    @test M.M2m_crewslot_dbcol_scratch.objects.filter("mechanic_id" => mech[:id]).count() == 2
+
+    # WRITE path — DELETE, plus the read-back. `set` runs `_m2m_current_ids` (a `SELECT <related
+    # column>` whose result frame is then indexed BY that same column name) and then remove+add in
+    # one transaction, so a mismatch between the SELECT and the read-back surfaces as `removed == 0`.
+    diff = manager.set(crew_b)
+    @test diff.added == 0
+    @test diff.removed == 1
+    @test Set([row[:name] for row in manager.all().list()]) == Set(["March"])
+
+    # READ path — forward and reverse traversal both join on the physical columns.
+    fwd = M.M2m_mechanic_dbcol_scratch.objects.filter("crews__name" => "March").values("driverref").list()
+    @test length(fwd) == 1
+    @test fwd[1][:driverref] == "chapman"
+
+    rev = M.M2m_crew_dbcol_scratch.objects.filter("mechanics__driverref" => "chapman").values("name").list()
+    @test length(rev) == 1
+    @test rev[1][:name] == "March"
+
+    @test manager.clear() === nothing
+    @test isempty(manager.all().list())
+    @test M.M2m_crewslot_dbcol_scratch.objects.filter("mechanic_id" => mech[:id]).count() == 0
+
+    M.M2m_crewslot_dbcol_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_mechanic_dbcol_scratch.objects.delete(allow_delete_all=true)
+    M.M2m_crew_dbcol_scratch.objects.delete(allow_delete_all=true)
 end
 
 @testset "Many-to-Many: query and API surface" begin

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -91,6 +91,70 @@ end
 
 const M2MDBT = ManyToManyDbTableModels
 
+# ─────────────────────────────────────────────────────────────────────────────
+# #377 fixture: explicit `through=` models whose FOREIGN KEYS declare a `db_column`.
+#
+# The column-axis sibling of the block above. `db_table` is pinned here too, on purpose: that is the
+# shape a Django import produces for a legacy schema (an app label AND `db_column=` on the FKs), and
+# carrying both proves the two axes are independent rather than one accidentally covering the other.
+#
+# The FIELD names carry Django's `_id` suffix (`driver_id`, not `driver`) because that is exactly
+# what `process_class_fields!` emits, and it is the pair that makes the bug visible: the field is
+# `driver_id`, the column is `drv`, and every renderer used to reach for the former.
+#
+# TWO through models again, for the same reason as #363's fixture: `Contract` carries an extra
+# column so the mutator guard is exercised on the arm that refuses, `Signing` carries only the two
+# foreign keys so it is exercised on the arm that permits — and THAT arm is the one that regresses
+# if `_m2m_has_extra_fields` is left reading the column slot.
+# ─────────────────────────────────────────────────────────────────────────────
+module ManyToManyDbColumnModels
+  import PormG
+  import PormG.Models
+
+  Marque = Models.Model("marque", db_table = "racing_marque",
+    id = Models.IDField(),
+    name = Models.CharField(),
+  )
+
+  Pilot = Models.Model("pilot", db_table = "racing_pilot",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    marques = Models.ManyToManyField(Marque, through = "Contract", related_name = "pilots"),
+  )
+
+  Contract = Models.Model("contract", db_table = "racing_contract",
+    id = Models.IDField(),
+    # Field `pilot_id` → column "plt"; field `marque_id` → column "mrq". Deliberately unlike the
+    # field names in every character, not merely in case: SQLite compares identifiers
+    # case-insensitively, so a case-only difference would address the same column and could not
+    # discriminate a fixed tree from a broken one.
+    pilot_id = Models.ForeignKey(Pilot, db_column = "plt", on_delete = Models.CASCADE),
+    marque_id = Models.ForeignKey(Marque, db_column = "mrq", on_delete = Models.CASCADE),
+    signed_year = Models.IntegerField(null = true),   # the extra column that locks the mutators
+  )
+
+  Livery = Models.Model("livery", db_table = "racing_livery",
+    id = Models.IDField(),
+    name = Models.CharField(),
+  )
+
+  Scout = Models.Model("scout", db_table = "racing_scout",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    liveries = Models.ManyToManyField(Livery, through = "Signing", related_name = "scouts"),
+  )
+
+  Signing = Models.Model("signing", db_table = "racing_signing",
+    id = Models.IDField(),
+    scout_id = Models.ForeignKey(Scout, db_column = "sct", on_delete = Models.CASCADE),
+    livery_id = Models.ForeignKey(Livery, db_column = "lvr", on_delete = Models.CASCADE),
+  )
+
+  PormG.Models.set_models(@__MODULE__, "m2m_mock")
+end
+
+const M2MDBC = ManyToManyDbColumnModels
+
 @testset "ManyToManyField metadata and query generation" begin
   @test Models.is_many_to_many_field(M2M.Driver_championship.fields["drivers"])
   @test !("drivers" in M2M.Driver_championship.field_names)
@@ -358,6 +422,25 @@ end
   mgr_plain = PormG.QueryBuilder.ManyToManyManager(
     _m2m_detach_module(M2MDBT.Tester), M2MDBT.Squad, rel_plain, 1)
   @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_plain) == false
+
+  # ── #377: the arm that a column-axis fix breaks if it is done in ONE slot. `Signing` carries only
+  # the two foreign keys, so the mutators must stay open — but both of those keys declare a
+  # `db_column`, so a guard reading `owner_column`/`related_column` would match neither field name,
+  # count both foreign keys as "extra", and lock a relation that Django and PormG both permit.
+  # The guard reads `owner_field`/`related_field` for exactly this reason.
+  rel_dbcol_plain = Models.get_many_to_many_relation(M2MDBC.Scout, "liveries")
+  @test rel_dbcol_plain.owner_field != rel_dbcol_plain.owner_column      # the two axes really differ
+  mgr_dbcol_plain = PormG.QueryBuilder.ManyToManyManager(
+    _m2m_detach_module(M2MDBC.Scout), M2MDBC.Livery, rel_dbcol_plain, 1)
+  @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_dbcol_plain) == false
+
+  # ...and the guard did not become "always false" on the db_column path either: `Contract` adds
+  # `signed_year` on top of two renamed foreign keys, and still refuses.
+  rel_dbcol_extras = Models.get_many_to_many_relation(M2MDBC.Pilot, "marques")
+  mgr_dbcol_extras = PormG.QueryBuilder.ManyToManyManager(
+    _m2m_detach_module(M2MDBC.Pilot), M2MDBC.Marque, rel_dbcol_extras, 1)
+  @test PormG.QueryBuilder._m2m_has_extra_fields(mgr_dbcol_extras) == true
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder.add(mgr_dbcol_extras)
 
   # ── Negative control 2: the auto-generated join table. `through_model_resolved === nothing` is the
   # signal, and the answer is a fact about how the planner builds that table (`id` + the two FKs),
@@ -720,6 +803,271 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# #377: a `through=` model's foreign keys resolve their `db_column` into the join columns.
+#
+# `_infer_through_field` returns the through model's FIELD name, and the relation rendered that name
+# straight into SQL. It equals the physical column exactly when the field declares no `db_column`,
+# which is every fixture that existed before this one — so the slot read as correct while a legacy
+# schema (or any Django import carrying `db_column=`) joined and wrote against a column that is not
+# there. The relation now records both axes; this asserts the recorded pair AND the rendered SQL, in
+# both directions, because `_reverse_many_to_many_relation` is its own code path.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "explicit through= resolves the FK db_column into the join column (#377)" begin
+  # Preconditions. Without them every assertion below passes vacuously on a fixture whose field names
+  # and columns agree — the condition that hid this bug behind every earlier `through=` test.
+  @test Models.model_column(M2MDBC.Contract, "pilot_id") == "plt"
+  @test Models.model_column(M2MDBC.Contract, "marque_id") == "mrq"
+  @test haskey(M2MDBC.Contract.fields, "pilot_id")     # the FIELD really is spelled with `_id`
+  @test !haskey(M2MDBC.Contract.fields, "plt")         # ...and the column is not a field at all
+
+  fwd = Models.get_many_to_many_relation(M2MDBC.Pilot, "marques")
+  @test fwd.owner_column == "plt"          # was "pilot_id" — the bug
+  @test fwd.related_column == "mrq"        # was "marque_id"
+  # The field axis is kept, not discarded: it is what `_m2m_has_extra_fields` reads, and what
+  # `through_model.fields` is keyed on.
+  @test fwd.owner_field == "pilot_id"
+  @test fwd.related_field == "marque_id"
+  # The table axis (#363) is untouched by this — the two overrides are independent.
+  @test fwd.through_table == "racing_contract"
+
+  # The reverse relation is built by its own function; BOTH pairs must follow their side across the
+  # flip. A fix that swapped only the columns would leave the mutator guard reading the wrong end.
+  rev = Models.get_many_to_many_relation(M2MDBC.Marque, "pilots")
+  @test rev.reverse
+  @test rev.owner_column == "mrq"
+  @test rev.related_column == "plt"
+  @test rev.owner_field == "marque_id"
+  @test rev.related_field == "pilot_id"
+
+  # ── The half only SQL can prove. Both spellings are asserted as QUOTED identifiers: a bare
+  # `occursin("plt", sql)` would be satisfied by any substring, and the field name `pilot_id` is not
+  # a substring of anything else here, so the negative assertion is the one that fails pre-fix.
+  fwd_sql = M2MDBC.Pilot.objects.filter(
+      "marques__name" => "Renault"
+    ).values(
+      "surname"
+    ).list(show_query=:dict)[:sql_text]
+  @test occursin("\"plt\"", fwd_sql)
+  @test occursin("\"mrq\"", fwd_sql)
+  @test !occursin("\"pilot_id\"", fwd_sql)
+  @test !occursin("\"marque_id\"", fwd_sql)
+  # Both join legs really are present, so the assertions above are about the keys and not about a
+  # query that silently lost its joins.
+  @test occursin("\"racing_contract\"", fwd_sql)
+  @test occursin("\"racing_marque\"", fwd_sql)
+
+  rev_sql = M2MDBC.Marque.objects.filter(
+      "pilots__surname" => "Senna"
+    ).values(
+      "name"
+    ).list(show_query=:dict)[:sql_text]
+  @test occursin("\"plt\"", rev_sql)
+  @test occursin("\"mrq\"", rev_sql)
+  @test !occursin("\"pilot_id\"", rev_sql)
+  @test !occursin("\"marque_id\"", rev_sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #377: a `source_field` / `target_field` pin is a FIELD name, and resolves like an inferred one.
+#
+# The pin is the only route to the join columns on a self-relation, where `_infer_through_field`
+# refuses to guess (#364) — so leaving it unresolved would have fixed the inferred case and left the
+# one case that CANNOT use inference still broken. Django reads `through_fields` the same way:
+# `_get_m2m_attr` matches each entry against the through FK's `name`, then returns its `column`.
+#
+# The second half pins the refusal for a pin that names no field. It used to surface as a bare
+# `KeyError` from `through_model.fields[…]`, naming neither model nor field — and it is now the
+# likeliest mistake anyone will make here, because pinning the COLUMN name was the documented
+# workaround for #377 before this commit removed the need for it.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a source_field/target_field pin is a field name and resolves its db_column (#377)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  # Pinned to the FIELD names, on a through model whose FKs both rename their column. Identical
+  # output to the inferred path — the pin selects WHICH foreign key, it does not bypass resolution.
+  pinned = Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "pilot_id", target_field = "marque_id"),
+    M2MDBC.Marque, "Marque", settings)
+  @test pinned.owner_column == "plt"
+  @test pinned.related_column == "mrq"
+  @test pinned.owner_field == "pilot_id"
+  @test pinned.related_field == "marque_id"
+
+  # A pin naming the COLUMN is refused, and the message says which model, which option, which pin,
+  # and what it could have written instead.
+  err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "plt", target_field = "marque_id"),
+    M2MDBC.Marque, "Marque", settings)
+  @test occursin("source_field", err.value.msg)
+  @test occursin("plt", err.value.msg)
+  @test occursin("contract", err.value.msg)          # the through model, by name
+  # The suggestion is scoped to the end that was pinned: `source_field` stands for the owner side, so
+  # only the through model's foreign keys TO that side are offered. Listing `marque_id` here would
+  # suggest a key that this option cannot legally take.
+  @test occursin("pilot_id", err.value.msg)
+  @test !occursin("marque_id", err.value.msg)
+
+  # The target side is guarded too, and reports ITS option rather than the source one.
+  err2 = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "pilot_id", target_field = "mrq"),
+    M2MDBC.Marque, "Marque", settings)
+  @test occursin("target_field", err2.value.msg)
+  @test !occursin("source_field", err2.value.msg)
+
+  # A pin naming a real field that is NOT a foreign key. `haskey` alone accepts this, and it then
+  # died a line later on `sIntegerField` having no `pk_field` — a raw `FieldError`, not a
+  # `PormGError`, naming neither model nor field.
+  err3 = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "signed_year", target_field = "marque_id"),
+    M2MDBC.Marque, "Marque", settings)
+  @test occursin("not a foreign key", err3.value.msg)
+  @test occursin("signed_year", err3.value.msg)
+  @test occursin("pilot_id", err3.value.msg)         # the key it could have named
+
+  # ── The one that never failed at all: BOTH ends pinned to real foreign keys, but to each other's
+  # side. Existence holds for both, so a `haskey`-only guard builds a relation with the join keys
+  # swapped — SQL that executes and silently returns the wrong rows. Django refuses it as
+  # `fields.E339`; so does PormG now.
+  err4 = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "marque_id", target_field = "pilot_id"),
+    M2MDBC.Marque, "Marque", settings)
+  @test occursin("not a foreign key to pilot", err4.value.msg)
+
+  # ...and the check is per-END, not "is it any foreign key": `pilot_id` is a perfectly good pin for
+  # the SOURCE side and is refused only when offered as the target.
+  @test Models._relation_from_many_to_many(
+    M2MDBC.Pilot, "Pilot", "marques",
+    Models.ManyToManyField(M2MDBC.Marque, through = M2MDBC.Contract,
+                           source_field = "pilot_id", target_field = "marque_id"),
+    M2MDBC.Marque, "Marque", settings).owner_field == "pilot_id"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #377: a pin is still honoured when the through model's foreign keys are UNRESOLVED.
+#
+# The per-end check (`fields.E339`) asks whether the pinned field points at this end's model, and a
+# `String` `.to` cannot answer that: it holds the target's Julia BINDING, and case-folding a binding
+# back to a model name only works while the binding is `uppercasefirst(model.name)` — the flaw #388
+# closed elsewhere. `Driver = Model("drivers", …)` breaks it, and that is this file's own house
+# idiom (see `M2M` at the top). Whether a through model's keys are still strings at this point
+# depends on where its binding sorts in `set_models`' registration loop, so a strict test here would
+# accept or refuse the SAME models file across a rename.
+#
+# It is also the wrong direction to fail: `_infer_through_field` already refuses this shape, and
+# pinning is the documented rescue for exactly that. The pin path is therefore lenient about what it
+# cannot verify — while the E338 half, which catches the common slip, still fires.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a pin survives an unresolved through-model foreign key (#377)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  # Singular binding, PLURAL model name — so `format_model_name("Driver") != "drivers"` and the
+  # string comparison cannot match. This is the precondition; without it the test is vacuous.
+  team = Models.Model("teams", id = Models.IDField(), name = Models.CharField())
+  driver = Models.Model("drivers", id = Models.IDField(), surname = Models.CharField())
+  membership = Models.Model("membership",
+    id = Models.IDField(),
+    driver = Models.ForeignKey("Driver", on_delete = Models.CASCADE),
+    team = Models.ForeignKey("Team", on_delete = Models.CASCADE),
+  )
+  @test membership.fields["driver"].to isa String        # genuinely unresolved
+  @test Models.format_model_name("Driver") != driver.name # ...and unrecoverable by case fold
+
+  pinned = Models._relation_from_many_to_many(
+    driver, "Driver", "teams",
+    Models.ManyToManyField(team, through = membership, source_field = "driver", target_field = "team"),
+    team, "Team", settings)
+  @test pinned.owner_field == "driver"
+  @test pinned.related_field == "team"
+  @test pinned.owner_column == "driver"
+  @test pinned.related_column == "team"
+
+  # The leniency is scoped to the UNVERIFIABLE case. With the same models resolved, the per-end check
+  # is live again and a pin naming the wrong side is refused — so this is not a blanket opt-out.
+  resolved_through = Models.Model("membership_resolved",
+    id = Models.IDField(),
+    driver = Models.ForeignKey(driver, on_delete = Models.CASCADE),
+    team = Models.ForeignKey(team, on_delete = Models.CASCADE),
+  )
+  @test resolved_through.fields["driver"].to isa PormGModel
+  err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "teams",
+    Models.ManyToManyField(team, through = resolved_through,
+                           source_field = "team", target_field = "team"),
+    team, "Team", settings)
+  @test occursin("not a foreign key to drivers", err.value.msg)
+  # And the suggestion never contradicts the refusal: it lists the key that WOULD have worked rather
+  # than claiming there is none. Asserted as the WHOLE clause — a bare `occursin("driver", ...)` is
+  # vacuous here, because the owner model is itself named `drivers` and every branch of the message
+  # interpolates it, including the "no foreign key at all" branch this is meant to exclude.
+  @test occursin("Foreign keys to drivers: driver", err.value.msg)
+  @test !occursin("no foreign key to drivers at all", err.value.msg)
+
+  # ── The cost of the leniency, pinned so it is a decision rather than an accident. With `.to`
+  # unresolved the per-end check cannot be made, so a SWAPPED pin — the mistake E339 exists to catch
+  # — is accepted here. That is the same behavior as before #377 (the pin path never consulted `.to`
+  # at all), and refusing instead is exactly what broke a working pin during review. The guard
+  # resumes the moment the reference resolves, which the `err` case above proves.
+  #
+  # Whoever "hardens" this back into a fail-closed check should have to delete this assertion first.
+  swapped = Models._relation_from_many_to_many(
+    driver, "Driver", "teams",
+    Models.ManyToManyField(team, through = membership, source_field = "team", target_field = "driver"),
+    team, "Team", settings)
+  @test swapped.owner_field == "team"
+  @test swapped.related_field == "driver"
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #377: two DISTINCT through fields that collide on one `db_column` are refused, with the remedy
+# that actually applies.
+#
+# The fail-closed guard on the resolved pair (#364) newly sees this case, because before #377 it
+# compared field names and two different fields never collided. Its original message — "set
+# source_field and target_field to distinct names" — is the wrong advice here: the NAMES are
+# distinct, the columns are not, and no pin can fix a `db_column` clash.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "two through fields colliding on one db_column are refused with the right remedy (#377)" begin
+  settings = PormG.Configuration.Settings(connections = M2MMockPostgres(), change_data = true)
+
+  marque = Models.Model("collide_marque", id = Models.IDField(), name = Models.CharField())
+  pilot = Models.Model("collide_pilot", id = Models.IDField(), surname = Models.CharField())
+  clash = Models.Model("collide_contract",
+    id = Models.IDField(),
+    pilot_id = Models.ForeignKey(pilot, db_column = "shared", on_delete = Models.CASCADE),
+    marque_id = Models.ForeignKey(marque, db_column = "shared", on_delete = Models.CASCADE),
+  )
+
+  err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    pilot, "Collide_pilot", "marques",
+    Models.ManyToManyField(marque, through = clash),
+    marque, "Collide_marque", settings)
+  @test occursin("shared", err.value.msg)
+  @test occursin("both map to that column", err.value.msg)
+  @test occursin("db_column", err.value.msg)
+  # NOT the pin advice — the two names are already distinct, so re-pinning cannot help.
+  @test !occursin("distinct names", err.value.msg)
+
+  # The original remedy is still the one given when the two ends really do name ONE field, which is
+  # what the #364 guard was written for.
+  same = Models.Model("collide_same", id = Models.IDField(), name = Models.CharField())
+  err_same = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    same, "Collide_same", "peers",
+    Models.ManyToManyField(same, source_field = "peer_id", target_field = "peer_id"),
+    same, "Collide_same", settings)
+  @test occursin("distinct names", err_same.value.msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # #363 did not disturb the AUTO-derived path.
 #
 # That path already stored a physical name (`_many_to_many_table_name` returns `field.db_table`
@@ -732,6 +1080,16 @@ end
   auto = Models.get_many_to_many_relation(M2M.Driver_championship, "drivers")
   @test auto.through_table == "driver_championships_drivers"
   @test auto.through_model_resolved === nothing          # the "no through model" tag
+
+  # #377 left this path byte-identical too, and the two axes COLLAPSE here rather than merely
+  # agreeing by luck: `synthesize_many_to_many_through_models` builds the join table from these
+  # strings, so the field name IS the column and there is no `db_column` to resolve. That matters for
+  # the same reason as the table name above — the unique index is derived from these slots, so a
+  # value that shifted would make `makemigrations` propose dropping a live index.
+  @test auto.owner_field == auto.owner_column
+  @test auto.related_field == auto.related_column
+  @test auto.owner_column == "driver_championships_id"
+  @test auto.related_column == "drivers_id"
 
   # A field-level `db_table` pin still wins on the auto path — it names the synthesized join table,
   # and it must NOT be confused with a through MODEL's `db_table` (#345, and the note in
@@ -950,19 +1308,43 @@ end
 
   # The guard sits AFTER the `through` block, so the explicit path is covered too — there
   # `source_field`/`target_field` bypass `_infer_through_field` entirely.
+  #
+  # A SELF-relation through model, so both ends are legitimately the same model. That is what makes
+  # this arm reach the guard at all: since #377 a pin must be a foreign key to the side it stands
+  # for, so pinning both ends to one key across DIFFERENT models is caught earlier and more
+  # precisely (asserted below). Here both keys point at `driver`, both pins are individually valid,
+  # and the collision is the only thing left to catch — a stricter version of what this arm always
+  # meant to test.
+  rivalry = Models.Model("rivalry",
+    id = Models.IDField(),
+    challenger = Models.ForeignKey(driver, on_delete=Models.CASCADE),
+    defender = Models.ForeignKey(driver, on_delete=Models.CASCADE),
+  )
+  through_collide = Models.ManyToManyField(driver, through=rivalry,
+                                           source_field="challenger", target_field="challenger")
+  through_err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "rivals", through_collide, driver, "Driver", settings)
+  @test occursin("cannot carry the same column twice", through_err.value.msg)
+  # WHICH remedy, not just the shared prefix: one field named twice is the "distinct names" branch,
+  # and asserting it here keeps this arm self-contained rather than leaning on the #377 testset.
+  @test occursin("distinct names", through_err.value.msg)
+
+  # The shape this arm used to use — one pin naming a foreign key to the OTHER side — is now refused
+  # before the guard is reached, by the per-end pin check (#377). Pinned here so the two rules stay
+  # distinguishable: a future change that collapsed them would leave the assertion above green while
+  # silently widening what the pin check accepts.
   target = Models.Model("team", id = Models.IDField())
   through_model = Models.Model("membership",
     id = Models.IDField(),
     driver = Models.ForeignKey(driver, on_delete=Models.CASCADE),
     team = Models.ForeignKey(target, on_delete=Models.CASCADE),
   )
-  # `through_model.fields["driver"]` exists, so nothing else on this path can throw — which is
-  # exactly why the cause is asserted: a DIFFERENT future error is what would masquerade here.
-  through_collide = Models.ManyToManyField(target, through=through_model,
-                                           source_field="driver", target_field="driver")
-  through_err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
-    driver, "Driver", "teams", through_collide, target, "Team", settings)
-  @test occursin("cannot carry the same column twice", through_err.value.msg)
+  wrong_side = Models.ManyToManyField(target, through=through_model,
+                                      source_field="driver", target_field="driver")
+  wrong_err = @test_throws PormG.ModelDefinitionError Models._relation_from_many_to_many(
+    driver, "Driver", "teams", wrong_side, target, "Team", settings)
+  @test occursin("not a foreign key to team", wrong_err.value.msg)
+  @test !occursin("cannot carry the same column twice", wrong_err.value.msg)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1110,7 +1492,9 @@ end
   @test occursin("multiple foreign keys", err.value.msg)
   @test occursin("source_field", err.value.msg)
 
-  # And pinning both ends resolves it — the through model's own FK field names become the columns.
+  # And pinning both ends resolves it. The pin names the through model's own FK FIELDS; each is then
+  # resolved to its physical column (#377), which is a no-op here because neither declares a
+  # `db_column` — the `db_column`-carrying case is covered by its own testset above.
   resolved = Models._relation_from_many_to_many(
     driver, "Racer", "rivals",
     Models.ManyToManyField(driver, through=rivalry, source_field="challenger", target_field="defender"),


### PR DESCRIPTION
Closes #377

The through-side join columns of a `ManyToManyField(through=)` were the through model's Julia **field names**, rendered raw. That equals the physical column exactly when the field declares no `db_column` — true of every fixture in the suite, which is why the slot read as correct while a legacy schema joined and wrote against a column that is not there:

```sql
-- before                                          -- real columns: drv, tm
INNER JOIN "racing_membership" AS "Tb_1" ON "Tb"."id"        = "Tb_1"."driver_id"
INNER JOIN "racing_team"       AS "Tb_2" ON "Tb_1"."team_id" = "Tb_2"."id"
```

This is the **column axis** of #363 (PR #378), which settled the table axis and filed this one as deferred. Same shape of fix: resolve **once at construction**, into a slot whose name states the axis, rather than at each of the eight render sites.

## The split, and why it is not bookkeeping

`ManyToManyRelation` now carries both axes:

| slot | meaning |
| :--- | :--- |
| `owner_column` / `related_column` | **physical** — the only thing that reaches SQL |
| `owner_field` / `related_field` | the through model's **field name** |

`_m2m_has_extra_fields` compares against `keys(through_model.fields)` to decide whether the direct mutators are allowed. Resolving into a *single* slot would have repaired the SQL and, in the same commit, locked `add`/`remove`/`clear`/`set` on every FK-only through model that renames a column — the mirror image of the trap #363 fell into on the table axis. A mutation test pins exactly that: reading the column slot there fails **only** the "FK-only + `db_column` mutators stay open" assertion and nothing else.

Django keeps the same two slots for the same reason — `contribute_to_class` binds `m2m_column_name` to the through FK's `column` (`db_column or attname`) and `m2m_field_name` to its `name`.

## The auto path is byte-identical

`synthesize_many_to_many_through_models` is gated on `field.through === nothing || continue`, so the explicit branch never reaches the builder that derives the join table's unique-index name from these slots. `makemigrations` cannot propose dropping a live index. Verified independently by review and pinned by an assertion.

## Also: `source_field` / `target_field` are validated

They are now checked the way Django checks `through_fields`. Previously a pin naming no field died as a bare `KeyError`; one naming a non-FK field as a raw `FieldError` (neither a `PormGError`); and one naming the **wrong** foreign key did not fail at all — it built a relation with the join keys swapped, producing SQL that executes and returns the wrong rows. Now `fields.E338` and `fields.E339` respectively, with a message that names the model, the pin, and the keys that would have worked.

That check is **deliberately lenient when the through FK's `to` is still a string**. A string `to` holds the target's Julia *binding* (#360/#386), and recovering a model from it by case-fold only works while the binding is `uppercasefirst(model.name)` — the flaw #388 closed elsewhere. `Driver = Model("drivers", …)` breaks it, and whether a through model's keys are resolved at that point depends on where its binding sorts in `set_models`' registration loop, so a strict test would accept or refuse the same models file across a rename. Refusing also points the wrong way: `_infer_through_field` already fails on that shape and **pinning is the documented rescue**. Inference stays strict — it chooses among candidates, where leniency picks wrong sides and invents spurious ambiguity — and the asymmetry is documented at both sites.

## Deliberately not done

- **A swapped pin on an *unresolved* through model is still accepted**, exactly as before this PR. Pinned by a test, so re-hardening it into a fail-closed check is a decision rather than a drive-by — that hardening is what broke a working pin during review.
- **No `UPGRADING.md` entry, no `Project.toml` bump.** Every input newly refused was already broken. One behavior worth knowing: a through model with `db_column` foreign keys had its mutators *spuriously* locked by the extra-fields guard and they now work — but that configuration cannot have been running, since its joins addressed a column that does not exist.

## Verification

- Unit **7737/7737**.
- `test/integration/test_many_to_many.jl` green on **both** `db_2` (PostgreSQL) and `db_sl` (SQLite) — 19/19 on the new testset. New fixtures self-heal via `_ensure_m2m_scratch_schema!`, including a `_M2M_SCRATCH_TABLE_COLUMNS` entry so a database migrated by a pre-fix tree is rebuilt rather than dying later on "no such column".
- Docs build clean; the doc example's SQL shape **and rows** confirmed against live `db_sl/f1.sqlite`.
- **Six mutation tests**, each discriminating: reverting the resolution, reading the column slot in the extra-fields guard, dropping the pin guard, and reverting the leniency each fail exactly the assertions that claim to cover them.
- Two rounds of independent review. Round 2 caught a **blocking regression in round 1's own fix** (the strict `.to` comparison above), reproduced against the `origin/main` pre-image before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
