### PR TITLE
fix(#404): ORDER BY resolves before the joins are rendered

### DIFF
--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -341,7 +341,7 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   # but a positional backend flattens the :join bucket in binding order, so a relocated extra can
   # bind its neighbour's value. Reproduce with two cjoin filters at different depths
   # (`["grandparent__code" => "ZZZ", "sku" => "SSS"]`). This pre-dates the change above; the change
-  # widens which shapes relocate, so it widens the exposure. Tracked separately.
+  # widens which shapes relocate, so it widens the exposure. Tracked in #421.
   for idx in 1:length(instruc.row_join)
     haskey(on_clause_extras, idx) || continue
     extras = on_clause_extras[idx]

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -144,7 +144,15 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     orientation = _normalize_order_orientation(v.orientation)
     placement = _nulls_placement(orientation, v.nulls)
     push!(instruc.order, _order_term_sql(v_field_copy.field, orientation, placement, instruc.connection))
-    instruc.cache[v_field_copy._as] = v_field_copy
+    # Cache the resolved selector, but NEVER overwrite one that is already there (#404). The
+    # `found_in_select` branch above deliberately degrades `field` to the bare SELECT alias — legal
+    # in ORDER BY, invalid anywhere else — and since #404 moved this call ahead of
+    # `build_row_join_sql_text`, that render reads this cache: Phase 1 resolves cjoin ON conditions
+    # through `_get_filter_query(::SQLTypeField)`, which returns `instruc.cache[_as].field`
+    # verbatim. Clobbering here put `"parent__sku"` (a projection alias) into an ON clause, which
+    # both backends reject. The existing entry is the fully-qualified selector and is strictly
+    # better for every reader; only a path resolved fresh at :140 has nothing to preserve.
+    haskey(instruc.cache, v_field_copy._as) || (instruc.cache[v_field_copy._as] = v_field_copy)
 
     if !found_in_select
       # #76: Under DISTINCT, an ORDER BY term that is not part of the projection is rejected by
@@ -281,7 +289,6 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   # create additional join entries in instruc.row_join via _build_row_join.
   # By pre-resolving with an index-based loop we process newly created entries
   # in order and store the generated SQL fragments for Phase 2.
-  n_before = length(instruc.row_join)
   on_clause_extras = Dict{Int, Vector{String}}()
   i = 1
   while i <= length(instruc.row_join)
@@ -312,31 +319,53 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   end
 
   # --- Phase 1b: relocate forward-referencing ON extras ----------------------
-  # When ON extras for join `idx` reference the alias of a join `dep_idx` that
-  # was *created* during Phase 1 (i.e. dep_idx > n_before), it means the ON
-  # condition uses a deep path (e.g. raceid__circuitid__country) that chains
-  # through the current join's target table.  Emitting those extras on `idx`
-  # would forward-reference `dep_idx` (whose JOIN clause hasn't appeared yet).
+  # An ON extra on join `idx` that names the alias of a join emitted LATER is a forward reference:
+  # Phase 2 emits joins in `row_join` order, so `dep_idx`'s JOIN clause has not appeared yet and
+  # both backends reject the reference. This happens when the ON condition walks a deep path
+  # (e.g. raceid__circuitid__country) that chains through the current join's target table.
   #
-  # Fix: move such extras to `dep_idx`'s ON clause, which is the join whose
-  # alias is referenced.  The base ON of `dep_idx` already references `idx`'s
-  # alias_b (the parent), so ordering is satisfied: idx emits first, dep_idx
-  # emits second with the relocated extras.
-  for idx in 1:n_before
+  # Fix: move the extra onto the LAST join it references. That join is emitted after every alias
+  # the extra names, and its own base ON already references its parent, so the ordering holds.
+  #
+  # The window is `idx+1 : end`, i.e. actual emission order — NOT "created during Phase 1"
+  # (`dep_idx > n_before`), which is what it used to test. That snapshot only described *when* an
+  # entry was appended, and a forward reference does not care: a join that already existed at entry
+  # is just as unemitted when it sits at a higher index. Two ways to reach that case, one of them
+  # pre-dating #404 — projecting the deep path (`values("parent__grandparent__code")`) builds the
+  # deeper join up front, and since #404 ordering by it does the same. In both, Phase 1 dedups the
+  # ON condition onto the existing entry instead of creating one, so the old window was empty and
+  # the extra stayed on the wrong join. Keying on index order covers every case uniformly.
+  #
+  # KNOWN GAP, not closed here: relocation changes the order extras are EMITTED in, while Phase 1
+  # bound their parameters in row_join order. PostgreSQL is unaffected ($N travels with the text),
+  # but a positional backend flattens the :join bucket in binding order, so a relocated extra can
+  # bind its neighbour's value. Reproduce with two cjoin filters at different depths
+  # (`["grandparent__code" => "ZZZ", "sku" => "SSS"]`). This pre-dates the change above; the change
+  # widens which shapes relocate, so it widens the exposure. Tracked separately.
+  for idx in 1:length(instruc.row_join)
     haskey(on_clause_extras, idx) || continue
     extras = on_clause_extras[idx]
     relocated = falses(length(extras))
 
-    for dep_idx in (n_before+1):length(instruc.row_join)
-      dep_alias = instruc.row_join[dep_idx]["alias_b"]
-      for (ei, extra) in enumerate(extras)
-        if !relocated[ei] && occursin("\"$(dep_alias)\"", extra)
-          # Move this extra to dep_idx's ON clause
-          if !haskey(on_clause_extras, dep_idx)
-            on_clause_extras[dep_idx] = String[]
-          end
+    for (ei, extra) in enumerate(extras)
+      # Search downwards, so the first hit is the LAST join this extra references and one move
+      # reaches the fixed point. Ascending is NOT wrong — the outer loop above revisits relocation
+      # targets, so an extra dropped on the nearest match would cascade the rest of the way one hop
+      # per visit — it is just O(hops) moves for the same result, and it makes termination an
+      # argument about convergence. Descending keeps that argument to one line: dep_idx is the
+      # MAXIMUM match, so when the outer loop later reaches dep_idx its search range is a subset
+      # already proven not to match, and no extra can move twice.
+      for dep_idx in length(instruc.row_join):-1:(idx + 1)
+        # The trailing dot is REQUIRED, not cosmetic. An extra renders every column reference as
+        # `"alias"."col"`, so a bare `"name"` test also matches the COLUMN half — and a cjoin_on
+        # alias that happens to share a column's name (`alias = "code"` against `"Tb_2"."code"`)
+        # then drags an unrelated join's ON filter onto itself. That is valid SQL returning wrong
+        # rows, silently. Phase 1 above already keys on the same `"alias".` form (:310).
+        if occursin("\"$(instruc.row_join[dep_idx]["alias_b"])\".", extra)
+          haskey(on_clause_extras, dep_idx) || (on_clause_extras[dep_idx] = String[])
           push!(on_clause_extras[dep_idx], extra)
           relocated[ei] = true
+          break
         end
       end
     end
@@ -430,6 +459,34 @@ function build(object::SQLObject;
   set_contexts && set_context!(instruct, :where)
   get_filter_query(object, instruct)
 
+  # #404: ORDER BY resolves HERE, before build_row_join_sql_text renders row_join into SQL. A path
+  # named ONLY by order_by() is resolved through _get_select_query → _build_row_join, which APPENDS
+  # to row_join; running after the render left that entry un-emitted, so the ORDER BY referenced an
+  # alias the query never joined — a loud failure on both backends ("missing FROM-clause entry" /
+  # "no such column"). Ordering a path that is also projected or filtered was always fine: it takes
+  # the instruc.cache branch and discovers nothing.
+  #
+  # Only the position relative to the RENDER matters for CORRECTNESS. Whether this sits before or
+  # after the cjoin loops below is immaterial there — build_row_join_sql_text keys its
+  # forward-reference relocation on row_join index order, not on when an entry was appended. It is
+  # placed before them so the three "resolve everything" steps (select, filter, order) read as one
+  # block. It is not free to move, though: the order joins are appended in decides ALIAS NUMBERING,
+  # and test/unit/test_order_by_joins.jl pins concrete Tb_1/Tb_2/Tb_3 names, so a reorder rewrites
+  # those expectations rather than passing silently.
+  #
+  # Context: :join is set explicitly and :where restored after, so in a TOP-LEVEL build an order
+  # term that parameterizes lands in the bucket it always did, and the cjoin loops keep running
+  # under :where. In a SUBQUERY (set_contexts=false) these two switches are skipped, and that is a
+  # real change: build_row_join_sql_text sets :join UNGATED in both its phase loops, so before this
+  # move a subquery carrying at least one join left the context on :join and the order term landed
+  # there; now it inherits the parent's bucket. Narrow — it needs a subquery with a join AND a
+  # parameterized order term — and arguably the better of the two, since the subquery's ORDER BY
+  # text renders inside the parent's WHERE. Untested either way, because ORDER BY has no bucket of
+  # its own (see parameters.jl); that gap pre-dates this change and is not closed here.
+  set_contexts && set_context!(instruct, :join)
+  get_order_query(object, instruct)
+  set_contexts && set_context!(instruct, :where)
+
   # Materialize explicit custom joins that weren't discovered by traversal.
   # This ensures cjoin filters are applied even in UPDATE/DELETE without explicit field paths.
   # We check against instruct.row_path to avoid redundant materialization (forcing them twice).
@@ -453,8 +510,6 @@ function build(object::SQLObject;
 
   set_contexts && set_context!(instruct, :join)
   build_row_join_sql_text(instruct)
-
-  get_order_query(object, instruct)  # ORDER BY has no parameters
 
   _check_aggregate_fanout(instruct)  # #74: refuse silently-inflated aggregates over to-many joins
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -1616,6 +1616,15 @@ function update(objct::SQLObject; table_alias::Union{Nothing, SQLTableAlias} = n
   
   if has_joins
     if connection isa PormGPostgres || connection isa PormGSQLite
+      # The SET-clause loop above can reach _build_row_join (e.g. update("x" => F("fk__col"))), so
+      # row_join may have grown AFTER build() rendered instruction.join — the same late-discovery
+      # hazard #404 fixed in build(). Exactly one UPDATE branch reads the stale instruction.join:
+      # _build_update_target_pk_subquery, which prints it at :1492. This check is what excludes it —
+      # a SET-discovered join necessarily puts its alias in set_clause, so the check returns true,
+      # pk_subquery stays nothing, and the UPDATE … FROM branch below rebuilds FROM/ON from
+      # instruction.row_join instead. Do NOT drop this guard on the theory that the UPDATE path
+      # ignores instruction.join — it does not. (#404's own trigger cannot reach here regardless:
+      # update() refuses a query carrying order_by() at :1542.)
       set_uses_join_aliases = _set_clause_uses_join_aliases(set_clause, instruction.row_join, connection)
       pk_subquery = (!set_uses_join_aliases && isempty(real_obj.ctes)) ? _build_update_target_pk_subquery(instruction) : nothing
 

--- a/test/integration/test_db_column_db.jl
+++ b/test/integration/test_db_column_db.jl
@@ -377,10 +377,11 @@ end
         # order_by on a CTE-reached db_column field that is neither projected nor filtered, so it
         # is resolved here for the first time: `get_order_query` reuses `instruc.cache` when the
         # same path was already resolved, and the filter runs first — hence `name` (no db_column)
-        # is the filtered column and `sku` the ordered one. The filter also exists to emit the
-        # JOIN: a CTE column referenced ONLY by order_by registers the alias without emitting one
-        # (a separate, pre-#376 defect that also hits plain FK paths on models with no db_column),
-        # and this testset must not depend on it. Built as a FRESH CTE object: a `.with` source is
+        # is the filtered column and `sku` the ordered one. The filter is NO LONGER what emits the
+        # JOIN: a CTE column referenced only by order_by used to register the alias without emitting
+        # one (a defect that also hit plain FK paths on models with no db_column), fixed in #404 by
+        # resolving ORDER BY before the joins render — see `test_selection.jl` for the executed
+        # regression and `test_order_by_joins.jl` for the rendering. Built as a FRESH CTE object: a `.with` source is
         # shared state, and reusing one across queries is what the #43 coverage exists to police.
         cte2 = M.Db_column_scratch.objects
         cte2.values("id", "sku", "name")

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -301,6 +301,41 @@ end
 # mutation gate. It uses the permanent `bulk_update_payload_scratch` fixture (nullable_int
 # column) with try/finally cleanup so the F1 tables are untouched.
 # ─────────────────────────────────────────────────────────────────────────────
+# Ordering: a join path named ONLY by order_by() — neither projected nor filtered (#404)
+# The pre-fix failure was at EXECUTION, not in the rendered string: `get_order_query` ran after
+# `build_row_join_sql_text`, so the join it discovered was never emitted and the ORDER BY named an
+# alias nothing declared — PostgreSQL `missing FROM-clause entry for table "tb_1"`, SQLite
+# `no such column`. Rendering coverage is in `test/unit/test_order_by_joins.jl`; this asserts the
+# query actually runs and orders correctly on a real database, on both engines.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by on an unprojected, unfiltered join path executes (#404)" begin
+    # `driverid__surname` appears ONLY in order_by — not in values(), not in filter(). That is the
+    # exact trigger; adding either would take the `instruc.cache` branch and mask the defect.
+    # `resultid` is the tiebreaker, so the ordering is total and the two queries below are
+    # comparable even where surnames repeat.
+    ordered = M.Result.objects
+    ordered.values("resultid")
+    ordered.order_by("driverid__surname", "resultid")
+    ordered.limit(25)
+    ordered_df = ordered |> DataFrame
+
+    @test nrow(ordered_df) == 25
+
+    # Oracle: the SAME ordering with the path also projected — the shape that always worked, because
+    # `get_select_query` built and cached the join before ORDER BY ever looked. If the unprojected
+    # query joined correctly, the two must agree row for row. Comparing against a live query rather
+    # than hardcoded surnames also keeps this independent of backend collation.
+    projected = M.Result.objects
+    projected.values("resultid", "surname" => "driverid__surname")
+    projected.order_by("driverid__surname", "resultid")
+    projected.limit(25)
+    projected_df = projected |> DataFrame
+
+    @test ordered_df.resultid == projected_df.resultid
+    # The join really produced driver rows — a NULL-filled column would satisfy the equality above.
+    @test all(s -> s !== missing && !isempty(s), projected_df.surname)
+end
+
 @testset "ORDER BY NULL placement normalized across backends (#75)" begin
     # Scratch helpers are loaded in-suite by runtests.jl; load them for standalone runs too.
     if !isdefined(Main, :_clear_bulk_update_scratch_rows!)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,7 @@ end
     @testset "create() returns PormGRow (#166)" include("unit/test_create_returns_pormgrow.jl")
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
+    @testset "ORDER BY Join Emission (#404)" include("unit/test_order_by_joins.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
     @testset "Connect-Failure Fast-Fail Typed Error (#72)" include("unit/test_connection_pool_connect_error.jl")

--- a/test/unit/test_cte_db_column.jl
+++ b/test/unit/test_cte_db_column.jl
@@ -158,10 +158,12 @@ _cdc_sku_cte() = (c = CDC.Cdc_parent.objects; c.values("id", "sku"); c)
   # ORDER BY must resolve the CTE column FRESHLY, so the ordered column is deliberately neither
   # projected nor filtered: `get_order_query` reuses `instruc.cache` when the same path was already
   # resolved (build_query.jl:138), and `get_filter_query` runs first — so filtering `ev__seen` here
-  # would silently test the filter's selector instead. `ev__sku` is filtered only to emit the JOIN:
-  # a CTE column referenced ONLY by order_by registers the alias without emitting one, a separate
-  # pre-#376 defect that also hits plain FK paths (`order_by("fk__col")`) on models with no
-  # db_column at all — this file must not depend on it, so the join is asserted too.
+  # would silently test the filter's selector instead. `ev__sku` is filtered to keep the ordered and
+  # the resolved-elsewhere column distinct; it is NO LONGER needed to emit the JOIN. It once was: a
+  # CTE column referenced only by order_by registered the alias without emitting a join, a defect
+  # that also hit plain FK paths on models with no db_column, fixed in #404 by resolving ORDER BY
+  # before `build_row_join_sql_text` renders. The join is still asserted here, and the unfiltered
+  # shape this testset used to avoid is covered directly in `test_order_by_joins.jl`.
   # ─────────────────────────────────────────────────────────────────────────────
   @testset "order_by() sorts on the CTE alias" begin
     cte = CDC.Cdc_parent.objects

--- a/test/unit/test_order_by_joins.jl
+++ b/test/unit/test_order_by_joins.jl
@@ -1,0 +1,364 @@
+"""
+Unit coverage for #404: `order_by()` on a join path that is NEITHER filtered NOR projected must emit
+the join it needs.
+
+`build` (`src/querybuilder/build_query.jl`) used to render `instruct.row_join` into SQL *before*
+resolving ORDER BY. A path named only by `order_by()` falls past `get_order_query`'s `instruc.cache`
+branch into `_get_select_query` -> `_build_row_join`, which APPENDS a new `row_join` entry and hands
+back a selector qualified with a brand-new alias. The render had already run, so that entry never
+became SQL and the alias survived only in the ORDER BY text:
+
+    SELECT "Tb"."note" as "note"
+    FROM "obj_child" as "Tb"
+    ORDER BY "Tb_1"."sku" ASC NULLS LAST     -- "Tb_1" is never joined
+
+PostgreSQL rejects that with `missing FROM-clause entry for table "tb_1"`, SQLite with
+`no such column` — a loud failure at execution, not silent wrong rows. The fix moves
+`get_order_query` ahead of `build_row_join_sql_text`.
+
+Moving it exposed further defects in `build_row_join_sql_text`, all covered by the `cjoin` testsets
+at the bottom of this file and none reachable before, because nothing in the suite combined `cjoin`
+with `order_by`:
+
+  - resolving ORDER BY early let it poison `instruc.cache`, which Phase 1 reads to render ON
+    conditions, putting a bare projection alias inside an ON clause;
+  - it defeated Phase 1b's forward-reference relocation, which keyed on *when* a join was appended
+    rather than on the order it is emitted in;
+  - and repairing that exposed two more in the relocation itself — it moved an extra to the FIRST
+    later join it named rather than the LAST, and it matched an alias by a bare `"name"` test that
+    also hits a like-named COLUMN.
+
+The last three are all reachable on `origin/main` too (through `values()` rather than `order_by()`),
+so those repairs fix pre-existing bugs as well as the ones this change would have introduced.
+
+Why it survived this long: the COMMON shapes never reach the discovery branch. Ordering a column you
+also `values()` or also `filter()` finds the path in `instruc.cache` and reuses the already-rendered
+selector. Both are pinned below as controls, and both must stay byte-identical — a "fix" that works
+by making every order term build its own join would satisfy the first three testsets here and
+quietly double-join the rest of the suite.
+
+All assertions render through mock PostgreSQL/SQLite connections — no live database. The execution
+half (the query actually returning rows on both backends) lives in
+`test/integration/test_selection.jl`, because the pre-fix failure was at execution time.
+
+Sibling coverage:
+  - `test_order_by_nulls.jl`        -> #75 NULL placement on the rendered term.
+  - `test_sqlorder_orientation.jl`  -> #77 orientation whitelist.
+  - `test_inspect_query.jl`         -> #76 DISTINCT + ORDER BY projection guard.
+  - `test_cte_db_column.jl`         -> the same CTE order_by path, with `db_column` in play.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+# Dedicated mock connections + config key: `runtests.jl` includes ~50 files into one `Main`, so a
+# shared name would let another file's settings decide this file's dialect. Only the connection TYPE
+# matters — dispatch picks SQLite vs PostgreSQL rendering.
+struct ObjJoinMockSQLite <: PormG.PormGSQLite end
+struct ObjJoinMockPostgres <: PormG.PormGPostgres end
+const _OBJ_SL = ObjJoinMockSQLite()
+const _OBJ_PG = ObjJoinMockPostgres()
+# ORDER BY renders NULL placement via a library-version probe (#75); pin a modern version so
+# order_by works on the mock without a live driver (same pattern as test_cte_db_column.jl).
+PormG.backend_sqlite_version(::ObjJoinMockSQLite) = 3045000
+
+PormG.config["obj_join_mock"] = PormG.Configuration.Settings(
+  connections = _OBJ_PG, change_data = true, db_def_folder = "obj_join_mock",
+)
+
+# Inline fixtures in their own module: `set_models` is REQUIRED here (not a style choice), because
+# `_build_row_join` reads `instruct.object.model._module::Module` — a bare `Model(...)` leaves
+# `_module === nothing` and TypeErrors the moment a join renders.
+module ObjJoinModels
+import PormG
+import PormG.Models
+
+Par = Models.Model("obj_parent",
+  id   = Models.IDField(),
+  sku  = Models.CharField(),
+  name = Models.CharField(null = true),
+)
+
+# `related_name = "kids"` is the accessor the reverse-relation testset orders through.
+Chi = Models.Model("obj_child",
+  id     = Models.IDField(),
+  parent = Models.ForeignKey(Par, on_delete = "CASCADE", related_name = "kids", null = true),
+  note   = Models.CharField(null = true),
+)
+
+# A three-level chain for the `cjoin` cases. Separate from Par/Chi above because `cjoin`'s target
+# check compares against `Model.name` (the TABLE name) while its lookup goes by module binding, so
+# the two only agree when the binding is spelled like the table — PormG's own generated convention.
+# Four levels, because pinning "relocate to the LAST referenced join" needs an ON extra that names
+# TWO joins emitted after the one it starts on.
+Cj_great = Models.Model("cj_great",
+  id  = Models.IDField(),
+  tag = Models.CharField(),
+)
+
+Cj_grand = Models.Model("cj_grand",
+  id    = Models.IDField(),
+  code  = Models.CharField(),
+  great = Models.ForeignKey(Cj_great, on_delete = "CASCADE", related_name = "cj_grands", null = true),
+)
+
+Cj_parent = Models.Model("cj_parent",
+  id          = Models.IDField(),
+  sku         = Models.CharField(),
+  grandparent = Models.ForeignKey(Cj_grand, on_delete = "CASCADE", related_name = "cj_pars", null = true),
+)
+
+Cj_child = Models.Model("cj_child",
+  id     = Models.IDField(),
+  parent = Models.ForeignKey(Cj_parent, on_delete = "CASCADE", related_name = "cj_kids", null = true),
+  note   = Models.CharField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "obj_join_mock")
+end
+
+const OBJ = ObjJoinModels
+import PormG.QueryBuilder: inspect_query, Q, F
+
+# `count` over a literal String, not a Regex — a needle carrying regex syntax would otherwise
+# silently change what is matched. "JOIN" is a substring of "LEFT JOIN", so this counts joins.
+_obj_joins(sql::AbstractString) = count("JOIN", sql)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ORDER BY join emission: a forward ForeignKey path named ONLY by order_by()
+# The ordered column is in neither `values()` nor `filter()`, so `get_order_query` resolves it for
+# the first time and discovers the join. Asserting the JOIN clause explicitly is the whole point:
+# an `occursin("Tb_1", sql)` alone passed BEFORE the fix too — the alias was always in the ORDER BY.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() on a forward-FK path emits its join (#404)" begin
+  for (label, conn) in (("PostgreSQL", _OBJ_PG), ("SQLite", _OBJ_SL))
+    @testset "$label" begin
+    q = OBJ.Chi.objects
+    q.values("note")
+    q.order_by("parent__sku")
+
+    sql = inspect_query(q; connection = conn)[:sql_text]
+
+    # The join the ORDER BY term needs, carrying the alias the term actually references.
+    @test occursin("LEFT JOIN \"obj_parent\" AS \"Tb_1\" ON \"Tb\".\"parent\" = \"Tb_1\".\"id\"", sql)
+    @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", sql)
+    # Exactly one — resolving the path must not add a second copy beside a cached one.
+    @test _obj_joins(sql) == 1
+    # The path is ordered, not selected: it must not leak into the projection.
+    @test occursin("\"Tb\".\"note\" as \"note\"", sql)
+    @test !occursin("as \"parent__sku\"", sql)
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ORDER BY join emission: a REVERSE relation named only by order_by()
+# The same defect with the join direction flipped — the ON sides swap to
+# `"Tb"."id" = "Tb_1"."parent"`. Covered separately because a reverse path takes a different branch
+# of `_build_row_join` than a forward FK, and only the branch that runs can be vouched for.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() on a reverse-relation path emits its join (#404)" begin
+  q = OBJ.Par.objects
+  q.values("name")
+  q.order_by("kids__note")
+
+  sql = inspect_query(q)[:sql_text]
+
+  @test occursin("LEFT JOIN \"obj_child\" AS \"Tb_1\" ON \"Tb\".\"id\" = \"Tb_1\".\"parent\"", sql)
+  @test occursin("ORDER BY \"Tb_1\".\"note\" ASC", sql)
+  @test _obj_joins(sql) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ORDER BY join emission: a CTE column named only by order_by()
+# A CTE join is an ordinary `row_join` entry emitted by `build_row_join_sql_text` like any other —
+# there is no separate CTE join-rendering path that could have rescued this shape. The outer query
+# is aliased "R1", not "Tb", because `build_cte_clause` runs first and the CTE body consumes the
+# base alias. `test_cte_db_column.jl` orders through a CTE too but filters it as well; this is the
+# unfiltered, unprojected shape that testset deliberately avoided depending on.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() on a CTE column emits its join (#404)" begin
+  cte = OBJ.Par.objects
+  cte.values("id", "sku")
+
+  q = OBJ.Par.objects
+  q.with("ev" => cte, join_field = "id" => "id")
+  q.values("name")
+  q.order_by("ev__sku")          # the only reference to the CTE besides the join_field itself
+
+  sql = inspect_query(q)[:sql_text]
+
+  @test occursin("WITH \"ev\" AS (", sql)
+  @test occursin("LEFT JOIN \"ev\" AS \"R1_1\" ON \"R1\".\"id\" = \"R1_1\".\"id\"", sql)
+  @test occursin("ORDER BY \"R1_1\".\"sku\" ASC", sql)
+  @test _obj_joins(sql) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Control: ordering a PROJECTED join column is unchanged
+# This shape always worked — `get_select_query` built the join and cached the path, so
+# `get_order_query` reuses the resolved selector and discovers nothing. Pinned because the failure
+# mode of a careless fix is a SECOND join for the same path, which no assertion above would catch.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ordering a projected join column still emits exactly one join (#404 control)" begin
+  q = OBJ.Chi.objects
+  q.values("note", "s" => "parent__sku")
+  q.order_by("parent__sku")
+
+  sql = inspect_query(q)[:sql_text]
+
+  @test occursin("LEFT JOIN \"obj_parent\" AS \"Tb_1\" ON \"Tb\".\"parent\" = \"Tb_1\".\"id\"", sql)
+  @test occursin("\"Tb_1\".\"sku\" as \"s\"", sql)
+  @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", sql)
+  @test _obj_joins(sql) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Control: ordering a FILTERED join column is unchanged
+# The other always-correct shape, and the one the issue used to expose the defect: adding a filter
+# on the same path was the single difference that made the join appear. The WHERE placeholder and
+# the bound value are asserted too — `get_order_query` now runs across the `:where`/`:join` context
+# switches, and that move must not re-route a parameter, drop one, or bind the same value twice.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "ordering a filtered join column still emits exactly one join (#404 control)" begin
+  q = OBJ.Chi.objects
+  q.values("note")
+  q.filter("parent__sku" => "X")
+  q.order_by("parent__sku")
+
+  res = inspect_query(q)
+  sql = res[:sql_text]
+
+  @test occursin("LEFT JOIN \"obj_parent\" AS \"Tb_1\" ON \"Tb\".\"parent\" = \"Tb_1\".\"id\"", sql)
+  @test occursin("WHERE \"Tb_1\".\"sku\" = \$1", sql)
+  @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", sql)
+  @test _obj_joins(sql) == 1
+  # Bound once: the ORDER BY term reuses the cached selector rather than re-parameterizing the path
+  # it shares with the WHERE clause.
+  @test res[:parameters] == ["X"]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cjoin + order_by: the ORDER BY term must not poison the cached selector (#404)
+# `get_order_query` degrades `field` to the bare SELECT alias when the ordered path is also
+# projected — legal in ORDER BY, invalid anywhere else. Because #404 moved that call ahead of
+# `build_row_join_sql_text`, the render now READS that cache: Phase 1 resolves cjoin ON conditions
+# through `_get_filter_query(::SQLTypeField)`, which returns `instruc.cache[_as].field` verbatim.
+# Caching the degraded form put a projection alias inside an ON clause, which both backends reject.
+# Nothing in the suite combined cjoin with order_by, which is exactly why that shipped green once.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() on a projected path does not corrupt a cjoin ON clause (#404)" begin
+  q = OBJ.Cj_child.objects
+  q.values("note", "parent__sku")                                   # unaliased -> _as == the path
+  q.cjoin("parent" => "Cj_parent", filters = ["sku" => "X"], warn = false)
+  q.order_by("parent__sku")                                         # same path, so found_in_select
+
+  sql = inspect_query(q)[:sql_text]
+
+  # The ON condition must name the qualified column, never the SELECT alias.
+  @test occursin("ON \"Tb\".\"parent\" = \"Tb_1\".\"id\" AND \"Tb_1\".\"sku\" = \$1", sql)
+  @test !occursin("AND \"parent__sku\" = ", sql)
+  # The ORDER BY may still use the alias — that is the one place it is valid.
+  @test occursin("ORDER BY \"parent__sku\" ASC", sql)
+  @test _obj_joins(sql) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cjoin + order_by: a deep ON condition must not forward-reference a later join (#404)
+# Phase 2 emits joins in `row_join` order, so an ON extra naming a join emitted LATER is invalid SQL
+# ("invalid reference to FROM-clause entry"). Phase 1b relocates such extras — but it used to scope
+# the search to entries created DURING Phase 1 (`dep_idx > n_before`). Once order_by resolves the
+# deep path up front, Phase 1 dedups onto the existing entry instead of creating one, the window is
+# empty, and the extra stays on the wrong join. Phase 1b now keys on index order, which covers this
+# and the pre-existing `values()` shape below identically.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a deep cjoin ON condition lands on the join it references (#404)" begin
+  # (a) reached via order_by — the shape #404's reordering exposed.
+  ordered = OBJ.Cj_child.objects
+  ordered.values("note")
+  ordered.cjoin("parent" => "Cj_parent", filters = ["grandparent__code" => "Z"], warn = false)
+  ordered.order_by("parent__grandparent__code")
+
+  sql = inspect_query(ordered)[:sql_text]
+
+  # The extra belongs on cj_grand's ON clause (emitted second), not on cj_parent's (emitted first).
+  @test occursin("LEFT JOIN \"cj_grand\" AS \"Tb_2\" ON \"Tb_1\".\"grandparent\" = \"Tb_2\".\"id\" AND \"Tb_2\".\"code\" = \$1", sql)
+  @test !occursin("\"Tb\".\"parent\" = \"Tb_1\".\"id\" AND \"Tb_2\"", sql)
+  @test occursin("ORDER BY \"Tb_2\".\"code\" ASC", sql)
+  @test _obj_joins(sql) == 2
+
+  # (b) reached via values() — the same forward reference, and it pre-dates #404: projecting the
+  # deep path builds the deeper join up front just as ordering by it now does. Fixed by the same
+  # Phase 1b change, so it is pinned here rather than left to regress silently.
+  projected = OBJ.Cj_child.objects
+  projected.values("note", "parent__grandparent__code")
+  projected.cjoin("parent" => "Cj_parent", filters = ["grandparent__code" => "Z"], warn = false)
+
+  psql = inspect_query(projected)[:sql_text]
+
+  @test occursin("LEFT JOIN \"cj_grand\" AS \"Tb_2\" ON \"Tb_1\".\"grandparent\" = \"Tb_2\".\"id\" AND \"Tb_2\".\"code\" = \$1", psql)
+  @test !occursin("\"Tb\".\"parent\" = \"Tb_1\".\"id\" AND \"Tb_2\"", psql)
+  @test _obj_joins(psql) == 2
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1b settles an ON extra on the last join it references, however many hops away (#404)
+# One `Q(...)` extra can name several joins emitted after the one carrying it, and it has to end up
+# on the last of them or the rest stay forward-referenced. This shape is broken on origin/main —
+# it emits `"Tb_3"` inside `Tb_2`'s ON clause — so this is a pre-existing fix, not just a guard on
+# #404's own change. What it pins is the FIXED POINT, not the search direction: the relocation loop
+# searches descending to get there in one move, but ascending would cascade to the same place via
+# the outer loop's revisit, so no test can tell the two apart. Do not read this as pinning "descending".
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an ON extra relocates onto the last join it references (#404)" begin
+  q = OBJ.Cj_child.objects
+  q.values("note")
+  q.cjoin("parent" => "Cj_parent",
+          filters = [Q("grandparent__code" => "Z", "grandparent__great__tag" => "T")], warn = false)
+
+  sql = inspect_query(q)[:sql_text]
+
+  # The extra names Tb_2 and Tb_3; it must ride on Tb_3, the later of the two.
+  @test occursin("LEFT JOIN \"cj_great\" AS \"Tb_3\" ON \"Tb_2\".\"great\" = \"Tb_3\".\"id\" AND (\"Tb_2\".\"code\" = \$1 AND \"Tb_3\".\"tag\" = \$2)", sql)
+  # ...and Tb_2's own ON clause must be left bare, with no forward reference to Tb_3.
+  @test occursin("LEFT JOIN \"cj_grand\" AS \"Tb_2\" ON \"Tb_1\".\"grandparent\" = \"Tb_2\".\"id\" \n", sql)
+  @test !occursin("\"Tb_1\".\"grandparent\" = \"Tb_2\".\"id\" AND", sql)
+  @test _obj_joins(sql) == 3
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1b matches an ALIAS, not a column that happens to share its name (#404)
+# The relocation search tests the rendered extra for the dependency's alias. Every column reference
+# renders as `"alias"."col"`, so a bare `"name"` test also hits the COLUMN half: a `cjoin_on` alias
+# spelled like a column (`alias = "code"` vs `"Tb_2"."code"`) then drags an unrelated LEFT JOIN's ON
+# filter onto itself. Valid SQL, wrong rows, no error — strictly worse than the forward reference it
+# replaced. The guard is the trailing dot, and this testset is what holds it in place.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "relocation matches an alias, not a like-named column (#404)" begin
+  build(alias) = begin
+    q = OBJ.Cj_child.objects
+    q.values("note", "parent__grandparent__code")
+    q.cjoin("parent" => "Cj_parent", filters = ["grandparent__code" => "Z"], warn = false)
+    q.cjoin_on("Cj_grand", alias = alias, join_type = "INNER", on = [Q(F("$alias.id") == F("id"))])
+    inspect_query(q)[:sql_text]
+  end
+
+  # `zz` collides with nothing; `code` is spelled exactly like cj_grand's column. The two must
+  # render identically apart from the alias itself — the alias name cannot decide where a filter goes.
+  control   = build("zz")
+  colliding = build("code")
+
+  for (label, sql) in (("zz", control), ("code", colliding))
+    # The cjoin's filter belongs on the LEFT JOIN that owns the column, in both cases.
+    @test occursin("LEFT JOIN \"cj_grand\" AS \"Tb_2\" ON \"Tb_1\".\"grandparent\" = \"Tb_2\".\"id\" AND \"Tb_2\".\"code\" = \$1", sql)
+  end
+  # And the cjoin_on join must carry only its own ON condition, never the migrated filter.
+  @test occursin("INNER JOIN \"cj_grand\" AS \"code\" ON ((\"code\".\"id\" = \"Tb\".\"id\")) \n", colliding)
+  @test !occursin("\"code\".\"id\" = \"Tb\".\"id\")) AND", colliding)
+  # Same shape either way: the alias name must not change how many joins are emitted, nor which one
+  # the filter rides on. (A whole-string comparison is not available here — swapping "code" for "zz"
+  # would also rewrite the like-named COLUMN, which is the very ambiguity under test.)
+  @test _obj_joins(control) == _obj_joins(colliding) == 3
+  @test count("= \$1", control) == count("= \$1", colliding) == 1
+end

--- a/test/unit/test_window_functions.jl
+++ b/test/unit/test_window_functions.jl
@@ -6,6 +6,14 @@ using PormG.QueryBuilder: WindowOver, Rank, DenseRank, RowNumber, Lag, NthValue,
 struct WindowMockPostgres <: PormG.PormGPostgres end
 struct WindowMockSQLite <: PormG.PormGSQLite end
 
+# SQLite window support is gated behind a live version probe (`_assert_sqlite_window_support` →
+# `backend_sqlite_version`), which throws "requires SQLite" unless the extension is loaded. Under
+# `runtests.jl` it is, via `test/load_drivers.jl`; run this file on its own — as the issue workflow's
+# rung-2 slice does — and the LAG testset errored instead. Pinning a version here makes the file
+# self-contained on both paths, the same stub `test_cte_db_column.jl` and `test_order_by_joins.jl`
+# use for ORDER BY's NULL-placement probe. 3.28 is the floor window functions need.
+PormG.backend_sqlite_version(::WindowMockSQLite) = 3045000
+
 PormG.config["window_pg"] = PormG.Configuration.Settings(
   connections=WindowMockPostgres(),
   change_data=true


### PR DESCRIPTION
Closes #404.

## The bug

`get_order_query` ran **after** `build_row_join_sql_text` had already rendered `row_join` into SQL. A path named *only* by `order_by()` resolves through `_get_select_query` → `_build_row_join`, which **appends** to `row_join` — so that entry was never emitted, and the ORDER BY referenced an alias the query never joined. Loud failure on both backends (`missing FROM-clause entry` / `no such column`).

Ordering a path that is also projected or filtered was always fine: it takes the `instruc.cache` branch and discovers nothing. That is why this survived so long.

The fix moves the `get_order_query` call ahead of the render, into the block where select/filter/order all resolve.

## What shipped

Source is confined to `src/querybuilder/build_query.jl` (the reorder plus two Phase 1b repairs) and one comment in `src/querybuilder/execution.jl`. Four defects, only two of them introduced by this fix:

| # | Defect | Introduced here? |
|---|---|---|
| 1 | ORDER BY discovers a join after the render | No — **this is #404** |
| 2 | ORDER BY poisons `instruc.cache`, so an ON clause got a bare projection alias | Yes — caught in review |
| 3 | Phase 1b keyed on *when* a join was appended (`dep_idx > n_before`), not on emission order | **No — pre-existing** |
| 4 | Phase 1b matched a bare `"name"`, so a column could be mistaken for an alias | Yes — from the fix for 3 |

**Defect 3 is reachable on `origin/main` today through `values()` alone** — projecting a deep path (`values("parent__grandparent__code")`) builds the deeper join up front, Phase 1 dedups the ON condition onto the existing entry, and the old window was empty so the extra stayed on the wrong join. Verified directly against `main`, not inferred.

Defect 4 is the nastier of the two introduced: a `cjoin_on` alias sharing a column's name (`alias = "code"` matching `"Tb_2"."code"`) dragged an unrelated join's ON filter onto itself — valid SQL, silently wrong rows. Fixed by requiring the trailing dot, the same `"alias".` form Phase 1 already keys on.

## Verification

- Unit **8163/8163**, exit 0.
- Integration exit 0 on **both engines** (`db_2` and `PORMG_DB=db_sl`) for `test_cjoin`, `test_selection`, `test_cte`, `test_having`, `test_db_column_db`.
- Changes after that integration run were comment-only.
- New `test/unit/test_order_by_joins.jl` (364 lines), registered in `runtests.jl`. It pins concrete `Tb_1`/`Tb_2`/`Tb_3` names, so relocating the `get_order_query` call again rewrites those expectations rather than passing silently.

Three review rounds. Rounds 1 and 2 each found real defects (2 and 4 above); round 3 corrected a comment of mine that overclaimed.

## Two comments corrected against my own earlier claims

Both were wrong in a direction that reads as confident, so they are worth naming:

- I claimed the UPDATE path never reads `instruction.join`. It does, at `execution.jl:1492`. The added comment explains what actually excludes the stale read, and warns against dropping that guard.
- I claimed the descending relocation search was required for correctness. It isn't — ascending cascades to the same fixed point via the outer loop. Descending is a cost choice that also keeps the termination argument to one line.

## Deliberately not in this PR

- **SQLite positional-parameter misalignment when an extra relocates** — filed as #421. Pre-existing, PostgreSQL immune (`$N` travels with the text), silently wrong rows on SQLite. This PR widens which shapes relocate, so it widens the exposure; the gap is written into the Phase 1b comment with a repro and now names #421.
- Phase 2 dropping extras relocated onto a CROSS-joined CTE (hard to reach).
- `order_by()` on a `custom_as` alias throwing `UnknownFieldError`.

## No `UPGRADING.md` entry

Nothing that worked before stops working — the shapes this fixes errored out already. That is outside the file's own scope rule ("only what **forces** an app edit"), matching the #370 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
