### PR TITLE
fix(#389): FK referenced primary key arrives quote_ident-quoted

### DIFF
--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -5,6 +5,38 @@
 # ==============================================================================
 
 # ---
+# Shared identifier helpers
+# ---
+
+# The inverse of PostgreSQL's `quote_ident`, which is how the schema query emits every identifier
+# it aggregates. `quote_ident` wraps a name that needs quoting in `"` AND DOUBLES any `"` inside it,
+# so `Say"Hi` comes back as `"Say""Hi"`.
+#
+# `replace(s, "\"" => "")` — which this replaces at six call sites in `convertSQLToModel` — got the
+# common case right and the embedded-quote case silently WRONG: it rewrote `"Say""Hi"` to `SayHi`,
+# a name no column has, so `makemigrations` proposed `ADD COLUMN "SayHi"` plus a `DROP` of the real
+# one, forever, with no warning. Undoing the doubling makes the round trip exact instead.
+#
+# WHAT THAT DOES AND DOES NOT BUY, measured rather than assumed. The name now survives, so the
+# existing table converges and `Model_to_str` regenerates it faithfully — as a legal binding plus
+# `db_column="Say\"Hi"`, which is a rename of the BINDING, not of the column. What it does NOT do
+# is fail closed: `_validate_identifier` (querybuilder/sanitization.jl) guards the QUERY path only,
+# so a query naming that field still raises `InvalidValueError`, while `Dialect.create_table` will
+# happily emit `"Say"Hi"` and close the identifier early. That is the column-name half of the
+# `_quote_table_ddl` escaping #388/#59 applied to TABLE names, and it belongs with #394 — it is not
+# introduced here, but this function is what makes such a name reachable at all.
+#
+# A name with no surrounding pair is returned untouched — `quote_ident` leaves an already-legal
+# lowercase identifier bare. Note this is NOT a safe transform for a RAW producer: a column truly
+# named `"x"` reads back raw as `"x"` and would be stripped to `x`. The `indexes` CTE's
+# `index_columns` is the one raw identifier aggregate in the schema query, and it is deliberately
+# NOT passed through here (see its call site below).
+function _unquote_ident(name::AbstractString)::String
+  (length(name) >= 2 && startswith(name, '"') && endswith(name, '"')) || return String(name)
+  return replace(name[nextind(name, 1):prevind(name, lastindex(name))], "\"\"" => "\"")
+end
+
+# ---
 # Shared FK helpers (both backends)
 # ---
 
@@ -226,7 +258,10 @@ function convertSQLToModel(sql::String; type_map::Dict{String, Symbol} = sqlite_
   primary_key_regex = eachmatch(r"PRIMARY KEY\s*\((.+?)\)?\s*(AUTOINCREMENT)?\)", sql)
   for match in primary_key_regex
     primary_keys = match.captures[1]
-    primary_keys = replace(primary_keys, r"\"" => "") 
+    # Deliberately NOT `_unquote_ident`: this reader parses DDL PormG itself emitted, where an
+  # identifier is quoted but never contains a doubled `"`, so there is no doubling to undo and the
+  # blanket strip is exact here.
+  primary_keys = replace(primary_keys, r"\"" => "") 
     primary_keys = split(primary_keys, ",")
     auto_increment = isnothing(match.captures[2]) ? false : true
     # println(primary_keys)
@@ -1437,7 +1472,10 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
 
   # Extract primary key constraints
   # row[:primary_keys] is missing for keyless tables (e.g., Lap_times, Pit_stops that have no IDField)
-  pk_set = ismissing(row[:primary_keys]) ? Set{String}() : Set(split(row[:primary_keys], ", "))
+  # De-quoted (#389): the schema query aggregates these as `quote_ident(a.attname)`, and `col_name`
+  # — the only thing ever compared against this set — is normalized at parse time below.
+  pk_set = ismissing(row[:primary_keys]) ? Set{String}() :
+    Set(_unquote_ident(pk) for pk in split(row[:primary_keys], ", "))
     
   # Extract foreign key constraints
   # Widened past `(table, pk)` for #292 to carry the referential action, which the schema query
@@ -1454,27 +1492,51 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       split(row[:delete_rules], ", ") : fill("", length(fk_columns))
     for (i, (fk_col, fk_table, fk_pk)) in enumerate(zip(fk_columns, fk_tables, fk_pk_columns))
         rule = i <= length(delete_rules) ? delete_rules[i] : ""
-        # The parent table is DE-QUOTED (#360). The schema query aggregates it as
-        # `quote_ident(cf.relname)`, so any name that needs quoting — a space, punctuation, mixed
-        # case — arrives wrapped in `"`, while `table_name` comes from a bare `c.relname`. Stored
-        # quoted, `to_table` matched no imported model, so the pass-1 binding rewrite silently
-        # no-opped for exactly the names it exists to handle, and only on PostgreSQL. Same treatment
-        # (and same reason) as `index_map` below, which has de-quoted since #325.
-        fk_map[fk_col] = (table = replace(String(fk_table), "\"" => ""), pk = String(fk_pk),
-                          on_delete = _pg_confdeltype_to_on_delete(rule))
+        # ALL THREE halves are DE-QUOTED. The schema query aggregates each through
+        # `quote_ident`, so any name that needs quoting — a space, punctuation, mixed case —
+        # arrives wrapped in `"` as part of the Julia string. Same treatment (and same reason) as
+        # `index_map` below, which has de-quoted since #325.
+        #
+        #   * `table` since #360: stored quoted, `to_table` matched no imported model, so the
+        #     pass-1 binding rewrite silently no-opped for exactly the names it exists to handle.
+        #   * `pk` and the dict KEY since #389, which is the rest of that same fix. A quoted `pk`
+        #     lands verbatim on the field as `pk_field`, and `Models.fk_target_column` returns it
+        #     unchanged — an introspected field's `.to` is still a String binding, so the
+        #     resolve-through-the-parent branch never runs (and once `set_models` DOES resolve it,
+        #     the lookup misses anyway, because `fields_dict` is keyed de-quoted below). Three
+        #     things broke on that one value: `Dialect.add_foreign_key` emitted
+        #     `REFERENCES "parent"(""Id"")`, `_compare_field_foreign_key` reported the key as
+        #     changed on every `makemigrations`, and the query builder threw `InvalidValueError`
+        #     because `SAFE_IDENTIFIER_PATTERN` forbids a `"`. The KEY moves in the SAME change on
+        #     purpose: it is looked up with `col_name`, so normalizing one side alone would break
+        #     FK detection outright for every mixed-case column.
+        fk_map[_unquote_ident(fk_col)] =
+          (table = _unquote_ident(fk_table),
+           pk = _unquote_ident(fk_pk),
+           on_delete = _pg_confdeltype_to_on_delete(rule))
     end
   end
 
   # Extract index information — physical column ⇒ index name, for the single-column secondary
-  # indexes the `indexes` CTE keeps. Both halves are stored UNQUOTED (#325): the key has to match
-  # `fields_dict`, which is keyed by the de-quoted column name below, and the value is re-quoted by
-  # `_drop_index`. A mixed-case name (#57) arrived here wrapped in `"` and matched neither.
+  # indexes the `indexes` CTE keeps. Both halves end up UNQUOTED (#325), but they get there
+  # differently, and the asymmetry is in the SQL rather than here:
+  #
+  #   * the KEY comes from `array_agg(a.attname)` — RAW, the only identifier aggregate in the
+  #     schema query that is not wrapped in `quote_ident`. It is therefore already the physical
+  #     name and is taken verbatim. Running it through `_unquote_ident` would be actively wrong:
+  #     a column genuinely named `"x"` reads back raw as `"x"` and would be stripped to `x`, which
+  #     no longer matches the `fields_dict` key built from the `quote_ident`-ed `columns`
+  #     aggregate — reintroducing the #325 churn for that name class.
+  #   * the VALUE comes from `array_agg(quote_ident(c.relname))` and does need the inverse; it is
+  #     re-quoted by `_drop_index` on the way out.
+  #
+  # A mixed-case name (#57) used to arrive here and match neither half.
   index_map = Dict{String, String}()
   if !ismissing(row[:index_columns])
     indexes = split(row[:index_columns], ", ")
     index_names = split(row[:index_names], ", ")
     for (index, index_name) in zip(indexes, index_names)
-      index_map[replace(index, "\"" => "")] = replace(index_name, "\"" => "")
+      index_map[String(index)] = _unquote_ident(index_name)
     end
   end
    
@@ -1482,7 +1544,21 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
   for col in columns    
       col_parts = split(replace(col, "double precision" => "double_precision")
       , " ")
-      col_name = col_parts[1]
+      # De-quoted ONCE, here (#389). `columns` is aggregated as `quote_ident(a.attname)`, so a
+      # mixed-case name (or a reserved word) arrives wrapped in `"`. Every consumer below —
+      # `index_map`, `pk_set`, `fk_map`, `fields_dict` — is keyed on the de-quoted form, and
+      # normalizing at the single parse site is what keeps them agreeing. Before this the reader
+      # de-quoted at two of those four sites and left the other two quoted, which happened to work
+      # only because their counterparts were quoted too.
+      #
+      # NOT covered: an identifier containing a SPACE. `col_parts` splits the aggregate on `" "`
+      # one line up, so `"Parent Id"` is torn in half before any de-quoting can help, and the
+      # column is emitted under the phantom name `Parent`. `fk_map`'s key survives it (that
+      # aggregate splits on `", "`), so the two sides genuinely disagree for exactly that class of
+      # name — a live PG/SQLite divergence, since the SQLite reader takes `PRAGMA` output raw.
+      # Fixing it means changing the `columns` aggregate's format, not the de-quoting, so it is out
+      # of scope for #389. No issue filed yet — see this PR's body.
+      col_name = _unquote_ident(col_parts[1])
       col_type = lowercase(col_parts[2])
       generated::Bool = false
       max_length = nothing
@@ -1492,8 +1568,9 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # Detect if the column is indexed. #325: this probed a `Dict{String,String}` with a `Symbol`
       # key, which `haskey` never matches — so `db_index` was a hard `false` for every plain
       # PostgreSQL column, and every `db_index=true` field re-proposed its own CREATE INDEX on every
-      # `makemigrations`. `col_name` is de-quoted to match `index_map`'s keys.
-      db_index = haskey(index_map, replace(String(col_name), "\"" => ""))
+      # `makemigrations`. Both sides are de-quoted: `index_map`'s keys when it is built, and
+      # `col_name` at its single parse site above (#389).
+      db_index = haskey(index_map, col_name)
 
       @pormg_debug false
 
@@ -1662,7 +1739,7 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       end
       
       # Add field to fields dictionary
-      fields_dict[replace(col_name, "\"" => "")] = field
+      fields_dict[col_name] = field
   end
 
   # Construct and return the model

--- a/test/integration/test_importers_introspection.jl
+++ b/test/integration/test_importers_introspection.jl
@@ -32,6 +32,7 @@
   # Child before parent: since #276 SQLite enforces foreign keys, so dropping the parent while the
   # child still references it raises instead of silently succeeding.
   fixtures = ("pormg_it_fk_child", "pormg_it_fk_parent",
+              "pormg_it_MixedChild", "pormg_it_MixedParent",
               "pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored",
               "pormg_it_uniq")
   drop_fixtures() = for t in fixtures
@@ -78,6 +79,24 @@
          fk_o2o        INTEGER UNIQUE REFERENCES "pormg_it_fk_parent"(id) ON DELETE CASCADE
        )"""
 
+  # #389 fixture: the ONLY mixed-case identifiers in this file. Every other fixture is lowercase,
+  # so PostgreSQL's `quote_ident` returns them unquoted and the whole quoting hazard is invisible —
+  # which is exactly why the bug survived here. A quoted mixed-case parent PK (`"Id"`) is what the
+  # `referenced_primary_keys` aggregate wraps in `"`, and the mixed-case CHILD column (`"ParentId"`)
+  # covers the `fk_cols` / `col_name` pairing that has to be normalized in the same change.
+  mixed_parent_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_MixedParent" ("Id" BIGINT PRIMARY KEY, "Label" VARCHAR(50))""" :
+    """CREATE TABLE "pormg_it_MixedParent" ("Id" INTEGER PRIMARY KEY, "Label" TEXT)"""
+  mixed_child_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_MixedChild" (
+         id         BIGINT PRIMARY KEY,
+         "ParentId" BIGINT REFERENCES "pormg_it_MixedParent"("Id") ON DELETE CASCADE
+       )""" :
+    """CREATE TABLE "pormg_it_MixedChild" (
+         id         INTEGER PRIMARY KEY,
+         "ParentId" INTEGER REFERENCES "pormg_it_MixedParent"("Id") ON DELETE CASCADE
+       )"""
+
   # #318: TWO separate single-column UNIQUEs on one table plus a composite. This is the ONLY place
   # PostgreSQL's `unique_constraints` CTE actually runs, and the two-uniques shape is precisely what
   # it got wrong (it merged both constraints' columns into one per-table array, then rejected both
@@ -98,6 +117,8 @@
   ddl(ignored_ddl)
   ddl(fk_parent_ddl)
   ddl(fk_child_ddl)
+  ddl(mixed_parent_ddl)
+  ddl(mixed_child_ddl)
   ddl(uniq_ddl)
   # #347: a composite NON-unique index on the same table, deliberately in the REVERSE column order
   # of the composite UNIQUE declared above. Both backends excluded every multi-column index from
@@ -248,6 +269,48 @@
     Core.eval(uniq_mod, :(import PormG.Models))
     uniq_reloaded = Core.eval(uniq_mod, Meta.parse(uniq_src))
     @test uniq_reloaded.cache["composite_indexes"]["indexes"][1].fields == ["b", "a"]
+
+    # ── 3d. Mixed-case FK/PK identifiers survive quote_ident (#389) ──────────
+    # PostgreSQL aggregates `fk_cols`, `fk_tables` and `referenced_primary_keys` through
+    # `quote_ident`, so a mixed-case name arrives with the `"` characters as part of the string.
+    # #360 de-quoted the table half; the referenced PK stayed quoted and landed verbatim on
+    # `pk_field` (an introspected field's `.to` is a String binding, so `fk_target_column` returns
+    # it unchanged). That one value made `Dialect.add_foreign_key` emit
+    # `REFERENCES "parent"(""Id"")` — two quote pairs, because the caller adds one around a value
+    # that already carries one — made `_compare_field_foreign_key` report the key as changed on
+    # every makemigrations, and made the query builder throw `InvalidValueError`
+    # (`SAFE_IDENTIFIER_PATTERN` forbids a `"`).
+    #
+    # This is the live half of test/unit/test_introspection_guards.jl's #389 block. It runs on both
+    # backends even though only PostgreSQL has the hazard: SQLite reads FK metadata from
+    # `PRAGMA foreign_key_list`, whose identifiers come back raw, so this pins that the two engines
+    # agree on the same schema rather than assuming it.
+    mixed_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_MixedParent", "pormg_it_MixedChild"])
+    mixed_by_name = Dict(lowercase(string(m.name)) => m for m in mixed_models)
+
+    @test haskey(mixed_by_name, "pormg_it_mixedchild")
+    @test haskey(mixed_by_name, "pormg_it_mixedparent")
+    mixed_child  = mixed_by_name["pormg_it_mixedchild"]
+    mixed_parent = mixed_by_name["pormg_it_mixedparent"]
+
+    # The parent's mixed-case PRIMARY KEY is detected as the key. `pk_set` is `quote_ident`-ed too,
+    # and is compared against `col_name`; normalizing one without the other leaves the table keyless.
+    @test haskey(mixed_parent.fields, "Id")
+    @test mixed_parent.fields["Id"] isa PormG.Models.sIDField
+
+    # The mixed-case CHILD column is still recognised as a foreign key — the mutation gate for
+    # moving `fk_cols` and `col_name` together.
+    @test haskey(mixed_child.fields, "ParentId")
+    @test mixed_child.fields["ParentId"] isa PormG.Models.sForeignKey
+
+    # THE defect: the referenced parent column, unquoted, both raw and resolved.
+    @test mixed_child.fields["ParentId"].pk_field == "Id"
+    @test PormG.Models.fk_target_column(mixed_child.fields["ParentId"]) == "Id"
+
+    # The #360 half still holds for a mixed-case parent table.
+    @test mixed_child.fields["ParentId"].to_table == "pormg_it_MixedParent"
+    @test mixed_child.fields["ParentId"].on_delete === PormG.Models.CASCADE
 
     # ── 4. The regenerated module registers via set_models (#287/#291) ───────
     # THE regression assertion. Before #292 this threw ModelDefinitionError ("declares on_delete

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -432,9 +432,12 @@ end
 # `Symbol` key never matches a `String` key, so `db_index` was a hard `false` for every plain
 # PostgreSQL column. Every `db_index=true` field therefore compared unequal to its own live table
 # forever, and `Dialect.alter_field` has no `db_index` branch, so the migration it triggered emitted
-# no DDL for it. The de-quoting half matters just as much: the CTE passes column names through
-# `quote_ident`, so a mixed-case column (#57) arrives wrapped in `"` and would miss even with the
-# key type fixed.
+# no DDL for it. The name half matters just as much: `index_map`'s key must equal the `fields_dict`
+# key, which is built from the `quote_ident`-ed `columns` aggregate and de-quoted on the way in.
+# `index_columns`, uniquely among the schema query's identifier aggregates, is `array_agg(a.attname)`
+# — RAW — so a mixed-case column (#57) arrives here ALREADY unquoted and the two sides meet in the
+# middle. This fixture used to spell it `"mixedCase"`, a shape production never emits, which meant
+# the mixed-case path was pinned against the wrong input (#389).
 #
 # The CTE's own filters (non-unique, non-partial, single-column) run against a live database in
 # test/integration/test_migration_bootstrap.jl — nothing here executes SQL.
@@ -444,14 +447,16 @@ end
     table_name    = "db_index_guard",
     columns       = "id bigint NOT NULL, slug character varying(120), plain text, \"mixedCase\" text",
     primary_keys  = "id",
-    # What the `indexes` CTE hands back: one entry per indexed column, `quote_ident`-ed, with the
-    # index names aligned positionally.
-    index_columns = "slug, \"mixedCase\"",
+    # What the `indexes` CTE hands back: one entry per indexed column, RAW (`array_agg(a.attname)`,
+    # no `quote_ident` — verified against a live catalog), with the `quote_ident`-ed index names
+    # aligned positionally.
+    index_columns = "slug, mixedCase",
     index_names   = "db_index_guard_slug_idx, db_index_guard_mixedcase_idx"))
 
   # THE mutation gate — all three are `false` on main.
   @test model.fields["slug"].db_index
-  @test model.fields["mixedCase"].db_index      # the de-quoting half (#57)
+  @test model.fields["mixedCase"].db_index      # the de-quoting half (#57) — of `col_name`,
+                                                # since the index side arrives raw
   @test !model.fields["plain"].db_index         # …and it did not over-mark
 
   # The index NAME is carried too, de-quoted, because the planner needs it to DROP the index when a
@@ -550,5 +555,214 @@ end
     @test model.fields["profile_id"] isa PormG.Models.sOneToOneField
     @test model.fields["profile_id"].to       == "Driver_profile"
     @test model.fields["profile_id"].to_table == "driver profile"
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #389: FK metadata arrives `quote_ident`-quoted, and every half must be de-quoted together
+#
+# The PostgreSQL schema query aggregates `fk_cols`, `fk_tables` and `referenced_primary_keys`
+# through `quote_ident`, so a mixed-case identifier arrives with the `"` characters as part of the
+# Julia string. #360 (PR #386) de-quoted the TABLE half; this is the rest of it.
+#
+# The one that bites is `referenced_primary_keys` → `pk_field`. Stored quoted, `fk_target_column`
+# returns it unchanged — an introspected field's `.to` is still a String binding, so the
+# resolve-through-the-parent branch never runs. Three things break on that one value:
+# `Dialect.add_foreign_key` emits `REFERENCES "parent"(""Id"")` (TWO quote pairs — the caller adds
+# one around a value that already carries one; the issue body's `"""Id"""` is wrong),
+# `_compare_field_foreign_key` reports the key as changed on every `makemigrations`, and the query
+# builder throws `InvalidValueError` because `SAFE_IDENTIFIER_PATTERN` forbids a `"`.
+#
+# `fk_cols` and `col_name` move in the SAME change on purpose: `fk_map`'s keys come from `fk_cols`
+# and are looked up with `col_name`, so normalizing one side alone would break FK detection for
+# every mixed-case column. Both are covered below — the second testset is that mutation gate.
+#
+# Fully hermetic: `convertSQLToModel(::DataFrameRow)` takes the metadata and nothing else.
+# The live-database half is test/integration/test_importers_introspection.jl.
+# ─────────────────────────────────────────────────────────────────────────────
+# `add_foreign_key` dispatches on the abstract backend marker and never touches connection state,
+# so a bare marker struct is a sufficient `conn`. Declared at top level, like every other mock in
+# test/unit/ (a struct inside a `@testset` body parses, but is not the house pattern).
+struct MockPg389 <: PormG.PormGPostgres end
+
+@testset "quote_ident-quoted FK metadata is de-quoted (#389)" begin
+  @testset "a mixed-case parent primary key lands unquoted on pk_field" begin
+    # Exactly what the production query emits for a parent keyed on `"Id"`: quote_ident quotes the
+    # mixed-case pk and the mixed-case table, and leaves the all-lowercase child column alone.
+    model = convertSQLToModel(_introspection_row(
+      table_name              = "pit_stop",
+      columns                 = "id bigint NOT NULL, parent_id bigint",
+      primary_keys            = "id",
+      foreign_keys            = "parent_id",
+      foreign_tables          = "\"MixedParent\"",
+      referenced_primary_keys = "\"Id\"",
+      delete_rules            = "a"))
+
+    fk = model.fields["parent_id"]
+    @test fk isa PormG.Models.sForeignKey
+
+    # THE defect. Before the fix this was the four-character string `"Id"` — quote characters
+    # included — not the two-character `Id`.
+    @test fk.pk_field == "Id"
+
+    # …and the resolved form, which is what the planner and the DDL actually consume. For an
+    # INTROSPECTED field this equals `pk_field` by construction — `.to` is still a String binding,
+    # so `fk_target_column`'s resolve-through-the-parent branch cannot run and it returns the value
+    # verbatim. So this asserts propagation, not an independent fact; the genuinely separate
+    # consequence is pinned by the `_compare_field_foreign_key` testset below.
+    @test PormG.Models.fk_target_column(fk) == "Id"
+
+    # The #360 half still holds — this fix must not disturb it.
+    @test fk.to_table == "MixedParent"
+  end
+
+  @testset "the emitted ALTER references the parent column with ONE pair of quotes" begin
+    # The consequence the issue leads with. `add_foreign_key` interpolates its identifiers verbatim
+    # — every one is pre-quoted by the CALLER — so this reproduces `planner.jl`'s call shape exactly
+    # (`"\"$resolved_pk\""`). With a quoted `pk_field` the result was `REFERENCES ... (""Id"")`,
+    # which is a syntax error, not merely ugly. (The issue body says `"""Id"""`; the measured output
+    # is two pairs, because the caller adds ONE pair around a value that already carries one.)
+    model = convertSQLToModel(_introspection_row(
+      table_name              = "pit_stop",
+      columns                 = "id bigint NOT NULL, parent_id bigint",
+      primary_keys            = "id",
+      foreign_keys            = "parent_id",
+      foreign_tables          = "\"MixedParent\"",
+      referenced_primary_keys = "\"Id\"",
+      delete_rules            = "a"))
+
+    resolved_pk = PormG.Models.fk_target_column(model.fields["parent_id"])
+    sql = PormG.Dialect.add_foreign_key(MockPg389(), "pit_stop", "\"pit_stop_parent_id_fk\"",
+                                        "\"parent_id\"", "\"MixedParent\"", "\"$resolved_pk\"")
+
+    @test occursin("(\"Id\")", sql)
+    @test !occursin("\"\"", sql)   # no doubled quote anywhere in the statement
+  end
+
+  @testset "a declared key compares EQUAL to the introspected one (no perpetual ALTER)" begin
+    # The consequence the issue leads with and the one a user actually notices, reached through a
+    # DIFFERENT path than the two above: `planner.jl` asks `_compare_field_foreign_key(declared,
+    # live)`, which compares `fk_target_column` on both sides. Declared `Id` vs live `"Id"` is
+    # `false`, so the planner pushes an alteration for that column on EVERY `makemigrations` —
+    # forever, and on SQLite as a full table rebuild. Nothing above constrains this: those pin the
+    # stored value, not the comparison that consumes it.
+    live = convertSQLToModel(_introspection_row(
+      table_name              = "pit_stop",
+      columns                 = "id bigint NOT NULL, parent_id bigint",
+      primary_keys            = "id",
+      foreign_keys            = "parent_id",
+      foreign_tables          = "\"MixedParent\"",
+      referenced_primary_keys = "\"Id\"",
+      delete_rules            = "a")).fields["parent_id"]
+
+    # What a hand-written or regenerated model file declares for that same column.
+    declared = PormG.Models.ForeignKey("MixedParent", pk_field = "Id")
+    declared.to_table = "MixedParent"
+
+    @test PormG.Models._compare_field_foreign_key(declared, live)
+    # Symmetric — the planner calls it (new, old) and nothing should depend on the order.
+    @test PormG.Models._compare_field_foreign_key(live, declared)
+  end
+
+  @testset "a mixed-case FK COLUMN is still detected as a foreign key" begin
+    # The mutation gate for moving `fk_cols` and `col_name` together. `fk_map`'s key comes from
+    # `fk_cols` and is probed with `col_name`; de-quoting either one alone makes this lookup miss,
+    # and the column silently degrades from a ForeignKey to a plain BigIntegerField — FK detection
+    # broken for every mixed-case column, which is strictly worse than the bug being fixed.
+    model = convertSQLToModel(_introspection_row(
+      table_name              = "pit_stop",
+      columns                 = "id bigint NOT NULL, \"ParentId\" bigint",
+      primary_keys            = "id",
+      foreign_keys            = "\"ParentId\"",
+      foreign_tables          = "\"MixedParent\"",
+      referenced_primary_keys = "\"Id\"",
+      delete_rules            = "a"))
+
+    # `fields_dict` is keyed de-quoted, so this is the name the rest of PormG sees.
+    @test haskey(model.fields, "ParentId")
+    @test model.fields["ParentId"] isa PormG.Models.sForeignKey
+    @test model.fields["ParentId"].pk_field == "Id"
+    @test model.fields["ParentId"].to_table == "MixedParent"
+  end
+
+  @testset "a mixed-case PRIMARY KEY column is still detected as the key" begin
+    # `pk_set` comes from `quote_ident(a.attname)` too, and is compared against `col_name`. The two
+    # used to agree only because BOTH were quoted; normalizing `col_name` without normalizing
+    # `pk_set` would leave the table keyless, which no other assertion in this file would catch.
+    model = convertSQLToModel(_introspection_row(
+      table_name   = "mixed_key",
+      columns      = "\"Id\" bigint NOT NULL, label character varying(50)",
+      primary_keys = "\"Id\""))
+
+    @test haskey(model.fields, "Id")
+    @test model.fields["Id"] isa PormG.Models.sIDField
+    @test model.fields["Id"].primary_key
+  end
+
+  @testset "an embedded quote round-trips instead of being silently deleted" begin
+    # `quote_ident` DOUBLES an embedded `"`, so `Say"Hi` — a legal PostgreSQL column name — comes
+    # back as `"Say""Hi"`. The old `replace(s, "\"" => "")` deleted every quote and produced
+    # `SayHi`, a column that does not exist: `makemigrations` then proposed `ADD COLUMN "SayHi"`
+    # alongside a `DROP` of the real one, on every run, silently. `_unquote_ident` undoes the
+    # doubling instead, so the name survives: the existing table converges, and `Model_to_str`
+    # regenerates it as a legal binding plus `db_column="Say\"Hi"` — a rename of the BINDING, not
+    # of the column. It does NOT make such a name safe everywhere: `Dialect.create_table` still
+    # emits `"Say"Hi"` and closes the identifier early (the column-name twin of the `db_table`
+    # escaping in #388, and #394's family), and the query path raises `InvalidValueError` from
+    # `_validate_identifier`. Surviving intact and being universally usable are different claims;
+    # only the first is made here.
+    model = convertSQLToModel(_introspection_row(
+      table_name              = "odd_names",
+      columns                 = "id bigint NOT NULL, \"Say\"\"Hi\" bigint",
+      primary_keys            = "id",
+      foreign_keys            = "\"Say\"\"Hi\"",
+      foreign_tables          = "\"Par\"\"ent\"",
+      referenced_primary_keys = "\"Sa\"\"y\"",
+      delete_rules            = "a"))
+
+    @test haskey(model.fields, "Say\"Hi")
+    @test model.fields["Say\"Hi"].pk_field == "Sa\"y"
+    @test model.fields["Say\"Hi"].to_table == "Par\"ent"
+  end
+
+  @testset "the RAW index aggregate is not run through the quote_ident inverse" begin
+    # The mutation gate for the one identifier aggregate that is NOT `quote_ident`-ed:
+    # `indexes.index_columns` is a bare `array_agg(a.attname)`. Undoing a doubling that was never
+    # applied corrupts exactly one name class — a column whose real name IS quoted.
+    #
+    # Real name `"x"` (three characters). `columns` carries `quote_ident("\"x\"")` = `"""x"""`,
+    # `index_columns` carries the raw `"x"`. De-quote both and they still agree; de-quote only the
+    # `columns` side, as it must be, and take the raw side verbatim, and they agree too. Run
+    # `_unquote_ident` on BOTH and the index key collapses to `x` while the field key stays `"x"`
+    # — the #325 db_index churn, reintroduced for that name class by the #389 fix itself.
+    model = convertSQLToModel(_introspection_row(
+      table_name    = "d1_probe",
+      columns       = "id bigint NOT NULL, \"\"\"x\"\"\" bigint",
+      primary_keys  = "id",
+      index_columns = "\"x\"",
+      index_names   = "d1_probe_x_idx"))
+
+    @test haskey(model.fields, "\"x\"")
+    @test model.fields["\"x\""].db_index
+    @test model.cache["index"]["\"x\""] == "d1_probe_x_idx"
+  end
+
+  @testset "the all-lowercase case is unchanged (control)" begin
+    # quote_ident leaves a legal lowercase identifier alone, so this is the shape every existing
+    # fixture exercises. It is a NO-REGRESSION CONTROL for the common path, not a mutation gate:
+    # a lowercase name carries no quotes, so no partial normalization can make it fail.
+    model = convertSQLToModel(_introspection_row(
+      table_name              = "results",
+      columns                 = "id bigint NOT NULL, driverid bigint",
+      primary_keys            = "id",
+      foreign_keys            = "driverid",
+      foreign_tables          = "drivers",
+      referenced_primary_keys = "driverid",
+      delete_rules            = "c"))
+
+    @test model.fields["driverid"] isa PormG.Models.sForeignKey
+    @test model.fields["driverid"].pk_field == "driverid"
+    @test model.fields["driverid"].to_table == "drivers"
+    @test model.fields["driverid"].on_delete === PormG.Models.CASCADE
   end
 end


### PR DESCRIPTION
Closes #389

## The defect

The PostgreSQL schema query aggregates every FK identifier through `quote_ident`, so a mixed-case parent primary key arrived as the Julia string `"\"Id\""` — quote characters included — and was stored verbatim as `pk_field`. PR #386 de-quoted the *table* half (#360); this is the remainder.

Three consequences, all from that one value:

- `Dialect.add_foreign_key` emitted `REFERENCES "parent"(""Id"")` — **two** quote pairs, because the caller adds one around a value that already carries one. (The issue body says `"""Id"""`; the measured output is two. Corrected in the code comments.)
- `Models._compare_field_foreign_key` reported the key as changed on every `makemigrations` — a full table rebuild on SQLite, forever.
- The query builder threw `InvalidValueError`, since `SAFE_IDENTIFIER_PATTERN` forbids a `"`.

## Approach

`col_name` is normalized **once at its parse site** rather than at each point of use, so the four consumers — `index_map`, `pk_set`, `fk_map`, `fields_dict` — all key on the same form. Previously two of those four de-quoted and two did not, which worked only because their counterparts were quoted too.

The `fk_map` **key** moves in the same change on purpose: it is looked up with `col_name`, and normalizing one side alone would break FK detection outright for every mixed-case column. The issue calls this out; a targeted mutation test pins it.

## Scope beyond the issue's task list — flagging deliberately

The issue asked for `referenced_primary_keys` → `pk_field` plus a decision on `fk_cols`/`col_name`. This PR also **replaces the blanket `replace(s, "\"" => "")` with `_unquote_ident`**, a real inverse of `quote_ident`, at six call sites — four of which the issue never mentions.

Rationale: `quote_ident` **doubles** an interior `"`, so a legal PostgreSQL column `Say"Hi` comes back as `"Say""Hi"` and the blanket strip rewrote it to `SayHi` — a name no column has. `makemigrations` then proposed `ADD COLUMN "SayHi"` alongside a `DROP` of the real one, on every run, silently. Leaving four sites fail-open while three were fixed would have been worse than either extreme. This also repaired an **unlisted** pairing found in review: `_pg_composite_indexes` yields raw names looked up in `model.fields`, where `Say"Hi` vs `SayHi` disagreed and the entire composite index was dropped at `@debug` level.

This half is cleanly separable if you would rather it landed on its own.

## What is deliberately NOT done

- **`index_columns` is not run through the inverse.** It is the one identifier aggregate the query leaves raw (`array_agg(a.attname)`), so undoing a doubling that was never applied would corrupt a column whose real name is itself quoted — reintroducing the #325 churn for that class. Found independently and confirmed in review with a measured failure; pinned by a test that fails under exactly that mutation and nothing else.
- **Spaced identifiers.** `split(col, " ")` tears `"Parent Id"` in half before de-quoting can help, emitting a phantom column `Parent`. `fk_map`'s key survives it (that aggregate splits on `", "`), so the two sides genuinely disagree for that name class. Pre-existing, PostgreSQL-only, and a live PG/SQLite divergence. Documented in place; **no issue filed yet**.
- **The composite-parent-PK fan-out.** The `foreign_keys` CTE joins the parent's whole PK index, so the positional `zip` is wrong for a composite parent key. Out of scope; **no issue filed yet**.
- **`Dialect.create_table` column-name escaping.** A surviving `Say"Hi` now reaches DDL that emits `"Say"Hi"`, closing the identifier early — the column-name twin of the `db_table` escaping fixed in #388/#59, and #394's family. Not introduced here, but this PR makes such a name reachable. The code comment says so rather than claiming a fail-closed guarantee that does not exist (`_validate_identifier` guards the query path only).
- **No `UPGRADING.md` entry.** This forces no consuming-app source edit; the sibling introspection fixes (#360/#386, #399) took none either.
- **SQLite unchanged.** `PRAGMA table_info` / `PRAGMA foreign_key_list` return identifiers raw — verified, no hazard.

## Also corrected

The #325 `db_index` fixture had spelled `index_columns` as `quote_ident`-ed since it was written — a shape production never emits. It was the only thing making the wrong treatment of that aggregate look necessary, so the mixed-case `db_index` path had been pinned against the wrong input.

## Verification

| | |
|---|---|
| Unit suite | **7834 / 7834** |
| Integration `db_2` (PostgreSQL) | **2187 / 2187** |
| Integration `db_sl` (SQLite) | **2119 pass + 1 pre-existing PG-only `@test_skip`** |
| Mutation check vs unfixed reader | **10 failures across 5 of 7 new testsets** |
| Independent review | 2 rounds, 13 findings, all addressed |

New coverage: 25 assertions in `test/unit/test_introspection_guards.jl` (hermetic, via the existing `_introspection_row` harness) plus the first mixed-case fixture in `test/integration/test_importers_introspection.jl` — every prior fixture there is lowercase, which is exactly why this survived.

Two testsets pass both before and after by design and are labelled as controls, not gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
