### PR TITLE
fix(#399): every Django auto-increment key imports as IDField

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -426,8 +426,25 @@ The function supports conversion of the following Django field types:
 - `OneToOneField` → `OneToOneField`
 
 ### Special Fields
-- `AutoField` → `AutoField`
+- `AutoField` → `IDField` (reported — see below)
+- `BigAutoField` → `IDField`
+- `SmallAutoField` → `IDField` (reported — see below)
 - `ImageField` → `ImageField`
+
+!!! note "Every Django auto key imports as `IDField` — including `AutoField`"
+    `BigAutoField` is Django 3.2+'s `DEFAULT_AUTO_FIELD`. It is BIGINT auto-increment, which is
+    exactly what `IDField` is, so it imports silently.
+
+    `AutoField` (INTEGER) and `SmallAutoField` (SMALLINT) map to `IDField` too — **not** to PormG's
+    own `AutoField`, despite the shared name. `IDField` is the only integer key type PormG's
+    introspection reads back: every non-UUID primary key it finds comes back as one, whatever the
+    column's real width. A model declaring any other key type therefore never matches what the
+    database reports, and `makemigrations` proposes the same `ALTER` on that column *on every run,
+    forever*. It is also why the implicit `id` this importer injects has always been an `IDField`.
+
+    Both are annotated in the generated file, so the substitution is visible. Your existing column
+    is **not** re-typed — but a table PormG *creates* from these models gets BIGINT rather than
+    INTEGER or SMALLINT.
 
 
 ## Field Mapping
@@ -773,8 +790,8 @@ field and its source line; it is never dropped silently.
 
 | | |
 |---|---|
-| **Imported** | Fields (including definitions wrapped across lines), `ForeignKey` / `OneToOneField` / `ManyToManyField` — including `"self"`, `"<app_label>.<Class>"` and `settings.AUTH_USER_MODEL` targets, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints`, `Meta.indexes`, `Meta.index_together` (the last three: see the whitelists above), abstract-base inheritance, `AbstractUser` auth columns, `TextChoices` / `IntegerChoices` enumerations |
-| **Imported, but degraded and annotated** | A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them. A `primary_key=True` on a field type PormG cannot key on — the column survives, the key does not, and no `id` is substituted; the model is then unusable by relations until you re-declare the key (see the warning above) |
+| **Imported** | Fields (including definitions wrapped across lines; Django's `BigAutoField` maps to `IDField`, an exact match), `ForeignKey` / `OneToOneField` / `ManyToManyField` — including `"self"`, `"<app_label>.<Class>"` and `settings.AUTH_USER_MODEL` targets, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints`, `Meta.indexes`, `Meta.index_together` (the last three: see the whitelists above), abstract-base inheritance, `AbstractUser` auth columns, `TextChoices` / `IntegerChoices` enumerations |
+| **Imported, but degraded and annotated** | An `AutoField` or `SmallAutoField` — imported as `IDField`, because `IDField` is the only integer key type PormG's introspection reads back (see the note under *Supported Django Fields*); the key is faithful, the declared width is not. A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them. A `primary_key=True` on a field type PormG cannot key on — the column survives, the key does not, and no `id` is substituted; the model is then unusable by relations until you re-declare the key (see the warning above) |
 | **Reported and skipped** | `Meta.ordering` and every other option with no PormG equivalent; a `UniqueConstraint` or an `Index` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`) |
 | **Not supported** | Field types PormG does not implement — these raise, naming the field and class, rather than importing something wrong. Model methods, managers, signals and validators are Python and have no PormG counterpart |
 

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -3624,11 +3624,20 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     end
 
     field_name = parsed.name
-    field_type = django_field_type(parsed.type)
+    # Django's spelling and PormG's are tracked SEPARATELY (#399), because only one of the two jobs
+    # wants the mapped name. `django_type` is what the models.py actually wrote, and it is what every
+    # path that REPORTS or IGNORES a field must name: `autofields_ignore` is documented in Django's
+    # vocabulary (`["Manager"]`), and a marker naming a type the author never typed is #371 all over
+    # again. `field_type` — the mapped name — exists for the CONSTRUCTOR lookup and nothing else.
+    # They differ only for the names in `DJANGO_AUTO_KEY_TYPES`; for every other type the map is the
+    # identity and the two are the same string. `AutoField` is why this separation is not academic:
+    # it is a name BOTH vocabularies use, for two different field types.
+    django_type = String(parsed.type)
+    field_type = django_field_type(django_type)
     field_args_str = parsed.args
 
     # Parse field arguments
-    options, related_model = parse_field_args(field_args_str, field_type, parameters_ignore;
+    options, related_model = parse_field_args(field_args_str, django_type, parameters_ignore;
                                               enums = enums, class_name = class_name,
                                               enum_scopes = enum_scopes, class_label = class_label,
                                               field_name = field_name, markers = markers)
@@ -3639,7 +3648,24 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     # then drop it, so the synthetic `id` was suppressed and the model came out with NO fields at
     # all. `_import_django_apps` then skipped it silently — while the class index had already handed
     # it a binding, so every ForeignKey to it named a binding the generated file never defined.
-    field_type in autofields_ignore && continue
+    #
+    # Matched on `django_type`, NOT the mapped name: the option is documented as "Django field types
+    # to ignore", so `autofields_ignore = ["BigAutoField"]` has to mean the name in the models.py.
+    # Matching the mapped name would make that entry a silent no-op AND make `["AutoField"]` quietly
+    # swallow types the caller never named.
+    django_type in autofields_ignore && continue
+
+    # A narrower Django key came through as the one PormG can round-trip — the key is faithful, the
+    # declared width is not. Reported for the same reason every other degrade in this file is:
+    # whoever opens the generated file months from now has no other way to learn that the models.py
+    # said something narrower. Placed AFTER the ignore check, so a field the caller dropped is not
+    # reported as imported.
+    if haskey(DJANGO_DEGRADED_FIELD_TYPES, django_type)
+      @warn "import: no PormG key type round-trips this Django field type; imported as IDField" class=class_label field=field_name django_type=django_type django_width=DJANGO_AUTO_KEY_TYPES[django_type]
+      push!(markers, "# PormG: field '$(field_name)' on '$(class_label)' is a Django " *
+                     "$(django_type) ($(DJANGO_AUTO_KEY_TYPES[django_type])) — imported as " *
+                     "$(field_type) (BIGINT). " * DJANGO_DEGRADED_FIELD_TYPES[django_type])
+    end
 
     # The key this statement writes, computed up front so the bookkeeping below can name it without
     # restating the ForeignKey `_id` rule.
@@ -3740,7 +3766,48 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
 
 end
 
+# Django's auto-increment key types → the PormG constructor to call. ALL of them resolve to
+# `IDField`, and the reason is not "closest match" — it is that `IDField` is the ONLY integer key
+# type an imported model can be given without condemning it to a migration that never converges:
+#
+#   * `introspection.jl` force-converts every non-UUID primary key it reads to `IDField` (the
+#     `elseif primary_key` branch — deliberate, see #334), so `IDField` is what the database will
+#     ALWAYS appear to hold, whatever the column's real width;
+#   * `Dialect.describes_same_column` returns `false` outright when either side declares a key, so
+#     the "different Julia type, same physical column" escape hatch is closed for exactly this case;
+#   * a model declaring anything else therefore never equals what introspection reports,
+#     `planner.jl` pushes `:type`, and `makemigrations` proposes the same ALTER on that column on
+#     every single run, forever.
+#
+# `AutoField` (#399) is the counter-intuitive entry: PormG HAS a field by that name, so mapping the
+# Django type onto it is the obvious move and it is the wrong one — `sAutoField` is not a fixed
+# point of the introspection above. The synthetic `id` this file injects has always used `IDField`
+# for the same reason; these mappings just stop a DECLARED key from being treated worse than an
+# undeclared one.
+#
+# `BigAutoField` and `SmallAutoField` had no PormG counterpart at all, and
+# `getfield(Models, :BigAutoField)` used to abort the import of the WHOLE file — every other model
+# in it lost to one column.
+const DJANGO_AUTO_KEY_TYPES = Dict{String, String}(
+  "AutoField"      => "INTEGER",   # Django: serial
+  "BigAutoField"   => "BIGINT",    # Django: bigserial — 3.2+'s DEFAULT_AUTO_FIELD, an exact match
+  "SmallAutoField" => "SMALLINT",  # Django: smallserial
+)
+
+# The subset whose substitution actually LOSES something a reader of the generated file would
+# otherwise never learn. `BigAutoField` is absent on purpose: BIGINT auto-increment is precisely
+# what `IDField` is, so reporting it would be noise, and a marker emitted for everything is a
+# marker that means nothing.
+const DJANGO_DEGRADED_FIELD_TYPES = Dict{String, String}(
+  dj => "PormG has no $(width) auto-increment key it can round-trip: introspection reports EVERY " *
+        "integer primary key as IDField, so any narrower type here would leave makemigrations " *
+        "proposing the same ALTER on this column on every run. Your EXISTING column is not " *
+        "re-typed; but a table PormG CREATES from this model gets BIGINT, not $(width)."
+  for (dj, width) in DJANGO_AUTO_KEY_TYPES if width != "BIGINT"
+)
+
 function django_field_type(field_type::AbstractString)::String
+  haskey(DJANGO_AUTO_KEY_TYPES, field_type) && return "IDField"
   return String(field_type)
 end
 

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -92,8 +92,14 @@ end
         @test occursin("Cust_adminHOD = Models.Model(\"cust_adminhod\"", generated)
         # `id` is emitted as `id`, not `_id` (#317): it was only ever prefixed because PormG's
         # `reserved_words` list wrongly carried it — it is an ordinary Julia identifier.
-        @test occursin("id = Models.AutoField()", generated)
-        @test !occursin("_id = Models.AutoField()", generated)
+        #
+        # The DECLARED `id = models.AutoField(primary_key=True)` on `Cust_adminHOD` now renders as
+        # `IDField` (#399), which every synthetic `id` in this file also renders as — so the
+        # rendered line alone no longer pins the name to THIS class. The marker does: it names the
+        # class and the field, and it is emitted only for the declaration, never for a synthetic id.
+        @test occursin("field 'id' on 'Cust_adminHOD' is a Django AutoField (INTEGER)", generated)
+        @test occursin("id = Models.IDField()", generated)
+        @test !occursin("_id = Models.IDField()", generated)
         @test occursin("user_id = Models.OneToOneField(\"CustomUser\"", generated)
         @test occursin("criado_em = Models.DateTimeField(auto_now=true)", generated)
         @test !occursin("objects = Models.Manager", generated)

--- a/test/unit/test_import_django_project.jl
+++ b/test/unit/test_import_django_project.jl
@@ -1682,9 +1682,10 @@ end
 #     `primary_key` and constructs with `false`. Reading the built fields alone concludes "no key"
 #     and adds an `id` — naming a column the Django table has not got, which breaks every query that
 #     expands the field list. This is a legacy-schema shape, not a hypothetical.
-#   - `AutoField()` DECLARES nothing, but PormG's AutoField defaults `primary_key = true`. Reading
+#   - `AutoField()` DECLARES nothing, but the field it builds defaults `primary_key = true`. Reading
 #     the declarations alone concludes "no key" and adds an `id` beside it — two primary keys, the
-#     very defect #369 is about.
+#     very defect #369 is about. (Since #399 that build is an `IDField`, not an `sAutoField`; the
+#     asymmetry this case guards is unchanged, both types default the key to `true`.)
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "a primary key PormG cannot express is reported, never replaced by an id (#369)" begin
     unkeyable = """
@@ -1743,13 +1744,19 @@ class Thing(models.Model):
 """
     generated2, key2, existed2 = import_project(["access" => auto]; output_file = "auto_pk.jl")
     try
-        @test occursin("codigo = Models.AutoField()", generated2)
-        @test !occursin("Models.IDField()", generated2)
-        @test !occursin("# PormG:", generated2)
+        # `IDField`, not `AutoField` (#399) — but the property under test is unchanged: a bare
+        # `models.AutoField()` declares no `primary_key`, yet the field it BUILDS is the key, so the
+        # synthetic `id` must stay away. Asserted on the built model rather than on the rendered
+        # text, since `codigo` and a phantom `id` would now render as the same field type.
+        @test occursin("codigo = Models.IDField()", generated2)
+        # ...and it must not be reported as unkeyable either — the built field is a fine key.
+        @test !occursin("declares its primary key", generated2)
         sandbox2 = Module()
         Core.eval(sandbox2, Meta.parse(generated2))
-        @test Base.invokelatest(PormG.Models.get_model_pk_field,
-                                Core.eval(sandbox2, :(auto_pk.Thing))) == :codigo
+        thing = Core.eval(sandbox2, :(auto_pk.Thing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) == :codigo
+        @test !haskey(thing.fields, "id")
+        @test length(thing.fields) == 2
     finally
         cleanup_project_test!(key2, existed2)
     end
@@ -3100,3 +3107,210 @@ class Dupla(models.Model):
         cleanup_project_test!(config_key, db_dir_existed)
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#399): every Django auto-increment key type maps to IDField
+#
+# `BigAutoField` (3.2+'s `DEFAULT_AUTO_FIELD`) and `SmallAutoField` do not exist in `PormG.Models`
+# at all, and `getfield(Models, :BigAutoField)` used to abort the import of the whole FILE — every
+# other model in it lost to one column. `AutoField` does exist, and mapping Django's onto it is the
+# obvious move — which is why it is the one worth pinning hardest.
+#
+# ALL THREE map to `IDField`, and the reason is round-tripping, not closeness: PostgreSQL
+# introspection force-converts every non-UUID primary key it reads to `IDField`, and
+# `Dialect.describes_same_column` refuses to equate two field types when either declares a key — so
+# an `sAutoField` key can never equal what the database reports, `planner.jl` pushes `:type`, and
+# `makemigrations` proposes the same ALTER on that column on every run, forever. `IDField` is the
+# only integer key type that is a fixed point of the introspection the model gets diffed against,
+# which is also why the synthetic `id` has always used it.
+#
+# Asserts that:
+#   1. `id = models.<Any>AutoField(primary_key=True)` imports without error and produces exactly one
+#      primary key (:id), rendered as `IDField`;
+#   2. Non-id declarations (`seq = models.BigAutoField(primary_key=True)`, and the SmallAutoField
+#      spelling) import cleanly, suppress synthetic `id`, and make :seq the primary key;
+#   3. Implicit/unadorned `models.BigAutoField()` declarations import and resolve primary keys correctly;
+#   4. The generated module evaluates in a sandbox and `get_model_pk_field` succeeds;
+#   5. `AutoField` and `SmallAutoField` carry a `# PormG:` marker naming the width they lost, while
+#      `BigAutoField` — BIGINT auto-increment, exactly what IDField is — is imported silently;
+#   6. `autofields_ignore` still speaks Django's vocabulary: it matches the name the models.py wrote,
+#      not the PormG type the importer substituted.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Django importer maps every auto-increment key type to IDField (#399)" begin
+    # 1. BigAutoField on explicit id
+    big_id_src = """
+from django.db import models
+
+class BigThing(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen1, key1, existed1 = import_project(["core" => big_id_src]; output_file = "big_id_test.jl")
+    try
+        @test occursin("id = Models.IDField()", gen1)
+        @test occursin("name = Models.CharField(max_length=50)", gen1)
+        # An EXACT match loses nothing, so it must not be reported. The negative half of the marker
+        # contract: without it, "we emit a marker" is satisfied by emitting one for everything.
+        @test !occursin("BigAutoField", gen1)
+        sandbox1 = Module()
+        Core.eval(sandbox1, Meta.parse(gen1))
+        model1 = Core.eval(sandbox1, :(big_id_test.BigThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model1) == :id
+        @test length(model1.fields) == 2
+    finally
+        cleanup_project_test!(key1, existed1)
+    end
+
+    # 2. SmallAutoField on explicit id
+    small_id_src = """
+from django.db import models
+
+class SmallThing(models.Model):
+    id = models.SmallAutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen2, key2, existed2 = import_project(["core" => small_id_src]; output_file = "small_id_test.jl")
+    try
+        @test occursin("id = Models.IDField()", gen2)
+        @test occursin("name = Models.CharField(max_length=50)", gen2)
+        # NOT AutoField: `sAutoField` is not a fixed point of introspection for a key column, so it
+        # would leave makemigrations proposing an ALTER on this column on every run.
+        @test !occursin("Models.AutoField", gen2)
+        # The width IS lost, so the generated file has to say so — naming the DJANGO type, which is
+        # the only name the author ever typed.
+        @test occursin("# PormG: field 'id' on 'core.SmallThing' is a Django SmallAutoField", gen2)
+        @test occursin("imported as IDField", gen2)
+        sandbox2 = Module()
+        Core.eval(sandbox2, Meta.parse(gen2))
+        model2 = Core.eval(sandbox2, :(small_id_test.SmallThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model2) == :id
+        @test length(model2.fields) == 2
+    finally
+        cleanup_project_test!(key2, existed2)
+    end
+
+    # 3. BigAutoField on custom non-id field
+    big_seq_src = """
+from django.db import models
+
+class SeqThing(models.Model):
+    seq = models.BigAutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen3, key3, existed3 = import_project(["core" => big_seq_src]; output_file = "big_seq_test.jl")
+    try
+        @test occursin("seq = Models.IDField()", gen3)
+        @test !occursin("id = Models.IDField()", gen3)
+        sandbox3 = Module()
+        Core.eval(sandbox3, Meta.parse(gen3))
+        model3 = Core.eval(sandbox3, :(big_seq_test.SeqThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model3) == :seq
+        @test !haskey(model3.fields, "id")
+        @test haskey(model3.fields, "seq")
+    finally
+        cleanup_project_test!(key3, existed3)
+    end
+
+    # 4. SmallAutoField on custom non-id field
+    small_seq_src = """
+from django.db import models
+
+class SmallSeqThing(models.Model):
+    seq = models.SmallAutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen4, key4, existed4 = import_project(["core" => small_seq_src]; output_file = "small_seq_test.jl")
+    try
+        @test occursin("seq = Models.IDField()", gen4)
+        @test !occursin("id = Models.IDField()", gen4)
+        @test occursin("# PormG: field 'seq' on 'core.SmallSeqThing' is a Django SmallAutoField", gen4)
+        sandbox4 = Module()
+        Core.eval(sandbox4, Meta.parse(gen4))
+        model4 = Core.eval(sandbox4, :(small_seq_test.SmallSeqThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model4) == :seq
+        @test !haskey(model4.fields, "id")
+        @test haskey(model4.fields, "seq")
+    finally
+        cleanup_project_test!(key4, existed4)
+    end
+
+    # 5. BigAutoField without explicit primary_key kwarg
+    big_no_kw_src = """
+from django.db import models
+
+class ImplicitBigThing(models.Model):
+    id = models.BigAutoField()
+    title = models.CharField(max_length=30)
+"""
+    gen5, key5, existed5 = import_project(["core" => big_no_kw_src]; output_file = "big_no_kw_test.jl")
+    try
+        @test occursin("id = Models.IDField()", gen5)
+        sandbox5 = Module()
+        Core.eval(sandbox5, Meta.parse(gen5))
+        model5 = Core.eval(sandbox5, :(big_no_kw_test.ImplicitBigThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model5) == :id
+        @test length(model5.fields) == 2
+    finally
+        cleanup_project_test!(key5, existed5)
+    end
+
+    # 6. `autofields_ignore` matches what the models.py WROTE, not what the importer substituted.
+    #    Both directions are asserted, because only the pair proves the option reads the Django name:
+    #    "BigAutoField" must drop the column, and "IDField" — the type it maps to, which appears
+    #    nowhere in this models.py — must NOT. Mapping inside the shared `field_type` variable
+    #    passes the first check and fails the second.
+    ignore_src = """
+from django.db import models
+
+class IgnoreThing(models.Model):
+    seq = models.BigAutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen6, key6, existed6 = import_project(["core" => ignore_src]; output_file = "ignore_django_name.jl",
+                                          autofields_ignore = ["Manager", "BigAutoField"])
+    try
+        @test !occursin("seq = Models.IDField()", gen6)
+        @test occursin("name = Models.CharField(max_length=50)", gen6)
+        # The column is gone, so nothing claimed the key and Django's implicit `id` takes over.
+        @test occursin("id = Models.IDField()", gen6)
+    finally
+        cleanup_project_test!(key6, existed6)
+    end
+
+    gen7, key7, existed7 = import_project(["core" => ignore_src]; output_file = "ignore_pormg_name.jl",
+                                          autofields_ignore = ["Manager", "IDField"])
+    try
+        @test occursin("seq = Models.IDField()", gen7)
+        @test !occursin("id = Models.IDField()", gen7)
+    finally
+        cleanup_project_test!(key7, existed7)
+    end
+
+    # 8. Plain `AutoField` — the counter-intuitive one. PormG HAS a field by that name, so mapping
+    #    the Django type onto it is the obvious move and it is wrong: `sAutoField` is not a fixed
+    #    point of introspection for a key column. Pinned as a POSITIVE (IDField is emitted) and a
+    #    NEGATIVE (the same-named PormG type is not), because only the pair rules out the obvious
+    #    mapping being reintroduced.
+    plain_auto_src = """
+from django.db import models
+
+class PlainAutoThing(models.Model):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=50)
+"""
+    gen8, key8, existed8 = import_project(["core" => plain_auto_src]; output_file = "plain_auto_test.jl")
+    try
+        @test occursin("id = Models.IDField()", gen8)
+        @test !occursin("Models.AutoField", gen8)
+        @test occursin("# PormG: field 'id' on 'core.PlainAutoThing' is a Django AutoField (INTEGER)", gen8)
+        @test occursin("imported as IDField (BIGINT)", gen8)
+        sandbox8 = Module()
+        Core.eval(sandbox8, Meta.parse(gen8))
+        model8 = Core.eval(sandbox8, :(plain_auto_test.PlainAutoThing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, model8) == :id
+        @test length(model8.fields) == 2
+    finally
+        cleanup_project_test!(key8, existed8)
+    end
+end
+


### PR DESCRIPTION
Closes #399

`BigAutoField` and `SmallAutoField` do not exist in `PormG.Models`, so `getfield(Models, :BigAutoField)` threw `UndefVarError`, the #342 retry found no `choices`/`default` to drop, and `InvalidMigrationError` propagated out of the import — **one such declaration lost the whole file**: no models, no markers, every other class in the project gone. Same class of failure #268 and #342 closed for other causes; this path escaped both.

## What changed

All three Django auto-increment key types now resolve to `IDField`:

| Django | column | outcome |
|---|---|---|
| `AutoField` | INTEGER (`serial`) | → `IDField`, **reported** |
| `BigAutoField` | BIGINT (`bigserial`) | → `IDField`, exact match, silent |
| `SmallAutoField` | SMALLINT (`smallserial`) | → `IDField`, **reported** |

**The reason is round-tripping, not closeness.** `introspection.jl` force-converts every non-UUID primary key it reads to `IDField` (the `elseif primary_key` branch — deliberate, per #334), and `Dialect.describes_same_column` returns `false` outright when either side declares a key, so #325's "different Julia type, same physical column" escape hatch is closed for exactly this case. A model declaring any other key type therefore never equals what the database reports, `planner.jl` pushes `:type`, and `makemigrations` proposes the same `ALTER` on that column **on every run, forever**. `IDField` is the only integer key type that is a fixed point of the introspection the model gets diffed against — which is also why the synthetic `id` this importer injects has always been one.

## Scope widened, deliberately

`AutoField → AutoField` was **not** in #399. The review flagged it as a pre-existing sibling of the same defect — PormG *has* a field by that name, so mapping Django's onto it is the obvious move and it is the one that never converges — and the maintainer approved folding it in. Leaving it would have left two adjacent mappings taking opposite positions on the same question.

## Django's vocabulary vs PormG's

The first cut mapped inside one shared `field_type` variable. That made `autofields_ignore = ["BigAutoField"]` a silent no-op while `["AutoField"]` quietly swallowed types the caller never named — the option is documented in Django's vocabulary — and had markers and `_common_kwargs` warnings naming a PormG type the author never typed, which is #371 again. The two are now tracked separately:

- `django_type` — what the models.py wrote: every **report**, and `autofields_ignore`
- `field_type` — the mapped name: the constructor lookup, nothing else

Both directions are pinned by tests; only the pair proves the option reads the Django name.

## Reporting

`AutoField`/`SmallAutoField` carry a `# PormG:` marker naming the width they lost. `BigAutoField` is silent *by construction* — `DJANGO_DEGRADED_FIELD_TYPES` is derived from `DJANGO_AUTO_KEY_TYPES` by excluding the BIGINT row, so a future auto type is one table row and the marker follows. An existing column is **not** re-typed; a table PormG *creates* from these models gets BIGINT.

## Tests

Two existing tests moved, both strengthened rather than relaxed:

- `test_import_django_models.jl`'s #317 guard asserted `id = Models.AutoField()`, discriminating only because `AutoField` appeared nowhere else in that file. It would have decayed into "some model somewhere has an IDField named id", so the positive is now the marker, which names the class **and** the field.
- `test_import_django_project.jl`'s #369 mirror case proved "no synthetic id" via `!occursin("Models.IDField()")` — meaningless once `codigo` is itself an `IDField`. It now asserts on the built model, and its blanket `!occursin("# PormG:")` became the specific report it was guarding against (`declares its primary key`).

New coverage: all three types on `id` and on a non-`id` field, implicit `BigAutoField()`, the marker's presence *and* its absence for the exact match, both `autofields_ignore` directions, and plain `AutoField` pinned as a positive (`IDField` emitted) **and** a negative (`Models.AutoField` not emitted) — only the pair stops the obvious mapping being reintroduced.

## Deliberately not done

- **Real `BigAutoField`/`SmallAutoField` field types** (the issue's option 2). `BigAutoField` would be a pure synonym for `IDField` — two public names for one concept. And a real `sSmallAutoField` would be *strictly worse* than this mapping until introspection stops flattening every integer key: it would earn the perpetual ALTER described above.
- **The introspection flattening itself.** It means `generate_models_from_db` against *any* database with a `serial`/`smallserial` key already proposes widening it — Django is not involved. Worth its own issue; the importer is only where it became visible.
- **The issue's option 3** — degrade loudly instead of aborting on any unknown `models.X`. Outside the acceptance criteria; the failure mode is still live for every Django type that is not one of these three. Follow-up.
- **No `UPGRADING.md` entry.** That log is for changes forcing app *source* edits; this changes generated-file output and produces a one-time converging ALTER, which the file explicitly excludes ("Not database migrations"). Nothing that was running stops running: every input newly mapped either aborted the import outright or produced a key that never converged.

## Verification

- Unit suite **7776/7776**, exit 0
- `#399` testset 37/37, `#369` testset 12/12
- Docs build clean
- No integration run: the change is confined to the Django importer, which the integration suites do not exercise, and it touches no SQL rendering or dialect path.

## Acceptance (#399)

- [x] `id = models.BigAutoField(primary_key=True)` imports without aborting, model has exactly one primary key
- [x] `models.SmallAutoField` likewise
- [x] A `BigAutoField` on a field not named `id` is handled the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)
