### PR TITLE
fix(#400, #410): the Django importer degrades a column instead of losing one silently or losing the file

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -27,6 +27,7 @@ import_models_from_django(
     django_prefix::Union{Nothing, String, Missing} = missing,
     auth_user_model::Union{Nothing, String} = nothing,
     strict_relations::Bool = false,
+    strict_fields::Bool = false,
     binding_overrides::AbstractDict = Dict{String, String}(),
     autofields_ignore::Vector{String} = ["Manager"],
     parameters_ignore::Vector{String} = ["help_text"]
@@ -41,6 +42,7 @@ import_models_from_django(
     output_path::Union{Nothing, String} = nothing,
     auth_user_model::Union{Nothing, String} = nothing,
     strict_relations::Bool = false,
+    strict_fields::Bool = false,
     binding_overrides::AbstractDict = Dict{String, String}(),
     autofields_ignore::Vector{String} = ["Manager"],
     parameters_ignore::Vector{String} = ["help_text"]
@@ -146,6 +148,12 @@ import_models_from_django("/path/to/your/models.py")
 - **`strict_relations::Bool`**: `false` (the default) imports a relation whose target is not in this
   import as a plain column, with a `# PormG:` marker. `true` raises `InvalidMigrationError` instead.
   See [Relation targets](@ref).
+
+- **`strict_fields::Bool`**: `false` (the default) **skips** a field whose Django type PormG does not
+  implement, with a `@warn` and a `# PormG:` marker naming the field, its class and its `models.py`
+  line. `true` raises `InvalidMigrationError` instead. The lenient default is not about tolerating one
+  bad column — before it, a single unimplemented type aborted the import of *every* model in *every*
+  app of the call. See the note under [Supported Django Fields](#Supported-Django-Fields).
 
 - **`binding_overrides::AbstractDict`**: spell a generated Julia binding differently from the derived
   one. See [Choosing your own binding](@ref).
@@ -400,15 +408,22 @@ and no `db_table` is emitted.
 
 ## Supported Django Fields
 
-The function supports conversion of the following Django field types:
+Every Django field type PormG implements is listed below, and the list is **exhaustive**: a
+`models.X` that is not on it has no PormG counterpart, and the note at the end of this section says
+what happens to it. Every entry except the three auto-key types maps by identity — same name, same
+column.
 
 ### Text Fields
 - `CharField` → `CharField`
 - `TextField` → `TextField`
 - `EmailField` → `EmailField`
+- `SlugField` → `SlugField`
+- `URLField` → `URLField`
 
 ### Numeric Fields
 - `IntegerField` → `IntegerField`
+- `PositiveIntegerField` → `PositiveIntegerField`
+- `PositiveSmallIntegerField` → `PositiveSmallIntegerField`
 - `BigIntegerField` → `BigIntegerField`
 - `FloatField` → `FloatField`
 - `DecimalField` → `DecimalField`
@@ -417,6 +432,7 @@ The function supports conversion of the following Django field types:
 - `DateField` → `DateField`
 - `DateTimeField` → `DateTimeField`
 - `TimeField` → `TimeField`
+- `DurationField` → `DurationField`
 
 ### Boolean Fields
 - `BooleanField` → `BooleanField`
@@ -424,12 +440,17 @@ The function supports conversion of the following Django field types:
 ### Relationship Fields
 - `ForeignKey` → `ForeignKey`
 - `OneToOneField` → `OneToOneField`
+- `ManyToManyField` → `ManyToManyField`
 
 ### Special Fields
 - `AutoField` → `IDField` (reported — see below)
 - `BigAutoField` → `IDField`
 - `SmallAutoField` → `IDField` (reported — see below)
   (PormG has no `AutoField` of its own — it was retired; see [Field Types](fields.md).)
+- `UUIDField` → `UUIDField`
+- `JSONField` → `JSONField`
+- `BinaryField` → `BinaryField`
+- `FileField` → `FileField`
 - `ImageField` → `ImageField`
 
 !!! note "Every Django auto key imports as `IDField`"
@@ -444,6 +465,18 @@ The function supports conversion of the following Django field types:
     Both are annotated in the generated file, so the substitution is visible. Your existing column
     is **not** re-typed — but a table PormG *creates* from these models gets BIGINT rather than
     INTEGER or SMALLINT.
+
+!!! note "A field type PormG does not implement costs its column, not the file"
+    Django ships plenty of types PormG has no counterpart for — `GenericIPAddressField`,
+    `SmallIntegerField`, `PositiveBigIntegerField`, `FilePathField`, `GeneratedField`. Each one costs
+    **its own column and nothing else**: every other field, every other class and every other app in
+    the same call still import. The skip is reported both ways, with a `@warn` and a `# PormG:` marker
+    naming the field, its class and its `models.py` line.
+
+    Mind the consequence: the skipped column is still in the database and now absent from the model,
+    so `makemigrations` reads it as drift and proposes **dropping** it. Declare that column by hand
+    before you migrate — or pass `strict_fields = true` to fail the import instead of receiving a
+    model with a column missing.
 
 
 ## Field Mapping
@@ -741,7 +774,11 @@ field and its source line; it is never dropped silently.
 
 - **Primary Key**: If no primary key is defined, `id = Models.IDField()` is automatically added.
   Declaring any field `primary_key=True` **suppresses** it, as in Django — including a field named
-  `id` itself, which then keeps its declared type
+  `id` itself, which then keeps its declared type. The addition is never a *replacement*: a class that
+  declares a field named `id` which is **not** the primary key keeps that column, and no implicit `id`
+  is written over it. Django rejects that shape itself (`models.E004`), so it can only arrive from a
+  `models.py` that never passed `manage.py check` — the model then comes out with **no** primary key,
+  reported by a `@warn` and a `# PormG:` marker, with the consequences in the warning below
 - **AbstractUser**: For models inheriting from `AbstractUser`, additional fields like `date_joined` are added.
   `id` is **not** one of them: `AbstractUser` inherits Django's implicit `id` from `models.Model`
   rather than owning it, so a user model keyed on its own field — `matricula = CharField(primary_key=True)`
@@ -790,9 +827,9 @@ field and its source line; it is never dropped silently.
 | | |
 |---|---|
 | **Imported** | Fields (including definitions wrapped across lines; Django's `BigAutoField` maps to `IDField`, an exact match), `ForeignKey` / `OneToOneField` / `ManyToManyField` — including `"self"`, `"<app_label>.<Class>"` and `settings.AUTH_USER_MODEL` targets, `Meta.db_table`, `Meta.unique_together`, `Meta.constraints`, `Meta.indexes`, `Meta.index_together` (the last three: see the whitelists above), abstract-base inheritance, `AbstractUser` auth columns, `TextChoices` / `IntegerChoices` enumerations |
-| **Imported, but degraded and annotated** | An `AutoField` or `SmallAutoField` — imported as `IDField`, because `IDField` is PormG's only integer key type (see the note under *Supported Django Fields*); the key is faithful, the declared width is not. A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them. A `primary_key=True` on a field type PormG cannot key on — the column survives, the key does not, and no `id` is substituted; the model is then unusable by relations until you re-declare the key (see the warning above) |
-| **Reported and skipped** | `Meta.ordering` and every other option with no PormG equivalent; a `UniqueConstraint` or an `Index` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`) |
-| **Not supported** | Field types PormG does not implement — these raise, naming the field and class, rather than importing something wrong. Model methods, managers, signals and validators are Python and have no PormG counterpart |
+| **Imported, but degraded and annotated** | An `AutoField` or `SmallAutoField` — imported as `IDField`, because `IDField` is PormG's only integer key type (see the note under *Supported Django Fields*); the key is faithful, the declared width is not. A model whose base lives in another file — its own fields only. A relation whose target is not in this import — the column survives as a `BigIntegerField`, the relation does not (a `ManyToManyField` has no column, so it is dropped); `strict_relations = true` raises instead. A `Meta.db_table` that is computed rather than a plain string literal — ignored, name derived from the class. A `db_table` on an abstract base — not inherited by its children. A `unique_together` that is a name rather than a literal, or names a field that did not import. A field whose enum this file cannot see — the column survives, the enumeration does not. A field whose `choices` and/or `default` the field type rejects at construction — including a lone `default` on a field with no choices at all, such as one longer than `max_length` — the column survives without them. A `primary_key=True` on a field type PormG cannot key on — the column survives, the key does not, and no `id` is substituted; the model is then unusable by relations until you re-declare the key (see the warning above). A class-declared field named `id` that is **not** the primary key — the declared column is kept and Django's implicit `id` is not substituted over it, so the model has no key until you declare one |
+| **Reported and skipped** | `Meta.ordering` and every other option with no PormG equivalent; a `UniqueConstraint` or an `Index` PormG cannot express; multi-table inheritance; proxy models; a field-shaped call the importer cannot read (`tags = ArrayField(...)`); a field whose Django type PormG does not implement (`GenericIPAddressField`, `SmallIntegerField`, …) — the field, its class and its `models.py` line are named, and every other field, class and app in the call still imports, with `strict_fields = true` raising instead. Both leave the live column addressable by nothing in the model, so `makemigrations` reads it as drift |
+| **Not supported** | Model methods, managers, signals and validators are Python and have no PormG counterpart |
 
 Nothing in the middle two rows is dropped in silence: each one produces a `@warn` at import time and
 a `# PormG:` comment in the generated file, naming the class app-qualified when a label is known

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -1535,6 +1535,7 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
                              model_path::String,
                              auth_user_model::Union{Nothing, String},
                              strict_relations::Bool,
+                             strict_fields::Bool,
                              binding_overrides::Dict{String, String},
                              autofields_ignore::Vector{String},
                              parameters_ignore::Vector{String})
@@ -1706,10 +1707,12 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       # Process fields separately
       # `class_name` and `class_label` both go down, and they are not interchangeable: the first is
       # the enum scope key, the second is what the reports NAME (#371). See `process_class_fields!`.
-      declared_pk = process_class_fields!(fields_dict, class_content, class_name,
-                                          _inherits_auth_user(graph, class), autofields_ignore,
-                                          parameters_ignore, markers, graph.enums,
-                                          _enum_scopes(graph, class); class_label = class_label)
+      declared_pk, unsupported_pk, unsupported_fields =
+        process_class_fields!(fields_dict, class_content, class_name,
+                              _inherits_auth_user(graph, class), autofields_ignore,
+                              parameters_ignore, markers, graph.enums,
+                              _enum_scopes(graph, class); class_label = class_label,
+                              strict_fields = strict_fields)
 
       # Django's implicit `id`, added only when nothing claimed the key — DERIVED, per field, from
       # what was built and from what the models.py declared, never tracked with a class-wide flag
@@ -1727,9 +1730,56 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       #     builds a field that IS the key, because the `IDField` it maps to (DJANGO_AUTO_KEY_TYPES,
       #     below) defaults `primary_key = true`.
       # `get_model_pk_field`, which reads this model downstream, sees only the first.
+      #
+      # `unsupported_pk` is a THIRD reading, and it disagrees with both of the above in the same
+      # direction: a `codigo = models.GenericIPAddressField(primary_key=True)` builds nothing and
+      # declares nothing this function can see, yet Django's table is keyed on that column all the
+      # same. Substituting `id` there would name a column that table has not got — the very defect
+      # the two readings above exist to prevent, reached through #410's new skip path.
       built_pk = any(f -> f.primary_key, values(fields_dict))
-      if !built_pk && isempty(declared_pk)
-          fields_dict[:id] = Models.IDField()
+      if !built_pk && isempty(declared_pk) && isempty(unsupported_pk)
+          # #400: the implicit `id` is an ADDITION, never a replacement. `fields_dict` is a Dict, so
+          # the plain assignment this used to be clobbered a column the class had declared under that
+          # name — silently, with the declared type gone from the artifact and nothing saying so. It
+          # was the last silent column loss left in this importer, and it broke the one promise the
+          # whole file is built on.
+          #
+          # Django rejects the shape itself (`models.E004`: "'id' can only be used as a field name if
+          # the field also sets 'primary_key=True'"), so it cannot come from a project that passes
+          # `manage.py check` — but hand-edited, legacy and partially-migrated `models.py` files are
+          # exactly the input this importer exists to read, and it cannot validate them.
+          #
+          # The declared column WINS, consistent with #369's rule for a declared key PormG cannot
+          # express: report the gap, never destroy a column to paper over it. That leaves the model
+          # with no primary key, which is not a soft outcome — hence the same consequences spelled
+          # out in the `lost_pk` marker below.
+          #
+          # "Is the name taken" is asked of the CLASS, not of `fields_dict`. The two answers differ:
+          # #410 skips a column whose type PormG cannot build, so `id = models.SmallIntegerField()`
+          # CLAIMS the name and leaves the dict untouched. A `haskey` test alone called that free and
+          # wrote an `IDField` over it — this very clobber, one skip path along, and with the field's
+          # own marker already in the file saying that column was not imported.
+          skipped_id = :id in unsupported_fields
+          if haskey(fields_dict, :id) || skipped_id
+            @warn "import: a class-declared field named 'id' is not the primary key; no implicit id was substituted and this model has none" class=class_label declared_id_imported=!skipped_id
+            push!(markers, "# PormG: '$(class_label)' declares a field named 'id' that is NOT its " *
+                           "primary key. Django's implicit `id` was NOT substituted for it — " *
+                           (skipped_id ?
+                              "that column is not imported at all (its Django type has no PormG " *
+                              "counterpart; see the marker above), and claiming a BIGINT " *
+                              "auto-increment key in its place would mis-type the one column " *
+                              "every query reads. " :
+                              "that would silently destroy the declared column below. ") *
+                           "This model therefore has NO primary key, which leaves it unusable by " *
+                           "anything that needs one: a ManyToManyField pointing at it makes the " *
+                           "WHOLE generated file fail to load, and a ForeignKey pointing at it " *
+                           "loads and is silently wrong. Declare the real key by hand — mark this " *
+                           "column `primary_key = true` if that is what the table does. (Django " *
+                           "rejects this shape itself, models.E004, so it can only reach here " *
+                           "from a models.py that never passed `manage.py check`.)")
+          else
+            fields_dict[:id] = Models.IDField()
+          end
       end
 
       # Declared keys that did NOT survive into a built one — the field type refused `primary_key`
@@ -1776,10 +1826,34 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       # time (inherited statements, synthetic keys, degraded relations) — any of which could empty it
       # again. A hard error rather than a marker: there is no such thing as a table with no columns,
       # so reaching this means the two passes disagree, and that has to be loud.
-      isempty(fields_dict) && throw(InvalidMigrationError(
-        "import: internal — '$(_django_ref_label(entry))' was indexed but has no field to emit, so " *
-        "any relation pointing at it would name a binding this file does not define. This is a " *
-        "PormG bug; please report it with the models.py that triggered it."))
+      #
+      # #410 gave it reachable, non-internal paths, so the message forks. A class can now empty
+      # `fields_dict` two ways, and both are the caller's models.py rather than a PormG bug: its only
+      # field is an unimplemented type that declared `primary_key=True`, or its only field is an
+      # unimplemented type NAMED `id` — either way the column is skipped and the implicit `id` that
+      # would have saved the model is correctly suppressed. Accusing PormG of an internal bug there
+      # sends the reader hunting in the wrong repository.
+      #
+      # Forked on `unsupported_fields`, not `unsupported_pk`: the second shape leaves the latter
+      # empty and would otherwise land on the "PormG bug" text.
+      #
+      # It still aborts: there is no honest degrade for a model with zero addressable columns, and
+      # every relation pointing at it was already rewritten to a binding this file would not define.
+      if isempty(fields_dict)
+        throw(isempty(unsupported_fields) ?
+          InvalidMigrationError(
+            "import: internal — '$(_django_ref_label(entry))' was indexed but has no field to " *
+            "emit, so any relation pointing at it would name a binding this file does not define. " *
+            "This is a PormG bug; please report it with the models.py that triggered it.") :
+          InvalidMigrationError(
+            "import: '$(_django_ref_label(entry))' has no column left to emit. At least one of " *
+            "its fields uses a Django field type PormG does not implement, and no implicit `id` " *
+            "could be substituted for the gap: the class either keys its table on one of those " *
+            "columns or declares `id` as one of them. If it declares other fields, they were " *
+            "dropped for reasons of their own — the warnings above name every one that did not " *
+            "survive. A model with no column cannot be emitted, and any relation pointing at it " *
+            "would name a binding this file does not define. Declare the missing columns by hand."))
+      end
       # `entry.name`, not `class_name`: a cross-app collision or a `binding_overrides` entry may
       # have renamed this model. `class_name` stays the source of every DJANGO-derived name below
       # (the table, the join columns), because those follow the Python class, not our handle.
@@ -2041,7 +2115,7 @@ function _django_source_text(model_py_string::String)::String
 end
 
 """
-  import_models_from_django(model_py_string::String; db::String = DB_PATH, force_replace::Bool = false, file::String = "automatic_models.jl", output_path::Union{Nothing, String} = nothing, django_prefix::Union{Nothing, String, Missing} = missing, auth_user_model::Union{Nothing, String} = nothing, strict_relations::Bool = false, binding_overrides::AbstractDict = Dict{String, String}(), autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
+  import_models_from_django(model_py_string::String; db::String = DB_PATH, force_replace::Bool = false, file::String = "automatic_models.jl", output_path::Union{Nothing, String} = nothing, django_prefix::Union{Nothing, String, Missing} = missing, auth_user_model::Union{Nothing, String} = nothing, strict_relations::Bool = false, strict_fields::Bool = false, binding_overrides::AbstractDict = Dict{String, String}(), autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
 
 Imports Django models from a given `model.py` file content string and generates corresponding Julia models.
 
@@ -2068,6 +2142,7 @@ pairs instead — see the [`Vector{Pair}` method](@ref import_models_from_django
   `through=`, is left alone.
 - `auth_user_model::Union{Nothing, String}`: which model `settings.AUTH_USER_MODEL` refers to, spelled as Django spells it (`"access.User"`, or a bare `"User"` when unambiguous). Defaults to `nothing`, which auto-detects the single class inheriting `AbstractUser`. If a relation names `settings.AUTH_USER_MODEL` and there is not exactly one candidate, the import raises `InvalidMigrationError` naming them — deliberately hard, since one omitted keyword would otherwise turn every user relation in the project into a plain integer column.
 - `strict_relations::Bool`: when `false` (the default), a relation whose target is not in this import keeps its column and loses only the relation metadata, with a `# PormG:` marker saying so. `true` raises `InvalidMigrationError` instead. The lenient default is what makes the importer usable on a project that touches `django.contrib`.
+- `strict_fields::Bool`: when `false` (the default), a field whose Django type PormG does not implement (`GenericIPAddressField`, `SmallIntegerField`, …) is skipped — the column is not imported, and a `@warn` plus a `# PormG:` marker name the field, its class and its `models.py` line. `true` raises `InvalidMigrationError` instead. The lenient default exists because the alternative is not "one bad column": before it, a single unimplemented type aborted the import of every model in every app of the call. Note the skipped column still exists in the database, so `makemigrations` reads it as drift and proposes dropping it until you declare it by hand — which is the case `true` is for.
 - `binding_overrides::AbstractDict`: `"<app_label>.<ClassName>" => "<JuliaBinding>"` (or a bare class name when unambiguous), to spell a generated binding differently from the derived one. The value must be a legal, capitalized Julia identifier that no other model claims; every violation is an error rather than a silent fallback.
 - `autofields_ignore::Vector{String}`: Fields to ignore automatically. Defaults to `["Manager"]`.
 - `parameters_ignore::Vector{String}`: Parameters to ignore during field processing. Defaults to `["help_text"]`.
@@ -2098,6 +2173,7 @@ function import_models_from_django(
     django_prefix::Union{Nothing, String, Missing} = missing,
     auth_user_model::Union{Nothing, String} = nothing,
     strict_relations::Bool = false,
+    strict_fields::Bool = false,
     binding_overrides::AbstractDict = Dict{String, String}(),
     autofields_ignore::Vector{String} = ["Manager"],
     parameters_ignore::Vector{String} = ["help_text"]
@@ -2129,13 +2205,14 @@ function import_models_from_django(
                       file = file, model_path = model_path,
                       auth_user_model = auth_user_model,
                       strict_relations = strict_relations,
+                      strict_fields = strict_fields,
                       binding_overrides = Dict{String, String}(String(k) => String(v) for (k, v) in binding_overrides),
                       autofields_ignore = autofields_ignore,
                       parameters_ignore = parameters_ignore)
 end
 
 """
-  import_models_from_django(apps::AbstractVector{<:Pair}; db::String = DB_PATH, force_replace::Bool = false, file::String = "automatic_models.jl", output_path::Union{Nothing, String} = nothing, auth_user_model::Union{Nothing, String} = nothing, strict_relations::Bool = false, binding_overrides::AbstractDict = Dict{String, String}(), autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
+  import_models_from_django(apps::AbstractVector{<:Pair}; db::String = DB_PATH, force_replace::Bool = false, file::String = "automatic_models.jl", output_path::Union{Nothing, String} = nothing, auth_user_model::Union{Nothing, String} = nothing, strict_relations::Bool = false, strict_fields::Bool = false, binding_overrides::AbstractDict = Dict{String, String}(), autofields_ignore::Vector{String} = ["Manager"], parameters_ignore::Vector{String} = ["help_text"])
 
 Import a **multi-app** Django project — `"<app_label>" => "<models.py path or source>"` pairs — into
 one generated module.
@@ -2192,6 +2269,7 @@ function import_models_from_django(
     output_path::Union{Nothing, String} = nothing,
     auth_user_model::Union{Nothing, String} = nothing,
     strict_relations::Bool = false,
+    strict_fields::Bool = false,
     binding_overrides::AbstractDict = Dict{String, String}(),
     autofields_ignore::Vector{String} = ["Manager"],
     parameters_ignore::Vector{String} = ["help_text"]
@@ -2283,6 +2361,7 @@ function import_models_from_django(
                       file = file, model_path = model_path,
                       auth_user_model = auth_user_model,
                       strict_relations = strict_relations,
+                      strict_fields = strict_fields,
                       binding_overrides = Dict{String, String}(String(k) => String(v) for (k, v) in binding_overrides),
                       autofields_ignore = autofields_ignore,
                       parameters_ignore = parameters_ignore)
@@ -3572,7 +3651,8 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
                                enums = Dict{Tuple{Int, String}, Dict{String, _PyEnum}}(),
                                enum_scopes::Vector{Tuple{Int, String}} =
                                  Tuple{Int, String}[(1, String(class_name)), (1, "")];
-                               class_label::AbstractString = class_name)
+                               class_label::AbstractString = class_name,
+                               strict_fields::Bool = false)
   # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
   # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
   # class reaching `AbstractUser` through an abstract base both qualify — an equality test on the
@@ -3585,8 +3665,28 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
   # legacy user table keyed on `matricula` came out with TWO primary keys and could never load.
   # Do not re-add it.
   #
-  # Returns the field keys whose surviving declaration said `primary_key=True` — see the loop.
+  # Returns `(declared_pk, unsupported_pk, unsupported_fields)`. Each answers a different question the
+  # caller has to ask, and none of the three can be derived from `fields_dict` after the fact —
+  # which is the whole reason they exist:
+  #
+  #   - `declared_pk` — keys whose declaration said `primary_key=True` and whose field this function
+  #     actually BUILT. The caller reports the ones that did not survive as a built key (`lost_pk`),
+  #     with wording that names the reason: a field type PormG cannot make a primary key.
+  #   - `unsupported_pk` — the same claim from a field whose TYPE PormG does not implement (#410).
+  #     There is no column to report a lost key on, so it is kept OUT of `declared_pk`, whose report
+  #     would otherwise name a column the generated file does not contain; the field's own marker
+  #     carries the consequence instead. It still suppresses the implicit `id`: a key of an
+  #     unimplemented type is a key the Django table HAS, and substituting `id` for it would name a
+  #     column that table has not got (#369).
+  #   - `unsupported_fields` — EVERY key skipped as an unimplemented type, key or not. This is what
+  #     answers "did the class claim this name", which is not the same question as "is there a field
+  #     at this key" and must not be approximated by it: `id = models.SmallIntegerField()` claims
+  #     `id` and leaves `fields_dict` untouched, so a `haskey` test answered "free" and wrote an
+  #     `IDField` over it — the #400 clobber again, one skip path further along, with the field's own
+  #     marker already in the file saying that column was not imported.
   declared_pk = Set{Symbol}()
+  unsupported_pk = Set{Symbol}()
+  unsupported_fields = Set{Symbol}()
 
   if is_auth_user
       fields_dict[:password] = Models.CharField()
@@ -3619,7 +3719,9 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
         # scrolls away; whoever opens the generated file months later needs to see the gap there.
         push!(markers, "# PormG: field '$(parsed.name)' on '$(class_label)' (models.py line " *
                        "$(stmt.lineno)) is a field-shaped call the importer cannot read — NOT " *
-                       "imported. Declare it in PormG by hand.")
+                       "imported. Declare it in PormG by hand; until you do, the column is still " *
+                       "in the database and absent from this model, so makemigrations reads it as " *
+                       "drift and proposes DROPPING it.")
       end
       continue
     end
@@ -3638,11 +3740,36 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     field_type = django_field_type(django_type)
     field_args_str = parsed.args
 
+    # A Django field type PormG does not implement (#410). DECIDED here, ACTED on below — the two
+    # cannot be one statement, and the gap between them is the whole design:
+    #
+    #   * deciding here mutes the option-level reports for a column that will not exist.
+    #     `parse_field_args` says things like "…has no choices slot… The column is unaffected", and
+    #     for a skipped field every one of them describes a column that is about to not exist. BOTH
+    #     of its channels have to go: the markers into a throwaway vector, and the `@warn`s into a
+    #     `NullLogger`. Muting only one leaves the console contradicting the artifact.
+    #   * acting below — after `autofields_ignore` and after the primary-key bookkeeping — is what
+    #     makes the skip safe. A type the CALLER dropped must not be reported as unimplemented, and a
+    #     `primary_key=True` on an unimplemented type has to be SEEN, or the caller substitutes an
+    #     `id` for a key the Django table really has (#369's defect, reached from a new direction).
+    #
+    # The options are still parsed in full rather than scanned for `primary_key` by hand: a second,
+    # simpler reader of Django's argument syntax is a second thing to keep in step with the first.
+    #
+    # `NullLogger` silences EVERY level, `@error` included. That is safe only because every log site
+    # reachable from `parse_field_args` is a field-OPTION report on the column being skipped — the
+    # helpers below it (`parse_value`, `parse_choices`, `split_field_options`) emit nothing at all. If
+    # you ever add an `@error` in there for something structural, exempt it from this scope or it
+    # will vanish without trace for exactly the fields already in trouble.
+    unsupported_type = !_is_pormg_field_type(field_type)
+
     # Parse field arguments
-    options, related_model = parse_field_args(field_args_str, django_type, parameters_ignore;
-                                              enums = enums, class_name = class_name,
-                                              enum_scopes = enum_scopes, class_label = class_label,
-                                              field_name = field_name, markers = markers)
+    parse_args() = parse_field_args(field_args_str, django_type, parameters_ignore;
+                                    enums = enums, class_name = class_name,
+                                    enum_scopes = enum_scopes, class_label = class_label,
+                                    field_name = field_name,
+                                    markers = unsupported_type ? String[] : markers)
+    options, related_model = unsupported_type ? with_logger(parse_args, NullLogger()) : parse_args()
 
     # An IGNORED field type contributes no column, so it cannot be the primary key either. Tested
     # BEFORE the primary-key bookkeeping below for that reason (#346): the other order let
@@ -3690,6 +3817,68 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     else
       delete!(declared_pk, field_key)
     end
+    # The same last-write-wins, for #410's sets: a child overriding an inherited field of an
+    # unimplemented type with one this importer CAN build drops the old claim along with it. Both are
+    # re-added a few lines below if this statement is itself unimplemented.
+    delete!(unsupported_pk, field_key)
+    delete!(unsupported_fields, field_key)
+
+    # #410: a field type PormG does not implement. Skip the COLUMN, not the file. Before this, one
+    # `models.GenericIPAddressField` aborted `_import_django_apps` outright and every model in every
+    # app of the call was lost — the same blast radius #268, #342 and #399 each closed for one
+    # specific CAUSE, walked back into by the next unmapped type. Degrading is the general fix;
+    # mapping names one at a time is a treadmill.
+    #
+    # `strict_fields` mirrors `strict_relations` for the caller who would rather fail the import than
+    # receive a model with a column missing — the two failure modes are not ranked, they are a choice
+    # (a missing column reads as drift to `makemigrations`, and that is not always the cheaper one).
+    if unsupported_type
+      strict_fields && throw(InvalidMigrationError(
+        "import: field '$(field_name)' in class '$(class_label)' (models.py line $(stmt.lineno)) is " *
+        "a models.$(django_type), a field type PormG does not implement, and strict_fields = true. " *
+        "Declare that column by hand, add \"$(django_type)\" to autofields_ignore to drop it " *
+        "deliberately, or set strict_fields = false to import the model without it."))
+      # The declaration WINS over whatever sits at this key, exactly as a buildable one would.
+      # `class_content` merges abstract bases by concatenation and lets the last write win, so an
+      # inherited `codigo = CharField(primary_key=True)` overridden by an unimplemented type used to
+      # leave the BASE's field standing — the model rendered a VARCHAR(10) primary key over a
+      # SMALLINT column while the marker beside it said that column was not imported. A skip that
+      # does not delete is not a skip; it is a silent fallback to the wrong type.
+      #
+      # The reach is per-KEY, not per-declaration, so it also crosses statements: `owner_id =
+      # models.SmallIntegerField()` removes the column an earlier `owner = models.ForeignKey(...)`
+      # built, because both write `:owner_id`. That is deliberate — it is precisely what a BUILDABLE
+      # `owner_id = models.IntegerField()` already does — and Django rejects the pair itself
+      # (models.E007, a column-name clash), so no valid project can reach it. The alternative,
+      # leaving the FK standing, is worse: the marker would then claim a column that is right there.
+      delete!(fields_dict, field_key)
+      push!(unsupported_fields, field_key)
+
+      # A DECLARED key of a type that never became a column. Moved out of `declared_pk` so the
+      # caller's `lost_pk` report — which names a column it says was "imported WITHOUT" its key —
+      # does not describe a column the generated file has not got; the marker below carries the
+      # consequence instead. It still suppresses the implicit `id`: see the note on the sets above.
+      declared_key = field_key in declared_pk
+      if declared_key
+        delete!(declared_pk, field_key)
+        push!(unsupported_pk, field_key)
+      end
+      @warn "import: field type PormG does not implement; the column is NOT imported" class=class_label field=field_name django_type=django_type line=stmt.lineno primary_key=declared_key
+      push!(markers, "# PormG: field '$(field_name)' on '$(class_label)' (models.py line " *
+                     "$(stmt.lineno)) is a models.$(django_type), a field type PormG does not " *
+                     "implement — NOT imported. Declare it by hand; until you do, the column is " *
+                     "still in the database and absent from this model, so makemigrations reads " *
+                     "it as drift and proposes DROPPING it." *
+                     (declared_key ?
+                        " It is also this model's PRIMARY KEY in Django, so the model below has " *
+                        "NO key. No `id` was substituted, because Django's table has no such " *
+                        "column — but that leaves the model unusable by anything that needs a " *
+                        "key: a ManyToManyField pointing at it makes the WHOLE generated file " *
+                        "fail to load, and a ForeignKey pointing at it loads and is silently " *
+                        "wrong." : "") *
+                     " Pass strict_fields = true to fail the import instead of skipping a column.")
+      continue
+    end
 
     # Instantiate the field
     try
@@ -3718,8 +3907,10 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
       # The retry SUCCEEDING is the whole safety property, and no inspection of the error is needed
       # to get it. Removing exactly these two kwargs changes nothing else, so a construction that
       # starts working without them failed because of them; one that still fails falls through to
-      # the normal path untouched. An unsupported field TYPE (#268) never reaches a different
-      # outcome for the same reason — the retry fails identically and rethrows.
+      # the normal path untouched. An unsupported field TYPE (#268) no longer reaches this block at
+      # all: #410 skips it before the `try`, so `getfield(Models, …)` here can no longer raise
+      # `UndefVarError`. What still lands here is a type PormG HAS whose arguments it refuses —
+      # `DecimalField(primary_key=True)` is the standing example, and it rethrows below.
       #
       # The `haskey` test below is an OPTIMIZATION, not a guard: with neither kwarg present the
       # filter removes nothing and the retry would simply repeat the same failing call. Do not read
@@ -3764,7 +3955,8 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     end
   end
 
-  return declared_pk
+  return (declared_pk = declared_pk, unsupported_pk = unsupported_pk,
+          unsupported_fields = unsupported_fields)
 
 end
 
@@ -3813,6 +4005,30 @@ function django_field_type(field_type::AbstractString)::String
   haskey(DJANGO_AUTO_KEY_TYPES, field_type) && return "IDField"
   return String(field_type)
 end
+
+"""
+    _is_pormg_field_type(t) -> Bool
+
+True when `t` — a type name ALREADY mapped through [`django_field_type`](@ref) — is one this importer
+can hand to `getfield(Models, …)` and call.
+
+Both halves are load-bearing, and neither is a stand-in for the other:
+
+  * `isdefined` is the real question. `getfield(Models, :GenericIPAddressField)` is the `UndefVarError`
+    that used to abort the import of the whole project (#410), and Django ships plenty of types PormG
+    has no counterpart for — `SmallIntegerField`, `PositiveBigIntegerField`, `FilePathField`,
+    `GenericIPAddressField`, `GeneratedField`.
+  * the suffix test stops a `models.X(...)` call that is NOT a column from being constructed merely
+    because `Models` happens to define the same name. `models.UniqueConstraint(...)` and
+    `models.Index(...)` are the live examples: both resolve in `Models`, neither is a field, and both
+    are legal Python outside a `Meta` block. Reusing `_FIELD_NAME_SUFFIXES` keeps that judgement in
+    ONE place — it is the same "does this name a column" test `_looks_like_a_field_call` applies.
+
+Deliberately NOT a check that the constructed value `isa PormGField`: finding that out means calling
+the constructor, which is the throw this exists to avoid.
+"""
+_is_pormg_field_type(t::AbstractString)::Bool =
+  any(sfx -> endswith(t, sfx), _FIELD_NAME_SUFFIXES) && isdefined(Models, Symbol(t))
 
 # `class_name` seeds `enum_scopes` — the key vector into `enums`, which is keyed by `(app_index,
 # BARE Python class name)` — so it must not be app-qualified; the app is already the `Int`.

--- a/test/unit/test_import_django_models.jl
+++ b/test/unit/test_import_django_models.jl
@@ -187,35 +187,73 @@ class SupportedThing(models.Model):
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Django Importer: unsupported field types fail with field context
-# This locks the current explicit-failure behavior for valid Django models that
-# contain field classes PormG does not implement.
+# Django Importer: an unsupported field type costs its column, not the file (#410)
+#
+# This testset used to lock the OPPOSITE contract — "unsupported field types fail with field
+# context" — and #410 retired it deliberately. The failure context was never the problem; the blast
+# radius was. `getfield(Models, :ArrayField)` raised out of `_import_django_apps`, so one column PormG
+# cannot represent cost every model in every app of the call, and #268, #342 and #399 each closed that
+# for one specific cause before the next unmapped type walked back into it.
+#
+# Run through the SINGLE-APP arity on purpose: the multi-app coverage lives in
+# `test_import_django_project.jl`, and `strict_fields` has to reach both entry points.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "Django importer reports unsupported field types" begin
+@testset "Django importer reports and skips unsupported field types (#410)" begin
     django_text = """
 from django.db import models
 
 class UnsupportedFieldModel(models.Model):
     tags = models.ArrayField(null=True)
+    label = models.CharField(max_length=50)
 """
     config_key, db_dir_existed = temp_import_config!()
 
     try
-        # #268 audit: importer failures are typed; a wrapped PormG error rethrows as itself,
-        # anything foreign (here: the unsupported-field UndefVarError) wraps as InvalidMigrationError.
-        err = @test_throws PormG.InvalidMigrationError import_models_from_django(
+        import_models_from_django(
             django_text;
             db = config_key,
             file = "unsupported_field_unit.jl",
             force_replace = true,
+        )
+        generated = read(joinpath(config_key, "unsupported_field_unit.jl"), String)
+
+        # The model is emitted, and the readable column with it — the assertion the old contract
+        # could not make, because nothing was emitted at all.
+        @test occursin("UnsupportedFieldModel = Models.Model(", generated)
+        @test occursin("label = Models.CharField(max_length=50)", generated)
+        # The unreadable one is gone...
+        @test !occursin("tags = Models.", generated)
+        # ...and reported with the same three facts the old exception carried: the field, the class
+        # and the type. Plus the models.py line, which the exception never gave.
+        @test occursin("# PormG: field 'tags' on 'UnsupportedFieldModel' (models.py line 4) is a " *
+                       "models.ArrayField", generated)
+        @test occursin("NOT imported", generated)
+    finally
+        cleanup_import_test!(config_key, db_dir_existed)
+    end
+
+    # `strict_fields = true` restores the raise for a caller who would rather fail than receive a
+    # model with a column missing — through the single-app arity, which threads the keyword
+    # independently of the pairs one.
+    config_key2, db_dir_existed2 = temp_import_config!()
+    try
+        # #268 audit: importer failures are typed. The old `UndefVarError` wrapped as an
+        # `InvalidMigrationError`; the guard raises one of its own, so the type is unchanged.
+        err = @test_throws PormG.InvalidMigrationError import_models_from_django(
+            django_text;
+            db = config_key2,
+            file = "unsupported_field_strict_unit.jl",
+            force_replace = true,
+            strict_fields = true,
         )
 
         message = sprint(showerror, err.value)
         @test occursin("tags", message)
         @test occursin("UnsupportedFieldModel", message)
         @test occursin("ArrayField", message)
+        @test occursin("strict_fields = true", message)
     finally
-        cleanup_import_test!(config_key, db_dir_existed)
+        cleanup_import_test!(config_key2, db_dir_existed2)
     end
 end
 

--- a/test/unit/test_import_django_project.jl
+++ b/test/unit/test_import_django_project.jl
@@ -3314,3 +3314,600 @@ class PlainAutoThing(models.Model):
     end
 end
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#400): the implicit `id` is an ADDITION, never a replacement
+#
+# `fields_dict` is a `Dict` and the synthetic key used to be a plain assignment into it, so a class
+# declaring its own field named `id` had that column overwritten — the declared type gone from the
+# artifact, no `@warn`, no `# PormG:` marker. It was the last silent column loss left in a file whose
+# entire contract is that nothing it cannot represent is dropped quietly.
+#
+# Django rejects the shape itself (`models.E004`), which is precisely why the importer has to handle
+# it: it reads hand-edited, legacy and partially-migrated `models.py` files that never passed
+# `manage.py check`, and it cannot validate them.
+#
+# The declared column wins, matching #369's rule for a declared key PormG cannot express: report the
+# gap, never destroy a column to paper over it.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a declared field named id is preserved, not overwritten by the implicit key (#400)" begin
+    declared_id = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.UUIDField()
+    nome = models.CharField(max_length=10)
+"""
+    generated, config_key, db_dir_existed = import_project(["access" => declared_id];
+                                                           output_file = "declared_id.jl")
+    try
+        # THE assertion, and it is a PAIR on purpose. The positive alone would pass on a build that
+        # emitted both columns; the negative alone would pass on one that dropped the field outright.
+        # Together they pin "the declared column survived AND nothing was substituted for it".
+        @test occursin("id = Models.UUIDField()", generated)
+        @test !occursin("Models.IDField()", generated)
+        # ...and the consequence is stated in the ARTIFACT, not only in a console warning that
+        # scrolls away before anyone opens the generated file.
+        @test occursin("# PormG: 'access.Thing' declares a field named 'id' that is NOT its primary key",
+                       generated)
+        @test occursin("has NO primary key", generated)
+
+        # The model loads, and it really is keyless. Asserted on the BUILT model: the rendered text
+        # cannot distinguish "no primary key" from "a key PormG renders without the kwarg".
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(declared_id.Thing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) === nothing
+        @test length(thing.fields) == 2
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # Identical for an `AbstractUser` subclass — the issue's second acceptance box. Before #369 this
+    # path was accidentally CORRECT (the auth branch set the old class-wide `has_primary_key` flag
+    # unconditionally, so the fallback never ran); removing that flag made the two paths consistently
+    # wrong. They have to stay consistent now that they are right.
+    auth_declared_id = """
+from django.db import models
+from django.contrib.auth.models import AbstractUser
+
+class User(AbstractUser):
+    id = models.UUIDField()
+"""
+    gen_auth, key_auth, existed_auth = import_project(["access" => auth_declared_id];
+                                                       output_file = "declared_id_auth.jl")
+    try
+        @test occursin("id = Models.UUIDField()", gen_auth)
+        @test !occursin("Models.IDField()", gen_auth)
+        @test occursin("# PormG: 'access.User' declares a field named 'id' that is NOT its primary key",
+                       gen_auth)
+        # The `AbstractUser` columns still land — the fix guards ONE key, it does not disable the
+        # auth branch.
+        @test occursin("password = Models.CharField()", gen_auth)
+        @test occursin("date_joined = Models.DateTimeField()", gen_auth)
+
+        sandbox_auth = Module()
+        Core.eval(sandbox_auth, Meta.parse(gen_auth))
+        user = Core.eval(sandbox_auth, :(declared_id_auth.User))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, user) === nothing
+    finally
+        cleanup_project_test!(key_auth, existed_auth)
+    end
+
+    # The CONTROL, and the reason the guard is `haskey` rather than "a field named id exists": the
+    # legal shape must be untouched. `id = models.UUIDField(primary_key=True)` is a real Django model
+    # and has always imported correctly — it must not acquire a marker announcing a problem it does
+    # not have. Without this, a guard that fired on every declared `id` would still pass everything
+    # above.
+    keyed_id = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.UUIDField(primary_key=True)
+    nome = models.CharField(max_length=10)
+"""
+    gen_keyed, key_keyed, existed_keyed = import_project(["access" => keyed_id];
+                                                          output_file = "declared_id_keyed.jl")
+    try
+        @test occursin("id = Models.UUIDField(", gen_keyed)
+        @test !occursin("declares a field named 'id'", gen_keyed)
+        @test !occursin("has NO primary key", gen_keyed)
+        sandbox_keyed = Module()
+        Core.eval(sandbox_keyed, Meta.parse(gen_keyed))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox_keyed, :(declared_id_keyed.Thing))) == :id
+    finally
+        cleanup_project_test!(key_keyed, existed_keyed)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#410): an unimplemented field type costs its COLUMN, not the file
+#
+# `process_class_fields!` resolves the constructor by name, and #342's retry cannot help an unknown
+# TYPE — so one `models.GenericIPAddressField` raised out of `_import_django_apps` and every model in
+# every app of the call was lost. Django ships plenty of types PormG does not implement
+# (`SmallIntegerField`, `PositiveBigIntegerField`, `FilePathField`, `GeneratedField`, …), and #268,
+# #342 and #399 each closed this blast radius for one specific cause before the next unmapped type
+# walked straight back into it.
+#
+# The column is now skipped and reported; `strict_fields = true` restores the raise for callers who
+# would rather fail than receive a model with a column missing.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an unimplemented Django field type skips its column, not the import (#410)" begin
+    # The issue's own reproduction, plus a second app: the blast radius was per-CALL, not per-file.
+    unknown_type = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.BigAutoField(primary_key=True)
+    ip = models.GenericIPAddressField()
+    nome = models.CharField(max_length=10)
+
+class EverythingElse(models.Model):
+    nome = models.CharField(max_length=40)
+"""
+    untouched_app = """
+from django.db import models
+
+class Untouched(models.Model):
+    nome = models.CharField(max_length=5)
+"""
+    generated, config_key, db_dir_existed = import_project(["racing" => unknown_type,
+                                                            "access" => untouched_app];
+                                                           output_file = "unknown_field_type.jl")
+    try
+        # The rest of the DECLARING class survives...
+        @test occursin("nome = Models.CharField(max_length=10)", generated)
+        # ...its SIBLING class in the same file survives...
+        @test occursin("EverythingElse = Models.Model(", generated)
+        # ...and so does the other app, which the old failure took down with it.
+        @test occursin("Untouched = Models.Model(", generated)
+        # The column itself is gone, and that is what the marker exists to say.
+        @test !occursin("ip = Models.", generated)
+
+        # The report names the field, the class AND the models.py line — a reader with the generated
+        # file open has to be able to find the declaration in the Django source.
+        @test occursin("# PormG: field 'ip' on 'racing.Thing' (models.py line 5) is a " *
+                       "models.GenericIPAddressField", generated)
+        @test occursin("NOT imported", generated)
+        # The hazard the skip creates: the live column is now invisible to the model, so the planner
+        # reads it as drift. Saying so in the artifact is the difference between a documented gap and
+        # a surprise `DROP COLUMN` in someone's next migration plan.
+        @test occursin("proposes DROPPING it", generated)
+
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(unknown_field_type.Thing))
+        @test !haskey(thing.fields, "ip")
+        @test haskey(thing.fields, "nome")
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) == :id
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # `strict_fields = true` — the opt-out, mirroring `strict_relations`. Asserted on the MESSAGE and
+    # not just the type: this importer raises `InvalidMigrationError` for a dozen reasons, so the type
+    # alone would let the guard be deleted and the test still pass on someone else's error.
+    strict_src = """
+from django.db import models
+
+class Thing(models.Model):
+    ip = models.GenericIPAddressField()
+    nome = models.CharField(max_length=10)
+"""
+    key_strict, existed_strict = project_config!()
+    try
+        err = nothing
+        try
+            import_models_from_django(["racing" => strict_src]; db = key_strict,
+                                      file = "strict_fields.jl", force_replace = true,
+                                      strict_fields = true)
+        catch e
+            err = e
+        end
+        @test err isa PormG.InvalidMigrationError
+        msg = sprint(showerror, err)
+        @test occursin("field 'ip' in class 'racing.Thing'", msg)
+        @test occursin("models.GenericIPAddressField", msg)
+        @test occursin("strict_fields = true", msg)
+        # ...and it really did abort: nothing was written.
+        @test !isfile(joinpath(key_strict, "strict_fields.jl"))
+    finally
+        cleanup_project_test!(key_strict, existed_strict)
+    end
+
+    # #410 × #369. The skipped field DECLARED the primary key, so the two-reading test that decides
+    # the implicit `id` needs a THIRD reading: nothing was built, and nothing survives in `declared_pk`
+    # to look at, yet Django's table is keyed on that column. Substituting an `id` here would name a
+    # column that table has not got — #369's defect, reached from the new skip path.
+    unknown_pk = """
+from django.db import models
+
+class Thing(models.Model):
+    codigo = models.SmallIntegerField(primary_key=True)
+    nome = models.CharField(max_length=10)
+"""
+    gen_pk, key_pk, existed_pk = import_project(["racing" => unknown_pk];
+                                                 output_file = "unknown_pk_type.jl")
+    try
+        # NO phantom key. This is the assertion the whole `unsupported_pk` set exists for.
+        @test !occursin("Models.IDField()", gen_pk)
+        @test occursin("nome = Models.CharField(max_length=10)", gen_pk)
+        # The marker carries the key consequence too, so one report covers the whole outcome.
+        @test occursin("# PormG: field 'codigo' on 'racing.Thing'", gen_pk)
+        @test occursin("It is also this model's PRIMARY KEY in Django", gen_pk)
+        # ...and NOT through the `lost_pk` report, whose wording ("imported WITHOUT it") would
+        # describe a column this file does not contain.
+        @test !occursin("declares its primary key on", gen_pk)
+
+        sandbox_pk = Module()
+        Core.eval(sandbox_pk, Meta.parse(gen_pk))
+        thing_pk = Core.eval(sandbox_pk, :(unknown_pk_type.Thing))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing_pk) === nothing
+        @test length(thing_pk.fields) == 1
+    finally
+        cleanup_project_test!(key_pk, existed_pk)
+    end
+
+    # A model whose ONLY column is an unimplemented type declared `primary_key=True` has nothing left
+    # to emit — the skip removes the column and the declared key suppresses the implicit `id` that
+    # would otherwise have saved it. That still aborts (there is no honest degrade for a table with no
+    # columns, and pass 1 already handed this class a binding every relation was rewritten to), but it
+    # must not accuse PormG of an internal bug: this is the caller's models.py, and the old message
+    # sent the reader hunting in the wrong repository.
+    no_column = """
+from django.db import models
+
+class Thing(models.Model):
+    codigo = models.SmallIntegerField(primary_key=True)
+"""
+    key_empty, existed_empty = project_config!()
+    try
+        err = nothing
+        try
+            import_models_from_django(["racing" => no_column]; db = key_empty,
+                                      file = "no_column.jl", force_replace = true)
+        catch e
+            err = e
+        end
+        @test err isa PormG.InvalidMigrationError
+        msg = sprint(showerror, err)
+        @test occursin("'racing.Thing' has no column left to emit", msg)
+        @test !occursin("This is a PormG bug", msg)
+    finally
+        cleanup_project_test!(key_empty, existed_empty)
+    end
+
+    # ORDERING, and both halves of it are load-bearing.
+    #
+    # 1. `autofields_ignore` still wins. A type the CALLER asked to drop must not be reported as an
+    #    unimplemented one — the option is their deliberate choice, and a marker would be noise.
+    # 2. The option-level reports are suppressed for a skipped field. `parse_field_args` would
+    #    otherwise push "…has no choices slot… The column is unaffected" for this very field, one line
+    #    from "…NOT imported" — an artifact contradicting itself about the same column.
+    ordering_src = """
+from django.db import models
+
+class Thing(models.Model):
+    ip = models.GenericIPAddressField(choices=[('a', 'A')])
+    porta = models.SmallIntegerField()
+    nome = models.CharField(max_length=10)
+"""
+    gen_ord, key_ord, existed_ord = import_project(["racing" => ordering_src];
+                                                    output_file = "unknown_ordering.jl",
+                                                    autofields_ignore = ["Manager",
+                                                                         "SmallIntegerField"])
+    try
+        # `porta` was dropped by the caller: no column, and no report either.
+        @test !occursin("porta", gen_ord)
+        # `ip` was dropped by PormG: reported once, as a TYPE problem...
+        @test occursin("field 'ip' on 'racing.Thing'", gen_ord)
+        # ...and not a second time as an option problem on a column that does not exist.
+        @test !occursin("has no choices slot", gen_ord)
+        @test occursin("nome = Models.CharField(max_length=10)", gen_ord)
+    finally
+        cleanup_project_test!(key_ord, existed_ord)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#400 × #410): a SKIPPED field named `id` claims the name too
+#
+# The #400 guard asks "is the name `id` taken". `fields_dict` is the wrong place to ask, because
+# #410 introduced a way for a declaration to claim a name and leave no entry there: a field whose
+# Django type PormG cannot build is skipped. A `haskey` test alone called that name free and wrote
+# `id = Models.IDField()` over it — the #400 clobber again, one skip path along, and worse than the
+# original, because the file then carried BOTH the marker saying that column was not imported and a
+# rendered `IDField` claiming it is a BIGINT auto-increment primary key.
+#
+# Found by review, not by the first draft of the fix. The guard now consults the set of skipped keys.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an id skipped as an unimplemented type still suppresses the implicit key (#400, #410)" begin
+    skipped_id = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.SmallIntegerField()
+    nome = models.CharField(max_length=10)
+"""
+    generated, config_key, db_dir_existed = import_project(["racing" => skipped_id];
+                                                           output_file = "skipped_id.jl")
+    try
+        # THE assertion: no phantom key over a name the class already claimed.
+        @test !occursin("Models.IDField()", generated)
+        @test occursin("nome = Models.CharField(max_length=10)", generated)
+
+        # Both reports are present and they AGREE — the artifact must not say a column was skipped
+        # and then render one at the same key.
+        @test occursin("field 'id' on 'racing.Thing' (models.py line 4) is a models.SmallIntegerField",
+                       generated)
+        @test occursin("# PormG: 'racing.Thing' declares a field named 'id' that is NOT its primary key",
+                       generated)
+        # The second marker explains the SKIP, not the clobber — the two branches of that message
+        # are not interchangeable, and only this one is true here.
+        @test occursin("that column is not imported at all", generated)
+        @test !occursin("would silently destroy the declared column below", generated)
+
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(skipped_id.Thing))
+        @test !haskey(thing.fields, "id")
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) === nothing
+        @test length(thing.fields) == 1
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # The same class with NOTHING else to emit. `fields_dict` comes out empty, which reaches the
+    # tripwire — and that has to report the caller's models.py, not accuse PormG of an internal bug.
+    # This shape leaves `unsupported_pk` empty (no `primary_key=True` anywhere), which is why the
+    # tripwire forks on the wider "any skipped field" set.
+    only_skipped_id = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.SmallIntegerField()
+"""
+    key_only, existed_only = project_config!()
+    try
+        err = nothing
+        try
+            import_models_from_django(["racing" => only_skipped_id]; db = key_only,
+                                      file = "only_skipped_id.jl", force_replace = true)
+        catch e
+            err = e
+        end
+        @test err isa PormG.InvalidMigrationError
+        msg = sprint(showerror, err)
+        @test occursin("'racing.Thing' has no column left to emit", msg)
+        @test !occursin("This is a PormG bug", msg)
+    finally
+        cleanup_project_test!(key_only, existed_only)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#410): a skip DELETES the key, so an inherited column cannot survive it
+#
+# Abstract bases merge by concatenation and the last write wins — that is how a child overriding an
+# inherited field works at all (`class_content = vcat(_inherited_statements(...), class.body)`). A
+# skip that only `continue`s therefore does not skip: the BASE's field stays at that key, and the
+# model renders the base's type while the marker beside it says the column was not imported.
+#
+# The concrete failure: a child overriding `codigo = CharField(max_length=10, primary_key=True)` with
+# an unimplemented type emitted a VARCHAR(10) primary key over a SMALLINT column. A silent fallback to
+# the wrong type is strictly worse than the missing column the marker promises.
+#
+# Found by review. The same mechanism covers an `AbstractUser` column overridden by an unimplemented
+# type, since those are seeded into the same dict before the loop runs.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an unimplemented type overriding an inherited field removes it, not just itself (#410)" begin
+    overridden = """
+from django.db import models
+
+class Base(models.Model):
+    codigo = models.CharField(max_length=10, primary_key=True)
+
+    class Meta:
+        abstract = True
+
+class Thing(Base):
+    codigo = models.SmallIntegerField(primary_key=True)
+    nome = models.CharField(max_length=10)
+"""
+    generated, config_key, db_dir_existed = import_project(["racing" => overridden];
+                                                           output_file = "overridden_skip.jl")
+    try
+        # The base's field must NOT survive its own override.
+        @test !occursin("codigo = Models.CharField", generated)
+        @test !occursin("primary_key=true", generated)
+        @test occursin("nome = Models.CharField(max_length=10)", generated)
+        # ...and no implicit `id` either: Django keys this table on `codigo`.
+        @test !occursin("Models.IDField()", generated)
+        # The marker is now TRUE about the column it names.
+        @test occursin("field 'codigo' on 'racing.Thing'", generated)
+        @test occursin("It is also this model's PRIMARY KEY in Django", generated)
+
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(overridden_skip.Thing))
+        @test !haskey(thing.fields, "codigo")
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) === nothing
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # The MIRROR direction, which the first draft already handled and which must stay handled: an
+    # inherited field of an unimplemented type overridden by one PormG CAN build. The child's field
+    # wins outright — no lingering skip claim suppressing the key or the implicit `id`.
+    reverse_override = """
+from django.db import models
+
+class Base(models.Model):
+    codigo = models.SmallIntegerField(primary_key=True)
+
+    class Meta:
+        abstract = True
+
+class Thing(Base):
+    codigo = models.CharField(max_length=10, primary_key=True)
+"""
+    gen_rev, key_rev, existed_rev = import_project(["racing" => reverse_override];
+                                                    output_file = "reverse_override.jl")
+    try
+        @test occursin("codigo = Models.CharField(", gen_rev)
+        @test !occursin("Models.IDField()", gen_rev)
+        sandbox_rev = Module()
+        Core.eval(sandbox_rev, Meta.parse(gen_rev))
+        @test Base.invokelatest(PormG.Models.get_model_pk_field,
+                                Core.eval(sandbox_rev, :(reverse_override.Thing))) == :codigo
+    finally
+        cleanup_project_test!(key_rev, existed_rev)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#410): `_is_pormg_field_type` needs BOTH halves, and this pins the second
+#
+# The predicate is `endswith(t, "Field"|"Key") && isdefined(Models, Symbol(t))`. The `isdefined` half
+# is what the whole issue is about and every other testset exercises it. The SUFFIX half is invisible
+# until you delete it: `Models.Index` and `Models.UniqueConstraint` both resolve, so without it a
+# `models.Index(...)` assignment in a class body would be handed to `getfield(Models, :Index)` and
+# constructed as though it were a column — putting a non-field into `fields_dict`, where the very next
+# line reads `.primary_key` off it and takes the whole import down. That is the exact blast radius
+# #410 exists to remove, reintroduced through the back door.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a models.X call that is not a column is skipped, not constructed (#410)" begin
+    not_a_field = """
+from django.db import models
+
+class Thing(models.Model):
+    nome = models.CharField(max_length=10)
+    idx = models.Index(fields=['nome'])
+"""
+    generated, config_key, db_dir_existed = import_project(["racing" => not_a_field];
+                                                           output_file = "not_a_field.jl")
+    try
+        # The import survives — which is the property under test. `Models.Index` exists, so the
+        # `isdefined` half alone would have let it through to the constructor.
+        @test occursin("Thing = Models.Model(", generated)
+        @test occursin("nome = Models.CharField(max_length=10)", generated)
+        @test !occursin("idx = Models.", generated)
+        @test occursin("field 'idx' on 'racing.Thing'", generated)
+        @test occursin("models.Index", generated)
+
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(not_a_field.Thing))
+        @test !haskey(thing.fields, "idx")
+        # The implicit key is still added: nothing here claimed `id` or the primary key.
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) == :id
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # `strict_fields = true` must not over-fire. A models.py using only types PormG implements
+    # imports unchanged under it — the guard is a report about the TYPE, not a stricter parser.
+    clean_src = """
+from django.db import models
+
+class Thing(models.Model):
+    nome = models.CharField(max_length=10)
+    quando = models.DateTimeField(null=True)
+    quanto = models.DecimalField(max_digits=6, decimal_places=2)
+"""
+    gen_clean, key_clean, existed_clean = import_project(["racing" => clean_src];
+                                                          output_file = "strict_clean.jl",
+                                                          strict_fields = true)
+    try
+        @test occursin("nome = Models.CharField(max_length=10)", gen_clean)
+        @test occursin("quando = Models.DateTimeField(", gen_clean)
+        @test occursin("quanto = Models.DecimalField(", gen_clean)
+        @test occursin("id = Models.IDField()", gen_clean)
+        @test !occursin("does not implement", gen_clean)
+    finally
+        cleanup_project_test!(key_clean, existed_clean)
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Django Importer (#410): the two edges of the skip that a review pass, not a
+# first draft, is what finds
+#
+# Both come from the same property: the skip DELETES its key, and the tripwire that reports an empty
+# model forks on "was anything skipped". Neither shape is exotic enough to leave unpinned, and
+# neither is covered by the testsets above.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the skip deletes per KEY, and the empty-model report stays true (#410)" begin
+    # A. The delete crosses statements, because `owner = ForeignKey(...)` and `owner_id = <unsupported>`
+    #    write the SAME key. The FK goes, and that is the intended answer: it is exactly what a
+    #    buildable `owner_id = models.IntegerField()` already does to that FK, and leaving the FK
+    #    standing would make the marker claim a column that is rendered right below it. Django rejects
+    #    the pair itself (models.E007, a column-name clash), so no project that passes
+    #    `manage.py check` can reach this — it is pinned so the behavior is a decision, not an
+    #    accident of statement order.
+    fk_clash = """
+from django.db import models
+
+class Other(models.Model):
+    nome = models.CharField(max_length=5)
+
+class Thing(models.Model):
+    owner = models.ForeignKey(Other, on_delete=models.CASCADE)
+    owner_id = models.SmallIntegerField()
+    nome = models.CharField(max_length=10)
+"""
+    generated, config_key, db_dir_existed = import_project(["racing" => fk_clash];
+                                                           output_file = "fk_key_clash.jl")
+    try
+        # The later declaration wins the key outright — no half-imported relation left behind.
+        @test !occursin("owner_id = Models.ForeignKey", generated)
+        @test occursin("field 'owner_id' on 'racing.Thing'", generated)
+        # Everything else on the class, and the FK's target model, are untouched.
+        @test occursin("nome = Models.CharField(max_length=10)", generated)
+        @test occursin("Other = Models.Model(", generated)
+        # The model still gets its implicit key: nothing here claimed `id` or the primary key.
+        sandbox = Module()
+        Core.eval(sandbox, Meta.parse(generated))
+        thing = Core.eval(sandbox, :(fk_key_clash.Thing))
+        @test !haskey(thing.fields, "owner_id")
+        @test Base.invokelatest(PormG.Models.get_model_pk_field, thing) == :id
+    finally
+        cleanup_project_test!(config_key, db_dir_existed)
+    end
+
+    # B. `fields_dict` can be emptied by TWO different mechanisms at once: this class loses `id` to
+    #    the unimplemented-type skip and `tags` to the relation degrade (a ManyToManyField has no
+    #    column, so an unresolvable target drops it entirely). The tripwire fires on the first, so its
+    #    message must not blame the unimplemented type for the second — a reader sent after the wrong
+    #    cause is worse served than one sent after none.
+    two_causes = """
+from django.db import models
+
+class Thing(models.Model):
+    id = models.SmallIntegerField()
+    tags = models.ManyToManyField('outside.NotImported')
+"""
+    key_two, existed_two = project_config!()
+    try
+        err = nothing
+        try
+            import_models_from_django(["racing" => two_causes]; db = key_two,
+                                      file = "two_causes.jl", force_replace = true)
+        catch e
+            err = e
+        end
+        @test err isa PormG.InvalidMigrationError
+        msg = sprint(showerror, err)
+        @test occursin("'racing.Thing' has no column left to emit", msg)
+        @test !occursin("This is a PormG bug", msg)
+        # "At least one", not "the field(s) it declares" — the latter was false here, because `tags`
+        # is a type PormG implements perfectly well and was dropped for its target, not its type.
+        @test occursin("At least one of its fields uses a Django field type PormG does not implement",
+                       msg)
+        @test occursin("dropped for reasons of their own", msg)
+    finally
+        cleanup_project_test!(key_two, existed_two)
+    end
+end


### PR DESCRIPTION
Closes #400
Closes #410

Two paths in the Django importer broke the contract `docs/src/import_django.md` states plainly — *"Nothing in the middle two rows is dropped in silence"* — in opposite directions. They land together because they touch the same field/primary-key path, the same survival table, and the same test file.

## #400 — a declared column was destroyed in silence

`_import_django_apps` wrote Django's implicit key with a plain assignment into a `Dict`:

```julia
if !built_pk && isempty(declared_pk)
    fields_dict[:id] = Models.IDField()      # clobbers whatever the field loop put at :id
end
```

So `class Thing(models.Model): id = models.UUIDField()` (not the key) came out as `id = Models.IDField()` — declared type gone, no `@warn`, no marker. It was the last silent column loss left in the importer.

**Now:** the declared column wins, nothing is substituted, and a `@warn` + `# PormG:` marker states that the model has **no primary key**, with the consequences the existing `lost_pk` marker already spells out. Django rejects the shape itself (`models.E004`) — which is exactly why the importer has to handle it, since it reads hand-edited and partially-migrated files it cannot validate.

The rejected alternative was "keep the `IDField` and report the replacement"; it preserves current output but still destroys a column, which is inconsistent with the importer's schema-fidelity stance everywhere else.

## #410 — one unreadable column destroyed the whole import

`process_class_fields!` resolves the constructor by name, and #342's retry cannot help an unknown *type*. One `models.GenericIPAddressField` raised out of `_import_django_apps` and every model in every app of the call was lost. Django ships plenty PormG does not implement — `SmallIntegerField`, `PositiveBigIntegerField`, `FilePathField`, `GeneratedField`.

**Now:** the column is skipped and reported (`@warn` + marker naming the field, its class and its `models.py` line); everything else imports. New `strict_fields::Bool = false` mirrors `strict_relations` for callers who would rather fail than receive a model with a column missing — the skipped column is still in the database, so `makemigrations` reads it as drift and proposes dropping it.

`_is_pormg_field_type` is `endswith(t, "Field"|"Key") && isdefined(Models, Symbol(t))`. Both halves matter: `isdefined` is the actual question, and the suffix test stops a `models.X(...)` call that is not a column (`models.Index`, `models.UniqueConstraint` both resolve in `Models`) from reaching the constructor.

## Where the two meet

`process_class_fields!` now returns three sets rather than one, because the caller asks three different questions and `fields_dict` only answers the last:

| set | question |
|---|---|
| `declared_pk` | keys that declared `primary_key=True` **and** were built — feeds the existing `lost_pk` report |
| `unsupported_pk` | the same claim from a type PormG cannot build — suppresses the implicit `id` without appearing in a report that names a column the file has not got |
| `unsupported_fields` | **every** skipped key — answers "did the class claim this name", which `haskey(fields_dict, …)` cannot |

A skip also `delete!`s its key. Without that, an inherited or `AbstractUser`-seeded column survived its own override: a child overriding `codigo = CharField(max_length=10, primary_key=True)` with an unimplemented type rendered a `VARCHAR(10)` primary key over a `SMALLINT` column while the marker beside it said that column was not imported.

## Docs

`strict_fields` in both signatures and the parameter list; the unimplemented-type row moved out of **Not supported** into **Reported and skipped**; the Primary Key bullet extended to the non-key `id`. The *Supported Django Fields* list was also completed — it omitted `SlugField`, `URLField`, `PositiveIntegerField`, `PositiveSmallIntegerField`, `DurationField`, `ManyToManyField`, `UUIDField`, `JSONField`, `BinaryField` and `FileField`, all of which import fine, and the new skip note would have made that omission actively misleading. The exhaustiveness claim was verified programmatically against every name `_is_pormg_field_type` accepts.

## Verification

- Full unit suite **8260/8260**; docs build clean
- **91 new assertions** across six testsets in `test_import_django_project.jl`
- **Six source mutations, each killed its assertions** — including the suffix half of `_is_pormg_field_type`, which errors the whole testset when removed
- The testset in `test_import_django_models.jl` that locked the *old* "unsupported field types fail with field context" contract was rewritten to lock the new one; it also covers the single-app arity, so `strict_fields` is exercised through both entry points

## Review

Two independent review passes. The first found four real defects, two of them introduced by the fix and reproduced against a live import before being fixed:

1. a declared `id` of an *unimplemented* type still got a phantom `IDField` — the #410 skip defeated the #400 guard, and the file then carried both the "not imported" marker and a rendered `IDField`
2. the skip did not delete its key (the override case above)
3. a stale comment claiming unsupported types still reach the `catch` retry
4. `parse_field_args` markers were muted for a skipped field but its `@warn`s were not, so the console contradicted the artifact

Fixing (1) exposed a third bug: `class Thing: id = models.SmallIntegerField()` alone empties `fields_dict` with `unsupported_pk` empty, which landed on the "This is a PormG bug" tripwire message. The tripwire now forks on the wider set and its message was reworded to stay true when a degraded relation also contributed.

The second pass found no confirmed defects.

## Deliberately not done

- **No `UPGRADING.md` entry and no `Project.toml` bump.** Nothing here forces a consuming-app source edit: #410 is a widening (imports that used to die now succeed) and `strict_fields` is opt-in, while #400 only changes output for a shape Django's own system check rejects. #369 is the precedent — same shape, same file, no entry.
- **No "closest type" substitution** (`SmallIntegerField` → `IntegerField`). Inventing a column width ships a wrong schema quietly, and a narrower integer would leave `makemigrations` proposing the same `ALTER` forever, exactly as `DJANGO_AUTO_KEY_TYPES` documents.
- **Two pre-existing `id`-clobber paths left alone**, and worth a follow-up issue: the `_looks_like_a_field_call` route (`parsed.type === nothing`, so the field key is unknowable — `id = TreeForeignKey(...)` produces column `id_id` in Django and leaves `id` genuinely free, so suppressing on the name would be wrong there) and `autofields_ignore` (the caller explicitly asked for that type to be dropped).
- **`NullLogger` kept over a level-filtering logger.** `MinLevelLogger` is from LoggingExtras, not the stdlib; every log site reachable from `parse_field_args` is a field-option report on the column being skipped, and a comment now warns the next editor not to add a structural `@error` inside that scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
