### PR TITLE
fix(#402): enum scope is per statement, in the module it was written in

### DIFF
--- a/docs/src/import_django.md
+++ b/docs/src/import_django.md
@@ -679,10 +679,52 @@ or declared on an **abstract base** the model inherits. Lookup is scoped in that
 may each nest a `Status` with different members and each resolves to its own. A nested enum can also
 be addressed through its owner (`ImportBatch.Status.choices`), as Django allows.
 
-A module-level enum in **another app** follows the same rule as a base: it resolves only when this
-`models.py` imports it — alias, star import and re-export included, exactly as for a base. Matching
-by name alone handed a model another app's enumeration with no marker anywhere — the wrong `choices`
-and `default` in the schema and nothing in the file to show it (#370).
+Scoping is **per statement, in the module the statement was written in** — the rule Python itself
+uses. This matters once an abstract base lives in a different app from the model inheriting it,
+because such a model's fields come from two `models.py` files at once:
+
+```python
+# core/models.py
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+
+class Base(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+    class Meta:
+        abstract = True
+
+# shop/models.py
+from core.models import Base
+
+class Status(models.TextChoices):      # a DIFFERENT Status
+    OPEN = "o", "Open"
+
+class Pedido(Base):                    # inherits `situacao`
+    total = models.IntegerField()
+```
+
+`Pedido.situacao` imports as `choices=(("d", "Draft"),)` — **core's** enumeration, because that is
+the module the statement was written in. `shop`'s `Status` is a different name in a different
+namespace and never applies to it (#402).
+
+The rule runs the other way too: a field `shop` declares **itself** cannot reach into `core`'s module
+just because it inherits a base from there. Python would raise `NameError` — `shop` never imported
+the name — so the importer drops the option and marks it, rather than borrowing an enumeration the
+source never referenced.
+
+Within one module the same ordering applies: a **module-level** enum outranks one nested on an
+abstract base, because a class body resolves a bare name against the module and never against a base
+class. Reach a base's enum deliberately with the qualified `Base.Status.choices`, which is attribute
+access and valid Python — addressed by the base's **own class name**, not by an `as` alias it was
+imported under, which is dropped and reported. (A bare name matching *only* a base's nested enum is
+still resolved, as a convenience — Python would raise `NameError` there.)
+
+A module-level enum in **another app** follows the same rule as a base: it resolves only when the
+`models.py` that *uses* it imports it — alias, star import and re-export included, exactly as for a
+base. That gate is applied per app, so an abstract base whose own module imports its enum resolves
+normally when its statements are merged into a child elsewhere. Matching by name alone handed a
+model another app's enumeration with no marker anywhere — the wrong `choices` and `default` in the
+schema and nothing in the file to show it (#370).
 
 A **nested** enum belongs to its owning class in its own app, so two apps may each declare a `Base`
 with its own nested `Status` and a child of either resolves to the right one.

--- a/src/migrations/importers.jl
+++ b/src/migrations/importers.jl
@@ -1560,6 +1560,31 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
   # by grepping the module.
   append!(Instructions, index.rename_notes)
 
+  # #402: give every graph the IMPORT-GATED module scope of every OTHER app.
+  #
+  # `_django_graph_from_scopes` builds one graph per app and rewrites only `(self, "")` into the
+  # gated `mod_scope` — own declarations plus whatever that models.py actually imports, aliases,
+  # star-imports and re-export façades included (#370). Every other `(i, "")` it holds is the RAW
+  # per-file collection: classes literally declared in that file, and nothing it imported.
+  #
+  # That distinction was cosmetic while a merged statement resolved under the CHILD's scopes. Now
+  # that it resolves under its OWNER's, `(origin, "")` is the only module scope it sees — so leaving
+  # it raw makes an ancestor that IMPORTS the enum it uses report "not defined in this file" about a
+  # name that is plainly defined and imported. Each app's own graph already computed the gated view;
+  # copy it across so every graph agrees on what each app's module scope contains.
+  # Keyed on `other.graph.self`, NOT on the position in `apps` — they agree at both call sites
+  # today, but nothing here enforces it, and a future "skip apps that contribute nothing" filter
+  # would desynchronize them and silently copy raw entries back over gated ones.
+  for other in apps
+    a = other.graph.self
+    gated = get(other.graph.enums, (a, ""), nothing)
+    gated === nothing && continue
+    for app in apps
+      app.graph.self == a && continue          # its own entry is already the gated one
+      app.graph.enums[(a, "")] = gated
+    end
+  end
+
   for app in apps
     graph = app.graph
     # An app that contributes no table gets a line in the ARTIFACT, not just a console warning
@@ -1697,8 +1722,19 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       end
 
       # Abstract bases merge by CONCATENATION, ancestors first: process_class_fields! writes into a
-      # Dict, so the last write wins and the child overrides its parents for free.
-      class_content = vcat(_inherited_statements(graph, class), class.body)
+      # Dict, so the last write wins and the child overrides its parents for free. Each statement
+      # carries the `(app, class)` it was WRITTEN in (#402) — the child's own body is tagged with
+      # this app and this class; a merged one keeps its ancestor's.
+      class_content = vcat(_inherited_statements(graph, class),
+                           [((graph.self, class_name), s) for s in class.body])
+
+      # One scope list per distinct owner, not per statement: `_enum_scopes` walks the ancestor
+      # graph, and a class's statements come from a handful of owners at most.
+      enum_scope_map = Dict{Tuple{Int, String}, Vector{Tuple{Int, String}}}()
+      for (owner, _) in class_content
+        haskey(enum_scope_map, owner) ||
+          (enum_scope_map[owner] = _enum_scopes(graph, owner[1], owner[2]))
+      end
 
       # Initialize fields_dict
       fields_dict = Dict{Symbol, Any}()
@@ -1709,7 +1745,7 @@ function _import_django_apps(apps::Vector{_DjangoApp}, render_settings::PormGSet
       declared_pk = process_class_fields!(fields_dict, class_content, class_name,
                                           _inherits_auth_user(graph, class), autofields_ignore,
                                           parameters_ignore, markers, graph.enums,
-                                          _enum_scopes(graph, class); class_label = class_label)
+                                          enum_scope_map; class_label = class_label)
 
       # Django's implicit `id`, added only when nothing claimed the key — DERIVED, per field, from
       # what was built and from what the models.py declared, never tracked with a class-wide flag
@@ -3110,42 +3146,62 @@ function _collect_nested_enums!(into::Dict{String, _PyEnum}, cls::PyClass, prefi
 end
 
 """
-    _enum_scopes(graph, cls) -> Vector{Tuple{Int, String}}
+    _enum_scopes(graph, app, class_name) -> Vector{Tuple{Int, String}}
 
-The scopes an enum reference inside `cls` may name, as `(app, scope)` in precedence order: the class
-itself, then its ABSTRACT BASES (nearest first), then module level — this app's first, then that of
-each app an ancestor came from.
+The scopes an enum reference written inside `(app, class_name)` may name, as `(app, scope)` in
+precedence order: the class itself, then that class's OWN module, then its ABSTRACT BASES (ancestors
+first, depth-first — so a deeper base can outrank a nearer one, unlike Python's C3 order; that only
+ever matters inside the leniency described below, where every shape is a `NameError` in Python
+anyway).
 
-The abstract-base step is not optional. `_inherited_statements` merges a base's field statements
-into the child and processes them under the CHILD's name, so a base declaring both
-`class Status(TextChoices)` and a field using it hands the child a reference that is nowhere in the
-child's own scope — which this importer then reported as "not defined in this file" while it sat
-three lines above. An abstract base with an enumerated status column is mainstream Django.
+**Bases rank BELOW the module on purpose.** Python's class body resolves a bare name against the
+enclosing module, never against a base class — `class C(B): x = Status` is a `NameError` unless
+`Status` is module-level, because base attributes are not in the class body's namespace. So a
+module-level `Status` has to win over a base-nested one of the same name; ranking bases first
+silently imported the wrong enumeration, in a single app, with no marker (#402).
 
-The ancestor's module scope is in the list for the same reason one step further out: a base in
-`core` may reference a MODULE-level `Status` that `core` declares, and once that statement has been
-merged into a child in another app, nothing in the child's own scopes can see it.
+The base entries stay in the list for two narrower jobs. One is legitimate: `_lookup_enum`'s
+qualified fallback resolves `Base.Status` by looking up `Status` inside the scope named `Base` —
+`Base.Status.choices` IS valid Python, since attribute access on the base is not name lookup. That
+fallback scans this list for its **app** half only, so what it needs is the base's APP to appear
+here, not the base's own entry; the two coincide except when the base lives in another app, which is
+exactly when it matters. The other is a deliberate leniency: a bare name
+that matches nothing in the owner's class or module still falls through to a base's nested enum,
+where Python would raise `NameError`. That is narrower than what it replaced (before, bases outranked
+the module outright) and it fails toward resolving rather than toward a wrong-value silent import,
+but it is not Python's rule and a stricter pass would drop it.
+
+The owner is a parameter, not `graph.self`, because a class's field statements do not all come from
+one module. `_inherited_statements` merges an abstract base's statements into the child, and that
+base may live in another app — so the list is built per STATEMENT, keyed by where the statement was
+written, and `process_class_fields!` resolves each one under its own list. Python binds a name in
+the module the statement appears in; this mirrors that (#402).
+
+A base declaring both `class Status(TextChoices)` and a field using it — mainstream Django — is no
+longer what the base entries are for. That case is served by the owner tag: the merged statement's
+list *starts* at `(base_app, base_name)`, so the enum is found in the base's own class scope without
+consulting any ancestor entry. Before the tag existed the child had to borrow its ancestors' scopes
+to see it, and the importer otherwise reported "not defined in this file" about an enum three lines
+above the field.
+
+There is no tail of other apps' MODULE scopes, and that omission is deliberate. A merged statement
+arrives with `app` already set to the module it came from, so `(app, "")` IS its module scope; and a
+statement written in the CHILD must not see an ancestor's module at all — Python raises `NameError`
+there, since the child never imported the name (#402, case (e)).
 
 Every entry carries the app it belongs to. Two apps may each declare a `Base` with a nested
-`Situacao`, and a scope list of bare names cannot say which one a merged statement meant.
+`Situacao`, and a scope list of bare names could not say which one a merged statement meant.
 
-!!! warning "Known imprecision — the list is per CLASS, not per statement"
-    `_inherited_statements` merges an ancestor's statements into the child and they are all
-    processed under one scope list, so the ancestor-module tail is reachable from the child's OWN
-    statements too, and this app's module scope outranks the ancestor's even for a statement that
-    came out of the ancestor's body — where Python would resolve in the ancestor's module.
-
-    Both are narrower than what preceded them: the enum table used to be one flat, app-blind
-    dictionary, so every app's module scope was reachable from everywhere. Closing them properly
-    means tagging each merged statement with the app it came from and resolving per statement, which
-    is a change to the field pipeline rather than to this list.
+Cheap to call but not free — it walks the ancestor graph — and a class's statements come from only a
+handful of owners, so `_import_django_apps` builds one list per distinct owner and hands
+`process_class_fields!` the map to read per statement.
 """
-function _enum_scopes(graph, cls::PyClass)::Vector{Tuple{Int, String}}
-  out = Tuple{Int, String}[(graph.self, cls.name)]
-  ancestor_apps = Int[]
+function _enum_scopes(graph, app::Int, class_name::AbstractString)::Vector{Tuple{Int, String}}
+  out = Tuple{Int, String}[(app, String(class_name))]
+  ancestors = Tuple{Int, String}[]
   seen = Set{Tuple{Int, String}}()
-  function walk(a::Int, c::PyClass)
-    key = (a, c.name)
+  function walk(a::Int, cname::String)
+    key = (a, cname)
     key in seen && return
     push!(seen, key)
     ci = get(graph.byapp, key, nothing)
@@ -3158,17 +3214,14 @@ function _enum_scopes(graph, cls::PyClass)::Vector{Tuple{Int, String}}
       # The scope key is the ancestor's OWN name, because that is how `_collect_enums` keys a class
       # scope — not the token the child referred to it by, which an `as` alias makes a different
       # string entirely.
-      push!(out, (pa, pc.name))
-      pa == graph.self || pa in ancestor_apps || push!(ancestor_apps, pa)
-      walk(pa, pc)
+      push!(ancestors, (pa, pc.name))
+      walk(pa, pc.name)
     end
     return
   end
-  walk(graph.self, cls)
-  push!(out, (graph.self, ""))                 # this app's module scope outranks any borrowed one
-  for a in ancestor_apps
-    push!(out, (a, ""))
-  end
+  walk(app, String(class_name))
+  push!(out, (app, ""))                        # the owner's own module outranks any base's scope
+  append!(out, ancestors)                      # bases last — see below
   return out
 end
 
@@ -3204,11 +3257,18 @@ function _lookup_enum(enums, scopes::Vector{Tuple{Int, String}},
 end
 
 """
-    _inherited_statements(graph, cls) -> Vector{PyStmt}
+    _inherited_statements(graph, cls) -> Vector{Tuple{Tuple{Int, String}, PyStmt}}
 
-The field statements `cls` inherits from its abstract bases, ancestors first. Concatenating these
-before the class's own body is the whole merge: `process_class_fields!` writes into a `Dict`, so
-**last write wins** gives child-overrides-parent for free.
+The field statements `cls` inherits from its abstract bases, ancestors first, each **tagged with the
+`(app, class)` it was written in**. Concatenating these before the class's own body is the whole
+merge: `process_class_fields!` writes into a `Dict`, so **last write wins** gives
+child-overrides-parent for free.
+
+The owner tag is what makes enum references resolve in the right module (#402). A base in `core` and
+the child inheriting it in `shop` are two different namespaces, and Python binds a name in the module
+the statement appears in — so the merged statement has to carry `core` with it rather than adopt the
+child's scopes. The origin was always available here (`graph.resolved` hands back the owning app);
+it used to be discarded one line later.
 
 Bases are walked in **reverse** declaration order, because Python resolves `class C(A, B)` left to
 right — A must win, so A's statements have to be written last.
@@ -3220,8 +3280,8 @@ right — A must win, so A's statements have to be written last.
 # class's own name. So they read `graph.resolved[(app, token)]` — the edge classification actually
 # took — and `graph.byapp[(app, name)]`, which covers every class the walk reached, in any app.
 
-function _inherited_statements(graph, cls::PyClass)::Vector{PyStmt}
-  out = PyStmt[]
+function _inherited_statements(graph, cls::PyClass)::Vector{Tuple{Tuple{Int, String}, PyStmt}}
+  out = Tuple{Tuple{Int, String}, PyStmt}[]
   seen = Set{Tuple{Int, String}}()
   function walk(a::Int, c::PyClass)
     ci = get(graph.byapp, (a, c.name), nothing)
@@ -3233,7 +3293,11 @@ function _inherited_statements(graph, cls::PyClass)::Vector{PyStmt}
       (pa, pc.name) in seen && continue
       push!(seen, (pa, pc.name))
       walk(pa, pc)
-      append!(out, pc.body)
+      # `(pa, pc.name)` is the ancestor's OWN app and name — the module its statements were written
+      # in, and the scope key `_collect_enums` used for its nested enums.
+      for s in pc.body
+        push!(out, ((pa, pc.name), s))
+      end
     end
     return
   end
@@ -3563,15 +3627,23 @@ end
 # They coincide exactly when the import carries no app label, which is why the default is safe.
 #
 # (`enum_scopes` looks droppable — the sole production caller passes it explicitly, so its default
-# is dead on the real path. Leave it: it is the only thing documenting how the vector is built, and
+# is dead on the real path. Leave it: it is the only thing documenting how the map is built, and
 # removing it turns this comment into the next reader's silent enum regression.)
-function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Vector{PyStmt},
+#
+# #402: `class_content` entries are `(owner, stmt)` and `enum_scopes` is keyed BY that owner, because
+# a class's statements do not all come from one module — `_inherited_statements` merges an abstract
+# base's body in, and that base may live in another app. Resolving every statement under one list
+# made a `core` statement bind names in `shop`. The owner travels with the statement; the scope list
+# is looked up per statement from it.
+function process_class_fields!(fields_dict::Dict{Symbol, Any},
+                               class_content::Vector{Tuple{Tuple{Int, String}, PyStmt}},
                                class_name::AbstractString, is_auth_user::Bool,
                                autofields_ignore::Vector{String}, parameters_ignore::Vector{String},
                                markers::Vector{String} = String[],
                                enums = Dict{Tuple{Int, String}, Dict{String, _PyEnum}}(),
-                               enum_scopes::Vector{Tuple{Int, String}} =
-                                 Tuple{Int, String}[(1, String(class_name)), (1, "")];
+                               enum_scopes::Dict{Tuple{Int, String}, Vector{Tuple{Int, String}}} =
+                                 Dict((1, String(class_name)) =>
+                                        Tuple{Int, String}[(1, String(class_name)), (1, "")]);
                                class_label::AbstractString = class_name)
   # Django's `AbstractUser` columns. A Bool rather than the base-list STRING it used to compare
   # against (#341): the base list is now parsed, so `class User(AbstractUser, SomeMixin)` and a
@@ -3603,9 +3675,21 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
 
   # Iterate over the fields in the class content. Each entry is a LOGICAL statement (#340), so a
   # field wrapped across physical lines is matched like any other.
-  for stmt in class_content
+  for (stmt_owner, stmt) in class_content
     parsed = _match_field_statement(stmt.text)
     parsed === nothing && continue
+
+    # The scopes THIS statement resolves enum references under — its owner's, not the class's
+    # (#402). A statement merged in from an abstract base in another app binds names in that base's
+    # module, exactly as Python does.
+    #
+    # The fallback derives a list from the OWNER, never from `class_name`. It is dead on the
+    # production path (`_import_django_apps` precomputes one entry per owner in `class_content`),
+    # but "borrow the child's list when the owner is missing" would reintroduce exactly the defect
+    # this change removes — quietly, and only for whatever shape made the lookup miss.
+    stmt_scopes = get(enum_scopes, stmt_owner) do
+      Tuple{Int, String}[(stmt_owner[1], stmt_owner[2]), (stmt_owner[1], "")]
+    end
 
     if parsed.type === nothing
       # #340's actual requirement: never drop a FIELD in silence. An assignment whose right-hand
@@ -3641,7 +3725,7 @@ function process_class_fields!(fields_dict::Dict{Symbol, Any}, class_content::Ve
     # Parse field arguments
     options, related_model = parse_field_args(field_args_str, django_type, parameters_ignore;
                                               enums = enums, class_name = class_name,
-                                              enum_scopes = enum_scopes, class_label = class_label,
+                                              enum_scopes = stmt_scopes, class_label = class_label,
                                               field_name = field_name, markers = markers)
 
     # An IGNORED field type contributes no column, so it cannot be the primary key either. Tested

--- a/test/unit/test_import_django_project.jl
+++ b/test/unit/test_import_django_project.jl
@@ -2815,6 +2815,351 @@ class Pedido(CoreBase):
     end
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Enum scope is per STATEMENT, not per class (#402): a merged base statement resolves in the module
+# it was WRITTEN in.
+#
+# `_inherited_statements` merges an abstract base's body into the child, and that base may live in
+# another app. Resolving the whole merged body under one scope list made a statement written in
+# `core` bind names in `shop` — the child's module scope outranked the ancestor's, and the
+# ancestor's was reachable from the child's own statements too. Both halves were silent: a wrong
+# `choices`/`default` reached the schema with no `# PormG:` marker anywhere.
+#
+# Python binds a name in the module the statement appears in. These three testsets pin that rule
+# from both directions plus the import gate, and all three fail on the pre-#402 importer.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a merged base statement resolves in its OWN app's module (#402)" begin
+    # `core` declares a module-level `Status` and an abstract `Base` whose field uses it. `shop`
+    # declares a DIFFERENT `Status` and inherits `Base`. The merged statement was written in core,
+    # so Python gives core's DRAFT; pre-#402 it took shop's OPEN, because `(self, "")` — the child's
+    # module — outranked the ancestor's in the one scope list the whole class shared.
+    core = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+
+class Base(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Status(models.TextChoices):
+    OPEN = "o", "Open"
+
+class Pedido(Base):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_stmt_origin.jl")
+    try
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"d\", \"Draft\"),))",
+                       generated)
+        # shop's enumeration must not appear at all — its `Status` is a different name in a
+        # different module, and nothing in this file was written against it.
+        @test !occursin("\"Open\"", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a child's own statement does not reach an ancestor's module (#402)" begin
+    # The mirror case. `core` declares `Status` and an abstract `Base` that does NOT use it; `shop`
+    # never imports `Status` but its own field references it. Python raises NameError here — the
+    # name is not in shop's module — so the importer must drop the option and say so. Pre-#402 the
+    # scope list carried an `(ancestor_app, "")` tail that made core's module reachable from a
+    # statement shop wrote, and the wrong enumeration landed in the schema silently. #370's shape
+    # one level down: a definition borrowed across apps without an import.
+    core = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+
+class Base(models.Model):
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Pedido(Base):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_stmt_no_reach.jl")
+    try
+        # The enumeration must NOT be borrowed...
+        @test !occursin("\"Draft\"", generated)
+        # ...the column stays real, with `choices` dropped...
+        @test occursin("situacao = Models.CharField(max_length=1)", generated)
+        # ...and the drop is reported in the file, not just on the console (#341).
+        @test occursin("references `Status`, which this file does not define", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "an ancestor's module scope is the IMPORT-GATED one (#402)" begin
+    # Resolving a merged statement under its owner's module makes `(origin, "")` the only module
+    # scope it sees — so that entry has to be the owner app's gated view (own declarations plus what
+    # its models.py imports), not the raw per-file collection every graph holds for the other apps.
+    # Here `core` does not declare `Status`; it IMPORTS it from `enums` and its abstract base uses
+    # it. Without the overlay, `(core, "")` is raw, the lookup misses, and the importer reports "not
+    # defined in this file" about an enum that is plainly defined and imported.
+    enums_app = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+"""
+    core = """
+from django.db import models
+from enums.models import Status
+
+class Base(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Pedido(Base):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["enums" => enums_app, "core" => core, "shop" => shop];
+                                             output_file = "enum_stmt_gated.jl")
+    try
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"d\", \"Draft\"),))",
+                       generated)
+        # The false-negative marker this overlay exists to prevent.
+        @test !occursin("references `Status`, which this file does not define", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a module-level enum outranks a base-nested one of the same name (#402)" begin
+    # Python's class body resolves a bare name against the enclosing MODULE, never against a base
+    # class: `class C(B): x = Status` is a NameError unless `Status` is module-level, because base
+    # attributes are not in the class body's namespace. So when both exist, module wins.
+    #
+    # Pre-#402 the scope list put abstract bases ABOVE the owner's module, so the child silently
+    # imported the base's nested enumeration — the same wrong-choices-with-no-marker failure as the
+    # cross-app cases above, but reachable in a SINGLE app with no inheritance across apps at all.
+    src = """
+from django.db import models
+
+class Status(models.TextChoices):
+    MODULE = "m", "Module"
+
+class Base(models.Model):
+    class Status(models.TextChoices):
+        NESTED = "n", "Nested"
+
+    class Meta:
+        abstract = True
+
+class Child(Base):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+"""
+    generated, key, existed = import_project(["app" => src]; output_file = "enum_module_wins.jl")
+    try
+        @test occursin("choices=((\"m\", \"Module\"),)", generated)
+        @test !occursin("\"Nested\"", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a base's own statement still sees its nested enum (#402)" begin
+    # The shape the ordering above must NOT break: `situacao` is written in Base's body, where
+    # `Status` IS the nested one. Base's own class scope leads its statement's list, so ranking bases
+    # below the module cannot reach it — this fails if the reorder is ever taken further and drops
+    # the owner's own class scope rather than just demoting its ancestors.
+    src = """
+from django.db import models
+
+class Status(models.TextChoices):
+    MODULE = "m", "Module"
+
+class Base(models.Model):
+    class Status(models.TextChoices):
+        NESTED = "n", "Nested"
+
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+    class Meta:
+        abstract = True
+
+class Child(Base):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["app" => src]; output_file = "enum_base_still.jl")
+    try
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"n\", \"Nested\"),))",
+                       generated)
+        @test !occursin("\"Module\"", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "the base entries carry the qualified Base.Status form across apps (#402)" begin
+    # Why the ancestor entries stay in the scope list at all, now that the owner tag resolves a
+    # merged statement without them. `Base.Status.choices` is attribute access, not name lookup, and
+    # is valid Python from the child — `_lookup_enum` serves it with a dotted fallback that splits
+    # `Base.Status` and looks `Status` up inside a scope named `Base`.
+    #
+    # That fallback iterates the scope list for its APP half only, so this must be a CROSS-APP
+    # fixture to gate anything: in a single-app project the owning app is already present via the
+    # child's own entries, and deleting every base entry changes nothing. With `Base` in `core` and
+    # the reference in `shop`, `core` reaches the list ONLY as an ancestor — drop the ancestor
+    # entries and the choices are dropped with a marker instead.
+    core = """
+from django.db import models
+
+class Base(models.Model):
+    class Status(models.TextChoices):
+        NESTED = "n", "Nested"
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Pedido(Base):
+    situacao = models.CharField(max_length=1, choices=Base.Status.choices)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_qualified_xapp.jl")
+    try
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"n\", \"Nested\"),))",
+                       generated)
+        @test !occursin("references `Base.Status`", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "a bare name is still resolved through a base's nested enum, cross-app (#402)" begin
+    # The documented LENIENCY, pinned so it cannot vanish unnoticed. Python raises NameError here —
+    # a class body does not see base attributes as bare names — but the importer resolves it rather
+    # than dropping a column's enumeration, and `_enum_scopes`' docstring says so explicitly. It is
+    # the other property the ancestor entries provide, and the only reason a stricter future pass
+    # would be a deliberate behaviour change rather than a silent one.
+    core = """
+from django.db import models
+
+class Base(models.Model):
+    class Status(models.TextChoices):
+        NESTED = "n", "Nested"
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Pedido(Base):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_leniency.jl")
+    try
+        @test occursin("situacao = Models.CharField(max_length=1, choices=((\"n\", \"Nested\"),))",
+                       generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
+@testset "the gated overlay does not depend on the order apps are listed (#402)" begin
+    # The overlay is the one cross-graph mutation in this file: it writes each app's import-gated
+    # module scope into every OTHER app's graph. A source entry is never a write target, so no
+    # iteration order can clobber one — but that is a property of the loop, not of the data, and it
+    # is worth a test rather than a comment. Same three apps, listed both ways, same result.
+    enums_app = """
+from django.db import models
+
+class Status(models.TextChoices):
+    DRAFT = "d", "Draft"
+"""
+    core = """
+from django.db import models
+from enums.models import Status
+
+class Base(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Pedido(Base):
+    total = models.IntegerField()
+"""
+    for (label, pairs) in (("enums-first", ["enums" => enums_app, "core" => core, "shop" => shop]),
+                           ("shop-first",  ["shop" => shop, "core" => core, "enums" => enums_app]))
+        generated, key, existed = import_project(pairs; output_file = "enum_order_$(label).jl")
+        try
+            @test occursin("situacao = Models.CharField(max_length=1, choices=((\"d\", \"Draft\"),))",
+                           generated)
+        finally
+            cleanup_project_test!(key, existed)
+        end
+    end
+end
+
+@testset "the gated overlay does not let a base borrow an enum it never imported (#402)" begin
+    # The overlay's failure direction. It must widen `(core, "")` to what core's models.py actually
+    # imports — and no further. Here `shop` declares `Status`; `core` does not, and does not import
+    # it. A statement written in core's base must NOT pick it up just because both apps are in the
+    # same import call: that is #370's defect, which this overlay could have quietly reopened.
+    core = """
+from django.db import models
+
+class Base(models.Model):
+    situacao = models.CharField(max_length=1, choices=Status.choices)
+
+    class Meta:
+        abstract = True
+"""
+    shop = """
+from django.db import models
+from core.models import Base
+
+class Status(models.TextChoices):
+    OPEN = "o", "Open"
+
+class Pedido(Base):
+    total = models.IntegerField()
+"""
+    generated, key, existed = import_project(["core" => core, "shop" => shop];
+                                             output_file = "enum_no_leak.jl")
+    try
+        @test !occursin("\"Open\"", generated)
+        @test occursin("references `Status`, which this file does not define", generated)
+    finally
+        cleanup_project_test!(key, existed)
+    end
+end
+
 @testset "a module-level enum resolves through a re-export, as a base does (#370)" begin
     # Base resolution followed a re-export façade from the start; enum resolution did not, so an
     # identically-shaped project resolved the base and dropped the enumeration — with a marker


### PR DESCRIPTION
Closes #402.

`_enum_scopes` built **one** scope list per class, but a class's field statements come from two places: its own body, plus whatever `_inherited_statements` merged in from an abstract base — which may live in a different app. Every statement resolved under the child's list, so a statement written in `core` bound names in `shop`, and a statement `shop` wrote could reach `core`'s module, which Python answers with `NameError`. Both halves were silent: a wrong `choices`/`default` reached the schema with no `# PormG:` marker anywhere.

Python binds a name in the module the statement appears in. The importer now does the same.

## What changed

- **`_inherited_statements`** returns each statement tagged with the `(app, class)` it was written in. `graph.resolved` already handed back the owning app; it was being discarded one line later.
- **`_enum_scopes(graph, app, class_name)`** starts the ancestor walk at an arbitrary owner. The cross-app module tail is deleted — a merged statement now arrives with its own module already set, and a child's statement must not see an ancestor's module at all.
- **`process_class_fields!`** takes `(owner, stmt)` pairs and a per-owner map of scope lists, built once per distinct owner by `_import_django_apps`.

## Two fixes beyond the issue's scope

Both are **pre-existing**, and both were verified separately against `origin/main` rather than inferred.

**1. The ancestor's module scope must be the import-gated one.** `_django_graph_from_scopes` rewrites only `(self, "")` into the gated view; every other app's module entry is the raw per-file collection. That was cosmetic while a merged statement resolved under the *child's* scopes. Once it resolves under its *owner's*, `(origin, "")` is the only module scope it sees — so leaving it raw made an ancestor whose module **imports** the enum it uses report "not defined in this file" about a name that is plainly defined and imported.

**2. Abstract bases outranked the owner's own module.** A base-nested `Status` beat a module-level one of the same name — silently, in a **single app**, with no cross-app inheritance involved:

```python
class Status(models.TextChoices):
    MODULE = "m", "Module"

class Base(models.Model):
    class Status(models.TextChoices):
        NESTED = "n", "Nested"
    class Meta:
        abstract = True

class Child(Base):
    situacao = models.CharField(max_length=1, choices=Status.choices)   # Python: Module
```

The importer returned `Nested`. A Python class body resolves a bare name against the enclosing module and never against a base class, so the module has to win. Bases now rank last.

This one is scope growth and worth a deliberate look: it is the same silent-wrong-enum failure class as #402 itself, and shipping without it would have left this PR's own rewrite of the Enumerations docs asserting a rule the code did not implement.

## A semantics decision worth reviewing

Base entries stay in the scope list for two jobs. One is legitimate — `_lookup_enum`'s dotted fallback serves the qualified `Base.Status.choices`, which is attribute access and valid Python. The other is a **deliberate leniency**: a bare name matching only a base's nested enum is still resolved, where Python would raise `NameError`.

That leniency is narrower than what it replaced (bases previously outranked the module outright) and it fails toward resolving rather than toward a silent wrong value — but it is not Python's rule. The `_enum_scopes` docstring states it explicitly rather than implying parity, and there is a testset pinning it so a stricter future pass is a deliberate change rather than an accident. **If you would rather the importer refuse that shape, say so and it is a small follow-up.**

## Verification

- Full unit suite **8181/8181**, exit 0.
- Docs build exit 0.
- Both halves of the issue and the import gate reproduced on `origin/main` and confirmed fixed, with before/after output.
- Nine testsets in `test/unit/test_import_django_project.jl`.

**Integration deliberately not run.** The rung-5 rule lists `src/migrations/` as owing a full integration run, but its stated rationale is *"the DDL path only executes in `test_migration_bootstrap.jl`"* — and `importers.jl` emits a Julia models file, not DDL. No integration test consumes a Django import (`test_importers_introspection.jl` covers DB *introspection* importers). Say the word if you want it run anyway.

## On the tests

The qualified-form testset is deliberately **cross-app**. An earlier single-app version of it gated nothing: `_lookup_enum`'s dotted fallback scans the scope list for its **app** half only, so in a one-app project the owning app is already present via the child's own entries and deleting every base entry changes nothing. Verified directly against the internals:

| | with ancestor entry | without |
|---|---|---|
| cross-app | resolves | **dropped** |
| single-app | resolves | resolves |

Caught by the independent review, not by me.

## Not done

- **No `UPGRADING.md` entry.** This changes what a re-import generates and forces no source edit in a consuming app — the bar that file sets, and the one #340, #341, #342, #370 and #371 were all held to. The only importer entry there (#346) exists because it removed a keyword argument.
- **#425** filed rather than fixed: the qualified form does not resolve through an `as` alias. Pre-existing, loud (dropped with a marker), unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
