### PR TITLE
fix(#396, #394): reverse-accessor determinism and the identifier partition

### DIFF
--- a/.github/skills/pormg-changed-code-review/SKILL.md
+++ b/.github/skills/pormg-changed-code-review/SKILL.md
@@ -155,7 +155,8 @@ The bullets below are permanent baselines, not an exhaustive list — Review Met
 - Flag migration changes that weaken destructive safeguards or skip `dry_run()` discipline
 - Flag docs or examples that regress to generic domains instead of Formula 1 scenarios
 - When a new subsystem file appears in `src/` that is not yet listed in `general.instructions.md`, flag it as an architecture-checkpoint gap
-- Flag any reintroduction of silent identifier stripping (e.g. `replace(id, r"[^a-zA-Z0-9_]" => "")` before quoting) — the correct contract is fail-closed: `_validate_identifier` throws on invalid input and never silently rewrites identifiers
+- Flag any reintroduction of silent identifier stripping (e.g. `replace(id, r"[^a-zA-Z0-9_]" => "")` before quoting) — neither half of the contract rewrites an identifier: an alias is fail-closed (`quote_identifier` → `_validate_identifier` throws), a physical table or column is escape-only (`safe_table_identifier` / `safe_column_identifier`)
+- Flag a new physical table/column identifier routed through `quote_identifier`, or a new alias routed through `safe_*_identifier` — that partition is the #394 fix, and mixing the two either refuses a legal `db_table`/`db_column` or drops the guard on a caller-supplied alias
 - Flag raw ANSI escape codes (`\e[`) embedded in `throw(...)` / `error(...)` messages — these must route through a taxonomy subtype's constructor or `_emsg` (both in `src/exceptions.jl` / `src/Kernel.jl`) so color degrades off-TTY; `@info`/`@warn`/`@error` logging may keep ANSI
 - Flag any new `throw(ArgumentError(...))` in `src/` — since #239 every PormG domain error is a `PormGError` subtype. `ArgumentError` is correct **only** for Julia-level API misuse (a missing kwarg, a missing path), not for a field, model, config, query, or migration problem
 

--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -78,15 +78,21 @@ For the unit-vs-integration split, see *Boundary With Public API Work* above and
 
 ### Identifier sanitization contract
 
-`sanitization.jl` uses a **fail-closed** model — never a silent-stripping one:
+`sanitization.jl` has **two rules, one per axis** (#394). Neither ever strips characters silently.
 
-- `_validate_identifier(id)` validates against `SAFE_IDENTIFIER_PATTERN` (`^[\p{L}_][\p{L}\p{M}\p{N}_]*$`) and throws `ArgumentError` on invalid input; it never silently removes characters.
-- `quote_identifier(id, conn)` calls `_validate_identifier` then wraps in double-quotes, preserving exact case and Unicode letters.
-- `sanitize_identifier(id, valid_ids)` checks the raw identifier against the whitelist (no pre-stripping), then delegates quoting to `quote_identifier`.
-- `safe_table_identifier(name, conn)` delegates directly to `quote_identifier` — no silent sanitize-and-warn fallback.
-- All SELECT aliases (`custom_as` and `_as`) are quoted via `quote_identifier` in `_query_select`, preserving mixed case and Unicode characters verbatim.
+| Kind of name | Function | Behavior |
+| --- | --- | --- |
+| Physical **table** — `model_table_name`, `relation.through_table`, a catalog row | `safe_table_identifier(name, conn)` | escape-only: `"` → `""`, then wrap |
+| Physical **column** — `field_db_column`, `model_column`, a `row_join` `key_a`/`key_b`\* | `safe_column_identifier(name, conn)` | the same |
 
-When adding any new identifier-quoting path, go through `quote_identifier` — never strip-and-quote.
+\* `key_b` is the one dual-natured slot: on a CTE join it holds the CTE's **projection alias**, not a physical column. `_with` validates that name fail-closed at declaration (`join_field.second`), which is why the render site can stay escape-only.
+| **Alias** / query-time name — `instruc.alias`, a `cjoin_on` alias, a `.with(...)` CTE name, a SELECT `_as`/`custom_as` | `quote_identifier(name, conn)` | fail-closed: `_validate_identifier` then wrap |
+
+- `_validate_identifier(id)` validates against `SAFE_IDENTIFIER_PATTERN` (`^[\p{L}_][\p{L}\p{M}\p{N}_]*$`) and throws **`InvalidValueError`** on invalid input; it never silently removes characters.
+- `_escape_identifier(name)` is the shared escape. `_quote_ident_raw` is the same thing without a `conn`, for a name interpolated into a SQL string literal that PostgreSQL re-parses as an identifier (`setval`'s `regclass`, `to_regclass`) — see `_table_ident_literal` in `execution.jl`.
+- `SAFE_JSON_KEY_PATTERN` is a **separate constant** with the same body, used only by `_validate_json_key_segments` (`build_joins.jl`). A JSON path segment is interpolated *unquoted* into a path literal, so the charset check is its entire guard; keeping the constants apart is what stops a relaxation of the identifier rules from widening it.
+
+**Do not unify these — the split is the fix.** A physical name is pinned by the model author via `db_table`/`db_column` (deliberately unvalidated, #59/#50) or read from the database catalog; validating it meant PormG refused to query a table its own DDL had just created. An alias is chosen at query-build time and names nothing that exists, so it stays strict. When adding a new identifier-quoting path, pick by which of the three it is — never strip-and-quote.
 
 ### Error message construction
 
@@ -282,6 +288,7 @@ julia -t auto --project=. test/integration/test_cte.jl
 - Do not fix SQL shape bugs only by changing test expectations without validating semantics
 - Do not bypass public API regressions when the failure is visible to package users
 - Do not mix unrelated SQL formatting changes into a targeted regression fix
-- Do not revert to silent identifier stripping (e.g. `replace(id, r"[^a-zA-Z0-9_]" => "")`) — the contract is fail-closed: validate via `_validate_identifier`, then quote; never silently rewrite an identifier
+- Do not revert to silent identifier stripping (e.g. `replace(id, r"[^a-zA-Z0-9_]" => "")`) — an alias is fail-closed (`quote_identifier`), a physical table or column is escape-only (`safe_table_identifier` / `safe_column_identifier`), and neither ever silently rewrites an identifier
+- Do not route a physical table or column through `quote_identifier`, or an alias through `safe_*_identifier` — the partition above **is** the contract, and collapsing it re-opens #394
 - Do not embed raw ANSI (`\e[...`) in a `throw`/`error`/`@info`/`@warn`/`@error`/`print` message — throw a taxonomy subtype (its constructor applies `_emsg`) or wrap with `_emsg` / `_emsg(io, …)` inside `show` methods, so color degrades off-TTY
 - Do not reintroduce a funnel that only maps a message to a type (the deleted `_argerr`); name the subtype at the call site

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,79 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## A CTE joined in a correlated `UPDATE … FROM` is refused instead of emitting broken SQL (#394)
+
+- **Version**: Unreleased
+- **PormG ref**: #394; `src/querybuilder/sanitization.jl`, `src/querybuilder/execution.jl`,
+  `src/Dialect.jl`, `src/Generator.jl`, `src/migrations/planner.jl`,
+  `docs/src/schema_conventions.md`
+- **Severity**: **behavior change (very narrow)** — one shape that was already failing now fails
+  earlier and with a message. Everything else in #394 is a widening and forces nothing. Part of the
+  `0.5.x` pre-publish wave.
+
+### What changed
+
+The bulk of #394 **removes** a restriction, and nothing about that needs migrating. A physical table
+or column identifier is now escaped rather than validated, so a `db_table` or `db_column` that
+PormG's DDL renders is one its queries can address and its migration plan can carry. A name that
+used to raise `InvalidValueError` on the first `SELECT` — a space, a leading digit, an embedded
+quote, anything the importers pin from a live catalog — simply works. Two adjacent gaps closed with
+it: `alter_field` on PostgreSQL emitted such a column name unescaped, and the generated
+`pending_migrations.jl` wrote each table as a bare Julia binding, so `makemigrations` could produce a
+plan file that `migrate` then failed to **parse**.
+
+The one thing that can now fail differently is a **CTE joined in a correlated `UPDATE … FROM`**.
+
+Two loops on that path wrapped their work in a `try`/`catch` that logged an `@error` and continued,
+so a failure dropped a table from the `FROM` list or an `ON` condition from the statement — and then
+issued it anyway. Those catches are gone: a join PormG cannot render is refused, not silently
+omitted.
+
+In practice only one shape reached them, and it was **already broken for an unrelated reason**:
+`update()` emits no `WITH` prefix (`build_cte_clause` is reached only from the read paths), so a
+`row_join` naming a CTE rendered `FROM "my_cte" AS "Tb_1"` against a relation the statement never
+declared. PostgreSQL and SQLite both rejected it. So this is not a case of apps having silently
+corrupted data — it is a backend error becoming a clear PormG one, raised before any SQL is built:
+
+> `A CTE cannot be joined in a correlated UPDATE ... FROM: the statement emits no WITH clause, so the
+> CTE it references is never declared. Scope the mutation with a filter or a subquery instead.`
+
+Both CTE shapes are covered — the CROSS-joined one (`.with(name, query)` with no `join_field`,
+correlated by an `F()` filter) and the keyed one. The sibling guard for an anchor-less `cjoin_on` has
+raised on this path since #45 and is unchanged.
+
+### How to find the calls to migrate
+
+There is nothing to grep for statically: the affected call is an `.update(...)` on a query that also
+declares a CTE **and** references it from a filter. It is easier to find in your logs — the old
+behavior always announced itself before failing:
+
+```bash
+# Anything matching either of these was a query that could not be built and was issued regardless.
+rg -n 'Error building FROM tables for join|Error building join condition for join' /path/to/logs
+```
+
+Expect no hits. If your app had one, it was raising a database error at that call already.
+
+### Migrate your app
+
+Scope the mutation with a filter or a subquery instead of correlating it against a CTE:
+
+```julia
+# ✗ BEFORE — the CTE is referenced from the filter, so it reaches the UPDATE's FROM list; the
+#            statement emits no WITH clause, so the database rejected the whole UPDATE.
+q = M.Result.objects
+q.with("fast_laps" => M.Lap_time.objects.filter("milliseconds__lt" => 90000).values("raceid"))
+q.filter("raceid" => F("fast_laps__raceid"))
+q.update("points" => 25)
+
+# ✓ AFTER — resolve the set first, then mutate against it.
+fast = M.Lap_time.objects.filter("milliseconds__lt" => 90000).values("raceid").list()
+M.Result.objects.
+    filter("raceid__@in" => unique(fast.raceid)).
+    update("points" => 25)
+```
+
 ## Reverse accessors — every relation in a multi-relation group is disambiguated (#396)
 
 - **Version**: Unreleased

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,103 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## Reverse accessors — every relation in a multi-relation group is disambiguated (#396)
+
+- **Version**: Unreleased
+- **PormG ref**: #396; `src/Models.jl`, `docs/src/many_to_many.md`,
+  `docs/src/read/values_and_joins.md`, `docs/src/fields.md`, `src/models/fields.jl`
+- **Severity**: **breaking (narrow, source-visible)** — a model declaring **two or more** relations to
+  the same target model, with `related_name` omitted on any of them, now installs different reverse
+  accessors on that target. A lookup path or a `related_objects[…]` read using the old key raises
+  `UnknownFieldError`. A model with one relation per target is untouched, and an explicit
+  `related_name` always wins. Part of the `0.5.x` pre-publish wave.
+
+### What changed
+
+The accessor a relation installs on its target was derived *while* `set_models` walked
+`pairs(model.fields)`, accumulating a per-target counter as it went. So in a group of N relations to
+one target, the field **visited first** kept the bare model name and the rest were suffixed
+`<model>_<field>`. `Model_Type.fields` is an unordered `Dict`, so which one that was is hash order —
+and adding an unrelated field to the model rehashed it.
+
+`ManyToManyField` never entered the counter at all. A model declaring both a self-`ForeignKey` and a
+self-`ManyToManyField` therefore derived the bare model name twice: a foreign-key-first walk raised
+`ModelDefinitionError`, and a many-to-many-first walk **silently replaced** the registered
+`ManyToManyRelation` with a `ReverseRelation` — the many-to-many reverse end disappeared with no
+error, and the manager filtering on it answered the opposite question.
+
+Three rules replace it:
+
+> **The count is taken before anything is registered, and it counts every relation — `ForeignKey`,
+> `OneToOneField` and `ManyToManyField` — that the model declares to that target.**
+>
+> **In a group of two or more, no relation keeps the bare model name.** Every member is
+> `<model>_<field>`, lowercased. A model with a single relation to a target is unchanged.
+>
+> **The accessor is checked against the target's field names and its existing accessors, on every
+> registration path.** A clash raises `ModelDefinitionError` naming both colliding ends and the name
+> they collide on — never a silent overwrite.
+
+The messages changed with it. They used to name the model twice and neither field ("The related_name
+X in the model Y is already defined"), which on a self-relation read as the model colliding with
+itself; they now name `Model.field` for both ends, say whether PormG or you chose the name, and end
+with the remedy.
+
+Also, and unlikely to force anything: PormG no longer writes a derived name back onto
+`field.related_name`. That write-back used to be the idempotency latch; the derivation is a pure
+function now, so it is dead weight. `related_name === nothing` again means *"the declaration named
+none"*, which is what stops `Models.Model_to_str` baking a PormG-invented accessor into a regenerated
+model file. If you read `field.related_name` expecting the derived string, read
+`target.related_objects` instead — that is where the accessor actually lives.
+
+### How to find the calls to migrate
+
+Only a model with **two or more relations to one target and at least one omitted `related_name`** is
+affected. Find the groups first, then the reads.
+
+```bash
+# 1. Candidate groups — the same target named twice inside one model. Read the hits: a group whose
+#    members all pin related_name explicitly is NOT affected.
+rg -n --glob '**/*models*.jl' 'ForeignKey\(|OneToOneField\(|ManyToManyField\('
+
+# 2. Then the reads of the OLD bare key, for each affected child model. Substitute its lowercase
+#    logical name (django_prefix stripped, as get_model_name derives it).
+rg -n --glob '**/*.jl' '"tb_cidadao__|related_objects\["tb_cidadao"\]'
+```
+
+You do not have to derive the new names by hand: `set_models` logs every one it derives at `@info` —
+`<model>.<field> declares no related_name and is one of N relations to <target>; its reverse accessor
+is <name>` — so loading the models once prints the complete list.
+
+### Migrate your app
+
+```julia
+# Tb_cidadao declares TWO foreign keys to Tb_localidade and names neither:
+#   co_localidade          = Models.ForeignKey(Tb_localidade, …)
+#   co_localidade_endereco = Models.ForeignKey(Tb_localidade, …)
+
+# ✗ BEFORE — one of the two answered to the bare model name, and which one was hash order.
+rows = eM.Tb_localidade.objects.
+    filter("tb_cidadao__no_cidadao" => "Senna").
+    values("no_localidade").
+    list()
+
+# ✓ AFTER — each is named after the field that carries it.
+rows = eM.Tb_localidade.objects.
+    filter("tb_cidadao_co_localidade__no_cidadao" => "Senna").
+    values("no_localidade").
+    list()
+```
+
+Or pin the names in the model and never think about it again — an explicit `related_name` is
+unaffected by any of this:
+
+```julia
+co_localidade          = Models.ForeignKey(Tb_localidade, …, related_name = "cidadaos"),
+co_localidade_endereco = Models.ForeignKey(Tb_localidade, …, related_name = "cidadaos_endereco"),
+```
+
+
 ## `AutoField` is retired, and introspection reports the real key type (#408, #409)
 
 - **Version**: Unreleased

--- a/docs/src/fields.md
+++ b/docs/src/fields.md
@@ -873,7 +873,8 @@ Order_line = Models.Model(
     unit_price = Models.DecimalField(max_digits=8, decimal_places=2)
 )
 
-# Multiple ForeignKeys to same model (requires related_name)
+# Multiple ForeignKeys to the same model — related_name is optional, but recommended.
+# Without it PormG derives one per field: `team_radio_sender` and `team_radio_recipient`.
 Team_radio = Models.Model(
     id = Models.IDField(),
     sender = Models.ForeignKey("Team_member", on_delete="CASCADE", related_name="sent_messages"),

--- a/docs/src/many_to_many.md
+++ b/docs/src/many_to_many.md
@@ -39,7 +39,17 @@ It tells PormG to create a link in **both** directions:
 1. **Forward Access**: From a fetched driver row, use the field name `sponsors` to get their sponsors (`driver.sponsors.all()`).
 2. **Reverse Access**: From a fetched sponsor row, use the `related_name` to get the drivers they sponsor (`sponsor.drivers.all()`).
 
-This is essential for multi-hop joins and reverse-lookups. Without it, PormG defaults to a less readable name (like `m2m_driver_endorsement_scratch_set`).
+This is essential for multi-hop joins and reverse-lookups. Without it, PormG derives one for you:
+
+- the **lowercase name of the declaring model** when it is that model's only relation to the target —
+  `m2m_driver_endorsement_scratch`;
+- **`<model>_<field>`** when the model declares two or more relations to the same target. Add a
+  `title_sponsor` foreign key alongside `sponsors`, both pointing at `M2m_sponsor_scratch`, and the
+  two reverse accessors become `m2m_driver_endorsement_scratch_title_sponsor` and
+  `m2m_driver_endorsement_scratch_sponsors`. Every member of such a group is suffixed, and PormG logs
+  each derived name at `@info` when it registers the models.
+
+There is no `_set` suffix; PormG is not Django here.
 
 ---
 
@@ -111,28 +121,40 @@ WHERE "Tb_2"."driverref" = $1
     the *same* model, so the default reverse name — the bare model name — reads like a foreign key
     rather than the other end of the link.
 
-    **It must differ from every field name on that model**, the relation's own field included.
-    `teammates = ManyToManyField("…", related_name="teammates")` is the tempting spelling for a link
-    you think of as symmetric, and it would leave the reverse end permanently shadowed by the
-    forward one. PormG rejects it with a `ModelDefinitionError` rather than letting the two collapse
-    into one accessor.
+    **A reverse accessor must differ from every field name on the model it lands on**, the relation's
+    own field included. `teammates = ManyToManyField("…", related_name="teammates")` is the tempting
+    spelling for a link you think of as symmetric, and it would leave the reverse end permanently
+    shadowed by the forward one. PormG rejects it with a `ModelDefinitionError` rather than letting
+    the two collapse into one accessor.
 
-!!! warning "A self-`ForeignKey` and a self-`ManyToManyField` on one model need an explicit `related_name`"
-    Both derive the *same* default reverse accessor — the model's own name — and the two
-    registration paths disagree about what to do when they collide: depending on the order the
-    model's fields happen to be iterated, you either get a `ModelDefinitionError` naming the model
-    twice and neither field, or the many-to-many reverse accessor is silently discarded
-    ([#396](https://github.com/PingoLee/PormG.jl/issues/396)).
+    That rule is not special to self-relations: the join builder resolves a *field* before a reverse
+    accessor at every hop, so any accessor equal to a field name on the target would register cleanly
+    and then be unreachable. PormG checks it on every relation, foreign key and many-to-many alike.
 
-    Give at least one of them an explicit `related_name` and the ambiguity disappears:
+!!! note "A self-`ForeignKey` and a self-`ManyToManyField` on one model get distinct accessors"
+    Both would derive the same bare model name, so PormG counts them as one group of two relations to
+    that target and suffixes each with its field name
+    ([#396](https://github.com/PingoLee/PormG.jl/issues/396)):
 
     ```julia
     M2m_teammate_scratch = Models.Model("m2m_teammate_scratch",
       id = Models.IDField(),
       driverref = Models.CharField(unique=true),
-      mentor = Models.ForeignKey("M2m_teammate_scratch", null=true, related_name="mentees"),
-      teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of")
+      mentor = Models.ForeignKey("M2m_teammate_scratch", null=true),
+      teammates = Models.ManyToManyField("M2m_teammate_scratch")
     )
+
+    # Reverse accessors on M2m_teammate_scratch:
+    #   m2m_teammate_scratch_mentor      → the foreign key, in reverse
+    #   m2m_teammate_scratch_teammates   → the many-to-many, in reverse
+    ```
+
+    Naming them yourself still reads better, and it is what a Django-imported model carries anyway
+    (Django's `fields.E304` requires it):
+
+    ```julia
+    mentor    = Models.ForeignKey("M2m_teammate_scratch", null=true, related_name="mentees"),
+    teammates = Models.ManyToManyField("M2m_teammate_scratch", related_name="teammate_of")
     ```
 
 !!! note "An explicit `through=` needs its ends named"

--- a/docs/src/read/values_and_joins.md
+++ b/docs/src/read/values_and_joins.md
@@ -138,9 +138,25 @@ df = query |> DataFrame
 
 ### Naming Reverse Relations
 
-By default, the name used to traverse backwards is the **lowercase name of the source model** (e.g., `result` for `Result`). 
+By default, the name used to traverse backwards is the **lowercase name of the source model** (e.g., `result` for `Result`) — as long as that model declares exactly **one** relation to the target.
 
-If you have multiple `ForeignKey`s pointing to the same target model, or if you simply prefer a more descriptive name, define a `related_name` on the `ForeignKey`:
+When a model declares **two or more** relations to the same target, one name cannot address them all, so PormG suffixes **every** member of that group with its own field name: `<model>_<field>`. No member keeps the bare model name, and PormG logs each derived name at `@info` when the models are registered.
+
+```julia
+# Incident points at Driver twice, so neither reverse accessor is the bare `incident`:
+Incident = Models.Model("incident",
+  id = Models.IDField(),
+  causing_driver_id  = Models.ForeignKey(Driver, pk_field="id"),
+  affected_driver_id = Models.ForeignKey(Driver, pk_field="id"),
+)
+
+query = M.Driver.objects
+query.values("surname", "incident_causing_driver_id__lap")
+```
+
+The count spans relation kinds: a `ManyToManyField` to the same target counts toward the group too, which is why a model carrying both a self-`ForeignKey` and a self-`ManyToManyField` gets two distinct accessors instead of one collision.
+
+Whenever you would rather read a name than derive it — and always when the group is larger than a pair — define a `related_name` on the field. An explicit name always wins:
 
 ```julia
 # Model definition snippet

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -116,6 +116,10 @@ validation. That is deliberate: the option exists to name a table PormG's own co
 produce. It is also **purely opt-in** — a model that does not set `db_table` derives its table name
 exactly as it always has, so no existing schema changes and nothing needs re-migrating.
 
+Every row of the table above holds for **any** spelling, including one PormG's own conventions would
+never produce — see [Identifier quoting and case](#Identifier-quoting-and-case) for the rule and why
+a physical name is escaped rather than validated.
+
 !!! note "Changing `db_table` on a migrated model is a table rename"
     The migration planner matches the live schema against your models by **physical** table name, so
     editing `db_table` on a model that is already migrated presents as "one table disappeared, another
@@ -503,30 +507,52 @@ Driver = Models.Model("driver",
 
 ## Identifier quoting and case
 
-**Column** identifiers are always emitted with **double quotes** (`"…"`) on **both** PostgreSQL and
-SQLite (no backticks, no backend-specific quoting), and they **preserve the declared field-name case**
-(#57) — so a field declared `driverId` becomes `"driverId"`.
+**Table and column** identifiers are emitted with **double quotes** (`"…"`) on **both** PostgreSQL
+and SQLite — no backticks, no backend-specific quoting — in DDL and in queries alike, and they
+**preserve the declared case** (#57), so a field declared `driverId` becomes `"driverId"`. An
+embedded `"` is escaped by doubling it, the standard SQL escape on both backends.
 
-The **table** identifier is *not* uniformly quoted. Some statements quote it (the
-SELECT/INSERT/UPDATE builder, `REFERENCES`) and others write it bare (`CREATE TABLE`, `CREATE INDEX`,
-the DELETE/cascade paths, PostgreSQL's `ADD CONSTRAINT`) — the split does not follow a
-DDL-versus-query line, so do not rely on one. What makes the mixture safe is that a model name is
-lowercase (see [Table names](#Table-names)): an unquoted lowercase identifier folds to itself on
-PostgreSQL, so the bare and quoted spellings address the same table either way.
+That uniformity is what makes a `db_table` or `db_column` outside PormG's own naming conventions
+usable. PormG used to apply two different rules to one name: the DDL renderer escaped and accepted
+anything, while the query builder validated against a strict pattern and rejected spaces, leading
+digits and punctuation — so a `db_table` outside that pattern migrated cleanly and then raised
+`InvalidValueError` on the first `SELECT`. PormG could create a table it was unable to address
+([#394]). The rule now depends on what kind of name it is:
 
-That is precisely what a mixed-case name used to break — one declaration migrating `driver_profile`
-and querying `"Driver_Profile"` — and why such a name is now rejected at declaration.
+| Kind of name | Rule | Why |
+| :--- | :--- | :--- |
+| A physical **table** — `db_table`, or the model name | escaped (`"` → `""`), then quoted | You pinned it, or PormG read it out of the database catalog. Either way it is a name that already exists. |
+| A physical **column** — `db_column`, or the field name | the same | `db_column` carries an arbitrary spelling for the same reason `db_table` does (#50). |
+| A query **alias** — a join alias, a `.with("name" => …)` CTE name, a `cjoin_on` alias, a `values("label" => …)` label | validated against `^[\p{L}_][\p{L}\p{M}\p{N}_]*$`, then quoted | Chosen while the query is built, frequently a literal you typed, and it names nothing that already exists — so there is nothing to be faithful to. |
+| A **JSON path** segment — the `a`/`b` in `payload__a__b` | validated against its own pattern | Interpolated *unquoted* into a path literal, so it has no quoting to fall back on. |
 
-!!! warning "Lowercase is necessary, not sufficient"
-    Because the table is written bare in `CREATE TABLE`, a model name must also be a valid unquoted
-    identifier. That part is **not** checked: `Models.Model("order", …)` (a reserved word) and
-    `Models.Model("driver profile", …)` (a space) are accepted and then emit invalid DDL. Stick to
-    lowercase `snake_case`.
+The invariant that follows is the one worth remembering:
 
-**Column** identifiers, by contrast, are quoted everywhere, so a column may be named anything the
-database accepts — including a SQL reserved word or a Julia keyword. Declare the field under a legal
-Julia identifier and name the column with `db_column`; that is the sanctioned way to address a column
-whose name is not a legal PormG field name (#317):
+> **Any name PormG's DDL will create, PormG's queries will address.**
+
+That guarantee is about the **physical** names — `db_table` and `db_column`. A model's own *field*
+names still have to be plain identifiers wherever PormG uses one as a query-time label: `bulk_update`
+builds a derived table whose column list is made of field names, and those go through the
+fail-closed rule like any other alias.
+
+Escaping is what makes that safe rather than merely permissive: a doubled `"` cannot terminate a
+quoted identifier, and a database interprets nothing else inside one. It is also, now, the *only*
+defence on a physical name — the query builder used to reject an odd spelling as a second layer and
+no longer does. That is the intended trade: `db_table` and `db_column` exist to carry names PormG did
+not choose, and a guard that refuses them is a guard against the feature.
+
+!!! note "The model name is still constrained — but by convention, not by the renderer"
+    A positional model name is validated **lowercase** (#300), so `Models.Model("Driver_Profile", …)`
+    is rejected and `db_table` is where a mixed-case physical name belongs. What is *not* checked is
+    everything else: `Models.Model("order", …)` (a reserved word) and `Models.Model("driver profile",
+    …)` (a space) are accepted, and since quoting is uniform they now migrate and query correctly
+    rather than emitting broken DDL. Stick to lowercase `snake_case` anyway — a model name is a
+    Julia-side identifier your own code reads, and `db_table` is the seam for anything else.
+
+Because column identifiers are quoted everywhere, a column may be named anything the database
+accepts — including a SQL reserved word or a Julia keyword. Declare the field under a legal Julia
+identifier and name the column with `db_column`; that is the sanctioned way to address a column whose
+name is not a legal PormG field name (#317):
 
 ```julia
 end_ = Models.DateTimeField(db_column = "end")   # field `end_` → column "end"
@@ -559,7 +585,9 @@ CREATE TABLE IF NOT EXISTS result (
 | `db_column` | authoritative: maps a field to a differently-named column (default: column == field name) |
 | Default `on_delete` | `NO ACTION` |
 | Timestamps | opt-in `auto_now` / `auto_now_add`; no implicit `created`/`modified` |
-| Quoting | columns always double-quoted on both backends (case-preserved); the table is quoted in some statements and bare in others — consistent only because the name is lowercase |
+| Quoting | every table and column identifier is double-quoted and `"`-escaped on both backends, in DDL and in queries alike (#394); aliases and CTE names are additionally validated |
 
 The migration *format* that records these schemas (file layout, checksum, tracking table) is a
 separate frozen contract — see [Migration Format Stability](migrations/stability.md).
+
+[#394]: https://github.com/PingoLee/PormG.jl/issues/394

--- a/src/Dialect.jl
+++ b/src/Dialect.jl
@@ -510,7 +510,7 @@ column actually held. `makemigrations` writes a reviewable plan before anything 
 where that substitution belongs.
 """
 function _postgres_bytea_cast_expression(field_name::Union{String, Symbol}, old_field::Union{Nothing, PormGField})
-  column_ref = "\"$(field_name)\""
+  column_ref = "\"$(_quote_table_ddl(field_name))\""
 
   if old_field isa Union{sCharField, sTextField, sImageField, sSlugField, sURLField}
     return "convert_to($(column_ref), 'UTF8')"
@@ -520,7 +520,7 @@ function _postgres_bytea_cast_expression(field_name::Union{String, Symbol}, old_
 end
 
 function _postgres_interval_cast_expression(field_name::Union{String, Symbol}, old_field::Union{Nothing, PormGField})
-  column_ref = "\"$(field_name)\""
+  column_ref = "\"$(_quote_table_ddl(field_name))\""
 
   if old_field isa Union{sFloatField, sDecimalField, sIntegerField, sBigIntegerField, sPositiveSmallIntegerField, sPositiveIntegerField}
     return "make_interval(secs => $(column_ref)::double precision)"
@@ -657,7 +657,7 @@ _requires_non_negative_check(field::PormGField)::Bool = field isa Union{sPositiv
 
 # The non-negative CHECK clause emitted both at CREATE TABLE and when a column's
 # type transitions into a positive integer field on ALTER.
-_non_negative_check_clause(col_name)::String = "CHECK (\"$(col_name)\" >= 0)"
+_non_negative_check_clause(col_name)::String = "CHECK (\"$(_quote_table_ddl(col_name))\" >= 0)"
 
 # BinaryField's `max_length` is a BYTE bound, and neither `bytea` nor `BLOB` accepts a length
 # parameter — so unlike CharField's `varchar(n)` it can only be expressed as a CHECK (#296).
@@ -670,9 +670,9 @@ _requires_byte_length_check(field::PormGField)::Bool =
 # `length()` returns BYTES for a BLOB (characters only for TEXT — which is why the SQLite table
 # rebuild casts legacy TEXT values to BLOB, see `alter_field`).
 _byte_length_check_clause(col_name, max_length::Int, ::PormGPostgres)::String =
-  "CHECK (octet_length(\"$(col_name)\") <= $(max_length))"
+  "CHECK (octet_length(\"$(_quote_table_ddl(col_name))\") <= $(max_length))"
 _byte_length_check_clause(col_name, max_length::Int, ::PormGSQLite)::String =
-  "CHECK (length(\"$(col_name)\") <= $(max_length))"
+  "CHECK (length(\"$(_quote_table_ddl(col_name))\") <= $(max_length))"
 
 # ── Physical-column identity (#325) ──────────────────────────────────────────────────────────────
 #
@@ -779,7 +779,7 @@ function field_to_column(col_name::String, field::PormGField, conn::PormGPostgre
   _requires_byte_length_check(field) && push!(constraints, _byte_length_check_clause(col_name, field.max_length, conn))
 
   # Combine everything into a single string: "col_name base_type constraints..."
-  return join(["\"$(col_name)\"", base_type, join(constraints, " ")], " ")
+  return join(["\"$(_quote_table_ddl(col_name))\"", base_type, join(constraints, " ")], " ")
 end
 
 function field_to_column(col_name::String, field::PormGField, conn::PormGSQLite; temporary_default::Any=nothing)::String
@@ -822,17 +822,23 @@ function field_to_column(col_name::String, field::PormGField, conn::PormGSQLite;
   _requires_byte_length_check(field) && push!(constraints, _byte_length_check_clause(col_name, field.max_length, conn))
 
   # Combine everything into a single string: "col_name base_type constraints..."
-  return join(["\"$(col_name)\"", base_type, join(constraints, " ")], " ")
+  return join(["\"$(_quote_table_ddl(col_name))\"", base_type, join(constraints, " ")], " ")
 end
 
 # ---
 # Functions to create migration queries
 #
 
-# Escape a table identifier for interpolation between double quotes (#59). `db_table` carries an
-# arbitrary user-supplied spelling and is deliberately not shape-validated (mirroring `db_column`), so
-# an embedded `"` would otherwise close the quoted identifier early. Doubling is the standard SQL
-# escape on both backends. A no-op for every name that does not contain a quote.
+# Escape an identifier for interpolation between double quotes (#59). `db_table` carries an arbitrary
+# user-supplied spelling and is deliberately not shape-validated (mirroring `db_column`), so an
+# embedded `"` would otherwise close the quoted identifier early. Doubling is the standard SQL escape
+# on both backends. A no-op for every name that does not contain a quote.
+#
+# #394 widened its USE, not its rule: it is now applied to COLUMN and constraint identifiers here too,
+# not only table names, because `db_column` is unvalidated for exactly the same reason `db_table` is
+# and the query side escapes both (`safe_table_identifier` / `safe_column_identifier` in
+# `querybuilder/sanitization.jl`). Escaping one axis and not the other just moves the DDL-vs-query
+# split rather than closing it. The name is kept for continuity — it is the DDL identifier escape.
 #
 # NOTE for anyone adding a DDL renderer: this is applied at the interpolation site, so a NEW statement
 # that writes `"$table_name"` without it is unescaped again. The functions that emit several
@@ -908,7 +914,7 @@ function create_table(conn::PormGSQLite, model::PormGModel)
       # the table being CREATED goes through `_quote_table_ddl` while the table being REFERENCED did
       # not, so a `db_table` holding a `"` closed the identifier early: a parent pinned to `Ev"il`
       # rendered `REFERENCES "Ev"il"("id")`, which is malformed SQL and a DDL-injection seam.
-      push!(columns, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(_quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"(\"$target_pk\") ON DELETE $on_delete_str")
+      push!(columns, "FOREIGN KEY (\"$(_quote_table_ddl(local_col))\") REFERENCES \"$(_quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"(\"$(_quote_table_ddl(target_pk))\") ON DELETE $on_delete_str")
     end
   end
 
@@ -998,7 +1004,14 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   field_name = field_db_column(new_field, string(field_name))
   # Escape ONCE here (#59) rather than at each of the ~20 `"$table_name"` interpolations below, so a
   # statement added later cannot forget it. A no-op for every name without an embedded quote.
-  table_name = _quote_table_ddl(string(table_name))
+  #
+  # `raw_table_name` exists because the escaped spelling must NOT reach the four `get_constraints_*`
+  # CATALOG lookups below (#394). Those query the catalog BY VALUE, so a table named `Ev"il` would be
+  # looked up as `Ev""il`, match nothing and return `nothing` — and the `DROP CONSTRAINT` that
+  # depends on the answer would simply never be emitted. Dropping a `unique` or a `primary_key` would
+  # silently do nothing, and `makemigrations` would re-propose the same no-op on every run.
+  raw_table_name = string(table_name)
+  table_name = _quote_table_ddl(raw_table_name)
   sql_statements = []
 
   # Non-negative CHECK constraint diffing on a type transition (Django-style).
@@ -1010,8 +1023,8 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   new_needs_check = _requires_non_negative_check(new_field)
   old_needs_check = old_field !== nothing && _requires_non_negative_check(old_field)
   if :type in colect_not_equal && old_needs_check && !new_needs_check
-    constraint = get_constraints_check(conn, string(table_name), string(field_name))
-    constraint !== nothing && push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(constraint)";""")
+    constraint = get_constraints_check(conn, raw_table_name, string(field_name))
+    constraint !== nothing && push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(_quote_table_ddl(constraint))";""")
   end
 
   # Byte-length CHECK diffing for BinaryField (#296), the `octet_length` analogue of the block
@@ -1023,19 +1036,19 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   old_byte_bound = (old_field !== nothing && _requires_byte_length_check(old_field)) ? old_field.max_length : nothing
   byte_bound_changed = any(attr -> attr in colect_not_equal, [:type, :max_length]) && new_byte_bound != old_byte_bound
   if byte_bound_changed && old_byte_bound !== nothing
-    constraint = get_constraints_byte_length_check(conn, string(table_name), string(field_name))
-    constraint !== nothing && push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(constraint)";""")
+    constraint = get_constraints_byte_length_check(conn, raw_table_name, string(field_name))
+    constraint !== nothing && push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(_quote_table_ddl(constraint))";""")
   end
 
   # Alter column type
   if any(attr -> attr in colect_not_equal, [:type, :max_length, :max_digits, :decimal_places])
     if new_field isa sCharField
       max_length = hasproperty(new_field, :max_length) ? new_field.max_length : 255
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE VARCHAR($max_length);""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE VARCHAR($max_length);""")
     elseif new_field isa sDecimalField
       max_digits = hasproperty(new_field, :max_digits) ? new_field.max_digits : 10
       decimal_places = hasproperty(new_field, :decimal_places) ? new_field.decimal_places : 2
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE DECIMAL($max_digits, $decimal_places);""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE DECIMAL($max_digits, $decimal_places);""")
       if old_field !== nothing
         old_max_digits = hasproperty(old_field, :max_digits) ? old_field.max_digits : nothing
         old_decimal_places = hasproperty(old_field, :decimal_places) ? old_field.decimal_places : nothing
@@ -1044,20 +1057,20 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
         end
       end
     elseif new_field isa sTimeField
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE TIME USING "$field_name"::time without time zone;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE TIME USING "$(_quote_table_ddl(field_name))"::time without time zone;""")
     elseif new_field isa sDurationField
       cast_expression = _postgres_interval_cast_expression(field_name, old_field)
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE INTERVAL USING $cast_expression;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE INTERVAL USING $cast_expression;""")
     elseif new_field isa sBinaryField
       # Only emit the TYPE change when the type actually moved. `max_length` alone lands in this
       # block too (it is in the trigger list above), and a redundant `TYPE bytea USING …` would
       # rewrite the whole table for nothing.
       if :type in colect_not_equal
         cast_expression = _postgres_bytea_cast_expression(field_name, old_field)
-        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE bytea USING $cast_expression;""")
+        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE bytea USING $cast_expression;""")
       end
     else
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" TYPE $(_get_column_type(new_field, conn));""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" TYPE $(_get_column_type(new_field, conn));""")
     end
   end
 
@@ -1075,20 +1088,20 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   # Set NOT NULL if specified
   if :null in colect_not_equal
     if !new_field.null
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" SET NOT NULL;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" SET NOT NULL;""")
     else
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" DROP NOT NULL;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" DROP NOT NULL;""")
     end
   end
 
   # Set unique if specified
   if :unique in colect_not_equal
     if new_field.unique
-      push!(sql_statements, """ALTER TABLE "$table_name" ADD UNIQUE ("$field_name");""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ADD UNIQUE ("$(_quote_table_ddl(field_name))");""")
     else
-      contrains = get_constraints_unique(conn, string(table_name), string(field_name))
+      contrains = get_constraints_unique(conn, raw_table_name, string(field_name))
       if contrains !== nothing
-        push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(contrains)";""")
+        push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(_quote_table_ddl(contrains))";""")
       end
     end
   end
@@ -1097,20 +1110,20 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   if :default in colect_not_equal
     if new_field.default !== nothing
       default_value = _format_default_sql_value(new_field.default, conn)
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" SET DEFAULT $default_value;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" SET DEFAULT $default_value;""")
     else
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" DROP DEFAULT;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" DROP DEFAULT;""")
     end
   end
 
   # Set primary key if specified
   if :primary_key in colect_not_equal
     if new_field.primary_key
-      push!(sql_statements, """ALTER TABLE "$table_name" ADD PRIMARY KEY ("$field_name");""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ADD PRIMARY KEY ("$(_quote_table_ddl(field_name))");""")
     else
-      contrains = get_constraints_pk(conn, string(table_name), string(field_name))
+      contrains = get_constraints_pk(conn, raw_table_name, string(field_name))
       if contrains !== nothing
-        push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(contrains)";""")
+        push!(sql_statements, """ALTER TABLE "$table_name" DROP CONSTRAINT "$(_quote_table_ddl(contrains))";""")
       end
     end
   end
@@ -1119,12 +1132,12 @@ function alter_field(conn::PormGPostgres, table_name::Union{Symbol,String}, fiel
   if :generated in colect_not_equal || :generated_always in colect_not_equal
     if new_field.generated
       if new_field.generated_always
-        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" ADD GENERATED ALWAYS AS IDENTITY;""")
+        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" ADD GENERATED ALWAYS AS IDENTITY;""")
       else
-        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" ADD GENERATED BY DEFAULT AS IDENTITY;""")
+        push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" ADD GENERATED BY DEFAULT AS IDENTITY;""")
       end
     else
-      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$field_name" DROP IDENTITY;""")
+      push!(sql_statements, """ALTER TABLE "$table_name" ALTER COLUMN "$(_quote_table_ddl(field_name))" DROP IDENTITY;""")
     end
   end
 
@@ -1150,12 +1163,12 @@ function add_field(conn::PormGSQLite, table_name::Union{String,Symbol}, field_na
 end
 
 function drop_field(conn::PormGPostgres, table_name::Union{String,Symbol}, field_name::Union{String,Symbol})
-  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$(_quote_table_ddl(field_name))";"""
 end
 
 function drop_field(conn::PormGSQLite, table_name::Union{String,Symbol}, field_name::Union{String,Symbol})
   # Modern SQLite supports DROP COLUMN. If not, we'd need recreation.
-  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP COLUMN "$(_quote_table_ddl(field_name))";"""
 end
 
 function alter_field(conn::PormGPostgres, model::PormGModel, field_name::Union{Symbol,String}, new_field::PormGField, old_field::Union{Nothing,PormGField}, colect_not_equal::Vector{Symbol})
@@ -1183,7 +1196,7 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
       target_pk = fk_target_column(f)
       # Referenced (parent) TABLE honors db_table (#59) via fk_target_table, escaped as in
       # `create_table` above (#388).
-      push!(columns_defs, "FOREIGN KEY (\"$local_col\") REFERENCES \"$(_quote_table_ddl(fk_target_table(f; column = f_name, model = model)))\"(\"$target_pk\") ON DELETE $on_delete_str")
+      push!(columns_defs, "FOREIGN KEY (\"$(_quote_table_ddl(local_col))\") REFERENCES \"$(_quote_table_ddl(fk_target_table(f; column = f_name, model = model)))\"(\"$(_quote_table_ddl(target_pk))\") ON DELETE $on_delete_str")
     end
   end
 
@@ -1220,8 +1233,8 @@ function alter_field(conn::PormGSQLite, model::PormGModel, field_name::Union{Sym
   select_exprs = String[]
   for (k, f) in model.fields
     col = field_db_column(f, string(k))
-    push!(insert_cols, "\"$col\"")
-    push!(select_exprs, f isa sBinaryField ? "CAST(\"$col\" AS BLOB)" : "\"$col\"")
+    push!(insert_cols, "\"$(_quote_table_ddl(col))\"")
+    push!(select_exprs, f isa sBinaryField ? "CAST(\"$(_quote_table_ddl(col))\" AS BLOB)" : "\"$(_quote_table_ddl(col))\"")
   end
   cols_joined = join(insert_cols, ", ")
   select_joined = join(select_exprs, ", ")
@@ -1236,11 +1249,11 @@ ALTER TABLE "$new_table_name" RENAME TO "$table_name";"""
 end
 
 function rename_field(conn::Union{PormGSQLite,PormGPostgres}, table_name::Union{String,Symbol}, old_field_name::Union{String,Symbol}, new_field_name::Union{String,Symbol})
-  return """ALTER TABLE "$(_quote_table_ddl(table_name))" RENAME COLUMN "$old_field_name" TO "$new_field_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" RENAME COLUMN "$(_quote_table_ddl(old_field_name))" TO "$(_quote_table_ddl(new_field_name))";"""
 end
 
 function drop_foreign_key(conn::PormGPostgres, table_name::Symbol, constraint_name::String)
-  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP CONSTRAINT "$constraint_name";"""
+  return """ALTER TABLE "$(_quote_table_ddl(table_name))" DROP CONSTRAINT "$(_quote_table_ddl(constraint_name))";"""
 end
 
 # NOTE (#83): there is intentionally no `drop_foreign_key(::PormGSQLite, …)`. SQLite has no
@@ -1248,11 +1261,14 @@ end
 # (see `alter_field(::PormGSQLite, model, …)` + `_sqlite_rebuild_preserving_indexes`), which omits
 # the FK clause. The planner's `_drop_fk_constraint_in_alteration` is therefore a no-op on SQLite.
 
+# The CREATE side escapes the index name (`planner.jl` wraps it in `_quote_table_ddl` before handing
+# it to `create_index`), so the DROP side must too (#394) — otherwise an index whose declared name
+# carries a `"` is created under one spelling and dropped under another, and `IF EXISTS` hides it.
 function drop_index(conn::PormGPostgres, index_name::String)
-  return """DROP INDEX IF EXISTS "$index_name";"""
+  return """DROP INDEX IF EXISTS "$(_quote_table_ddl(index_name))";"""
 end
 function drop_index(conn::PormGSQLite, index_name::String)
-  return """DROP INDEX IF EXISTS "$index_name";"""
+  return """DROP INDEX IF EXISTS "$(_quote_table_ddl(index_name))";"""
 end
 
 function rename_table(conn::Union{PormGSQLite,PormGPostgres}, old_table_name::String, new_table_name::String)

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -129,6 +129,34 @@ function dict_to_jl_str(d::OrderedDict{String, String})::String
   return "OrderedDict{String, String}(" * join(entries, ",\n ") * ")"
 end
 
+# A migration-plan key rendered as a Julia binding (#394). Plain when the physical table name is
+# already a legal identifier — which keeps every existing plan file byte-identical — and Julia's
+# `var"..."` raw-identifier form otherwise. Both escapes are needed inside `var"..."`: it follows
+# normal string rules, so a backslash or a quote in the table name would terminate it early.
+# Can this name be written as a BARE Julia binding? `Base.isidentifier` is necessary but not
+# sufficient: it accepts reserved words (`end`, `function`) that are a `ParseError` in assignment
+# position, and all-underscore names that parse and then discard. Parsing the assignment itself is
+# the only exact test, and it runs once per table during `makemigrations` (#394).
+function _plan_binds_bare(name::AbstractString)::Bool
+  Base.isidentifier(name) || return false
+  all(==('_'), name) && return false
+  ex = Meta.parse(string(name, " = 1"); raise = false)
+  return ex isa Expr && ex.head === :(=) && ex.args[1] === Symbol(name)
+end
+
+function _plan_binding(key)::String
+  name = String(key)
+  _plan_binds_bare(name) && return name
+  # An ALL-UNDERSCORE name (`_`, `___`) is the one case `var"..."` cannot rescue: Julia treats it as
+  # a DISCARD at any spelling, so the entry would parse and then hold nothing, and `get_all_dicts`
+  # would silently skip that table's migration. Prefixing is safe because the binding NAME is never
+  # read back — `get_all_dicts` collects every `OrderedDict` in the module regardless of what it is
+  # called, and the `# table:` comment written above each entry is what carries the real name for a
+  # human reading the plan.
+  stem = all(==('_'), name) ? "pormg_plan_" * name : name
+  return "var\"" * replace(replace(stem, "\\" => "\\\\"), "\"" => "\\\"") * "\""
+end
+
 function generate_migration_plan(file::String, migration_plan::OrderedDict{Symbol,OrderedDict{String,String}}, path::String) :: Nothing
   open(joinpath(path, file), "w") do f
       module_name = replace(basename(file), ".jl" => "")
@@ -152,7 +180,13 @@ function generate_migration_plan(file::String, migration_plan::OrderedDict{Symbo
         if value isa OrderedDict{String, String}
           # Convert this dictionary into parseable Julia code
           jl_code_str = dict_to_jl_str(value)
-          write(f, "$key = $jl_code_str\n\n")
+          # #394: `key` is a PHYSICAL table name and is written here as a Julia BINDING, so a name
+          # that is not a legal Julia identifier — a space, a leading digit, a quote: exactly the
+          # spellings `db_table` exists to carry — produced a plan file that could not be PARSED.
+          # `makemigrations` succeeded and `migrate` then died on its own output. `var"..."` is
+          # Julia's raw-identifier syntax and accepts any string; the reader walks `names(mod)`
+          # and `getfield` (`Migrations.get_all_dicts`), so it never sees which spelling was used.
+          write(f, "$(_plan_binding(key)) = $jl_code_str\n\n")
         else
           # If it's not a Dict, just write it plainly (or handle differently)
           write(f, "# (Not a Dict) $value\n\n")

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -207,9 +207,10 @@ end
   model_resolved::PormGModel  # the CHILD model itself
 end
 
-# Single constructor for the three `set_models` branches (>=2 FKs to one target, 1 FK with an
-# implicit accessor, 1 FK with an explicit `related_name`). They differ only in the Dict KEY they
-# store under; the relation itself is identical, and before #343 that identity was three copies of
+# Single constructor for every reverse FK/O2O relation. It served three `set_models` branches that
+# differed only in the Dict KEY they wrote under (>=2 relations to one target, one with an implicit
+# accessor, one with an explicit `related_name`); #396 collapsed those into `_register_reverse_accessor!`,
+# which derives the key first and writes once. Before #343 the relation itself was three copies of
 # one tuple literal. `Symbol(field.pk_field)` reproduces the old `field.pk_field |> Symbol` exactly,
 # including the `:nothing` degenerate for a pk_field `resolve_fk_target!` could not default.
 _reverse_relation(child::PormGModel, model_name::Symbol, binding::Symbol,
@@ -221,6 +222,165 @@ _reverse_relation(child::PormGModel, model_name::Symbol, binding::Symbol,
     binding        = binding,
     model_resolved = child,
   )
+
+# ── Reverse-accessor derivation and registration (#396) ────────────────────────────────────────
+# The accessor a relation installs on its TARGET when the declaration names none:
+#
+#   one relation to that target   →  the child's logical name        (`driver`)
+#   two or more                   →  `<child logical name>_<field>`  (`driver_mentor`, `driver_teammates`)
+#
+# The count is over EVERY relation this model declares to that target — ForeignKey, OneToOneField
+# AND ManyToManyField — and it is taken BEFORE anything is registered. Both halves are the fix.
+#
+# Before #396 the count accumulated as `pairs(model.fields)` was walked, so in a group of N the
+# field VISITED FIRST kept the bare name and the rest were suffixed. `fields` is an unordered
+# `Dict`, so which one that was is hash order — and adding an unrelated field to the model rehashed
+# it. Many-to-many never entered the count at all, so a self-`ForeignKey` and a self-`ManyToManyField`
+# on one model both derived the bare model name: whichever registered first won, and the other
+# either threw or (m2m-first) silently replaced a `ManyToManyRelation` with a `ReverseRelation`.
+#
+# SYMMETRIC on purpose: in a group of N, NO relation keeps the bare name. "The first one is special"
+# is only definable against an order, and there is none.
+#
+# `<model>_<field>` rather than a stem with a trailing `_id` trimmed. Field names are unique within a
+# model by construction, so this spelling is injective across the group for free; any trimming rule
+# can map two distinct fields (`mentor` + `mentor_id`) onto one string and turn a working schema into
+# a hard error. It is also the spelling PormG already used for the suffixed members of a multi-FK
+# group, which keeps the rename in a pure-foreign-key group down to the ONE member that used to win
+# the race. A group containing a `ManyToManyField` is different: many-to-many never entered the old
+# count at all, so its accessor was unconditionally the bare model name and every m2m in a group of
+# two or more is renamed. The `UPGRADING.md` entry states both halves.
+_derived_reverse_accessor(model_name::Symbol, field_name::AbstractString, count::Int)::String =
+  count > 1 ? lowercase(string(model_name, "_", field_name)) : String(model_name)
+
+# Lenient twin of `_resolve_model_reference` for the pre-scan's `strict = false` path (#396): a
+# many-to-many whose target cannot be resolved is skipped rather than aborting the scan. Narrowed to
+# `ModelDefinitionError` — the not-found case — so a genuine bug still surfaces, matching the
+# `UndefVarError` narrowing in `_resolve_target_model`.
+_try_resolve_model_reference(_module::Module, to)::Union{PormGModel, Nothing} =
+  try
+    _resolve_model_reference(_module, to)
+  catch e
+    e isa ModelDefinitionError ? nothing : rethrow()
+  end
+
+# One pass over `model.fields` that resolves every relation target and counts them per target, so the
+# registration pass can derive an accessor that does not depend on the order it walks in (#396).
+# Returns `(targets, counts)`: `targets` maps a FIELD NAME to its resolved target model; `counts` is
+# keyed on the target model's IDENTITY (`IdDict`), not its logical name — two models may share a
+# logical name, and they are two different reverse-accessor namespaces.
+#
+# `strict = true` (the `set_models` path) keeps the immediate throw of `resolve_fk_target!` on an
+# unresolvable target — see the comment at that call site for why that one is never collected into
+# the #303 contradiction list. It now fires before this model registers ANY of its relations rather
+# than part-way through, which is a state a successful run also produces; what changed is that it no
+# longer depends on hash order. `strict = false` (the `add_field!` path) resolves leniently and
+# simply does not count what it cannot resolve: adding one field must not abort on an unrelated
+# broken foreign key.
+function _collect_relation_targets(model::PormGModel, _module::Module; strict::Bool = true)
+  targets = Dict{String, PormGModel}()
+  counts  = IdDict{PormGModel, Int}()
+  for (field_name, field) in pairs(model.fields)
+    target = if field isa sForeignKey || field isa sOneToOneField
+      resolve_fk_target!(field, field_name, model.name, _module; strict = strict)
+    elseif is_many_to_many_field(field)
+      strict ? _resolve_model_reference(_module, field.to) :
+               _try_resolve_model_reference(_module, field.to)
+    else
+      nothing
+    end
+    target isa PormGModel || continue
+    targets[field_name] = target
+    counts[target] = get(counts, target, 0) + 1
+  end
+  return targets, counts
+end
+
+# Pick the accessor for one relation and announce it when PormG chose it out of a group (#396). An
+# explicit `related_name` always wins and is never logged — the user already knows that name. The
+# `@info` fires only for a DERIVED name in a group of two or more: a lone relation still gets the
+# bare model name, which is documented and stable, and logging that would be noise on every load.
+# Routed through `_emsg` so the highlight degrades off-TTY (log files, CI, structured sinks).
+function _reverse_accessor_for(model::PormGModel, model_name::Symbol, field_name::AbstractString,
+                               field, target::PormGModel, counts::IdDict{PormGModel, Int})::String
+  field.related_name === nothing || return String(field.related_name)
+  n = get(counts, target, 1)
+  accessor = _derived_reverse_accessor(model_name, field_name, n)
+  n > 1 && @info _emsg(
+    "$(model.name).$(field_name) declares no related_name and is one of $(n) relations to " *
+    "$(target.name); its reverse accessor is \e[31m$(accessor)\e[0m. " *
+    "Set \e[1mrelated_name\e[0m on the field to choose the name yourself.")
+  return accessor
+end
+
+# Who currently owns an accessor on a target model — for the collision message (#396). The three
+# pre-#396 messages named the model TWICE and neither field, which on a self-relation read as "the
+# model collided with itself"; naming the other end is the whole difference.
+#
+# A `ManyToManyRelation` reached through `related_objects` is always the REVERSED one, and
+# `_reverse_many_to_many_relation` swaps the sides — so the DECLARING model is its `related_model`
+# and the field that declared it is its `inverse_accessor`. The forward arm is defensive only.
+_accessor_holder(rel::ReverseRelation)::String = "$(rel.model_resolved.name).$(rel.fk_field)"
+_accessor_holder(rel::ManyToManyRelation)::String =
+  rel.reverse ? "$(rel.related_model).$(rel.inverse_accessor)" : "$(rel.owner_model).$(rel.field_name)"
+_accessor_holder(::Any)::String = "another relation"
+
+# Shared preamble for both collision messages (#396): which relation is asking, for which name, on
+# which model, and whether PormG or the user chose the name. A user who never wrote `related_name`
+# must not be sent looking for an option that is not in their own source.
+function _accessor_context(model::PormGModel, field_name::AbstractString,
+                           target::PormGModel, accessor::AbstractString, derived::Bool)::String
+  origin = derived ? " (derived — $(model.name).$(field_name) declares no related_name)" : ""
+  self   = _same_model_reference(target, model) ?
+    " The relation is self-referential, so both of its ends land on this one model." : ""
+  return "$(model.name).$(field_name) wants the reverse accessor \e[4m\e[31m$(accessor)\e[0m on " *
+         "\e[32m$(target.name)\e[0m$(origin).$(self)"
+end
+
+function _reverse_accessor_taken(model::PormGModel, field_name::AbstractString, target::PormGModel,
+                                 accessor::AbstractString, derived::Bool,
+                                 held_by::AbstractString)::ModelDefinitionError
+  return ModelDefinitionError(
+    _accessor_context(model, field_name, target, accessor, derived) *
+    " \e[32m$(held_by)\e[0m already holds that name there, and one accessor cannot address two " *
+    "relations — one of them would be unreachable. Give $(model.name).$(field_name) an explicit " *
+    "\e[1mrelated_name\e[0m.")
+end
+
+function _reverse_accessor_shadows_field(model::PormGModel, field_name::AbstractString,
+                                         target::PormGModel, accessor::AbstractString,
+                                         derived::Bool)::ModelDefinitionError
+  return ModelDefinitionError(
+    _accessor_context(model, field_name, target, accessor, derived) *
+    " But \e[32m$(target.name).$(accessor)\e[0m is a FIELD of that model, and the join builder " *
+    "resolves a field before a reverse accessor at every hop — so the relation would register " *
+    "cleanly and then be permanently unreachable. Give $(model.name).$(field_name) an explicit " *
+    "\e[1mrelated_name\e[0m.")
+end
+
+# The single guarded write for a reverse FK/O2O accessor (#396). All three pre-#396 branches did
+# exactly this and differed only in the key they wrote under; only two of them checked first, and the
+# unchecked one (a lone FK with no `related_name`) is how a many-to-many reverse relation got
+# silently overwritten by a `ReverseRelation`.
+#
+# The field check is `haskey(target.fields, accessor)` VERBATIM — deliberately NOT routed through
+# `_resolve_fk_short_form`. A `related_name` matching the SHORT FORM of a field (`circuit` against a
+# declared `circuit_id`) is legal and load-bearing (#345), and widening this check to the short form
+# would outlaw it. See `test/unit/test_complex_queries.jl` → "Short-form FK resolution defers to an
+# existing reverse accessor (#345)".
+function _register_reverse_accessor!(target::PormGModel, accessor::AbstractString,
+                                     model::PormGModel, model_name::Symbol, model_binding::Symbol,
+                                     field_name::AbstractString, field)::Nothing
+  derived = field.related_name === nothing
+  haskey(target.fields, accessor) &&
+    throw(_reverse_accessor_shadows_field(model, field_name, target, accessor, derived))
+  haskey(target.related_objects, accessor) &&
+    throw(_reverse_accessor_taken(model, field_name, target, accessor, derived,
+                                  _accessor_holder(target.related_objects[accessor])))
+  target.related_objects[accessor] =
+    _reverse_relation(model, model_name, model_binding, field_name, field)
+  return nothing
+end
 
 # A Model_Type is resolved schema state — its `fields`, `_module`, and `related_objects` are built once
 # by `set_models` and treated as an immutable, SHARED reference everywhere (the query builder copies query
@@ -501,7 +661,6 @@ function _render_contradictions(cs::Vector{ModelContradiction}, mod::Module)::St
                        "the schema contradicts itself. $(c.fix)" for c in ordered)
 end
 
-# TODO add related_name (like django validation) to check if the field is a ForeignKey and the related_name model is defined when models has more than one foreign key to the same model
 #
 # NOTE: keep this comment ABOVE the docstring. A comment between a docstring and the definition it
 # documents silently detaches it — `@doc` binds to the next expression, and the comment is not one,
@@ -530,8 +689,12 @@ Registration does four things:
    `MissingConfigurationError` from that implicit load if `path` holds no `connection.yml`.
 3. **Resolves relationships.** Each `ForeignKey`/`OneToOneField` target is resolved (a target given
    as a model-name `String` is replaced by the model object), `pk_field` defaults are applied, and
-   the reverse accessor is installed on the target. With two foreign keys to the same model, an
-   omitted `related_name` is auto-derived and logged. `ManyToManyField`s get their join-table
+   the reverse accessor is installed on the target. An omitted `related_name` is derived and logged:
+   the lowercase model name when it is the model's only relation to that target, `<model>_<field>`
+   for every member of a group of two or more — counting `ForeignKey`, `OneToOneField` and
+   `ManyToManyField` together (#396). A derived accessor is never written back onto the field. In
+   every case the accessor is checked against the target's field names and its already-registered
+   accessors; either clash raises `ModelDefinitionError`. `ManyToManyField`s get their join-table
    metadata built and cached.
 4. **Rejects contradictions.** `on_delete = SET_NULL` on a `null = false` field, or `SET_DEFAULT`
    with no `default`, raises `ModelDefinitionError` here — at declaration, rather than later as a
@@ -625,62 +788,38 @@ function set_models(_module::Module, path::String)::Nothing
   # field, then raised once below. See `_render_contradictions` for the ordering contract.
   contradictions = ModelContradiction[]
 
-  # Validate like django related_name, if the model has more than one foreign key to the same model the related_name must be defined
+  # #396: reverse-accessor wiring. Every relation a model declares to a given target is counted
+  # BEFORE any of them registers, so a derived accessor cannot depend on the order
+  # `pairs(model.fields)` happens to walk in. `_derived_reverse_accessor` carries the rule and why
+  # it is symmetric; `_register_reverse_accessor!` carries the guards.
   for model in models
-    dict_tables_c = Dict{String, Int}()
-    dict_tables_fiels = Dict{String, Vector{String}}()
     model.connect_key = connect_key
-    # Hoisted: both describe the CHILD (`model`) and are identical for every FK it declares. The
-    # logical name was recomputed per field before #343, inconsistently — sometimes inline, sometimes
-    # into a local of the same name.
+    # Hoisted: both describe the CHILD (`model`) and are identical for every relation it declares.
+    # The logical name was recomputed per field before #343, inconsistently — sometimes inline,
+    # sometimes into a local of the same name.
     model_name = get_model_name(model, settings)::Symbol
     model_binding = bindings[model]
-    # @pormg_debug model.name == "dash_tab_cvat"
-    # println(model.name)
+    # #65: single-sourced FK/O2O resolution + pk_field defaulting, shared with the migration prelude
+    # via `resolve_fk_target!`, with `strict=true` throwing on an unresolvable target. Since #396 it
+    # runs inside the pre-scan rather than mid-walk, so it fires before this model wires ANY of its
+    # relations instead of after however many happened to precede it in hash order. That is a state
+    # a successful run also produces, so nothing observable changed.
+    #
+    # The throw stays IMMEDIATE and out of #303's collector, permanently. Structurally, the resolved
+    # target drives every line of wiring below, so collecting would mean strict=false plus a
+    # `continue` that silently skips it — and it would change how the runtime path uses a helper
+    # SHARED with the migration prelude (`planner.jl` calls it strict=false). Semantically, a missing
+    # referent is not a contradiction between two settings on one field: the model graph cannot be
+    # built at all, so walking on produces cascading noise, not more signal.
+    targets, counts = _collect_relation_targets(model, _module)
+
     for (field_name, field) in pairs(model.fields)
       if field isa sForeignKey || field isa sOneToOneField
-        # #65: single-sourced FK/O2O resolution + pk_field defaulting, shared with the migration
-        # prelude via `resolve_fk_target!`. strict=true throws on an unresolvable target, so the
-        # returned value is always a resolved model here; it drives the reverse-relation wiring below.
-        #
-        # This one stays IMMEDIATE and out of #303's collector, permanently. Structurally, the
-        # return drives every line of wiring below it, so collecting would mean strict=false plus a
-        # `continue` that silently skips it — and it would change how the runtime path uses a helper
-        # SHARED with the migration prelude (`planner.jl` calls it strict=false). Semantically, a
-        # missing referent is not a contradiction between two settings on one field: the model graph
-        # cannot be built at all, so walking on produces cascading noise, not more signal.
-        field_to::PormGModel = resolve_fk_target!(field, field_name, model.name, _module; strict=true)
-        if haskey(dict_tables_c, field_to.name)
-          dict_tables_c[field_to.name] += 1
-          push!(dict_tables_fiels[field_to.name], field_name)
-        else
-          dict_tables_c[field_to.name] = 1
-          dict_tables_fiels[field_to.name] = [field_name]
-        end
-        if dict_tables_c[field_to.name] > 1
-          @pormg_debug false
-          if field.related_name === nothing
-            field.related_name = string(model_name, "_", field_name) |> lowercase
-            @info("The field $field_name in the model $(model.name) is a ForeignKey and the related_name is not defined, so the related_name was set to $(field.related_name)")
-          end
-          if haskey(field_to.related_objects, field.related_name)
-            throw(ModelDefinitionError("The related_name $(field.related_name) in the model $(model.name) is already defined"))
-          else
-            field_to.related_objects[field.related_name] = _reverse_relation(model, model_name, model_binding, field_name, field)
-          end
-        elseif dict_tables_c[field_to.name] == 1
-          @pormg_debug false
-          if field.related_name === nothing
-            field_to.related_objects[model_name |> string] = _reverse_relation(model, model_name, model_binding, field_name, field)
-          else
-            if haskey(field_to.related_objects, field.related_name)
-              throw(ModelDefinitionError("The related_name $(field.related_name) in the model $(model.name) is already defined"))
-            else
-              field_to.related_objects[field.related_name] = _reverse_relation(model, model_name, model_binding, field_name, field)
-            end
-          end
-        end
-        
+        field_to::PormGModel = targets[field_name]
+        accessor = _reverse_accessor_for(model, model_name, field_name, field, field_to, counts)
+        _register_reverse_accessor!(field_to, accessor, model, model_name, model_binding,
+                                    field_name, field)
+
         # check on_delete — a schema that contradicts itself is rejected at registration (#287).
         # These were `@error` logs until #287: they named the problem and then let the broken model
         # through, so the contradiction resurfaced later as a mangled UPDATE or a database-level
@@ -694,7 +833,13 @@ function set_models(_module::Module, path::String)::Nothing
         _collect_field_contradictions!(contradictions, model, field_name, field)
 
       elseif is_many_to_many_field(field)
-        _register_many_to_many_relation!(_module, settings, model, field_name, field)
+        # #396: the accessor is computed HERE, from the group, and threaded in — never re-derived
+        # inside the registrar. `_m2m_query` filters on `relation.inverse_accessor`, so the slot the
+        # manager reads and the key that lands in `related_objects` have to be the same string.
+        related_model::PormGModel = targets[field_name]
+        accessor = _reverse_accessor_for(model, model_name, field_name, field, related_model, counts)
+        _register_many_to_many_relation!(_module, settings, model, field_name, field;
+                                         related_model = related_model, reverse_accessor = accessor)
       end
     end
   end
@@ -1872,7 +2017,21 @@ function add_field!(model::PormGModel, field_name::Union{String, Symbol}, field:
       ))
     end
     model.fields[field_name] = field
-    _register_many_to_many_relation!(model._module, config[model.connect_key], model, field_name, field)
+    # #396: `add_field!` cannot see the group `set_models` pre-scans, so it counts what the model
+    # holds RIGHT NOW — the new field included, since it was inserted on the line above. Resolved
+    # leniently: an unrelated unresolvable foreign key must not abort adding a field.
+    #
+    # Accessors already installed for the siblings are NOT re-derived. A runtime addition cannot
+    # rename a name that is already in use somewhere, so a group may sit mixed — one member on the
+    # bare model name, the new one suffixed — until the next `set_models`, which rebuilds
+    # `related_objects` from scratch and normalizes the whole group.
+    settings = config[model.connect_key]
+    related_model = _resolve_model_reference(model._module, field.to)
+    _, counts = _collect_relation_targets(model, model._module; strict = false)
+    accessor = _reverse_accessor_for(model, get_model_name(model, settings)::Symbol, field_name,
+                                     field, related_model, counts)
+    _register_many_to_many_relation!(model._module, settings, model, field_name, field;
+                                     related_model = related_model, reverse_accessor = accessor)
     return nothing
   end
 
@@ -2994,6 +3153,7 @@ function _relation_from_many_to_many(
   settings::PormGSettings;
   _module::Union{Module, Nothing}=nothing,
   model_map::Union{Nothing, Dict{Symbol, Dict{Symbol, Union{Bool, PormGModel}}}}=nothing,
+  reverse_accessor::Union{Nothing, String}=nothing,
 )
   owner_pk_sym = get_model_pk_field(owner_model)
   related_pk_sym = get_model_pk_field(related_model)
@@ -3112,7 +3272,16 @@ function _relation_from_many_to_many(
       "Set source_field and target_field to distinct names." :
       "The fields $(owner_field) and $(related_field) both map to that column — give one of them a distinct db_column.")))
 
-  inverse_accessor = field.related_name === nothing ? get_model_name(owner_model, settings, false) : field.related_name
+  # #396: `set_models` computes this from the per-target relation group and threads it in, so the
+  # slot the many-to-many manager filters on (`_m2m_query` reads `relation.inverse_accessor`) is the
+  # SAME string that lands in the target's `related_objects`. Re-deriving it here instead would let
+  # the two disagree, and every `.all()` on the manager would traverse the join table backwards and
+  # silently answer the opposite question.
+  #
+  # The fallback is the lone-relation derivation — the only shape the callers that cannot see a group
+  # (`add_field!`, `synthesize_many_to_many_through_models`) can produce.
+  inverse_accessor = reverse_accessor !== nothing ? reverse_accessor :
+    (field.related_name === nothing ? get_model_name(owner_model, settings, false) : field.related_name)
   return ManyToManyRelation(
     field_name=field_name,
     through_table=through_table_name,
@@ -3172,8 +3341,14 @@ function _cache_many_to_many_relation!(model::PormGModel, accessor::String, rela
   return relation
 end
 
-function _register_many_to_many_relation!(_module::Module, settings::PormGSettings, model::PormGModel, field_name::String, field::sManyToManyField)::Nothing
-  related_model = _resolve_model_reference(_module, field.to)
+function _register_many_to_many_relation!(_module::Module, settings::PormGSettings, model::PormGModel,
+    field_name::String, field::sManyToManyField;
+    related_model::Union{Nothing, PormGModel}=nothing,
+    reverse_accessor::Union{Nothing, String}=nothing)::Nothing
+  # #396: `set_models` has already resolved the target and derived the accessor from the model's
+  # per-target relation group, and passes both in. The fallbacks serve `add_field!` and any caller
+  # that holds one field rather than a whole model.
+  related_model === nothing && (related_model = _resolve_model_reference(_module, field.to))
   relation = _relation_from_many_to_many(
     model,
     _find_model_binding_name(_module, model),
@@ -3183,35 +3358,36 @@ function _register_many_to_many_relation!(_module::Module, settings::PormGSettin
     _find_model_binding_name(_module, related_model),
     settings,
     _module=_module,
+    reverse_accessor=reverse_accessor,
   )
   _cache_many_to_many_relation!(model, field_name, relation)
 
-  reverse_accessor = relation.inverse_accessor
-  # #364: on a SELF-relation both accessors land on the SAME model but in two DIFFERENT dicts — the
-  # forward one in `model.cache["many_to_many"]` (written just above), the reverse one in
-  # `related_objects` — so the `haskey` check below is blind to a collision between them. And the
-  # readers resolve the cache FIRST (`has_many_to_many_accessor` / `get_many_to_many_relation`), so
-  # an equal name leaves the reverse relation permanently shadowed by the forward one. That is not a
-  # dead accessor: the manager's `_m2m_query` filters on `inverse_accessor`, so every `.all()` would
-  # traverse the join table backwards and silently answer the opposite question.
+  accessor = relation.inverse_accessor
+  derived = field.related_name === nothing
+  # #364, widened by #396: the accessor is checked against the TARGET's field names ALWAYS, not only
+  # on a self-relation. `_build_row_join` resolves a field before a reverse accessor at every hop, so
+  # a name that is also a field on the model the accessor lands on registers cleanly and is then
+  # permanently unreachable — surfacing later as a raw internal error rather than a definition one.
   #
-  # Checked against `model.fields` rather than just `field_name` because the join builder resolves a
-  # field before a reverse accessor (`_build_row_join`), so ANY field name shadows it the same way.
-  # A non-self relation cannot reach this — its two accessors live on different models, which is why
-  # the `haskey` guard alone was sufficient before a self-relation could be built at all.
-  if _same_model_reference(related_model, model) && haskey(model.fields, reverse_accessor)
-    # The default accessor is the bare model name, so this fires on models that never wrote a
-    # `related_name` at all — say where the name came from rather than pointing at an option the
-    # user cannot find in their own source.
-    origin = field.related_name === nothing ? " (derived from the model name, because related_name is unset)" : ""
-    throw(ModelDefinitionError(
-      "ManyToManyField $(model.name).$(field_name) is self-referential, so its reverse accessor " *
-      "\e[31m$(reverse_accessor)\e[0m$(origin) collides with a field of the same name on that model " *
-      "and would be silently unreachable. Give the reverse end a distinct related_name."))
-  end
-  haskey(related_model.related_objects, reverse_accessor) && throw(ModelDefinitionError("The related_name $(reverse_accessor) in the model $(model.name) is already defined"))
-  related_model.related_objects[reverse_accessor] = _reverse_many_to_many_relation(relation, reverse_accessor)
-  field.related_name === nothing && (field.related_name = reverse_accessor)
+  # The self case is this same rule with `related_model === model`, and it was the only one #364
+  # could reach: a self-relation puts both accessors on ONE model but in two DIFFERENT dicts — the
+  # forward one in `model.cache["many_to_many"]` (written just above), the reverse one in
+  # `related_objects` — and the readers consult the cache FIRST
+  # (`has_many_to_many_accessor` / `get_many_to_many_relation`). That is not a merely dead accessor:
+  # the manager's `_m2m_query` filters on `inverse_accessor`, so every `.all()` would traverse the
+  # join table backwards and silently answer the opposite question.
+  haskey(related_model.fields, accessor) &&
+    throw(_reverse_accessor_shadows_field(model, field_name, related_model, accessor, derived))
+  haskey(related_model.related_objects, accessor) &&
+    throw(_reverse_accessor_taken(model, field_name, related_model, accessor, derived,
+                                  _accessor_holder(related_model.related_objects[accessor])))
+  related_model.related_objects[accessor] = _reverse_many_to_many_relation(relation, accessor)
+  # #396: NO write-back to `field.related_name`. It used to be the idempotency latch — a second
+  # `set_models` run saw an explicit name and took a different branch to the same key — but the
+  # derivation is a pure function of the model name, the field name and the group size now, so the
+  # latch is dead weight. Removing it keeps `related_name === nothing` meaning "the declaration named
+  # none", which is what stops `Model_to_str` baking a PormG-invented accessor into a regenerated
+  # source file.
   return nothing
 end
 

--- a/src/migrations/planner.jl
+++ b/src/migrations/planner.jl
@@ -157,8 +157,9 @@ function _drop_index(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::Or
     # `model_name` is already the RESOLVED physical table name (db_table when set, #59) — every
     # producer of this Symbol keys on `model_table_name`. Do NOT re-normalize it through
     # `format_model_name`, which would lowercase a mixed-case db_table back into a different table.
+    # Escaped ONCE here; the interpolations below must NOT escape it again (#394).
     table_name = Dialect._quote_table_ddl(string(model_name))
-    drop_sql = """ALTER TABLE \"$table_name\" DROP CONSTRAINT IF EXISTS \"$index_name\";\nDROP INDEX IF EXISTS \"$index_name\";"""
+    drop_sql = """ALTER TABLE \"$table_name\" DROP CONSTRAINT IF EXISTS \"$(Dialect._quote_table_ddl(index_name))\";\nDROP INDEX IF EXISTS \"$(Dialect._quote_table_ddl(index_name))\";"""
     _configure_order_dict_migration_plan(migration_plan, model_name, "Remove index on $field_name", drop_sql)
   else
     _configure_order_dict_migration_plan(migration_plan, model_name, "Remove index on $field_name",
@@ -186,7 +187,7 @@ function _add_fk_constraint_in_alteration(conn::Union{PormGPostgres, PormGSQLite
     # `_quote_table_ddl` on the referenced table (#388): `add_foreign_key` interpolates
     # `ref_table_name` verbatim — every identifier it receives is pre-quoted HERE — so an embedded
     # `"` in a parent's `db_table` would close the identifier early and corrupt the ALTER.
-    Dialect.add_foreign_key(conn, model_name, "\"$constraint_name\"", "\"$local_col\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(new_field; column = field_name, model = model_name)))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+    Dialect.add_foreign_key(conn, model_name, "\"$(Dialect._quote_table_ddl(constraint_name))\"", "\"$(Dialect._quote_table_ddl(local_col))\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(new_field; column = field_name, model = model_name)))\"", "\"$(Dialect._quote_table_ddl(resolved_pk))\"", on_delete=on_delete_sql))
   end
   return nothing
 end
@@ -205,7 +206,7 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
       on_delete_sql = hasfield(typeof(field), :on_delete) ? Dialect._foreign_key_on_delete_sql(field.on_delete) : nothing
       _configure_order_dict_migration_plan(migration_plan, model_name, "New foreign key: $field_name",
       # Referenced table escaped as in `_add_fk_constraint_in_alteration` above (#388).
-      Dialect.add_foreign_key(conn, model_table_name(model), "\"$constraint_name\"", "\"$local_col\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"", "\"$resolved_pk\"", on_delete=on_delete_sql))
+      Dialect.add_foreign_key(conn, model_table_name(model), "\"$(Dialect._quote_table_ddl(constraint_name))\"", "\"$(Dialect._quote_table_ddl(local_col))\"",  "\"$(Dialect._quote_table_ddl(fk_target_table(field; column = field_name, model = model)))\"", "\"$(Dialect._quote_table_ddl(resolved_pk))\"", on_delete=on_delete_sql))
     # For SQLite, FKs are added in CREATE TABLE, so if we are adding a field to an existing table, 
     # we might need recreation if it's a FK.
     end
@@ -216,7 +217,7 @@ function _add_constrains(conn::Union{PormGPostgres, PormGSQLite}, migration_plan
     index_name = name * "_idx" |> lowercase
     index_col = Models.field_db_column(field, string(field_name))
     _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $field_name",
-    Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$index_col\""]))
+    Dialect.create_index(conn, "\"$(Dialect._quote_table_ddl(index_name))\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$(Dialect._quote_table_ddl(index_col))\""]))
   end
   nothing
 end
@@ -232,7 +233,7 @@ function _add_many_to_many_auto_constraints(conn::Union{PormGPostgres, PormGSQLi
     migration_plan,
     model_name,
     "Create many-to-many unique index",
-    Dialect.create_unique_index(conn, "\"$unique_index\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$owner_column\"", "\"$related_column\""])
+    Dialect.create_unique_index(conn, "\"$(Dialect._quote_table_ddl(unique_index))\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$(Dialect._quote_table_ddl(owner_column))\"", "\"$(Dialect._quote_table_ddl(related_column))\""])
   )
   return nothing
 end
@@ -266,7 +267,7 @@ function _add_unique_constraints(conn::Union{PormGPostgres, PormGSQLite}, migrat
       migration_plan,
       model_name,
       "Create unique constraint: $(index_name)",
-      Dialect.create_unique_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(table))\"", ["\"$col\"" for col in cols])
+      Dialect.create_unique_index(conn, "\"$(Dialect._quote_table_ddl(index_name))\"", "\"$(Dialect._quote_table_ddl(table))\"", ["\"$(Dialect._quote_table_ddl(col))\"" for col in cols])
     )
   end
   return nothing
@@ -298,7 +299,7 @@ function _add_indexes(conn::Union{PormGPostgres, PormGSQLite}, migration_plan::O
       migration_plan,
       model_name,
       "Create index: $(index_name)",
-      Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(table))\"", ["\"$col\"" for col in cols])
+      Dialect.create_index(conn, "\"$(Dialect._quote_table_ddl(index_name))\"", "\"$(Dialect._quote_table_ddl(table))\"", ["\"$(Dialect._quote_table_ddl(col))\"" for col in cols])
     )
   end
   return nothing
@@ -521,7 +522,7 @@ function _alter_table_fields(conn::Union{PormGPostgres, PormGSQLite}, migration_
         if !(conn isa PormGSQLite && get_constraints_index(conn, model_name, col) !== nothing)
           index_name = "$(hashed)_idx"
           _configure_order_dict_migration_plan(migration_plan, model_name, "Create index on $col",
-          Dialect.create_index(conn, "\"$index_name\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$col\""]))
+          Dialect.create_index(conn, "\"$(Dialect._quote_table_ddl(index_name))\"", "\"$(Dialect._quote_table_ddl(model_table_name(model)))\"", ["\"$(Dialect._quote_table_ddl(col))\""]))
         end
       else
         _drop_index(conn, migration_plan, model_name, col, index_name=live_index_name)

--- a/src/models/fields.jl
+++ b/src/models/fields.jl
@@ -326,7 +326,7 @@ Product = Models.Model(
 )
 ```
 
-Multiple foreign keys to same model (requires related_name):
+Multiple foreign keys to the same model — `related_name` is optional, but recommended:
 ```julia
 Message = Models.Model(
     id = IDField()
@@ -337,8 +337,13 @@ Message = Models.Model(
 ```
 
 # Related Names and Reverse Relations
-- If `related_name` is not specified, PormG automatically generates one
-- When multiple ForeignKeys point to the same model, `related_name` must be explicitly set
+- If `related_name` is not specified, PormG derives one and logs it at `@info`
+- The derivation counts **every** relation this model declares to that target — `ForeignKey`,
+  `OneToOneField` and `ManyToManyField` alike: the lowercase model name when it is the only one,
+  `<model>_<field>` for **every** member of a group of two or more (#396)
+- A derived name is never written back onto the field, so `related_name` stays `nothing` unless you set it
+- The reverse accessor must not match a field name on the model it lands on, or another accessor
+  already registered there; either raises `ModelDefinitionError` at `set_models`
 - The related name allows querying from the target model back to this model
 - If you can't remember the related name, you can type `your_query.objects.related_objects` or `your_model.related_objects` to see all related names
 
@@ -490,7 +495,7 @@ table with two foreign keys and a composite unique index.
 
 # Keyword Arguments
 - `through::Union{String, PormGModel, Nothing} = nothing`: explicit through model; skips auto table synthesis.
-- `related_name::Union{String, Nothing} = nothing`: reverse accessor on the target model.
+- `related_name::Union{String, Nothing} = nothing`: reverse accessor on the target model. Omitted, it is derived like a `ForeignKey`'s — the lowercase model name, or `<model>_<field>` when the model declares two or more relations to that target, many-to-many and foreign key counted together (#396).
 - `db_table::Union{String, Nothing} = nothing`: auto-through table name override. Ignored when `through` is given — the join table is then the through model's own table (its `db_table` if it declares one).
 - `source_field::Union{String, Nothing} = nothing`: the join key pointing at the source model. With an explicit `through`, it names a **field** on that model and the physical column is resolved from the field's `db_column` (#377); on the auto-synthesized table it names the column directly, since PormG creates it.
 - `target_field::Union{String, Nothing} = nothing`: the same, for the target model.

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -461,7 +461,7 @@ function _solve_field(field::String, model::PormGModel, instruct::SQLInstruction
   # Resolve to the physical column (db_column when set, else the field name) and quote
   # it to prevent SQL injection (#50). SELECT auto-aliases back to the field name, so
   # rows stay keyed by the declared field name even when the column differs.
-  return quote_identifier(Models.field_db_column(model.fields[field], field), instruct.connection)
+  return safe_column_identifier(Models.field_db_column(model.fields[field], field), instruct.connection)
 end
 _solve_field(field::String, _module::Module, model_name::Symbol, instruct::SQLInstruction) = _solve_field(field, getfield(_module, model_name), instruct)
 _solve_field(field::String, _module::Module, model_name::String, instruct::SQLInstruction) = _solve_field(field, _module, Symbol(model_name), instruct)
@@ -913,7 +913,7 @@ function _resolve_cjoin_on_alias_column(v::String, instruc::SQLInstruction)
   (col in target_model.field_names) || throw(UnknownFieldError(
     "cjoin_on: column '$(col)' not found on aliased model '$(target_model.name)' (alias '$(alias)')."))
   return string(quote_identifier(alias, instruc.connection), ".",
-                quote_identifier(Models.field_db_column(target_model.fields[col], col), instruc.connection))
+                safe_column_identifier(Models.field_db_column(target_model.fields[col], col), instruc.connection))
 end
 function _get_filter_query(v::SQLTypeFunction, instruc::SQLInstruction)
   return _get_select_query(v, instruc) # Does this have any coletaral efect?
@@ -1152,7 +1152,7 @@ end
 # (correct, merely non-sargable) rendering instead of quietly ranging on some other column.
 # Fail-safe, never fail-loud: a mismatch is a PormG-internal invariant, not a user error.
 function _checked_bucket_column(f_meta, last_segment::String, column_sql::String, instruc::SQLInstruction)
-  expected = quote_identifier(Models.field_db_column(f_meta, last_segment), instruc.connection)
+  expected = safe_column_identifier(Models.field_db_column(f_meta, last_segment), instruc.connection)
   endswith(column_sql, string(".", expected)) || return (nothing, "")
   return (f_meta, column_sql)
 end

--- a/src/querybuilder/build_joins.jl
+++ b/src/querybuilder/build_joins.jl
@@ -313,12 +313,18 @@ function _apply_many_to_many_branch(
 end
 
 # #27: validate JSON path key segments fail-closed. A segment is either a non-negative integer
-# (JSON array index) or a safe identifier (SAFE_IDENTIFIER_PATTERN — the same contract as SQL
-# identifiers). Anything else (spaces, dots, quotes, braces, empty) is rejected, so the validated
-# segments are safe to interpolate into the path literal. Returns the segments unchanged.
+# (JSON array index) or a safe key (`SAFE_JSON_KEY_PATTERN`). Anything else (spaces, dots, quotes,
+# braces, empty) is rejected, so the validated segments are safe to interpolate into the path
+# literal. Returns the segments unchanged.
+#
+# #394: this checks `SAFE_JSON_KEY_PATTERN`, NOT `SAFE_IDENTIFIER_PATTERN`, even though the two
+# bodies match today. A segment is interpolated UNQUOTED into a path literal inside a single-quoted
+# SQL string (PostgreSQL braces, SQLite `$.a.b`), so unlike a table or column name it has no quoting
+# to fall back on and this charset check is the entire guard. Keeping the constants separate is what
+# stops a future relaxation of the SQL-identifier rules from silently widening this one.
 function _validate_json_key_segments(segments::Vector{String})::Vector{String}
   for seg in segments
-    if occursin(r"^\d+$", seg) || occursin(SAFE_IDENTIFIER_PATTERN, seg)
+    if occursin(r"^\d+$", seg) || occursin(SAFE_JSON_KEY_PATTERN, seg)
       continue
     end
     throw(InvalidValueError("Invalid JSON key segment \e[31m$(seg)\e[0m in a JSON path lookup. Segments must be a non-negative integer (array index) or a simple key (letters, digits, underscore). Keys with spaces, dots, or quotes are not addressable via the `__` path syntax."))
@@ -334,7 +340,7 @@ function _render_json_lookup(instruct::SQLInstruction, alias::String, json_field
     field_name::String, key_segments::Vector{String}, full_field::Vector{String})::String
   segs = _validate_json_key_segments(key_segments)
   col = string(quote_identifier(alias, instruct.connection), ".",
-               quote_identifier(Models.field_db_column(json_field, field_name), instruct.connection))
+               safe_column_identifier(Models.field_db_column(json_field, field_name), instruct.connection))
   path = join(full_field, "__")
   instruct.json_lookup_cache[path] = (json_field, segs)
   instruct.tab_field_cache[path] = json_field
@@ -400,6 +406,10 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       row_join["a"] = Models.model_table_name(instruct.object.model)
       row_join["alias_a"] = instruct.alias
       row_join["b"] = cte_name  # CTE name becomes the table name
+      # #394: mark it. A correlated UPDATE ... FROM emits no `WITH` prefix, so a row_join naming a
+      # CTE renders `FROM "<cte>" AS "Tb_N"` against a relation the statement never declares.
+      # `_get_join_condition_list` refuses the whole class on this marker.
+      row_join["cte"] = "1"
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
       # "how" is never emitted for a CROSS entry (build_row_join_sql_text short-circuits on the
       # "cross" marker), but the deep-path loop below reads `row_join["how"]` as `prev_how`; set
@@ -442,6 +452,7 @@ function _build_row_join(field::Vector{String}, instruct::SQLInstruction; as::Bo
       row_join["a"] = Models.model_table_name(instruct.object.model)
 
       row_join["b"] = cte_name  # CTE name becomes the table name
+      row_join["cte"] = "1"     # #394 — see the CROSS branch above
       row_join["alias_b"] = _get_alias_name(instruct.row_join, instruct.alias)
       row_join["how"] = cte_dict["join_type"]::String
 

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -369,8 +369,15 @@ function build_row_join_sql_text(instruc::SQLInstruction)
       on_clause = join(extras, " AND ")
     else
       alias_a_quoted = quote_identifier(value["alias_a"], instruc.connection)
-      key_a_quoted = quote_identifier(value["key_a"], instruc.connection)
-      key_b_quoted = quote_identifier(value["key_b"], instruc.connection)
+      # #394: escape-only, because on every model-join branch these are PHYSICAL columns
+      # (`Models.model_column`). The one exception is a CTE join, where `key_b` is the CTE's
+      # projection ALIAS (`build_joins.jl` sets `row_join["key_b"] = cte_table_key`). That name is
+      # not unguarded: `_build_row_join` raises `UnknownFieldError` unless it matches a field of
+      # the CTE model, and that field came from a `values()` alias, which `_query_select` renders
+      # through the fail-closed `quote_identifier`. So the strict check happens where the caller
+      # wrote the name, exactly as it does for the CTE name itself since #394.
+      key_a_quoted = safe_column_identifier(value["key_a"], instruc.connection)
+      key_b_quoted = safe_column_identifier(value["key_b"], instruc.connection)
 
       # Build base ON clause
       on_clause = "$alias_a_quoted.$key_a_quoted = $alias_b_quoted.$key_b_quoted"

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -23,6 +23,19 @@ end
 function _with(q::SQLObject, name::String, query::SQLObjectHandler;
   join_field::Union{Pair{String,String},Nothing}=nothing,
   join_type::String="LEFT")
+  # #394: fail-closed on the CTE name HERE, at declaration. It is a query-time alias the caller typed,
+  # and it reaches SQL twice — as the `WITH <name> AS (...)` label and, when a `join_field` is given,
+  # as the JOIN target (`row_join["b"]`). Since #394 that second site quotes ESCAPE-ONLY, because
+  # every other thing landing in that slot is a physical table name; checking here removes the
+  # ordering dependency between the two renders entirely and puts the error on the call the user
+  # wrote. `build_cte_clause` still quotes fail-closed as defence in depth. Same rule as `_cjoin_on`.
+  _validate_identifier(name)
+  # ...and the CTE side of the join key, for the same reason. `_build_row_join` stores it as
+  # `row_join["key_b"]`, which since #394 is quoted escape-only because everything else in that slot
+  # is a physical column. This one is a CTE PROJECTION ALIAS, so it belongs to the fail-closed half
+  # of the contract. `join_field.first` is deliberately NOT checked: it names a field on the MAIN
+  # model and is resolved through `Models.model_column`, i.e. it is genuinely physical.
+  join_field !== nothing && _validate_identifier(join_field.second)
   cte_fields = _preset_cte_fields(name, query, join_field=join_field, join_type=join_type)
   if haskey(q.ctes, name)
     throw(QueryBuildError("CTE with name \"$(name)\" already exists in the query; please use a different name."))

--- a/src/querybuilder/deletion.jl
+++ b/src/querybuilder/deletion.jl
@@ -548,7 +548,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     pk_field = key[:key]
     # Outer WHERE targets the physical column (db_column when set); the subquery already
     # projects/aliases the key, so only this identifier needs resolving (#50).
-    push!(_where, """"$(Models.model_column(model, pk_field))" IN ($(query(key[:objct], parameters=parameters)))""")
+    push!(_where, """$(safe_column_identifier(Models.model_column(model, pk_field), connection)) IN ($(query(key[:objct], parameters=parameters)))""")
   end
   sql::String = ""
   if size(keys, 1) == 1
@@ -571,7 +571,7 @@ function delete_objects(connection::Union{PormGPostgres, PormGSQLite}, model::Po
     deleted_counter[model.name] = show_query === :execute ? (_query |> _count) : 0
     _query.values(pk_field) # Ensure the query is built
     @pormg_debug false
-    sql = "DELETE FROM $(safe_table_identifier(Models.model_table_name(model), connection)) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
+    sql = "DELETE FROM $(safe_table_identifier(Models.model_table_name(model), connection)) WHERE $(safe_column_identifier(Models.model_column(model, pk_field), connection)) IN ($(query(_query, parameters=parameters)))"
   end
 
   sql == "" && error(_emsg("PormG internal error in delete(): the generated SQL is empty — this should not happen; please report it."))
@@ -593,7 +593,7 @@ function update_field(connection::Union{PormGPostgres, PormGSQLite}, model::Porm
   parameters = get_parameter(connection)
   value_sql = value === nothing ? "NULL" : model.fields[field].formatter(value)
   # SET column and outer WHERE key both target the physical column (db_column) — #50.
-  sql = "UPDATE $(safe_table_identifier(Models.model_table_name(model), connection)) SET \"$(Models.model_column(model, field))\" = $(value_sql) WHERE \"$(Models.model_column(model, pk_field))\" IN ($(query(_query, parameters=parameters)))"
+  sql = "UPDATE $(safe_table_identifier(Models.model_table_name(model), connection)) SET $(safe_column_identifier(Models.model_column(model, field), connection)) = $(value_sql) WHERE $(safe_column_identifier(Models.model_column(model, pk_field), connection)) IN ($(query(_query, parameters=parameters)))"
   if show_query !== :execute
     return _show_query_result(show_query, sql, connection, model, :update, parameters=parameters)
   end

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -599,7 +599,7 @@ function _prepare_row_insert!(real_obj, model::PormGModel, settings, connection,
     model.fields[field].primary_key && (pk_exist = true; push!(pk_field, field))
 
      # Add safely quoted physical column (db_column when set) to columns list (#50)
-    push!(quoted_field_columns, quote_identifier(Models.field_db_column(model.fields[field], field), connection))
+    push!(quoted_field_columns, safe_column_identifier(Models.field_db_column(model.fields[field], field), connection))
 
     # Format and add value to parameters
     push!(param_values, add_parameter!(parameters, real_obj.insert[field] |> model.fields[field].formatter))
@@ -729,8 +729,8 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
   safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
 
   # Logical → quoted physical (db_column-aware), exactly as bulk_insert renders its clause.
-  qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
-  qset    = String[quote_identifier(Models.model_column(model, f), connection) for f in set_fields]
+  qtarget = String[safe_column_identifier(Models.model_column(model, f), connection) for f in target_fields]
+  qset    = String[safe_column_identifier(Models.model_column(model, f), connection) for f in set_fields]
   clause  = Dialect.on_conflict_clause(:update, qtarget, qset, connection)
 
   sql = """
@@ -768,7 +768,7 @@ function _update_or_create(objct::SQLObject; target_fields::Vector{String},
     # read-back each bind a FRESH parameter object (no cross-fetch reuse). The bound values are the
     # formatted lookup values — matching exactly what the INSERT bound.
     target_where = join(
-      ["$(quote_identifier(Models.model_column(model, f), connection)) = ?" for f in target_fields],
+      ["$(safe_column_identifier(Models.model_column(model, f), connection)) = ?" for f in target_fields],
       " AND ")
     precheck_sql = "SELECT 1 FROM $(safe_table_name) WHERE $(target_where) LIMIT 1;"
     readback_sql = "SELECT * FROM $(safe_table_name) WHERE $(target_where) LIMIT 1;"
@@ -858,7 +858,7 @@ function _get_or_create(objct::SQLObject; target_fields::Vector{String}, show_qu
     quoted_field_columns, param_values, _, _ =
       _prepare_row_insert!(real_obj, model, settings, connection, parameters)
     safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
-    qtarget = String[quote_identifier(Models.model_column(model, f), connection) for f in target_fields]
+    qtarget = String[safe_column_identifier(Models.model_column(model, f), connection) for f in target_fields]
     clause  = Dialect.on_conflict_clause(:nothing, qtarget, String[], connection)
     """
     INSERT INTO $(safe_table_name) (
@@ -938,17 +938,16 @@ end
 # literal early. A no-op for every name that does not contain one.
 _sql_literal(value::AbstractString)::String = replace(String(value), "'" => "''")
 
-# Quote an identifier WITHOUT charset validation (#59) — escape-only, unlike `quote_identifier`,
-# which also rejects anything outside SAFE_IDENTIFIER_PATTERN. For identifiers that come from the
-# database catalog (a `pg_class` row) or from a model's own `db_table`: neither is free-form user
-# input on this path, and validating them would newly reject legacy names that previously worked.
+# `_quote_ident_raw` moved to `sanitization.jl` with #394, where it now shares one definition of the
+# escape rule with `safe_table_identifier` / `safe_column_identifier`. It stays escape-only for the
+# reason it always was (#59): the identifiers reaching it come from the database catalog or from a
+# model's own `db_table`, neither of which is free-form user input.
 #
-# Load-bearing for the unowned-sequence fallback (#344): `setval`'s first argument is `regclass`,
-# so PostgreSQL re-parses it as an identifier and CASE-FOLDS any unquoted part. A catalog row
-# reading `public | Db_Table_id_seq` interpolated bare becomes `public.db_table_id_seq`, which does
-# not exist. `pg_get_serial_sequence` returns its answer already quoted, which is why the owned path
+# Load-bearing for the unowned-sequence fallback (#344): `setval`'s first argument is `regclass`, so
+# PostgreSQL re-parses it as an identifier and CASE-FOLDS any unquoted part. A catalog row reading
+# `public | Db_Table_id_seq` interpolated bare becomes `public.db_table_id_seq`, which does not
+# exist. `pg_get_serial_sequence` returns its answer already quoted, which is why the owned path
 # never needed this.
-_quote_ident_raw(name::AbstractString)::String = "\"$(replace(String(name), "\"" => "\"\""))\""
 
 # A model's physical table as a SQL *string literal* holding a *quoted identifier* — `'"Db_Table"'`.
 # The shape both `pg_get_serial_sequence` and `to_regclass` need: each takes TEXT that it re-parses
@@ -1060,7 +1059,7 @@ function _update_sequence(model::PormGModel, connection::PormGPostgres, pk_field
                                _quote_ident_raw(seqs_df[1, :sequencename]))
       end
 
-      safe_field_name = quote_identifier(col, connection)
+      safe_field_name = safe_column_identifier(col, connection)
       safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
       fetch(
         connection,
@@ -1130,7 +1129,7 @@ end
 
 function _update_sequence(model::PormGModel, connection::PormGSQLite, pk_field::Vector{String}, settings::PormGSettings)
   for field in pk_field
-    safe_field_name = quote_identifier(Models.model_column(model, field), connection)  # db_column (#50)
+    safe_field_name = safe_column_identifier(Models.model_column(model, field), connection)  # db_column (#50)
     safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
     # Matched against `sqlite_sequence.name`, which holds the table's ACTUAL name — so it must be
     # the resolved physical name (db_table when set, #59), not a fold of the logical one.
@@ -1412,13 +1411,14 @@ end
 function _build_from_tables(row_join::Vector{Dict{String, Union{String, Vector{FilterType}}}}, connection::Union{PormGPostgres, PormGSQLite})
   tables = String[]
   for join_dict in row_join
-    try
-      b = safe_table_identifier(join_dict["b"], connection)
-      alias_b = quote_identifier(join_dict["alias_b"], connection)
-      push!(tables, "$b AS $alias_b")
-    catch e
-      @error "Error building FROM tables for join: $join_dict" exception=(e, catch_backtrace())
-    end
+    # #394: no try/catch. This used to `@error` and CONTINUE, which dropped a table from a correlated
+    # FROM list and left the surviving aliases unconstrained — a wrong query emitted as a warning.
+    # Everything that can raise here is a defect, not a tolerable condition: a `KeyError` means the
+    # row_join is malformed, and an `InvalidValueError` means an INTERNALLY generated alias is not an
+    # identifier. Both have to surface.
+    b = safe_table_identifier(join_dict["b"], connection)
+    alias_b = quote_identifier(join_dict["alias_b"], connection)
+    push!(tables, "$b AS $alias_b")
   end
   return join(unique(tables), ", ")
 end
@@ -1433,18 +1433,32 @@ function _get_join_condition_list(row_join::Vector{Dict{String, Union{String, Ve
       throw(QueryBuildError("cjoin_on is not supported in a correlated UPDATE-FROM/DELETE-USING (setting a " *
                     "column from a joined table); scope the mutation with a filter/subquery instead."))
     end
+    # #394: the same rule, for a CTE. `update()` emits no `WITH` prefix — `build_cte_clause` is
+    # reached only from the three READ paths — so a row_join entry naming a CTE renders
+    # `FROM "<cte>" AS "Tb_N"` against a relation this statement never declares. That is as true of a
+    # KEYED CTE as of a CROSS-joined one, which is why the check is on the entry being a CTE rather
+    # than on the shape of its keys. The cross-joined case additionally carries SENTINEL empty key
+    # columns; those used to raise inside the loop below and be swallowed by a `catch` that dropped
+    # the ON condition entirely. Both fail here now, before any SQL is built.
+    if get(join_dict, "cte", nothing) !== nothing || get(join_dict, "cross", nothing) !== nothing
+      throw(QueryBuildError("A CTE cannot be joined in a correlated UPDATE ... FROM: the statement emits " *
+                    "no WITH clause, so the CTE it references is never declared. Scope the mutation with " *
+                    "a filter or a subquery instead."))
+    end
   end
   conditions = String[]
   for join_dict in row_join
-    try
-      alias_a = quote_identifier(join_dict["alias_a"], connection)
-      key_a = quote_identifier(join_dict["key_a"], connection)
-      alias_b = quote_identifier(join_dict["alias_b"], connection)
-      key_b = quote_identifier(join_dict["key_b"], connection)
-      push!(conditions, "$alias_a.$key_a = $alias_b.$key_b")
-    catch e
-      @error "Error building join condition for join: $join_dict" exception=(e, catch_backtrace())
-    end
+    # #394: no try/catch either — the guards above refuse to drop an ON clause, and until now the
+    # loop below dropped one anyway on any failure, with nothing but an `@error`. An UPDATE ... FROM
+    # or DELETE ... USING missing its ON condition matches every row of the joined table, so this is
+    # the one place a swallowed identifier error corrupts data rather than returning wrong rows.
+    # Everything reaching here is well-formed: both anchor-less shapes are refused above, and every
+    # `row_join` producer writes the alias/key set together with a PormG-generated `alias_b`.
+    alias_a = quote_identifier(join_dict["alias_a"], connection)
+    key_a = safe_column_identifier(join_dict["key_a"], connection)
+    alias_b = quote_identifier(join_dict["alias_b"], connection)
+    key_b = safe_column_identifier(join_dict["key_b"], connection)
+    push!(conditions, "$alias_a.$key_a = $alias_b.$key_b")
   end
   return conditions
 end
@@ -1469,7 +1483,7 @@ function _build_update_target_pk_subquery(instruction::SQLInstruction)::Union{St
 
   safe_table_name = safe_table_identifier(Models.model_table_name(instruction.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
-  quoted_pk = quote_identifier(Models.model_column(instruction.object.model, String(pk_field_sym)), instruction.connection)  # db_column (#50)
+  quoted_pk = safe_column_identifier(Models.model_column(instruction.object.model, String(pk_field_sym)), instruction.connection)  # db_column (#50)
 
   io = IOBuffer()
   print(io, "SELECT DISTINCT ", safe_alias, ".", quoted_pk)
@@ -1578,7 +1592,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
     validate_field_data(model, field, objct.insert[field], "update"; allow_primary_key = false)
     Models.is_many_to_many_field(model.fields[field]) && throw(QueryBuildError("ManyToManyField $(model.name).$(field) cannot be written in update(); use the many-to-many manager add, remove, clear, or set methods"))
     
-    quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)  # db_column (#50)
+    quoted_field = safe_column_identifier(Models.field_db_column(model.fields[field], field), connection)  # db_column (#50)
 
     if isa(objct.insert[field], SQLTypeF) || isa(objct.insert[field], SQLTypeFunction)
       f_value = _set_update_query(objct.insert[field], instruction)
@@ -1606,7 +1620,7 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
       pk_subquery = (!set_uses_join_aliases && isempty(real_obj.ctes)) ? _build_update_target_pk_subquery(instruction) : nothing
 
       if pk_subquery !== nothing && pk_field_sym !== nothing
-        quoted_pk = quote_identifier(Models.model_column(model, String(pk_field_sym)), connection)  # db_column (#50)
+        quoted_pk = safe_column_identifier(Models.model_column(model, String(pk_field_sym)), connection)  # db_column (#50)
         sql = """
         UPDATE $(safe_table_name) AS $(safe_alias)
         SET $(set_clause)

--- a/src/querybuilder/execution_bulk.jl
+++ b/src/querybuilder/execution_bulk.jl
@@ -471,7 +471,7 @@ function _allocate_sqlite_ids(model::PormGModel, connection::PormGSQLite, pk_fie
   safe_table = Models.model_table_name(model)
   safe_table_name = safe_table_identifier(safe_table, connection)
   safe_table_literal = replace(safe_table, "'" => "''")
-  safe_field = quote_identifier(Models.model_column(model, pk_field), connection)  # db_column (#50)
+  safe_field = safe_column_identifier(Models.model_column(model, pk_field), connection)  # db_column (#50)
   sql = """
   SELECT MAX(candidate) AS max_id
   FROM (
@@ -1423,7 +1423,7 @@ function bulk_copy(objct::SQLObjectHandler, df_o::DataFrames.DataFrame;
   # Security: Quote table name and physical column names (db_column when set, #50).
   # The CSV is positional (HEADER FALSE), so the data order still matches.
   safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
-  quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields_df]
+  quoted_fields = [safe_column_identifier(Models.model_column(model, string(field)), connection) for field in fields_df]
 
   # Construct the COPY command (CSV format for safety). NULL marker disambiguates ""
   # (quoted, an empty string) from missing (unquoted sentinel, NULL) — see _BULK_COPY_NULL (#86).
@@ -1584,7 +1584,7 @@ function _normalize_on_conflict(on_conflict, model::PormGModel, fields_df::Vecto
 
   # Explicit `String[...]` comprehensions (not `map`) so the element type is Vector{String}
   # even for an empty target/set, which the typed `on_conflict_clause` signature requires.
-  quoted(col) = quote_identifier(Models.model_column(model, col), connection)
+  quoted(col) = safe_column_identifier(Models.model_column(model, col), connection)
   return (action = action,
           target = String[quoted(col) for col in target],
           set = String[quoted(col) for col in set])
@@ -1610,7 +1610,7 @@ function _bulk_insert(model::PormGModel, connection::Union{PormGPostgres, PormGS
   # Security: Quote table name and physical column names (db_column when set, #50).
   # VALUES rows are positional and built in `fields` order, so they still align.
   safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
-  quoted_fields = [quote_identifier(Models.model_column(model, string(field)), connection) for field in fields]
+  quoted_fields = [safe_column_identifier(Models.model_column(model, string(field)), connection) for field in fields]
 
   # Construct the bulk insert SQL. The ON CONFLICT clause (#123) is rendered once by the caller
   # and binds no parameters, so the chunk-size math and the VALUES placeholders are untouched;
@@ -1792,9 +1792,11 @@ function _bulk_update(objct::SQLObjectHandler, df_o::DataFrames.DataFrame,
   for field in fields_df
     if !(field in deny_fields)
       # @pormg_debug
-      # SET target uses the physical column (db_column); the source.* reference and the
-      # VALUES/CTE source column list stay the field name (#50).
-      quoted_field = quote_identifier(Models.field_db_column(model.fields[field], field), connection)
+      # SET target uses the physical column (db_column) and is quoted escape-only like any physical
+      # name; the source.* reference and the VALUES/CTE source column list stay the FIELD name (#50)
+      # and are therefore ALIASES — they name columns of a derived table PormG invents here, not
+      # anything that exists in the schema — so they keep the fail-closed `quote_identifier` (#394).
+      quoted_field = safe_column_identifier(Models.field_db_column(model.fields[field], field), connection)
       quoted_source_field = quote_identifier(field, connection)
       if connection isa PormGPostgres
         field_type = _pg_bulk_cast_type(model.fields[field], connection)
@@ -1895,16 +1897,18 @@ function _bulk_update(model::PormGModel,
     throw(QueryBuildError("bulk_update() does not allow joined field paths (\"__\") — restrict filters and update columns to the model's own fields."))
   end
 
-  # Security: Quote table name and field names
+  # Security: Quote table name and field names. `quoted_fields` is the column list of the `source`
+  # derived table (PostgreSQL) / CTE (SQLite) below — an alias position, so fail-closed (#394).
   safe_table_name = safe_table_identifier(Models.model_table_name(model), connection)
   quoted_fields = [quote_identifier(field, connection) for field in fields]
 
   # Security: Build safe WHERE conditions with quoted identifiers
   safe_where_conditions::Vector{String} = []
   for filter in dinanic_filters
-    # WHERE target (Tb.) uses the physical column (db_column); the source.* reference
-    # and the source column list stay the field name (#50).
-    quoted_tb_field = quote_identifier(Models.field_db_column(model.fields[filter], filter), connection)
+    # WHERE target (Tb.) uses the physical column (db_column), escape-only; the source.* reference
+    # and the source column list stay the field name (#50) and are ALIASES on a derived table, so
+    # they stay fail-closed (#394). All three must agree byte-for-byte with the list emitted below.
+    quoted_tb_field = safe_column_identifier(Models.field_db_column(model.fields[filter], filter), connection)
     quoted_source_field = quote_identifier(filter, connection)
     if connection isa PormGPostgres
       field_type = _pg_bulk_cast_type(model.fields[filter], connection)

--- a/src/querybuilder/many_to_many.jl
+++ b/src/querybuilder/many_to_many.jl
@@ -144,8 +144,8 @@ function add(manager::ManyToManyManager, targets...)
   !settings.change_data && throw(_write_not_allowed("many-to-many add", conn_key))
 
   table_name = safe_table_identifier(manager.relation.through_table, connection)
-  owner_column = quote_identifier(manager.relation.owner_column, connection)
-  related_column = quote_identifier(manager.relation.related_column, connection)
+  owner_column = safe_column_identifier(manager.relation.owner_column, connection)
+  related_column = safe_column_identifier(manager.relation.related_column, connection)
   owner_value = _m2m_format_owner(manager)
 
   if connection isa PormGPostgres
@@ -196,8 +196,8 @@ function remove(manager::ManyToManyManager, targets...)
   !settings.change_data && throw(_write_not_allowed("many-to-many remove", conn_key))
 
   table_name = safe_table_identifier(manager.relation.through_table, connection)
-  owner_column = quote_identifier(manager.relation.owner_column, connection)
-  related_column = quote_identifier(manager.relation.related_column, connection)
+  owner_column = safe_column_identifier(manager.relation.owner_column, connection)
+  related_column = safe_column_identifier(manager.relation.related_column, connection)
   owner_value = _m2m_format_owner(manager)
 
   parameters = get_parameter(connection)
@@ -224,7 +224,7 @@ function clear(manager::ManyToManyManager)
   set_context!(parameters, :where)
   owner_placeholder = add_parameter!(parameters, _m2m_format_owner(manager))
   table_name = safe_table_identifier(manager.relation.through_table, connection)
-  owner_column = quote_identifier(manager.relation.owner_column, connection)
+  owner_column = safe_column_identifier(manager.relation.owner_column, connection)
   fetch(settings, "DELETE FROM $table_name WHERE $owner_column = $owner_placeholder;", parameters)
   return nothing
 end
@@ -235,8 +235,8 @@ function _m2m_current_ids(manager::ManyToManyManager)::Vector{Any}
   set_context!(parameters, :where)
   owner_placeholder = add_parameter!(parameters, _m2m_format_owner(manager))
   table_name = safe_table_identifier(manager.relation.through_table, connection)
-  owner_column = quote_identifier(manager.relation.owner_column, connection)
-  related_column = quote_identifier(manager.relation.related_column, connection)
+  owner_column = safe_column_identifier(manager.relation.owner_column, connection)
+  related_column = safe_column_identifier(manager.relation.related_column, connection)
   sql = "SELECT $related_column FROM $table_name WHERE $owner_column = $owner_placeholder;"
   df = fetch(settings, sql, parameters) |> DataFrames.DataFrame
   DataFrames.nrow(df) == 0 && return Any[]

--- a/src/querybuilder/sanitization.jl
+++ b/src/querybuilder/sanitization.jl
@@ -1,25 +1,59 @@
 
+# ── Identifier contract (#394) ────────────────────────────────────────────────────────────────
+# Two axes, not one. The user-facing statement is in `docs/src/schema_conventions.md` →
+# *Identifier quoting*.
+#
+#   PHYSICAL names (a table, a column) → ESCAPE-ONLY. They are either pinned by the model author via
+#     `db_table`/`db_column` — which are deliberately NOT shape-validated (#59/#50), because naming a
+#     table PormG's own conventions could not produce is the entire point of the option — or read out
+#     of the database catalog by introspection and round-tripped back into a `db_table`/`db_column`
+#     pin by `Model_to_str`. Validating them meant PormG rendered a table with
+#     `Dialect._quote_table_ddl`, which escapes and never validates, and then REFUSED to query the
+#     table it had just created, because `quote_identifier` validated and never escaped. Doubling `"`
+#     is the standard SQL escape on both backends and makes the identifier unterminatable, which is
+#     the whole threat; there is nothing else to defend against inside a quoted identifier.
+#
+#   ALIASES and other query-time names → FAIL-CLOSED. A join alias, a `cjoin_on` alias, a
+#     `.with(...)` CTE name and a `values("label" => ...)` SELECT alias are chosen while the query is
+#     built, are frequently literals the caller typed, and name nothing that already exists — so
+#     there is nothing to be faithful to and every reason to be strict.
+#
+# Do NOT collapse these back into one function. The split IS the fix: a single rule cannot be both
+# permissive enough for a legacy table name and strict enough for a caller-supplied alias.
 const SAFE_IDENTIFIER_PATTERN = r"^[\p{L}_][\p{L}\p{M}\p{N}_]*$"
+
+# #394: a JSON path segment is NOT a SQL identifier, and this constant is not duplication for its own
+# sake. `_validate_json_key_segments` (build_joins.jl) interpolates a segment UNQUOTED into a path
+# literal inside a single-quoted SQL string — PostgreSQL `'{a,b}'`, SQLite `'$.a.b'` — so it has no
+# quoting to fall back on and the charset check IS the entire guard there. It is kept separate, with a
+# body that merely happens to match the one above, so that relaxing the SQL-identifier rules can never
+# widen the JSON guard by accident. If you touch `SAFE_IDENTIFIER_PATTERN`, this one does not move.
+const SAFE_JSON_KEY_PATTERN = r"^[\p{L}_][\p{L}\p{M}\p{N}_]*$"
 
 function _validate_identifier(identifier::String)::String
     if !occursin(SAFE_IDENTIFIER_PATTERN, identifier)
-        throw(InvalidValueError("Invalid SQL identifier: $identifier"))
+        throw(InvalidValueError(
+            "Invalid SQL identifier: $(identifier). PormG requires a plain identifier here because " *
+            "this name is used as a query ALIAS — a join alias, a `.with(...)` CTE name, a " *
+            "`cjoin_on` alias, or a `values(\"label\" => ...)` label. A physical table or column may " *
+            "carry any spelling; pin it with db_table / db_column instead."))
     end
     return identifier
 end
 
+# The escape shared by every physical-identifier path (#394). Doubling is the standard SQL escape on
+# both backends and a no-op for every name that does not contain a quote. The DDL side has its own
+# copy in `Dialect._quote_table_ddl`, which returns the INNER text because its call sites supply the
+# surrounding quotes themselves.
+_escape_identifier(name::AbstractString)::String = replace(String(name), "\"" => "\"\"")
+
 """
-Sanitize SQL identifiers (table names, column names) to prevent injection.
-Only allows Unicode letters, combining marks, numbers, underscores, and validates
-against model schema.
+Quote a query ALIAS or other query-time name. Fail-closed: rejects anything outside
+`SAFE_IDENTIFIER_PATTERN`. For a physical table or column use `safe_table_identifier` /
+`safe_column_identifier` instead — validating those would refuse names PormG's own DDL creates (#394).
 """
-function sanitize_identifier(identifier::String, valid_identifiers::Vector{String})::String
-    # Validate against whitelist
-    if !(identifier in valid_identifiers)
-        throw(InvalidValueError("Invalid identifier: $identifier"))
-    end
-    
-    return quote_identifier(identifier, nothing)
+function quote_identifier(identifier::String, conn)::String
+    return "\"$(_validate_identifier(identifier))\""
 end
 
 """
@@ -34,29 +68,27 @@ function escape_like_pattern(pattern::String)::String
 end
 
 """
-Quote SQL identifiers based on database type
-"""
-function quote_identifier(identifier::String, conn)::String
-    return "\"$(_validate_identifier(identifier))\""
-end
-
-"""
-Validate and quote table name
+Quote a PHYSICAL table name — escape-only, no charset validation (#394). The query-side mirror of
+`Dialect._quote_table_ddl`, so a table PormG can create is a table PormG can address.
 """
 function safe_table_identifier(table_name::String, conn)::String
-    return quote_identifier(table_name, conn)
+    return "\"$(_escape_identifier(table_name))\""
 end
 
 """
-Validate field name against model and return quoted identifier
+Quote a PHYSICAL column name — escape-only, no charset validation (#394). The column axis of
+`safe_table_identifier`; `db_column` carries an arbitrary spelling for the same reason `db_table`
+does (#50).
 """
-function safe_field_identifier(field_name::String, model::PormGModel, conn)::String
-    # Validate field exists in model
-    if !(field_name in model.field_names)
-        throw(UnknownFieldError("Invalid field name: $field_name for model $(model.name)"))
-    end
-    return quote_identifier(field_name, conn)
+function safe_column_identifier(column_name::String, conn)::String
+    return "\"$(_escape_identifier(column_name))\""
 end
+
+# Escape-only and WITHOUT a `conn`, for interpolation into a SQL string literal that PostgreSQL then
+# re-parses as an identifier — `setval`'s `regclass` argument, `to_regclass`. See
+# `_table_ident_literal` in execution.jl, which composes this with `_sql_literal`. Lives here so the
+# escape rule has exactly one definition on the query side (#394; was execution.jl, #59/#344).
+_quote_ident_raw(name::AbstractString)::String = "\"$(_escape_identifier(name))\""
 
 """
     validate_field_data(model::PormGModel, field::String, value::Any, operation::String; allow_primary_key::Bool = true)

--- a/test/integration/common_setup.jl
+++ b/test/integration/common_setup.jl
@@ -56,7 +56,7 @@ import PormG: with_transaction, Models, Dialect
 import PormG.Configuration: with_tx_context, get_tx_connection
 import PormG.ConnectionPool: fetch_async, await_result
 import PormG.QueryBuilder: Sum, Avg, Case, When, Count, Q, Qor, F, page, Max, Min, Value, Round
-import PormG.QueryBuilder: quote_identifier, safe_table_identifier, escape_like_pattern
+import PormG.QueryBuilder: quote_identifier, safe_table_identifier, safe_column_identifier, escape_like_pattern
 
 cd(@__DIR__)  # Ensure we're in the test/integration directory
 

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -540,4 +540,29 @@ Db_table_col_scratch = Models.Model("db_table_col_scratch",
   sku = Models.CharField(db_column="product_sku", null=true),
 )
 
+
+# #394 — a physical TABLE name that PormG's DDL renders but its query builder used to REFUSE.
+# `db_table` is deliberately not shape-validated (#59), because naming what PormG's own conventions
+# could not produce is the point of the option — yet the query side ran every table through a
+# fail-closed identifier pattern that rejects a space. So `migrate` created this table and every
+# SELECT against it raised `InvalidValueError`. The same name also broke the generated
+# `pending_migrations.jl`, which writes each table as a Julia BINDING.
+#
+# A space rather than an embedded quote: it exercises the validator-versus-escaper split exactly,
+# without also stressing the introspection quote-doubling path (#389) inside the migration diff. No
+# index, no unique constraint and no foreign key, so the fixture stays clear of the index-name and
+# REFERENCES renderers, which Db_table_scratch above already covers.
+#
+# The COLUMN axis is deliberately absent here. A spaced `db_column` renders and queries correctly
+# (pinned in `test/unit/test_identifier_quoting.jl`), but PostgreSQL introspection tears it in half
+# on the `columns` aggregate — a pre-existing, separately-tracked defect (#414) whose fix is a change
+# to that aggregate's format, not to any quoting. Putting one here would make this fixture re-propose
+# `Add field / Remove field` on every `makemigrations` and fail the global no-drift assertion.
+Odd_identifier_scratch = Models.Model("odd_identifier_scratch",
+  db_table = "Odd Identifier Scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(max_length=30, null=true),
+  points = Models.IntegerField(null=true),
+)
+
 end

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -537,4 +537,29 @@ Db_table_col_scratch = Models.Model("db_table_col_scratch",
   sku = Models.CharField(db_column="product_sku", null=true),
 )
 
+
+# #394 — a physical TABLE name that PormG's DDL renders but its query builder used to REFUSE.
+# `db_table` is deliberately not shape-validated (#59), because naming what PormG's own conventions
+# could not produce is the point of the option — yet the query side ran every table through a
+# fail-closed identifier pattern that rejects a space. So `migrate` created this table and every
+# SELECT against it raised `InvalidValueError`. The same name also broke the generated
+# `pending_migrations.jl`, which writes each table as a Julia BINDING.
+#
+# A space rather than an embedded quote: it exercises the validator-versus-escaper split exactly,
+# without also stressing the introspection quote-doubling path (#389) inside the migration diff. No
+# index, no unique constraint and no foreign key, so the fixture stays clear of the index-name and
+# REFERENCES renderers, which Db_table_scratch above already covers.
+#
+# The COLUMN axis is deliberately absent here. A spaced `db_column` renders and queries correctly
+# (pinned in `test/unit/test_identifier_quoting.jl`), but PostgreSQL introspection tears it in half
+# on the `columns` aggregate — a pre-existing, separately-tracked defect (#414) whose fix is a change
+# to that aggregate's format, not to any quoting. Putting one here would make this fixture re-propose
+# `Add field / Remove field` on every `makemigrations` and fail the global no-drift assertion.
+Odd_identifier_scratch = Models.Model("odd_identifier_scratch",
+  db_table = "Odd Identifier Scratch",
+  id = Models.IDField(),
+  driverref = Models.CharField(max_length=30, null=true),
+  points = Models.IntegerField(null=true),
+)
+
 end

--- a/test/integration/test_db_table_db.jl
+++ b/test/integration/test_db_table_db.jl
@@ -125,6 +125,48 @@ end
 # check would have reported a #59 regression that wasn't one. With that fixed, the plan must be
 # empty for EVERY fixture — which also catches the failure this test is really about (a db_table
 # model diffing as a CREATE plus a DROP) under any spelling, not only the five listed by hand.
+# ─────────────────────────────────────────────────────────────────────────────
+# #394 — a physical TABLE name PormG's DDL renders but its query builder used to refuse.
+#
+# `Odd_identifier_scratch` pins `db_table = "Odd Identifier Scratch"`: a legal quoted identifier on
+# both backends and outside the query builder's fail-closed identifier pattern, so before #394
+# `migrate` created this table and the first SELECT against it raised `InvalidValueError`. The same
+# name also produced a `pending_migrations.jl` that could not be parsed, because the plan file writes
+# each table as a Julia binding. The unit layer pins the renderers agreeing on a string; only a live
+# database proves the statements they produce actually execute, and that the schema converges.
+#
+# The COLUMN axis is not exercised here — see the fixture comment in `models.jl`. It renders and
+# queries correctly, but PostgreSQL introspection tears a spaced column name in half (#414).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "db_table: a spaced table round-trips end to end (#394)" begin
+    pool = PormG.config[PORMG_DB_FOLDER].connections
+
+    cols = column_names(pool, "Odd Identifier Scratch")
+    @test "driverref" in cols
+    @test "points" in cols
+
+    # The folded/underscored twin must not exist — a renderer that sanitized the name instead of
+    # quoting it would have created one. SQLite folds case but not spaces, so this holds on both.
+    @test isempty(column_names(pool, "odd_identifier_scratch"))
+
+    M.Odd_identifier_scratch.objects.delete(allow_delete_all=true)
+
+    created = M.Odd_identifier_scratch.objects.create("driverref" => "senna", "points" => 41)
+    @test created[:driverref] == "senna"
+
+    row = M.Odd_identifier_scratch.objects.
+        filter("driverref" => "senna").
+        values("driverref", "points").
+        first()
+    @test row.points == 41
+
+    M.Odd_identifier_scratch.objects.filter("driverref" => "senna").update("points" => 91)
+    @test M.Odd_identifier_scratch.objects.filter("points" => 91).count() == 1
+
+    M.Odd_identifier_scratch.objects.filter("driverref" => "senna").delete()
+    @test M.Odd_identifier_scratch.objects.count() == 0
+end
+
 @testset "db_table: a re-diff proposes nothing (global, #325)" begin
     settings = PormG.config[PORMG_DB_FOLDER]
     conn = settings.connections
@@ -142,7 +184,7 @@ end
     # the two sides were keyed differently). A future change that legitimately relaxes the global
     # assertion must still not relax these.
     for name in (:Db_Table_Scratch, :db_table_scratch, :Db_Table_Col_Scratch, :db_table_col_scratch,
-                 :db_table_child_scratch)
+                 :db_table_child_scratch, Symbol("Odd Identifier Scratch"), :odd_identifier_scratch)
         @test !haskey(plan, name)
     end
 end

--- a/test/integration/test_importers_introspection.jl
+++ b/test/integration/test_importers_introspection.jl
@@ -308,7 +308,7 @@
     # `REFERENCES "parent"(""Id"")` — two quote pairs, because the caller adds one around a value
     # that already carries one — made `_compare_field_foreign_key` report the key as changed on
     # every makemigrations, and made the query builder throw `InvalidValueError`
-    # (`SAFE_IDENTIFIER_PATTERN` forbids a `"`).
+    # (before #394; a physical column is escaped rather than validated now).
     #
     # This is the live half of test/unit/test_introspection_guards.jl's #389 block. It runs on both
     # backends even though only PostgreSQL has the hazard: SQLite reads FK metadata from

--- a/test/integration/test_internals.jl
+++ b/test/integration/test_internals.jl
@@ -215,6 +215,11 @@ end
 
 @testset "SQL Injection Prevention Tests" begin
         
+  # Two rules, one per axis (#394). `quote_identifier` is the fail-closed ALIAS path; the
+  # `safe_*_identifier` pair is the escape-only PHYSICAL path, because a table or column name is
+  # pinned by the model author or read from the catalog, and validating it meant refusing names
+  # PormG's own DDL creates. The partition itself is covered exhaustively in
+  # `test/unit/test_identifier_quoting.jl`.
   @testset "Identifier Sanitization" begin
     # Test the SQLSanitizer module
     
@@ -229,6 +234,15 @@ end
     
     # Test table name sanitization
     @test safe_table_identifier("users", nothing) == "\"users\""
+
+    # A PHYSICAL name is escaped, not validated (#394) — the same strings refused above are legal
+    # as a `db_table`/`db_column`, and quote doubling is what makes them safe.
+    @test safe_table_identifier("driver profile", nothing) == "\"driver profile\""
+    @test safe_table_identifier("we\"ird", nothing) == "\"we\"\"ird\""
+    @test safe_column_identifier("Say\"Hi", nothing) == "\"Say\"\"Hi\""
+    # The doubled quote cannot terminate the identifier, which is the whole threat.
+    @test safe_table_identifier("x\"; DROP TABLE users; --", nothing) ==
+          "\"x\"\"; DROP TABLE users; --\""
     
     println("✅ All identifier sanitization tests passed!")
   end
@@ -321,6 +335,9 @@ end
     end
   end
 
+  # Every string below stays refused as an ALIAS after #394, and every one of them is legal as a
+  # physical `db_table`/`db_column`. That is the split, and it is deliberate: an alias is chosen at
+  # query-build time and names nothing that exists, so there is nothing to be faithful to.
   @testset "Advanced Sanitizer Unit Tests" begin
     # Test with Unicode and control characters
     # Sometimes 'latin1' or other encodings allow single-quote bypasses

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
     @testset "Execution Returns (show_query)" include("unit/test_execution_show.jl")
     @testset "Complex Query Patterns" include("unit/test_complex_queries.jl")
     @testset "Many-to-Many Relationships" include("unit/test_many_to_many.jl")
+    @testset "Reverse-accessor Namespace (#396)" include("unit/test_reverse_accessor_namespace.jl")
     @testset "Composite Uniqueness (unique_together #19)" include("unit/test_unique_constraints.jl")
     @testset "Composite Indexes (Meta.indexes #347)" include("unit/test_indexes.jl")
     @testset "Shared-state Read/Copy Path (#43)" include("unit/test_shared_state_readpath.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     @testset "Mixed-case Model Binding in Reverse Joins (#343)" include("unit/test_reverse_join_mixed_case_binding.jl")
     @testset "db_column Authoritative (#50)" include("unit/test_db_column.jl")
     @testset "db_table Authoritative (#59)" include("unit/test_db_table.jl")
+    @testset "Identifier Quoting Partition (#394)" include("unit/test_identifier_quoting.jl")
     @testset "Unresolved ForeignKey Target Is Never Guessed (#388)" include("unit/test_fk_unresolved_target.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")

--- a/test/unit/fixtures/django_project/racing/models.py
+++ b/test/unit/fixtures/django_project/racing/models.py
@@ -18,6 +18,11 @@ class Driver(models.Model):
     # Self-referential FK — Django's `"self"` literal. Emitted verbatim before #346, which made the
     # generated file throw at set_models. `related_name` because `teammates` below points at the same
     # model, and two relations to one target need distinct reverse accessors (Django: fields.E304).
+    #
+    # Django still REQUIRES this name, which is why it stays. PormG no longer does: since #396 it
+    # counts every relation to a target — many-to-many included — and derives `<model>_<field>` for
+    # each member of a group, so dropping `related_name` here would register two distinct accessors
+    # rather than colliding. Kept explicit so the fixture keeps mirroring a real Django project.
     mentor = models.ForeignKey('self', on_delete=models.SET_NULL, null=True, blank=True,
                                related_name='mentees')
     # Self-referential M2M. Django names the two join columns from_driver_id / to_driver_id, because

--- a/test/unit/test_aggregate_fanout.jl
+++ b/test/unit/test_aggregate_fanout.jl
@@ -29,6 +29,8 @@ import PormG.QueryBuilder: _extract_leading_alias
     @test _extract_leading_alias(["a", "b"]) === nothing
 
     # Logic: an identifier containing escaped (doubled) quotes is unescaped in the returned alias.
-    # Why: quote_identifier escapes embedded quotes as "" — extraction must reverse that faithfully.
+    # Why: `safe_column_identifier` escapes embedded quotes as "" — extraction must reverse that
+    # faithfully. Reachable in practice since #394: the query path escapes a physical column rather
+    # than refusing it, so a `db_column` carrying a quote now reaches this extractor.
     @test _extract_leading_alias("\"we\"\"ird\".\"c\"") == "we\"ird"
 end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -2150,10 +2150,13 @@ end
 end
 
 @testset "Related Objects - Auto-generated related_name key format" begin
-    # Just_a_nested_roll_back has a single FK to Just_a_test_deletion with no
-    # explicit related_name. The auto-generated key should be the lowercased
-    # model name of Just_a_nested_roll_back.
+    # Just_a_nested_roll_back has a SINGLE relation to Just_a_test_deletion with no explicit
+    # related_name, so it takes the lone-relation arm of the derivation: the lowercased model name of
+    # Just_a_nested_roll_back, bare. #396 changed only the other arm — a model with two or more
+    # relations to one target now suffixes every one of them with the field name — so this key is
+    # deliberately unchanged and this testset is the negative control for that.
     @test haskey(M.Just_a_test_deletion.related_objects, "just_a_nested_roll_back")
+    @test !haskey(M.Just_a_test_deletion.related_objects, "just_a_nested_roll_back_test")
 
     # Verify the relation structure. This was a bare 4-tuple until #343; the 4th slot (the child's
     # own PK) is gone with it, unread by anything, and two slots were ADDED that no string function
@@ -2199,7 +2202,17 @@ end
     Core.eval(dup_mod, :(const DupChild = $DupChild))
 
     # set_models should reject the duplicate related_name
-    @test_throws PormG.ModelDefinitionError PormG.Models.set_models(dup_mod, "mock_sl_path")
+    dup_err = @test_throws PormG.ModelDefinitionError PormG.Models.set_models(dup_mod, "mock_sl_path")
+
+    # #396: the message names BOTH ends of the collision and the name they collide on. It used to
+    # name the model twice ("The related_name same_name in the model dup_child is already defined")
+    # and neither field, which on a self-relation read as the model colliding with itself. Which of
+    # fk1/fk2 registers first is `Dict` hash order, so both spellings are asserted rather than one.
+    dup_msg = dup_err.value.msg
+    @test occursin("same_name", dup_msg)
+    @test occursin("dup_child.fk1", dup_msg)
+    @test occursin("dup_child.fk2", dup_msg)
+    @test occursin("dup_parent", dup_msg)
 end
 
 @testset "Delete Graph - Circular dependency detection" begin

--- a/test/unit/test_complex_queries.jl
+++ b/test/unit/test_complex_queries.jl
@@ -624,6 +624,12 @@ Race = Models.Model("fks_race",
 # there. PormG declares that FK as `circuit_id`, which `circuit` does not collide with. The clash is
 # only between the reverse name and the SHORT FORM the resolver would invent, which is exactly why
 # the resolver must defer rather than silently pick a side.
+#
+# #396 added a registration-time check that a reverse accessor does not shadow a field on the model
+# it lands on. That check is `haskey(related_model.fields, accessor)` VERBATIM and deliberately does
+# NOT go through `_resolve_fk_short_form` — widening it to the short form would outlaw this fixture.
+# If a future change makes this model set raise, the check has been over-widened, not this fixture
+# made wrong.
 Lap = Models.Model("fks_lap",
   id = Models.IDField(),
   name = Models.CharField(),

--- a/test/unit/test_db_table.jl
+++ b/test/unit/test_db_table.jl
@@ -234,6 +234,25 @@ DbtPlain.connect_key = "db_table_mock"
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # #394: whatever `create_table` renders, the query builder addresses. `db_table` is unvalidated by
+  # design (`_apply_db_table!` type-checks and nothing more), so the DDL side always accepted a name
+  # the query side then refused — PormG would migrate a table it could not select from. Comparing the
+  # two renderers is the only assertion that can catch that; each half looked correct alone.
+  # ─────────────────────────────────────────────────────────────────────────────
+  @testset "a db_table create_table accepts is one the query builder addresses (#394)" begin
+    for physical in ["Odd Table Name", "2fast", "cost\$usd", "Ev\"il"]
+      odd = Model("dbt_odd_scratch", db_table = physical, id = IDField(), name = CharField())
+      odd.connect_key = "db_table_mock"
+      escaped = replace(physical, "\"" => "\"\"")
+
+      for conn in (MockPostgresDbTable(), MockSQLiteDbTable())
+        @test occursin("CREATE TABLE IF NOT EXISTS \"$(escaped)\"", PormG.Dialect.create_table(conn, odd))
+      end
+      @test occursin("FROM \"$(escaped)\"", inspect_query(odd.objects)[:sql_text])
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Reads. The base table and any JOIN target both resolve through the same seam.
   # ─────────────────────────────────────────────────────────────────────────────
   @testset "SELECT and JOIN render db_table" begin

--- a/test/unit/test_fk_unresolved_target.jl
+++ b/test/unit/test_fk_unresolved_target.jl
@@ -118,11 +118,12 @@ end
     # Pinned parent: db_table differs from the logical name, and must WIN. Before #388 the String
     # branch ignored db_table entirely, so a pinned parent was referenced by the wrong name even
     # when the lowercase guess would otherwise have inverted cleanly.
-    # NOTE (#394): this spaced name renders fine in DDL but the query builder would REFUSE it —
-    # `SAFE_IDENTIFIER_PATTERN` rejects spaces while `_quote_table_ddl` does not, so PormG will
-    # migrate a table it cannot then join. That split predates #388 and is tracked separately; the
-    # name is kept here deliberately, because the DDL half is what this testset asserts and a space
-    # is the sharpest proof that `db_table` reaches the `REFERENCES` clause verbatim.
+    # A space is deliberate: it is the sharpest proof that `db_table` reaches the `REFERENCES`
+    # clause verbatim. It used to be a one-sided proof — the DDL rendered it and the query builder
+    # then REFUSED it, because `SAFE_IDENTIFIER_PATTERN` rejected a space that `_quote_table_ddl`
+    # escaped happily, so PormG would migrate a table it could not join. #394 closed that: a
+    # physical name is escaped rather than validated on both layers, and this same spelling is
+    # exercised end-to-end in `test/unit/test_identifier_quoting.jl`.
     pinned_parent = Model("fku_pinned_scratch", db_table = "Fku Pinned Table",
                           id = IDField(), surname = CharField())
 
@@ -177,12 +178,11 @@ end
   #    off it, so `db_table` wins and a sanitized binding is not folded into a fictional table.
   # ───────────────────────────────────────────────────────────────────────────────────────────
   @testset "first-hop join resolves the binding instead of lowercasing it" begin
-    # Fixture shapes are constrained here in a way the DDL testset above is not: the query builder
-    # runs every table through `SAFE_IDENTIFIER_PATTERN` (`sanitization.jl`), which rejects a space
-    # outright — so `driver profile`, the sharpest illustration of the defect, cannot reach a JOIN
-    # at all and would test that guard rather than this fix. MIXED CASE is the legal-identifier
-    # shape with the same property: the fold is not an identity, so the old lowercase and the new
-    # resolution give DIFFERENT answers and the assertions below can tell them apart.
+    # MIXED CASE rather than a spaced name, and it stays that way after #394 made a spaced table
+    # queryable: the property this testset needs is that the lowercase fold is NOT an identity, so
+    # the old lowercase and the new resolution give DIFFERENT answers and the assertions can tell
+    # them apart. A space has that property too, but it also exercises the escape path, which would
+    # make a failure here ambiguous between the binding resolution (#388) and the quoting (#394).
     #
     # Pinned parent: binding `Fku_pinned` -> lowercase `fku_pinned`, but the table is
     # `Fku_Pinned_Physical`. The old branch ignored `db_table` entirely, so it joined a table that

--- a/test/unit/test_identifier_quoting.jl
+++ b/test/unit/test_identifier_quoting.jl
@@ -1,0 +1,320 @@
+"""
+Unit coverage for the SQL identifier contract (#394).
+
+PormG had two rules for one job. `Dialect._quote_table_ddl` **escaped** `"` and never validated, so
+the DDL renderer accepted any spelling; `quote_identifier` **validated** against
+`SAFE_IDENTIFIER_PATTERN` and never escaped, so the query builder refused most of them. The result
+was a schema PormG would migrate and then could not query — reachable without anyone hand-writing a
+hostile string, because `db_table`/`db_column` are deliberately unvalidated (#59/#50) and the
+importers pin arbitrary catalog names into them.
+
+#394 replaces it with one rule per axis:
+
+  * a PHYSICAL name (table, column) is **escape-only** — `safe_table_identifier` /
+    `safe_column_identifier`, mirroring `Dialect._quote_table_ddl`;
+  * an ALIAS or other query-time name stays **fail-closed** — `quote_identifier`, because a join
+    alias, a `.with(...)` CTE name and a `values("label" => ...)` label are chosen at build time,
+    are often literals the caller typed, and name nothing that already exists;
+  * a JSON path segment keeps its own pattern, because it is interpolated **unquoted** into a path
+    literal and has no quoting to fall back on.
+
+All assertions render via mock connections; no live database is required.
+"""
+
+using Test
+using PormG
+using PormG.Models: Model, CharField, IDField, IntegerField, model_table_name
+import OrderedCollections
+using PormG.QueryBuilder: inspect_query, quote_identifier, safe_table_identifier,
+                          safe_column_identifier, _escape_identifier, _validate_identifier,
+                          _sql_literal
+
+struct MockPostgresIdent <: PormG.PormGPostgres end
+struct MockSQLiteIdent <: PormG.PormGSQLite end
+PormG.config["ident_mock"] = PormG.Configuration.Settings(
+  connections = MockPostgresIdent(),
+  change_data = true,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. The partition, over the exact set of hostile names the importer already round-trips.
+#
+# This list is copied from `test/unit/test_model_to_str_identifiers.jl`, which asserts that a
+# physical table carrying any of these spellings is preserved verbatim and pinned as `db_table` in
+# the generated model file. That equivalence IS #394: a name `Model_to_str` will write into a
+# `db_table` has to be a name the query builder can address, or `inspectdb` emits a model that
+# cannot be used.
+# ─────────────────────────────────────────────────────────────────────────────
+const HOSTILE_NAMES = ["we\"ird", "2fast", "driver profile", "cost\$usd", "_", "___", "end",
+                       "db_table", "admin--", "user name", "localização"]
+
+@testset "physical identifiers are escaped, never validated (#394)" begin
+  for name in HOSTILE_NAMES
+    # Neither raises, on either axis.
+    t = safe_table_identifier(name, nothing)
+    c = safe_column_identifier(name, nothing)
+    @test t == c                                  # one rule, two entry points
+    @test startswith(t, "\"") && endswith(t, "\"")
+    # The only transformation is quote doubling.
+    @test t == "\"" * replace(name, "\"" => "\"\"") * "\""
+  end
+
+  # Spelled out for the case that matters, so a reader does not have to evaluate the loop.
+  @test safe_table_identifier("driver profile", nothing) == "\"driver profile\""
+  @test safe_table_identifier("we\"ird", nothing) == "\"we\"\"ird\""
+  @test safe_column_identifier("Say\"Hi", nothing) == "\"Say\"\"Hi\""
+  @test safe_table_identifier("2fast", nothing) == "\"2fast\""
+
+  # An ordinary name is untouched — escaping is a no-op for everything without a quote.
+  @test safe_table_identifier("drivers", nothing) == "\"drivers\""
+  @test safe_column_identifier("driverid", nothing) == "\"driverid\""
+end
+
+@testset "aliases stay fail-closed (#394)" begin
+  # Every name the escape-only path now accepts is still refused as an ALIAS, except the ones that
+  # were always legal identifiers.
+  for name in ["we\"ird", "2fast", "driver profile", "cost\$usd", "admin--", "user name", ""]
+    @test_throws PormG.InvalidValueError quote_identifier(name, nothing)
+  end
+  for name in ["_", "___", "end", "db_table", "localização", "driverid"]
+    @test quote_identifier(name, nothing) == "\"$(name)\""
+  end
+
+  # The message points at the option that carries an arbitrary spelling, rather than leaving the
+  # caller to guess that aliases and physical names have different rules.
+  err = @test_throws PormG.InvalidValueError quote_identifier("driver profile", nothing)
+  @test occursin("ALIAS", err.value.msg)
+  @test occursin("db_table", err.value.msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. The defect itself: DDL and query must render the SAME spelling.
+#
+# Asserting each side in isolation is what let the split survive — both halves were individually
+# "correct". This compares them.
+# ─────────────────────────────────────────────────────────────────────────────
+const OddIdent = Model("odd_ident_scratch",
+  db_table  = "Odd Identifier",
+  id        = IDField(),
+  driverref = CharField(max_length = 30, db_column = "driver ref"),
+  points    = IntegerField(null = true),
+)
+OddIdent.connect_key = "ident_mock"
+
+@testset "a name the DDL renders is a name the query builder addresses (#394)" begin
+  for conn in (MockPostgresIdent(), MockSQLiteIdent())
+    ddl = PormG.Dialect.create_table(conn, OddIdent)
+    @test occursin("\"Odd Identifier\"", ddl)
+    @test occursin("\"driver ref\"", ddl)
+  end
+
+  q = OddIdent.objects
+  q.filter("driverref" => "senna")
+  q.values("driverref", "points")
+  sql = inspect_query(q)[:sql_text]
+
+  # The same two spellings, from the other layer. Before #394 this call raised
+  # `InvalidValueError: Invalid SQL identifier: Odd Identifier`.
+  @test occursin("FROM \"Odd Identifier\"", sql)
+  @test occursin("\"driver ref\"", sql)
+
+  # The value is still parameterized — loosening the identifier rule did not loosen anything about
+  # values, which is where user input actually flows.
+  @test !occursin("senna", sql)
+end
+
+@testset "an embedded quote is escaped identically on both layers (#394)" begin
+  evil = Model("evil_ident_scratch",
+    db_table = "Ev\"il",
+    id       = IDField(),
+    label    = CharField(max_length = 10, db_column = "Say\"Hi"),
+  )
+  evil.connect_key = "ident_mock"
+
+  for conn in (MockPostgresIdent(), MockSQLiteIdent())
+    ddl = PormG.Dialect.create_table(conn, evil)
+    @test occursin("\"Ev\"\"il\"", ddl)
+    # The column half is what #394 added to the DDL side — without it the query builder would start
+    # accepting a column the renderer still emits unescaped, moving the split instead of closing it.
+    @test occursin("\"Say\"\"Hi\"", ddl)
+  end
+
+  q = evil.objects
+  q.values("label")
+  sql = inspect_query(q)[:sql_text]
+  @test occursin("\"Ev\"\"il\"", sql)
+  @test occursin("\"Say\"\"Hi\"", sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. The query-time surfaces that must NOT have been loosened along with the rest.
+# ─────────────────────────────────────────────────────────────────────────────
+const IdentDriver = Model("ident_driver_scratch",
+  id       = IDField(),
+  surname  = CharField(max_length = 30),
+  points   = IntegerField(null = true),
+)
+IdentDriver.connect_key = "ident_mock"
+
+@testset "a CTE name is refused at the .with() call, not at render (#394)" begin
+  sub = IdentDriver.objects
+  sub.values("surname")
+
+  # #394 moved this check to declaration. `row_join["b"]` carries a physical table on every branch
+  # but the CTE ones, and that slot quotes escape-only now — so validating the CTE name only at
+  # render time would leave the guard depending on which renderer ran first.
+  q = IdentDriver.objects
+  @test_throws PormG.InvalidValueError q.with("bad name" => sub)
+  @test_throws PormG.InvalidValueError q.with("2fast" => sub)
+
+  # A legal name still works, and still renders.
+  ok = IdentDriver.objects
+  ok.with("recent" => sub)
+  ok.values("surname")
+  @test occursin("WITH \"recent\" AS", inspect_query(ok)[:sql_text])
+end
+
+@testset "a SELECT label is refused (#394)" begin
+  q = IdentDriver.objects
+  q.values("bad name" => "points")
+  @test_throws PormG.InvalidValueError inspect_query(q)
+end
+
+@testset "JSON path segments keep their own guard (#394)" begin
+  # `SAFE_JSON_KEY_PATTERN` is a separate constant from `SAFE_IDENTIFIER_PATTERN` precisely so a
+  # future relaxation of the identifier rules cannot widen this one. A segment is interpolated
+  # UNQUOTED into a path literal, so the charset check is the whole guard.
+  @test PormG.QueryBuilder.SAFE_JSON_KEY_PATTERN !== PormG.QueryBuilder.SAFE_IDENTIFIER_PATTERN
+
+  segs = PormG.QueryBuilder._validate_json_key_segments(["driver", "0", "team_name"])
+  @test segs == ["driver", "0", "team_name"]
+
+  for bad in ["a b", "a'b", "a}b", "a,b", "a.b", ""]
+    @test_throws PormG.InvalidValueError PormG.QueryBuilder._validate_json_key_segments([bad])
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. The two swallowing catches (#394).
+#
+# `_build_from_tables` used to drop a table from a correlated FROM list and `_get_join_condition_list`
+# used to drop an ON condition from a correlated UPDATE ... FROM / DELETE ... USING — both on any
+# exception, both reported only as an `@error`. A mutation missing its ON condition matches every row
+# of the joined table, so this is the one place a swallowed error corrupts data.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a malformed row_join raises instead of emitting wrong SQL (#394)" begin
+  RowJoin = Dict{String, Union{String, Vector{PormG.QueryBuilder.FilterType}}}
+
+  @test_throws KeyError PormG.QueryBuilder._build_from_tables(
+    [RowJoin("alias_b" => "Tb_1")], MockPostgresIdent())          # no "b"
+
+  @test_throws KeyError PormG.QueryBuilder._get_join_condition_list(
+    [RowJoin("alias_a" => "Tb", "alias_b" => "Tb_1", "key_b" => "id")], MockPostgresIdent())  # no "key_a"
+
+  # The other half of what the comment on those loops claims: an INTERNALLY generated alias that is
+  # not an identifier must surface too. A wrong fix that re-wrapped only the `quote_identifier`
+  # calls in a try/catch passes the `KeyError` cases above and fails this one.
+  @test_throws PormG.InvalidValueError PormG.QueryBuilder._get_join_condition_list(
+    [RowJoin("alias_a" => "bad alias", "alias_b" => "Tb_1", "key_a" => "id", "key_b" => "x")],
+    MockPostgresIdent())
+  @test_throws PormG.InvalidValueError PormG.QueryBuilder._build_from_tables(
+    [RowJoin("b" => "drivers", "alias_b" => "bad alias")], MockPostgresIdent())
+
+  # A CTE cannot be joined here at all: a correlated UPDATE ... FROM emits no WITH clause, so the
+  # relation the FROM list names is never declared. Both CTE shapes are refused before any SQL is
+  # built — the cross-joined one (which also carries sentinel empty key columns) and the keyed one.
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder._get_join_condition_list(
+    [RowJoin("b" => "fast_laps", "cte" => "1", "cross" => "1", "alias_a" => "Tb",
+             "alias_b" => "Tb_1", "key_a" => "", "key_b" => "")], MockPostgresIdent())
+  @test_throws PormG.QueryBuildError PormG.QueryBuilder._get_join_condition_list(
+    [RowJoin("b" => "fast_laps", "cte" => "1", "alias_a" => "Tb", "alias_b" => "Tb_1",
+             "key_a" => "raceid", "key_b" => "raceid")], MockPostgresIdent())
+
+  # The well-formed case still builds, so the assertions above are about the failure path only.
+  good = RowJoin("b" => "drivers", "alias_a" => "Tb", "alias_b" => "Tb_1",
+                 "key_a" => "id", "key_b" => "driverid")
+  @test PormG.QueryBuilder._build_from_tables([good], MockPostgresIdent()) == "\"drivers\" AS \"Tb_1\""
+  @test PormG.QueryBuilder._get_join_condition_list([good], MockPostgresIdent()) ==
+        ["\"Tb\".\"id\" = \"Tb_1\".\"driverid\""]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. The third layer: the migration PLAN FILE.
+#
+# `makemigrations` writes `pending_migrations.jl`, which is Julia source, and each table becomes a
+# BINDING in it (`Generator.generate_migration_plan`). So a physical name that is not a legal Julia
+# identifier produced a file that could not be parsed: `makemigrations` succeeded and `migrate` then
+# died on its own output with a `ParseError`. Every spelling `db_table` exists to carry is such a
+# name, which is why the DDL/query fix above is not the whole story.
+#
+# `var"..."` is Julia's raw-identifier syntax and accepts any string. The reader
+# (`Migrations.get_all_dicts`) walks `names(mod)` and `getfield`, so it never sees the spelling.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a migration plan file parses for any physical table name (#394)" begin
+  bind = PormG.Generator._plan_binding
+
+  # An ordinary name is emitted unchanged, so existing plan files stay byte-identical.
+  @test bind("db_table_scratch") == "db_table_scratch"
+  @test bind(:db_table_scratch) == "db_table_scratch"
+
+  # Anything else takes the raw-identifier form, with both string escapes applied.
+  @test bind("Odd Identifier Scratch") == "var\"Odd Identifier Scratch\""
+  @test bind("2fast") == "var\"2fast\""
+  @test bind("Ev\"il") == "var\"Ev\\\"il\""
+
+  # An all-underscore name is the one case `var"..."` cannot rescue: Julia discards it at any
+  # spelling. It gets a prefix, which is harmless because the reader never looks at the name.
+  @test bind("_") == "var\"pormg_plan__\""
+  @test bind("___") == "var\"pormg_plan____\""
+  # `Base.isidentifier` accepts reserved words, which are a ParseError in assignment position.
+  @test bind("end") == "var\"end\""
+
+  # What actually has to hold for every one of them: the entry PARSES and the dict is reachable the
+  # way `_load_migration_plan` reaches it — by value, not by name.
+  for name in HOSTILE_NAMES
+    probe = Module(Symbol("PlanBindProbe"))
+    Core.eval(probe, Meta.parse(string("import OrderedCollections")))
+    Core.eval(probe, Meta.parse(string(
+      bind(name), " = OrderedCollections.OrderedDict{String,String}(\"New model\" => \"CREATE TABLE\")")))
+    found = Base.invokelatest(PormG.Migrations.get_all_dicts, probe)
+    @test length(found) == 1
+  end
+
+  # End to end: write a plan naming a spaced table, include it back, and read the dict out the way
+  # `_load_migration_plan` does. Before #394 the `include` raised a ParseError.
+  mktempdir() do dir
+    plan = OrderedCollections.OrderedDict{Symbol, OrderedCollections.OrderedDict{String, String}}(
+      Symbol("Odd Identifier Scratch") => OrderedCollections.OrderedDict{String, String}(
+        "New model" => "CREATE TABLE IF NOT EXISTS \"Odd Identifier Scratch\" (\"id\" bigint);"),
+      :plain_table => OrderedCollections.OrderedDict{String, String}(
+        "New model" => "CREATE TABLE IF NOT EXISTS \"plain_table\" (\"id\" bigint);"),
+    )
+    PormG.Generator.generate_migration_plan("pending_migrations.jl", plan, dir)
+    written = read(joinpath(dir, "pending_migrations.jl"), String)
+    @test occursin("var\"Odd Identifier Scratch\" = ", written)
+    @test occursin("\nplain_table = ", written)   # untouched, no var"..." wrapper
+
+    mod = include(joinpath(dir, "pending_migrations.jl"))
+    dicts = Base.invokelatest(PormG.Migrations.get_all_dicts, mod)
+    @test length(dicts) == 2
+    @test any(d -> occursin("Odd Identifier Scratch", d["New model"]), dicts)
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. The two escapes are disjoint, so composing them cannot double-process.
+#
+# `_table_ident_literal` composes them to build `'"Db_Table"'` for `pg_get_serial_sequence` /
+# `to_regclass`, which take TEXT they re-parse as an identifier.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the identifier escape and the literal escape do not overlap (#394)" begin
+  @test _escape_identifier("a'b") == "a'b"        # identifier escape ignores single quotes
+  @test _sql_literal("a\"b") == "a\"b"            # literal escape ignores double quotes
+  @test _escape_identifier("a\"b") == "a\"\"b"
+  @test _sql_literal("a'b") == "a''b"
+
+  # Composed in either order, each escape sees only its own character.
+  both = "he said \"it's fine\""
+  @test _sql_literal(_escape_identifier(both)) ==
+        replace(replace(both, "\"" => "\"\""), "'" => "''")
+end

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -647,7 +647,10 @@ end
 # `Dialect.add_foreign_key` emits `REFERENCES "parent"(""Id"")` (TWO quote pairs — the caller adds
 # one around a value that already carries one; the issue body's `"""Id"""` is wrong),
 # `_compare_field_foreign_key` reports the key as changed on every `makemigrations`, and the query
-# builder throws `InvalidValueError` because `SAFE_IDENTIFIER_PATTERN` forbids a `"`.
+# builder addresses a column that does not exist. (It threw `InvalidValueError` when #389 was
+# written, because `SAFE_IDENTIFIER_PATTERN` forbade a `"`; since #394 a physical column is escaped
+# rather than validated, so the same bad value would now render as a column literally named `"Id"`.
+# Either way it is wrong — de-quoting at the source, which is what this testset pins, is the fix.)
 #
 # `fk_cols` and `col_name` move in the SAME change on purpose: `fk_map`'s keys come from `fk_cols`
 # and are looked up with `col_name`, so normalizing one side alone would break FK detection for
@@ -782,11 +785,11 @@ struct MockPg389 <: PormG.PormGPostgres end
     # alongside a `DROP` of the real one, on every run, silently. `_unquote_ident` undoes the
     # doubling instead, so the name survives: the existing table converges, and `Model_to_str`
     # regenerates it as a legal binding plus `db_column="Say\"Hi"` — a rename of the BINDING, not
-    # of the column. It does NOT make such a name safe everywhere: `Dialect.create_table` still
-    # emits `"Say"Hi"` and closes the identifier early (the column-name twin of the `db_table`
-    # escaping in #388, and #394's family), and the query path raises `InvalidValueError` from
-    # `_validate_identifier`. Surviving intact and being universally usable are different claims;
-    # only the first is made here.
+    # of the column. As of #394 the name is usable end to end as well: `Dialect.create_table`
+    # escapes a column identifier the same way it has escaped `db_table` since #388, and the query
+    # path escapes rather than validates it (`safe_column_identifier`). Both halves are asserted in
+    # `test/unit/test_identifier_quoting.jl`; what this testset pins is the narrower and still
+    # separate claim that introspection round-trips the spelling INTACT.
     model = convertSQLToModel(_introspection_row(
       table_name              = "odd_names",
       columns                 = "id bigint NOT NULL, \"Say\"\"Hi\" bigint",

--- a/test/unit/test_many_to_many.jl
+++ b/test/unit/test_many_to_many.jl
@@ -1387,23 +1387,26 @@ end
   other_err = @test_throws PormG.ModelDefinitionError Models._register_many_to_many_relation!(
     other_module, settings, other, "teammates", other.fields["teammates"])
   # This case covers the WIDENED half of the guard, so it is the one where a masquerading
-  # `ModelDefinitionError` from somewhere else would hide the most. Assert the cause.
-  @test occursin("collides with a field", other_err.value.msg)
+  # `ModelDefinitionError` from somewhere else would hide the most. Assert the cause, and that the
+  # message names BOTH ends of the collision (#396) rather than the model twice.
+  @test occursin("is a FIELD of that model", other_err.value.msg)
+  @test occursin("teammate_shadow2.teammates", other_err.value.msg)
+  @test occursin("teammate_shadow2.driverref", other_err.value.msg)
 
   # A DISTINCT related_name registers both ends, and they stay distinguishable. This is the
   # assertion that keeps the guard from being over-broad.
   @test Models.get_many_to_many_relation(M2MSELF.Teammate, "teammates").reverse == false
   @test M2MSELF.Teammate.related_objects["teammate_of"].reverse == true
 
-  # A NON-self relation is untouched: its two accessors land on DIFFERENT models, so a related_name
-  # matching a field on the OWNER is not a collision at all.
+  # A NON-self relation is untouched when the name does not exist ON THE TARGET: a `related_name`
+  # matching a field on the OWNER is not a collision at all, because the reverse accessor is
+  # installed on the target.
   #
-  # `chassis` exists on the owner and NOT on the target, deliberately. The reverse accessor is
-  # installed on the TARGET, so a name that also exists there would be a genuine shadow — the same
-  # failure this guard closes, one model over — and asserting success on it would pin a broken
-  # configuration as correct. That cross-model half is pre-existing and out of this issue's scope
-  # (the correct general check is `haskey(related_model.fields, …)`, equivalent to the shipped
-  # `haskey(model.fields, …)` only under the self gate); this fixture must not bless it either way.
+  # `chassis` exists on the owner and NOT on the target, deliberately — that is what makes this the
+  # negative control rather than a blessed shadow. #364 shipped the check gated behind
+  # `_same_model_reference`, so the cross-model half was pre-existing and out of its scope; #396
+  # replaced the gate with `haskey(related_model.fields, …)` on every registration path, and the
+  # positive cross-model case is asserted immediately below.
   sponsor = Models.Model("shadow_sponsor", id = Models.IDField(), name = Models.CharField())
   cross_module = Module(:M2MShadowCross)
   Core.eval(cross_module, :(import PormG; import PormG.Models))
@@ -1419,6 +1422,26 @@ end
     cross_module, settings, racer, "sponsors", racer.fields["sponsors"]) === nothing
   # And the reverse accessor it installed is genuinely reachable.
   @test sponsor.related_objects["chassis"] isa Models.ManyToManyRelation
+
+  # The positive cross-model case #364 deliberately left open and #396 closes: a `related_name` that
+  # names a field ON THE TARGET registers cleanly and is then permanently unreachable, because
+  # `_build_row_join` resolves a field before a reverse accessor at every hop. Now refused.
+  shadow_target = Models.Model("shadow_target", id = Models.IDField(), name = Models.CharField())
+  target_module = Module(:M2MShadowTarget)
+  Core.eval(target_module, :(import PormG; import PormG.Models))
+  Core.eval(target_module, :(Sponsor = $shadow_target))
+  Core.eval(target_module, :(Racer = Models.Model("shadow_racer2",
+    id = Models.IDField(),
+    sponsors = Models.ManyToManyField(Sponsor, related_name="name"),
+  )))
+  target_racer = Core.eval(target_module, :(Racer))
+  target_err = @test_throws PormG.ModelDefinitionError Models._register_many_to_many_relation!(
+    target_module, settings, target_racer, "sponsors", target_racer.fields["sponsors"])
+  @test occursin("is a FIELD of that model", target_err.value.msg)
+  @test occursin("shadow_racer2.sponsors", target_err.value.msg)
+  @test occursin("shadow_target.name", target_err.value.msg)
+  # Not misreported as self-referential — the two ends are on different models.
+  @test !occursin("self-referential", target_err.value.msg)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_reverse_accessor_namespace.jl
+++ b/test/unit/test_reverse_accessor_namespace.jl
@@ -1,0 +1,471 @@
+using Test
+using Logging
+using PormG
+using PormG.Models
+
+import PormG: PormGModel
+
+# ═════════════════════════════════════════════════════════════════════════════
+# #396 — the reverse-accessor namespace: derivation, determinism, and its guards
+#
+# UNIT, not integration, on purpose. Every defect #396 closes is a registration-time one — which key
+# a relation installs on its target, and whether a collision is detected — and none of it involves a
+# database round trip. The render assertions below use `inspect_query`, which returns the SQL text
+# before any connection is used, so they belong here too.
+#
+# What was wrong. `set_models` walked `pairs(model.fields)` and accumulated a per-target counter as
+# it went, so in a group of N relations to one target the field VISITED FIRST kept the bare model
+# name and the rest were suffixed `<model>_<field>`. `Model_Type.fields` is an unordered `Dict`, so
+# which one that was is hash order — and adding an unrelated field to the model rehashed it.
+# ManyToManyField never entered the counter at all, so a self-ForeignKey and a self-ManyToManyField
+# on one model both derived the bare model name; whichever registered first won, and the other
+# either threw or (m2m-first) silently replaced the `ManyToManyRelation` with a `ReverseRelation`.
+# ═════════════════════════════════════════════════════════════════════════════
+
+struct RanMockPostgres <: PormG.PormGPostgres end
+
+PormG.config["ran_mock"] = PormG.Configuration.Settings(
+  connections = RanMockPostgres(),
+  change_data = true,
+  db_def_folder = "ran_mock"
+)
+
+# Build a module, evaluate `decls` into it, and register it. Returns the module. Kept as a helper
+# because every collision testset below needs `set_models` to be a CALL it can wrap in
+# `@test_throws` — a `module ... end` block would raise while the file is being parsed.
+#
+# `Base.invokelatest` is load-bearing, not defensive. `Core.eval` defines the model bindings in a
+# NEWER world age than the one this function is executing in, so a direct call reaches `set_models`
+# with a world where `getfield(mod, :Driver)` does not resolve yet — it registers nothing and returns
+# quietly, leaving every `related_objects` empty. This is the same world-age seam `@import_models`
+# handles and the reason for the Julia 1.12 floor (#211). Every later call that has to see these
+# bindings (`set_models` re-runs, `add_field!`) needs the same treatment.
+function _ran_module(name::Symbol, decls::Expr; register::Bool = true)
+  mod = Module(name)
+  Core.eval(mod, :(import PormG; import PormG.Models))
+  Core.eval(mod, decls)
+  register && Base.invokelatest(Models.set_models, mod, "ran_mock")
+  return mod
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Symmetry — in a group of N, NO relation keeps the bare model name.
+#
+# The pre-#396 behaviour was for ONE of these two to answer to the bare `ran_incident`, and which
+# one was hash order over the field names. Asserting the bare key is ABSENT is the load-bearing half:
+# a test that only checked the two suffixed keys existed passed before and after.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a multi-FK group is symmetric — no relation keeps the bare model name (#396)" begin
+  SYM = _ran_module(:RanSymModels, quote
+    Driver = Models.Model("ran_driver",
+      id = Models.IDField(),
+      surname = Models.CharField(),
+    )
+    Incident = Models.Model("ran_incident",
+      id = Models.IDField(),
+      lap = Models.IntegerField(),
+      causing_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+      affected_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+  end)
+
+  @test Set(keys(SYM.Driver.related_objects)) ==
+        Set(["ran_incident_causing_driver_id", "ran_incident_affected_driver_id"])
+  @test !haskey(SYM.Driver.related_objects, "ran_incident")
+
+  # Each accessor points at the field it was named after — the suffix is not decoration.
+  @test SYM.Driver.related_objects["ran_incident_causing_driver_id"].fk_field === :causing_driver_id
+  @test SYM.Driver.related_objects["ran_incident_affected_driver_id"].fk_field === :affected_driver_id
+
+  # `OneToOneField` travels the same branch as `ForeignKey`, in the pre-scan AND in the registration
+  # walk. Those two conditions have to name the same set of types: drop `sOneToOneField` from either
+  # one and the walk indexes `targets` with a key the pre-scan never wrote.
+  O2O = _ran_module(:RanO2OModels, quote
+    Driver = Models.Model("rano2o_driver", id = Models.IDField(), surname = Models.CharField())
+    Profile = Models.Model("rano2o_profile",
+      id = Models.IDField(),
+      driverid = Models.OneToOneField(Driver, pk_field = "id"),
+      backup_driverid = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+  end)
+  @test Set(keys(O2O.Driver.related_objects)) ==
+        Set(["rano2o_profile_driverid", "rano2o_profile_backup_driverid"])
+  @test !haskey(O2O.Driver.related_objects, "rano2o_profile")
+
+  # A LONE relation is untouched: it still gets the bare model name. This is the negative control
+  # that keeps the fix from suffixing everything, which would be a far larger rename.
+  LONE = _ran_module(:RanLoneModels, quote
+    Circuit = Models.Model("ran_circuit", id = Models.IDField(), name = Models.CharField())
+    Race = Models.Model("ran_race",
+      id = Models.IDField(),
+      circuitid = Models.ForeignKey(Circuit, pk_field = "id"),
+    )
+  end)
+  @test collect(keys(LONE.Circuit.related_objects)) == ["ran_race"]
+  @test !haskey(LONE.Circuit.related_objects, "ran_race_circuitid")
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# 2. The accessor is a function of (model, field, group size) and of nothing else.
+#
+# The old derivation read one more input that is not on that list: where the field fell in the walk
+# over `pairs(model.fields)`. `Model_Type.fields` is an unordered `Dict`, so hash order decided which
+# relation kept the bare model name, and adding an unrelated field to the model could rehash it and
+# silently rename a lookup path.
+#
+# Testing that through fixtures is harder than it looks. `Dict` iteration is a function of the key
+# SET, so two models with the same field names walk identically however they were written, and even
+# a model with EXTRA fields usually preserves the relative order of the two foreign keys — a pair of
+# fixtures built to "perturb the hash" can easily perturb nothing at all. So this asserts the
+# property on the pure function directly, and then over a spread of padding sets to show that none
+# of them moves the answer. No single padding has to be proven to reorder anything.
+# ────────────────────────────────────────────────────────────────────────────
+@testset "a derived accessor depends only on model, field and group size (#396)" begin
+  # The pure function, both arms. This is the whole contract; everything else is plumbing.
+  @test Models._derived_reverse_accessor(:ranp_incident, "causing_driver_id", 1) == "ranp_incident"
+  @test Models._derived_reverse_accessor(:ranp_incident, "causing_driver_id", 2) ==
+        "ranp_incident_causing_driver_id"
+  @test Models._derived_reverse_accessor(:ranp_incident, "causing_driver_id", 7) ==
+        "ranp_incident_causing_driver_id"
+  # Injective across a group for free, because field names are unique within a model.
+  @test Models._derived_reverse_accessor(:ranp_incident, "causing_driver_id", 2) !=
+        Models._derived_reverse_accessor(:ranp_incident, "affected_driver_id", 2)
+
+  paddings = [
+    "",
+    "lap = Models.IntegerField(),",
+    "lap = Models.IntegerField(), weather = Models.CharField(), note = Models.CharField(null = true),",
+    "a = Models.CharField(), q2 = Models.CharField(), zzz = Models.IntegerField(null = true),",
+  ]
+  for (i, pad) in enumerate(paddings)
+    src = string(
+      "Driver = Models.Model(\"ranp", i, "_driver\", id = Models.IDField(), surname = Models.CharField())\n",
+      "Incident = Models.Model(\"ranp", i, "_incident\",\n",
+      "  id = Models.IDField(),\n  ", pad, "\n",
+      "  causing_driver_id = Models.ForeignKey(Driver, pk_field = \"id\"),\n",
+      "  affected_driver_id = Models.ForeignKey(Driver, pk_field = \"id\"),\n)\n")
+    mod = _ran_module(Symbol("RanPad", i), Meta.parse(string("begin\n", src, "\nend")))
+    # `invokelatest` for the same reason `_ran_module` needs it: the binding was defined in a newer
+    # world than this loop body is executing in.
+    driver = Base.invokelatest(getproperty, mod, :Driver)
+    @test Set(keys(driver.related_objects)) ==
+          Set(["ranp$(i)_incident_causing_driver_id", "ranp$(i)_incident_affected_driver_id"])
+    @test driver.related_objects["ranp$(i)_incident_causing_driver_id"].fk_field ===
+          :causing_driver_id
+    @test driver.related_objects["ranp$(i)_incident_affected_driver_id"].fk_field ===
+          :affected_driver_id
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. The shape #396 reports: a self-ForeignKey and a self-ManyToManyField, neither named.
+#
+# This is the canonical Django self-relation pairing (`Driver.mentor` + `Driver.teammates`) and it is
+# the exact shape `test/unit/fixtures/django_project/racing/models.py` carries — that fixture only
+# escapes the collision because its ForeignKey pins `related_name='mentees'`.
+#
+# Both relations now count toward the group, so they derive two distinct suffixed accessors and both
+# register. The `isa ManyToManyRelation` assertion is the regression: on the bug, an m2m-first walk
+# left `related_objects` holding a `ReverseRelation` under that key and the many-to-many reverse end
+# was gone with no error.
+# ─────────────────────────────────────────────────────────────────────────────
+# Hoisted to file scope: testset 4 renders queries against this same registration, and `Module(:X)`
+# names the module without binding `X` anywhere a later testset could reach.
+const RAN_SELF = _ran_module(:RanSelfModels, quote
+  Driver = Models.Model("ran_self_driver",
+    id = Models.IDField(),
+    surname = Models.CharField(),
+    mentor_id = Models.ForeignKey("Driver", null = true, pk_field = "id"),
+    teammates = Models.ManyToManyField("Driver"),
+  )
+end)
+
+@testset "a self-ForeignKey and a self-ManyToManyField no longer collide (#396)" begin
+  SELF = RAN_SELF
+
+  @test Set(keys(SELF.Driver.related_objects)) ==
+        Set(["ran_self_driver_mentor_id", "ran_self_driver_teammates"])
+
+  fk_rev = SELF.Driver.related_objects["ran_self_driver_mentor_id"]
+  m2m_rev = SELF.Driver.related_objects["ran_self_driver_teammates"]
+  @test fk_rev isa Models.ReverseRelation
+  @test fk_rev.fk_field === :mentor_id
+  @test m2m_rev isa Models.ManyToManyRelation   # ← the silent-overwrite regression
+  @test m2m_rev.reverse == true
+
+  # The forward accessor is intact and distinct from the reverse one. Readers consult
+  # `model.cache["many_to_many"]` before `related_objects`, so an equal name would leave the reverse
+  # end permanently shadowed rather than merely missing.
+  fwd = Models.get_many_to_many_relation(SELF.Driver, "teammates")
+  @test fwd.reverse == false
+
+  # The slot the manager filters on and the key that landed in `related_objects` are the SAME string.
+  # `_m2m_query` builds its lookup from `relation.inverse_accessor`; if `set_models` derived one name
+  # from the group while `_relation_from_many_to_many` re-derived another, every `.all()` on this
+  # manager would traverse the join table backwards and silently answer the opposite question.
+  @test fwd.inverse_accessor == "ran_self_driver_teammates"
+
+  # The write-back is gone on the MANY-TO-MANY path too, not only the foreign-key one. Both used to
+  # assign the derived name onto `field.related_name`; restoring either would put a PormG-invented
+  # accessor back into `Model_to_str`'s output for a regenerated model file.
+  @test SELF.Driver.fields["teammates"].related_name === nothing
+  @test SELF.Driver.fields["mentor_id"].related_name === nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Both derived accessors are reachable, and they are different queries.
+#
+# Asserting two distinct keys exist cannot tell you either one resolves. This renders the SQL.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "both derived accessors render a join (#396)" begin
+  SELF = RAN_SELF
+
+  via_fk = SELF.Driver.objects
+  via_fk.filter("ran_self_driver_mentor_id__surname" => "senna")
+  via_fk.values("surname")
+  fk_sql = inspect_query(via_fk)[:sql_text]
+
+  via_m2m = SELF.Driver.objects
+  via_m2m.filter("ran_self_driver_teammates__surname" => "prost")
+  via_m2m.values("surname")
+  m2m_sql = inspect_query(via_m2m)[:sql_text]
+
+  # The FK reverse is a single join back onto the same table.
+  @test occursin("FROM \"ran_self_driver\" as \"Tb\"", fk_sql)
+  @test occursin("\"ran_self_driver\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"mentor_id\"", fk_sql)
+  @test !occursin("ran_self_driver_teammates\" AS", fk_sql)   # not routed through the join table
+
+  # The m2m reverse is two legs through the synthesized join table.
+  @test occursin("\"ran_self_driver_teammates\" AS \"Tb_1\"", m2m_sql)
+  @test occursin("\"ran_self_driver\" AS \"Tb_2\"", m2m_sql)
+
+  @test fk_sql != m2m_sql
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. The previously UNGUARDED branch.
+#
+# A lone FK with no `related_name` wrote its key with a bare `setindex!` — the one registration path
+# of four that did not check first. Here another model's EXPLICIT `related_name` already holds the
+# name the derivation lands on, so the old code silently discarded whichever registered second.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a derived accessor cannot silently overwrite an existing one (#396)" begin
+  err = @test_throws PormG.ModelDefinitionError _ran_module(:RanTakenModels, quote
+    Driver = Models.Model("rant_driver", id = Models.IDField(), surname = Models.CharField())
+    # Derives the bare `rant_result` on Driver.
+    Result = Models.Model("rant_result",
+      id = Models.IDField(),
+      driverid = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+    # ...and claims that same name explicitly.
+    Penalty = Models.Model("rant_penalty",
+      id = Models.IDField(),
+      driverid = Models.ForeignKey(Driver, pk_field = "id", related_name = "rant_result"),
+    )
+  end)
+
+  msg = err.value.msg
+  @test occursin("rant_result", msg)
+  # Names BOTH ends. The three pre-#396 messages named the model twice and neither field, which on a
+  # self-relation read as "the model collided with itself".
+  @test occursin("rant_result.driverid", msg)
+  @test occursin("rant_penalty.driverid", msg)
+  @test occursin("rant_driver", msg)
+  # Whichever of the two registered first, the loser is named as the one that must be given a
+  # related_name — so the remedy is actionable regardless of hash order. Matched on the remedy
+  # sentence, because a bare `occursin("related_name", ...)` is already satisfied by the origin
+  # clause ("declares no related_name") and so cannot tell that the remedy survived at all.
+  @test occursin("an explicit", msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Cross-model field shadowing — the check #364 shipped behind a self-relation gate.
+#
+# `_build_row_join` resolves a FIELD before a reverse accessor at every hop, so an accessor equal to
+# a field name on the model it lands on registers cleanly and is then unreachable — surfacing later
+# as a raw internal error about a field with no `how` property, not a definition error.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a reverse accessor that shadows a field on the target is refused (#396)" begin
+  err = @test_throws PormG.ModelDefinitionError _ran_module(:RanShadowModels, quote
+    Driver = Models.Model("rans_driver",
+      id = Models.IDField(),
+      surname = Models.CharField(),
+      points = Models.IntegerField(),
+    )
+    Result = Models.Model("rans_result",
+      id = Models.IDField(),
+      driverid = Models.ForeignKey(Driver, pk_field = "id", related_name = "points"),
+    )
+  end)
+
+  msg = err.value.msg
+  @test occursin("is a FIELD of that model", msg)
+  @test occursin("rans_result.driverid", msg)
+  @test occursin("rans_driver.points", msg)
+  # Not misreported as self-referential — the two ends are on different models.
+  @test !occursin("self-referential", msg)
+  # The name was the user's, so no "derived" clause.
+  @test !occursin("derived", msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. The same shadow reached through a DERIVED name.
+#
+# The user never wrote `related_name` here, so a message pointing at that option without saying where
+# the name came from would send them looking for something that is not in their source.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a shadow via a derived accessor says where the name came from (#396)" begin
+  err = @test_throws PormG.ModelDefinitionError _ran_module(:RanShadowDerivedModels, quote
+    Driver = Models.Model("rand_driver",
+      id = Models.IDField(),
+      # A field named after the child model — so the child's DERIVED accessor lands on it.
+      rand_result = Models.CharField(),
+    )
+    Result = Models.Model("rand_result",
+      id = Models.IDField(),
+      driverid = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+  end)
+
+  msg = err.value.msg
+  @test occursin("is a FIELD of that model", msg)
+  @test occursin("declares no related_name", msg)
+  @test occursin("rand_result.driverid", msg)
+  @test occursin("rand_driver.rand_result", msg)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. No write-back, and registration is still idempotent.
+#
+# PormG used to assign the derived name onto `field.related_name`, and THAT is what made a second
+# `set_models` run reproduce the first: run two saw an explicit name and took a different branch to
+# the same key. The derivation is a pure function of (model name, field name, group size) now, so the
+# latch is gone — and with it the reason `Model_to_str` would bake a PormG-invented accessor into a
+# regenerated source file, since `related_name === nothing` again means "the declaration named none".
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a derived accessor is not written back onto the field (#396)" begin
+  IDEM = _ran_module(:RanIdempotentModels, quote
+    Driver = Models.Model("rani_driver", id = Models.IDField(), surname = Models.CharField())
+    Incident = Models.Model("rani_incident",
+      id = Models.IDField(),
+      causing_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+      affected_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+    Lap = Models.Model("rani_lap",
+      id = Models.IDField(),
+      driverid = Models.ForeignKey(Driver, pk_field = "id", related_name = "laps"),
+    )
+  end)
+
+  # Derived on both arms of the derivation — the group member and the lone relation.
+  @test IDEM.Incident.fields["causing_driver_id"].related_name === nothing
+  @test IDEM.Incident.fields["affected_driver_id"].related_name === nothing
+  # An EXPLICIT one is untouched.
+  @test IDEM.Lap.fields["driverid"].related_name == "laps"
+
+  before = Dict(k => v for (k, v) in IDEM.Driver.related_objects)
+  Base.invokelatest(Models.set_models, IDEM, "ran_mock")
+
+  @test Set(keys(IDEM.Driver.related_objects)) == Set(keys(before))
+  for k in keys(before)
+    @test IDEM.Driver.related_objects[k].fk_field === before[k].fk_field
+  end
+  # Still `nothing` after a second run — the write-back is genuinely gone, not merely unobserved on
+  # the first pass.
+  @test IDEM.Incident.fields["causing_driver_id"].related_name === nothing
+  @test IDEM.Incident.fields["affected_driver_id"].related_name === nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. An explicit `related_name` wins inside a group, and does not disturb its sibling.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an explicit related_name wins inside a group (#396)" begin
+  MIX = _ran_module(:RanMixedModels, quote
+    Driver = Models.Model("ranm_driver", id = Models.IDField(), surname = Models.CharField())
+    Incident = Models.Model("ranm_incident",
+      id = Models.IDField(),
+      causing_driver_id = Models.ForeignKey(Driver, pk_field = "id", related_name = "caused"),
+      affected_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+  end)
+
+  @test Set(keys(MIX.Driver.related_objects)) ==
+        Set(["caused", "ranm_incident_affected_driver_id"])
+  @test MIX.Driver.related_objects["caused"].fk_field === :causing_driver_id
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 10. `add_field!` counts what the model holds now, and `set_models` normalizes afterwards.
+#
+# A runtime addition cannot rename an accessor that is already registered and possibly in use, so the
+# group is briefly mixed. That is deliberate: the alternative is mutating other relations' keys out
+# from under whatever already resolved them.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "add_field! derives against the current group, set_models normalizes it (#396)" begin
+  ADD = _ran_module(:RanAddFieldModels, quote
+    Driver = Models.Model("rana_driver", id = Models.IDField(), surname = Models.CharField())
+    Team = Models.Model("rana_team",
+      id = Models.IDField(),
+      lead_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+    )
+  end)
+
+  # One relation to Driver so far → the bare name.
+  @test collect(keys(ADD.Driver.related_objects)) == ["rana_team"]
+
+  Base.invokelatest(Models.add_field!, ADD.Team, "reserves", Models.ManyToManyField("Driver"))
+
+  # The new relation sees a group of two and suffixes itself; the already-registered sibling keeps
+  # the name it was published under.
+  @test Set(keys(ADD.Driver.related_objects)) == Set(["rana_team", "rana_team_reserves"])
+  @test ADD.Driver.related_objects["rana_team_reserves"] isa Models.ManyToManyRelation
+  # The manager filters on `inverse_accessor`; it has to be the key that was registered, on this
+  # path as much as on the `set_models` one.
+  @test Models.get_many_to_many_relation(ADD.Team, "reserves").inverse_accessor == "rana_team_reserves"
+  @test ADD.Team.fields["reserves"].related_name === nothing
+
+  # A full re-registration rebuilds `related_objects` from scratch and normalizes the whole group.
+  Base.invokelatest(Models.set_models, ADD, "ran_mock")
+  @test Set(keys(ADD.Driver.related_objects)) ==
+        Set(["rana_team_lead_driver_id", "rana_team_reserves"])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 11. The @info announces exactly the derived group members.
+#
+# It has to fire for a name PormG chose out of a group — that is the only way a user learns the
+# accessor without reading the source of `set_models`. It must NOT fire for a lone relation (whose
+# bare name is documented and stable) or for an explicit `related_name` (which the user wrote), or it
+# becomes noise on every model load and gets filtered out.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the derived-accessor @info fires only for a group member (#396)" begin
+  # `collect_test_logs` returns `(logs, value)` — the records are the FIRST element.
+  logs, _ = Test.collect_test_logs() do
+    _ran_module(:RanLogModels, quote
+      Driver = Models.Model("ranl_driver", id = Models.IDField(), surname = Models.CharField())
+      Circuit = Models.Model("ranl_circuit", id = Models.IDField(), name = Models.CharField())
+      Incident = Models.Model("ranl_incident",
+        id = Models.IDField(),
+        causing_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+        affected_driver_id = Models.ForeignKey(Driver, pk_field = "id"),
+        circuitid = Models.ForeignKey(Circuit, pk_field = "id"),
+        stewardid = Models.ForeignKey(Driver, pk_field = "id", related_name = "stewarded"),
+      )
+    end)
+  end
+
+  derived = [r for r in logs if r.level == Logging.Info &&
+                                occursin("declares no related_name", string(r.message))]
+  msgs = join(string.(getfield.(derived, :message)), "\n")
+
+  # Two derived group members, and only those two.
+  @test length(derived) == 2
+  @test occursin("ranl_incident_causing_driver_id", msgs)
+  @test occursin("ranl_incident_affected_driver_id", msgs)
+  # The lone relation to Circuit keeps the bare name silently.
+  @test !occursin("ranl_incident_circuitid", msgs)
+  # The explicit one is never announced.
+  @test !occursin("stewarded", msgs)
+  # It names the group size, so the user can tell why the name is not the bare one.
+  @test occursin("one of 3 relations", msgs)
+end

--- a/test/unit/test_sequence_sync.jl
+++ b/test/unit/test_sequence_sync.jl
@@ -232,14 +232,57 @@ end
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Sequence Sync: only DATABASE failures are tolerated (#344)
-# The try covers the whole loop body, which means it also covers PormG's fail-closed
-# identifier guards (`quote_identifier` / `safe_table_identifier` → `_validate_identifier`).
-# Those raise `InvalidValueError` — a PormGError but NOT a DatabaseError — and relabelling
-# one as "sequence resync failed, check your GRANTs" would bury a real error and break the
-# fail-closed contract. The catch allowlists `DatabaseError` and `PoolError`; everything
-# else propagates.
+# The try covers the whole loop body, so it also covers every non-database way the body can fail.
+# Relabelling one of those as "sequence resync failed, check your GRANTs" would bury a real error.
+# The catch allowlists `DatabaseError` and `PoolError`; everything else propagates.
+#
+# The driver used to be a `db_table` that PormG's own identifier validator refused — an
+# `InvalidValueError` raised inside the try. #394 removed that producer: a physical table name is
+# escaped rather than validated now, so an odd `db_table` no longer raises anywhere. The ALLOWLIST is
+# unchanged and is still what this pins, so the error is injected through the mock instead. Picking
+# `InvalidValueError` keeps the original premise exactly — a PormGError that is not a DatabaseError.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "A non-database error during resync is not swallowed (#344)" begin
+  empty!(SEQUENCE_SYNC_SQL)
+
+  settings = PormG.Configuration.Settings(
+    connections = MockSetvalDenied(),
+    change_data = true,
+  )
+
+  original = SETVAL_DENIED[]
+  SETVAL_DENIED[] = PormG.InvalidValueError("not a database failure — must not be relabelled")
+  try
+    @test !(SETVAL_DENIED[] isa PormG.DatabaseError)   # the premise: outside the allowlist
+    @test !(SETVAL_DENIED[] isa PormG.PoolError)
+
+    # No transaction, so the warn path is the one being bypassed here — this raises because of the
+    # allowlist, not because of the transaction check.
+    #
+    # The message is checked, not just the type: `@test_throws InvalidValueError` alone cannot tell
+    # "the injected error propagated" from "some other InvalidValueError fired anywhere", and that
+    # distinction is the whole point of the assertion.
+    try
+      PormG.QueryBuilder._update_sequence(SequenceDriver, settings.connections, ["id"], settings)
+      @test false   # unreachable: the allowlist must let this through
+    catch e
+      @test e isa PormG.InvalidValueError
+      @test occursin("must not be relabelled", sprint(showerror, e))
+    end
+  finally
+    SETVAL_DENIED[] = original
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sequence Sync: a `db_table` the DDL accepts is one the resync can address (#394)
+# The inverse of what the testset above used to assert. `db_table` is deliberately NOT
+# shape-validated at declaration (#59) because naming a table PormG's conventions could not produce
+# is the point of the option — and until #394 the query side refused the very names it exists for, so
+# `_update_sequence` raised `InvalidValueError` on a table `create_table` had rendered happily.
+# Both spellings now agree: escape, do not validate.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "A resync addresses an odd db_table instead of refusing it (#394)" begin
   empty!(SEQUENCE_SYNC_SQL)
 
   settings = PormG.Configuration.Settings(
@@ -247,24 +290,16 @@ end
     change_data = true,
   )
 
-  # `db_table` is deliberately NOT shape-validated at declaration (#59), so an illegal identifier
-  # survives to `safe_table_identifier` inside the try.
-  bad = Model("badseq", db_table = "no spaces allowed!", id = IDField(), forename = CharField())
-  bad.connect_key = "sequence_sync_default"
+  odd = Model("badseq", db_table = "no spaces allowed!", id = IDField(), forename = CharField())
+  odd.connect_key = "sequence_sync_default"
 
-  # No transaction, so the warn path is the one being bypassed here — this raises because of the
-  # allowlist, not because of the transaction check.
-  #
-  # The message is checked, not just the type: `@test_throws InvalidValueError` alone cannot tell
-  # "the table-identifier guard fired inside the try" from "some other InvalidValueError fired
-  # anywhere", and that distinction is the whole point of the assertion.
-  try
-    PormG.QueryBuilder._update_sequence(bad, settings.connections, ["id"], settings)
-    @test false   # unreachable: the guard must raise
-  catch e
-    @test e isa PormG.InvalidValueError
-    @test occursin("no spaces allowed!", sprint(showerror, e))
-  end
+  PormG.QueryBuilder._update_sequence(odd, settings.connections, ["id"], settings)
+
+  @test length(SEQUENCE_SYNC_SQL) == 2
+  # `pg_get_serial_sequence` takes TEXT it re-parses as an identifier, so the name is quoted INSIDE
+  # a string literal — an unquoted mixed-case or spaced name would fold and resolve to nothing.
+  @test occursin("pg_get_serial_sequence('\"no spaces allowed!\"'", SEQUENCE_SYNC_SQL[1])
+  @test occursin("FROM \"no spaces allowed!\"", SEQUENCE_SYNC_SQL[2])
 end
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two `pre-publish` issues, kept as two separable commits.

Closes #396
Closes #394

---

## #396 — reverse accessors are derived from the whole relation group

`set_models` derived the accessor a relation installs on its target *while* walking `pairs(model.fields)`, accumulating a per-target counter as it went. `Model_Type.fields` is an unordered `Dict`, so in a group of N relations to one target the field **visited first** kept the bare model name and the rest were suffixed — hash order decided which, and adding an unrelated field to the model rehashed it.

`ManyToManyField` never entered the counter, so a self-`ForeignKey` + self-`ManyToManyField` on one model derived the bare model name twice: FK-first raised, m2m-first **silently replaced** the registered `ManyToManyRelation` with a `ReverseRelation`. That is the reported bug; the order-dependence underneath it was not reported.

**Now:** the count is taken before anything registers, over `ForeignKey`, `OneToOneField` and `ManyToManyField` together; in a group of two or more **no** relation keeps the bare name; and the accessor is checked against the target's field names and its existing accessors on **every** path — one of the four used to assign unguarded. Messages name `Model.field` for both colliding ends instead of naming the model twice and neither field.

The write-back of a derived name onto `field.related_name` is gone. It was the idempotency latch; the derivation is a pure function now, so `related_name === nothing` again means *"the declaration named none"* — which is what stops `Model_to_str` baking a PormG-invented accessor into a regenerated model file.

**Breaking, narrowly** — `UPGRADING.md` entry included. Downstream audit of `esus_back` (507 models, 1404 relations, simulating the real algorithm): zero collisions today, so the new guards break nothing at load; five multi-FK groups get renamed accessors, and a grep found no reads of any of them.

## #394 — physical identifiers are escaped, aliases stay fail-closed

`Dialect._quote_table_ddl` escaped and never validated; `quote_identifier` validated and never escaped — safe only *because* the pattern forbids a `"`. PormG would migrate a table it could never query, reachable without anyone writing a hostile string: `db_table`/`db_column` are unvalidated by design (#59/#50) and the importers pin arbitrary catalog names into them.

Identifiers are now partitioned by what they **are**:

| Kind | Function | Behavior |
|---|---|---|
| physical table | `safe_table_identifier` | escape-only |
| physical column | `safe_column_identifier` (new) | escape-only |
| alias / CTE name / SELECT label | `quote_identifier` (unchanged) | fail-closed |

An alias is chosen at build time and names nothing that exists, so there is nothing to be faithful to. A physical name is pinned by the author or read from the catalog, so validating it is actively wrong.

## Three bugs found on the way that neither issue mentions

1. **The migration plan file could not be parsed.** `pending_migrations.jl` is Julia source and writes each table as a *binding*, so `db_table = "Odd Identifier Scratch"` produced a `ParseError` — `makemigrations` succeeded and `migrate` died on its own output. Without this, #394's claim was hollow: the name was queryable but not migratable. Fixed with `var"..."`, plus the case the test caught — Julia discards **all-underscore** identifiers at any spelling, so `_` and `___` would have parsed and bound nothing, silently dropping that table's migration.
2. **`alter_field(::PormGPostgres)` emitted 15 unescaped column identifiers.** Without this the split would have *moved* from `CREATE` to `ALTER` rather than closing.
3. **An escaped table name leaked into four `get_constraints_*` catalog lookups**, so dropping a `unique` or `primary_key` on such a table emitted no DDL at all and `makemigrations` re-proposed it forever.

Also: `SAFE_JSON_KEY_PATTERN` split out (a JSON segment is interpolated **unquoted**, so its charset check must not widen with the identifier rules); `_with` validates the CTE name and join key at declaration; and the two `catch`es in `execution.jl` that logged an `@error` and **continued** — emitting a correlated mutation without the table or ON condition they had just failed to build — are gone. A CTE joined in a correlated `UPDATE … FROM` is refused outright: that statement emits no `WITH` clause, so the relation it references is never declared. That last one has its own narrow `UPGRADING.md` entry.

## Verification

| | Result |
|---|---|
| Unit | **8116 / 8116** (7964 on `main`) |
| PostgreSQL `db_2`, full | **2203 / 2203** |
| SQLite `db_sl`, full | **2132 pass, 1 broken** (pre-existing) |
| Docs build | exit 0 |

Two independent review passes (find + delta re-review). Every testset in both new files was mutation-checked: reverting `Models.jl` fails all of #396's; making `safe_*_identifier` validate again, dropping the `_with` guard, and restoring the two catches each fail their own #394 testsets.

## Deliberately not done

- **The spaced `db_column` is unit-only, not in the integration fixture.** It renders and queries correctly, but PostgreSQL introspection tears such a name in half on the `columns` aggregate — that is #414, already open, and its fix is a change to that aggregate's format, not to any quoting. Including it made the global no-drift assertion fail on every run.
- `get_constraints_*` still receives an escaped *field* name in one spot, left as pre-existing.
- The `_reverse_relation` / `_derived_reverse_accessor` comments note that the "only one member is renamed" claim holds for a pure-FK group; every many-to-many in a group of two or more is renamed, because m2m never entered the old count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
