### PR TITLE
fix(#421,#424): ON predicates carry their own parameters; CROSS joins refuse them

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,6 +38,138 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## An ON predicate that lands on a CROSS-joined CTE is refused instead of being dropped (#424)
+
+- **Version**: Unreleased
+- **PormG ref**: #424 (landed with #421); `src/querybuilder/build_query.jl`,
+  `docs/src/read/custom_joins.md`
+- **Severity**: **behavior change (very narrow)** — two shapes that silently returned row-multiplied
+  results now raise at query-build time. Part of the `0.5.x` pre-publish wave.
+
+### What changed
+
+A CTE declared **without** `join_field` is `CROSS JOIN`ed (#44), and a `CROSS JOIN` has no `ON`
+clause. If an `ON` predicate resolved onto such a CTE, PormG dropped it — not reported, not logged,
+dropped — and the join then matched every row:
+
+```sql
+-- BEFORE: the predicate against the CTE is simply gone.
+INNER JOIN "cj_parent" AS "b2" ON ("b2"."sku" = "R1"."note")
+CROSS JOIN "ev" AS "R1_1"
+```
+
+An unconstrained `CROSS JOIN` multiplies the base rows, so the query returned *more* rows than it
+should have, each of them wrong. On SQLite the dropped predicate's bound value was left orphaned in
+the parameter bucket, which sometimes surfaced as a placeholder-count error — but that was luck, not
+a guard, and #421 (which makes a predicate's values travel with its text) removes even that accident.
+
+**When does a CROSS-joined CTE acquire an ON predicate at all?** Exactly two ways, and it is worth
+stating as a rule rather than a list of call shapes — an earlier draft of this entry listed the
+shapes and missed half of them:
+
+1. **Its NAME collides with a join key.** Joins are registered under a key, and three unrelated
+   methods write one: `cjoin` uses its join **path**, `cjoin_on` uses its **alias**, and `on()` uses
+   its **path**. If any of those equals an unkeyed CTE's name, the CTE's CROSS entry inherits that
+   join's predicates. The collision does *not* have to involve a model field, and nothing has to be
+   relocated.
+2. **A predicate that names its alias is relocated onto it** — a `cjoin_on` whose `on` carries a
+   bare `"ev__col" => v` path. Unlike a keyed `cjoin`, whose `filters` are path-prefixed onto the
+   joined model and reject anything else, `cjoin_on`'s `on` expression is the entire `ON` clause, so
+   it accepts such a path. This was always the documented boundary (*"Referencing a third table
+   (another join's alias) inside one `cjoin_on` is also out of scope for now"*) — it simply was not
+   enforced.
+
+The most common way to hit (1) by accident is naming a CTE after a **model field**: join resolution
+consults the CTE registry *before* the model's fields, so `.with("parent" => …)` on a model that has
+a `parent` foreign key **shadows that field's join entirely** — `parent__x` stops meaning the
+relation and starts meaning the CTE. A `cjoin("parent" => …)` then hangs its filters on the CROSS
+entry. Note that the path-prefixing rule does **not** protect against this: it guards the filter
+*keys*, not the join *path*.
+
+PormG now refuses both before building any SQL, naming the CTE and both remedies:
+
+> `An ON predicate resolved onto R1_1, a CROSS-joined CTE (a .with(...) declared without
+> join_field). A CROSS JOIN has no ON clause to carry that predicate, so it would be dropped and the
+> join would match every row.`
+> `  Two shapes reach this: a cjoin_on whose ON expression names a path through another join, and a
+> .with("parent" => ...) whose name matches a model FIELD, which shadows that field's own join.`
+> `  Fix whichever applies: rename the CTE so it does not shadow a field, give it a join_field so it
+> emits a real ON clause, or move the predicate to .filter(...) (#44).`
+
+### How to find the calls to migrate
+
+Every affected query needs a `.with(...)` with **no** `join_field` — a keyed CTE emits a real `ON`
+clause and carries its predicates correctly, then and now. So start by listing CTE declarations:
+
+```bash
+rg -n '\.with\(' .          # then check which of these do NOT pass `join_field` in the same call
+```
+
+Grep cannot take you further, because the defect is a **name collision**, not a syntax. Run this over
+each query instead — it is the same rule the guard uses, and it catches the collision whether the
+other side is a `cjoin` path, a `cjoin_on` alias, or an `on()` path:
+
+```julia
+# Any unkeyed CTE whose name collides with a model field or a registered join key.
+for (name, cte) in q.object.ctes
+    cte["join_field"] === nothing || continue          # keyed CTEs are unaffected
+    if name in q.object.model.field_names
+        @warn "CTE name shadows a model field" cte = name
+    elseif haskey(q.object.custom_join, name)
+        @warn "CTE name collides with a cjoin/cjoin_on/on() key" cte = name
+    end
+end
+```
+
+The relocation route (2) is narrower and *is* greppable — a `cjoin_on` whose `on` list carries a
+`__` path:
+
+```bash
+rg -n --multiline 'cjoin_on\([^)]*on\s*=\s*\[[^\]]*"\w+__\w+"\s*=>' .
+```
+
+### Migrate your app
+
+**Shape B — rename the CTE (or key it).** The name collision is almost never intentional; the join it
+shadows is usually the one you wanted:
+
+```julia
+# ✗ BEFORE — "parent" is both a CTE and a ForeignKey field. The CTE won, silently.
+q.with("parent" => M.Cj_parent.objects.values("id", "sku"))
+q.cjoin("parent" => "Cj_parent", filters = ["sku" => "S"], warn = false)
+
+# ✓ AFTER — a name that shadows nothing; the FK path resolves as a normal join again.
+q.with("parent_stats" => M.Cj_parent.objects.values("id", "sku"))
+q.cjoin("parent" => "Cj_parent", filters = ["sku" => "S"], warn = false)
+```
+
+**Shape A — key the CTE, or move the predicate to `.filter(...)`.** Keying it is usually what you
+want, because it is the only one of the two that actually *relates* the CTE to the base rows:
+
+```julia
+# ✗ BEFORE — "ev__year" resolves onto the CROSS-joined CTE, which cannot carry it. The predicate was
+#            dropped and the join matched every row.
+q = M.Result.objects
+q.with("ev" => M.Race.objects.values("raceid", "year"))        # no join_field => CROSS JOIN
+q.values("resultid")
+q.cjoin_on("Driver", alias = "d",
+           on = [F("d.driverid") == F("driverid"), "ev__year" => 2009])
+
+# ✓ AFTER (preferred) — give the CTE a join_field. It emits a real ON clause, carries the predicate,
+#   and relates each base row to its own CTE row instead of to all of them.
+q = M.Result.objects
+q.with("ev" => M.Race.objects.values("raceid", "year"), join_field = "raceid" => "raceid")
+q.values("resultid")
+q.cjoin_on("Driver", alias = "d", on = [F("d.driverid") == F("driverid")])
+q.filter("ev__year" => 2009)
+```
+
+> ⚠️ Moving the predicate to `.filter(...)` **without** adding a `join_field` builds and runs, but it
+> is a plain filter over a Cartesian product, not a correlation — every base row is still paired with
+> every matching CTE row. A `CROSS JOIN`ed CTE is correlated by an `F()` comparison
+> (`filter("raceid" => F("ev__raceid"))`, #44), never by a literal predicate. If you are not writing
+> that comparison, you want `join_field`.
+
 ## A CTE joined in a correlated `UPDATE … FROM` is refused instead of emitting broken SQL (#394)
 
 - **Version**: Unreleased

--- a/docs/src/read/custom_joins.md
+++ b/docs/src/read/custom_joins.md
@@ -329,7 +329,13 @@ parameters from `on` route to the JOIN clause (ahead of any WHERE parameters).
     Reference the joined copy with `F("alias.col")`. Alias-qualified **operator pairs**
     (`"b2.col__@gte" => 3`) are not supported yet — express a joined-side comparison-to-literal by
     restructuring, or filter the base side with a bare pair (`"col__@gte" => 3`). Referencing a
-    *third* table (another join's alias) inside one `cjoin_on` is also out of scope for now.
+    *third* table (another join's alias) inside one `cjoin_on` is also out of scope for now — and
+    when that third table is a **CROSS-joined CTE** (`.with(...)` with no `join_field`), it now
+    raises `QueryBuildError` instead of quietly dropping the predicate (#424) — a `CROSS JOIN` has
+    no `ON` clause to carry one, so the join would otherwise match every row. The same guard fires
+    when a `cjoin_on`'s **alias** happens to equal an unkeyed CTE's name: that collision hands the
+    CTE this join's predicates. Rename the CTE, give it a `join_field`, or move the predicate to
+    `.filter(...)` (#44).
     `cjoin_on` works in reads and in the common `update()`/`delete()` (which scope rows via a
     subquery); only a **correlated** UPDATE-FROM/DELETE-USING (setting a column *from* a joined
     table) is unsupported and raises. Finally, a `cjoin_on` join is not tracked by the #74

--- a/docs/src/read/subqueries_and_ctes.md
+++ b/docs/src/read/subqueries_and_ctes.md
@@ -316,6 +316,14 @@ Notes:
 - **Cartesian-product guard.** Referencing a CTE column with *no* constraining filter is a
   Cartesian product; PormG emits a `@warn` naming the CTE. Add a correlating `filter(...)`, or
   pass `join_field`.
+- **Give a CTE a name that collides with nothing.** Two collisions bite. A **model field**: join
+  resolution consults the CTE registry *before* the model's own fields, so `.with("raceid" => …)` on
+  a model that *has* a `raceid` foreign key makes `raceid__*` mean the CTE, and the field's real join
+  is shadowed silently. A **join key**: a `cjoin` path, a `cjoin_on` alias, or an `on()` path spelled
+  the same way hands that join's predicates to the CTE. When an `ON` predicate ends up on an unkeyed
+  (CROSS-joined) CTE either way, PormG refuses the query rather than dropping the predicate and
+  matching every row (#424) — a `CROSS JOIN` has no `ON` clause to carry one. Rename the CTE, or give
+  it a `join_field` so it emits a real `ON` clause.
 
 ---
 

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -281,6 +281,16 @@ function get_filter_query(object::SQLObject, instruc::SQLInstruction)::Nothing
   return nothing
 end
 
+# One resolved cjoin ON condition: the rendered SQL fragment and the positional parameter values it
+# bound. The two MUST travel together (#421). Phase 1b below can move a fragment onto a different
+# join, and on a positional backend a value's INDEX in the `:join` bucket IS its binding — so a
+# fragment whose text moved while its values stayed put bound its neighbour's value. Silently wrong
+# rows on SQLite; PostgreSQL was always correct, because `$N` numbering travels with the text.
+struct OnExtra
+  sql::String
+  params::Vector{Any}
+end
+
 function build_row_join_sql_text(instruc::SQLInstruction)
   @pormg_debug false
 
@@ -289,7 +299,7 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   # create additional join entries in instruc.row_join via _build_row_join.
   # By pre-resolving with an index-based loop we process newly created entries
   # in order and store the generated SQL fragments for Phase 2.
-  on_clause_extras = Dict{Int, Vector{String}}()
+  on_clause_extras = Dict{Int, Vector{OnExtra}}()
   i = 1
   while i <= length(instruc.row_join)
     value = instruc.row_join[i]
@@ -299,17 +309,58 @@ function build_row_join_sql_text(instruc::SQLInstruction)
       on_conditions = value["on_conditions"]::Vector{FilterType}
       alias_a_quoted = quote_identifier(value["alias_a"], instruc.connection)
       original_alias = instruc.alias
-      extras = String[]
+      extras = OnExtra[]
 
       no_anchor = get(value, "no_anchor", "") == "1"
       for condition in on_conditions
+        # #421: lift the values this condition binds straight back out of the bucket. Phase 1b may
+        # still move the fragment, so nothing resolved here has a final clause position yet; Phase 2
+        # puts the values back at the point of emission.
+        #
+        # The mark/detach pair captures exactly this condition's run because the bucket it marks is
+        # the bucket every value lands in. Being precise about WHY, since the obvious phrasing —
+        # "nothing reachable from here switches context" — is false:
+        #
+        #   - The plain shapes (eq, @range, @contains, Q, Qor, F) never switch context at all. `@in`
+        #     does when its right side is a SUBQUERY that itself declares a `.with(...)`: that renders
+        #     through `build_cte_clause`, which switches to `:cte` and binds there. Both `?` end up in
+        #     the JOIN text while both values end up in `:cte`, so the mark (holding the `:join`
+        #     vector) correctly lifts NOTHING and the OnExtra carries markers with no params.
+        #     >> RESIDUAL #421 HOLE, not closed here. Those values do not travel with their text, so
+        #        relocating such a fragment desynchronizes them exactly as #421 did. It already
+        #        misbinds with no relocation at all: an ON list of
+        #        `["id__@gt" => 7, "parent__@in" => <subquery with a .with(...)>]` binds SQLite
+        #        ["CTEVAL","SUBVAL",7] against PostgreSQL's [7,"CTEVAL","SUBVAL"], because `:cte`
+        #        flattens before `:join` while the text order is the reverse. Different root cause
+        #        (bucket choice, not fragment movement); `OnExtra` neither causes nor repairs it.
+        #   - `Exists(...)` — which a `cjoin_on` ON expression DOES accept, though a keyed cjoin's
+        #     `filters` reject it — runs a NESTED build, and that build's own join render calls
+        #     `set_context!(:join)` UNGATED even under `set_contexts=false`. So context does move.
+        #     It is harmless here for a specific reason: the ambient context in this loop already IS
+        #     `:join`, and `_build_exists_query` restores the ambient one in a `finally` on both the
+        #     normal and the throwing exit. The invariant is therefore "the same bucket vector", not
+        #     "no switching happened" — which is exactly why the mark holds the bucket VECTOR rather
+        #     than the context symbol. A future shape that switched to a DIFFERENT bucket and failed
+        #     to restore it detaches nothing here instead of lifting an unrelated run.
+        #   - Nothing reachable from `_build_row_join` binds a parameter: `build_joins.jl` has no
+        #     `add_parameter!` at all, and `ctes.jl`'s only binding site is `build_cte_clause`, which
+        #     JOIN RESOLUTION never calls (its callers are in `execution.jl`, ahead of `build()`).
+        #     Note the careful scope — `build_cte_clause` IS reachable from `_get_filter_query`, just
+        #     not from join resolution: that is the `@in`-over-a-CTE-subquery case above.
+        #
+        # KNOWN LIMIT, neither caused nor repaired here: inside an `Exists(...)`, the nested query's
+        # own ON and WHERE parameters are already bound in the wrong order relative to its rendered
+        # text (same root cause — the ungated `:join` switch — but on the subquery's own values).
+        # `OnExtra` carries that run faithfully, preserving whatever order it arrived in.
+        mark = parameter_mark(instruc)
         condition_sql = _get_filter_query(condition, instruc)
+        condition_params = detach_parameters!(mark)
         # #45: anchor-less cjoin_on conditions already carry explicit aliases (bare F = base alias,
         # F("b2.col") = the joined copy), so skip the single-side base-alias remap the FK path needs.
         if !no_anchor
           condition_sql = replace(condition_sql, "\"$(original_alias)\"." => "$alias_a_quoted.")
         end
-        push!(extras, condition_sql)
+        push!(extras, OnExtra(condition_sql, condition_params))
       end
 
       instruc.alias = original_alias
@@ -336,12 +387,12 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   # ON condition onto the existing entry instead of creating one, so the old window was empty and
   # the extra stayed on the wrong join. Keying on index order covers every case uniformly.
   #
-  # KNOWN GAP, not closed here: relocation changes the order extras are EMITTED in, while Phase 1
-  # bound their parameters in row_join order. PostgreSQL is unaffected ($N travels with the text),
-  # but a positional backend flattens the :join bucket in binding order, so a relocated extra can
-  # bind its neighbour's value. Reproduce with two cjoin filters at different depths
-  # (`["grandparent__code" => "ZZZ", "sku" => "SSS"]`). This pre-dates the change above; the change
-  # widens which shapes relocate, so it widens the exposure. Tracked in #421.
+  # Relocation changes the order extras are EMITTED in, and on a positional backend that used to
+  # desynchronize the parameter bucket: Phase 1 bound in row_join order, Phase 2 emitted in
+  # relocated order, and nothing reconciled the two, so a relocated extra bound its neighbour's
+  # value (#421). Each extra now carries its own values and Phase 2 re-appends them as it emits,
+  # which makes binding order and emission order the same thing by construction. PostgreSQL never
+  # had the problem — `$N` numbering travels with the text.
   for idx in 1:length(instruc.row_join)
     haskey(on_clause_extras, idx) || continue
     extras = on_clause_extras[idx]
@@ -361,8 +412,8 @@ function build_row_join_sql_text(instruc::SQLInstruction)
         # alias that happens to share a column's name (`alias = "code"` against `"Tb_2"."code"`)
         # then drags an unrelated join's ON filter onto itself. That is valid SQL returning wrong
         # rows, silently. Phase 1 above already keys on the same `"alias".` form (:310).
-        if occursin("\"$(instruc.row_join[dep_idx]["alias_b"])\".", extra)
-          haskey(on_clause_extras, dep_idx) || (on_clause_extras[dep_idx] = String[])
+        if occursin("\"$(instruc.row_join[dep_idx]["alias_b"])\".", extra.sql)
+          haskey(on_clause_extras, dep_idx) || (on_clause_extras[dep_idx] = OnExtra[])
           push!(on_clause_extras[dep_idx], extra)
           relocated[ei] = true
           break
@@ -387,15 +438,47 @@ function build_row_join_sql_text(instruc::SQLInstruction)
     # the correlation is supplied by the main query's F() filter(s) in WHERE. Emit it and move on
     # before touching key_a/key_b (empty strings would fail identifier validation).
     if get(value, "cross", nothing) !== nothing
+      # #424: ...and it is the ONE branch below with no ON clause to merge `on_clause_extras[idx]`
+      # into, so a predicate that lands here simply vanishes.
+      #
+      # Do NOT enumerate call shapes here. That list was written twice and was wrong twice — first
+      # "unreachable", then "two shapes", and both missed producers. State the INVARIANT instead:
+      # `on_clause_extras[idx]` reaches a CROSS entry either because Phase 1b relocated a fragment
+      # that names its alias, or because the entry carries its own `on_conditions` — and it carries
+      # those exactly when `custom_join[<cte name>]` exists with non-empty filters. `custom_join` is
+      # written at three unrelated sites, keyed by a `cjoin` PATH, a `cjoin_on` ALIAS, and an `on()`
+      # PATH, so any of the three colliding with an unkeyed CTE's name produces this — with or
+      # without a model-field collision, and with or without any relocation. A fourth writer would
+      # inherit the same behavior, which is why the message below talks about name collision rather
+      # than about which method the caller used.
+      #
+      # Pre-fix every one of them emitted an unconstrained `CROSS JOIN` with the predicate gone — row
+      # multiplication, no error — while the orphaned value sat in the bucket with no `?` to consume
+      # it. #421 makes it worse before this makes it better: once values travel with the text, the
+      # orphan disappears too and the wrong query becomes perfectly well-formed. So fail closed, the
+      # same posture `_get_join_condition_list` takes on this marker (#394).
+      haskey(on_clause_extras, idx) && throw(QueryBuildError(
+        "An ON predicate resolved onto \e[4m\e[31m$(value["alias_b"])\e[0m, the CROSS-joined CTE " *
+        "\e[4m\e[31m$(value["b"])\e[0m (a \e[4m\e[32m.with(...)\e[0m declared without " *
+        "\e[4m\e[32mjoin_field\e[0m). A CROSS JOIN has no ON clause to carry that predicate, so it " *
+        "would be dropped and the join would match every row.\n  A CROSS-joined CTE picks up an ON " *
+        "predicate when its NAME collides with a join key — a \e[4m\e[32mcjoin\e[0m path, a " *
+        "\e[4m\e[32mcjoin_on\e[0m alias, or an \e[4m\e[32mon()\e[0m path — or when a predicate " *
+        "naming its alias is relocated onto it.\n  Rename the CTE so it collides with nothing, give " *
+        "it a \e[4m\e[32mjoin_field\e[0m so it emits a real ON clause, or move the predicate to " *
+        "\e[4m\e[32m.filter(...)\e[0m (#44)."))
       push!(instruc.join, """ CROSS JOIN $b_quoted AS $alias_b_quoted """)
       continue
     end
 
     if get(value, "no_anchor", "") == "1"
       # #45: anchor-less join — the ON clause is entirely the user's resolved extras (no equi-anchor).
-      extras = get(on_clause_extras, idx, String[])
+      extras = get(on_clause_extras, idx, OnExtra[])
       isempty(extras) && throw(QueryBuildError("cjoin_on produced no ON conditions for alias '$(value["alias_b"])'."))
-      on_clause = join(extras, " AND ")
+      on_clause = join((e.sql for e in extras), " AND ")
+      for extra in extras
+        reattach_parameters!(instruc, extra.params)   # #421: bind in EMISSION order
+      end
     else
       alias_a_quoted = quote_identifier(value["alias_a"], instruc.connection)
       # #394: escape-only, because on every model-join branch these are PHYSICAL columns
@@ -411,10 +494,13 @@ function build_row_join_sql_text(instruc::SQLInstruction)
       # Build base ON clause
       on_clause = "$alias_a_quoted.$key_a_quoted = $alias_b_quoted.$key_b_quoted"
 
-      # Append pre-resolved ON condition fragments
+      # Append pre-resolved ON condition fragments, re-binding each as it is emitted (#421). This
+      # loop runs in `row_join` order across joins and in vector order within one, which is exactly
+      # the order the rendered `?` markers appear in; nothing else in Phase 2 touches the bucket.
       if haskey(on_clause_extras, idx)
         for extra in on_clause_extras[idx]
-          on_clause *= " AND $extra"
+          on_clause *= " AND $(extra.sql)"
+          reattach_parameters!(instruc, extra.params)
         end
       end
     end

--- a/src/querybuilder/parameters.jl
+++ b/src/querybuilder/parameters.jl
@@ -120,6 +120,50 @@ end
 set_context!(instruc::SQLInstruction, context::Symbol) = instruc.parameters !== nothing ? set_context!(instruc.parameters, context) : nothing
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Detachable parameter runs (#421)
+#
+# A SQL fragment that is RENDERED in one order and EMITTED in another needs its positional values
+# to travel with it. `build_row_join_sql_text` is the case: Phase 1 resolves every cjoin ON
+# condition (binding as it goes), Phase 1b may relocate a fragment onto a later join, and Phase 2
+# emits in `row_join` order — so a value's INDEX in the `:join` bucket stopped matching its `?`,
+# and a relocated condition bound its neighbour's value.
+#
+# `parameter_mark` records the ACTIVE bucket and its length, `detach_parameters!` lifts everything
+# pushed since, and `reattach_parameters!` appends once the fragment's clause position is final.
+# The mark holds the bucket VECTOR, not the context symbol: a fragment whose resolution switched
+# context and failed to restore it then detaches nothing, rather than deleting an unrelated run.
+#
+# All no-ops on numbered backends. PostgreSQL's `$N` numbering already travels with the text, which
+# is exactly why #421 was SQLite-only.
+# ─────────────────────────────────────────────────────────────────────────────
+const ParameterMark = Tuple{Union{Nothing,Vector{Any}},Int}
+
+_positional_bucket(::PormGPostgresParam) = nothing
+_positional_bucket(sq::PormGSQLiteParam) = _current_bucket(sq)
+_positional_bucket(instruc::SQLInstruction) =
+  instruc.parameters === nothing ? nothing : _positional_bucket(instruc.parameters)
+
+function parameter_mark(instruc::SQLInstruction)::ParameterMark
+  bucket = _positional_bucket(instruc)
+  return (bucket, bucket === nothing ? 0 : length(bucket))
+end
+
+function detach_parameters!(mark::ParameterMark)::Vector{Any}
+  bucket, len = mark
+  (bucket === nothing || length(bucket) <= len) && return Any[]
+  values = bucket[len+1:end]
+  deleteat!(bucket, len+1:length(bucket))
+  return values
+end
+
+function reattach_parameters!(instruc::SQLInstruction, values::Vector{Any})
+  isempty(values) && return nothing
+  bucket = _positional_bucket(instruc)
+  bucket === nothing || append!(bucket, values)
+  return nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # add_parameter!  – push a value and return the placeholder string
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/integration/test_cjoin.jl
+++ b/test/integration/test_cjoin.jl
@@ -232,3 +232,67 @@ end
     end
 
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cjoin ON filters at two join depths bind the right values (#421)
+# `build_row_join_sql_text` bound ON conditions in `row_join` order (Phase 1) but emitted them in
+# relocated order (Phase 1b/2). PostgreSQL was unaffected — `$N` numbering travels with the text —
+# while SQLite flattens the `:join` bucket positionally, so the two conditions swapped values.
+#
+# The failure was at EXECUTION and completely silent: SQLite is dynamically typed, so binding
+# "Italy" into `year` and 2009 into `country` raises nothing. It just matches no row. A caller sees
+# an empty result and concludes there were no Italian races that season.
+#
+# This runs on BOTH engines on purpose. `db_2` is the control that was always correct, and the two
+# must agree — which is the assertion that would have caught the divergence in the first place.
+# Rendering/bucket coverage is in `test/unit/test_order_by_joins.jl` and
+# `test/unit/test_alignment_sqlite.jl`.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "cjoin ON filters across two join depths bind correctly (#421)" begin
+    # `circuitid__country` is one hop deeper than `year`, so its ON fragment forward-references the
+    # circuit join and gets relocated onto it. Listing it FIRST is what made binding order differ
+    # from emission order. INNER so the ON predicate actually restricts the returned rows.
+    deep_first = M.Result.objects
+    deep_first.values("resultid")
+    deep_first.cjoin("raceid" => "Race", join_type = "INNER",
+                     filters = ["circuitid__country" => "Italy", "year" => 2009], warn = false)
+    got = Set((deep_first |> DataFrame).resultid)
+
+    # Oracle: the same restriction written as WHERE predicates, which never relocate and so were
+    # never affected. Comparing against a live query rather than a hardcoded count keeps this
+    # independent of exactly how many Italian races the fixture holds.
+    oracle = M.Result.objects
+    oracle.values("resultid")
+    oracle.filter("raceid__circuitid__country" => "Italy", "raceid__year" => 2009)
+    expected = Set((oracle |> DataFrame).resultid)
+
+    # Guard against a vacuously-true Set() == Set(): pre-fix the cjoin returned EMPTY on SQLite,
+    # which would match an empty oracle without either being right.
+    @test !isempty(expected)
+    @test got == expected
+
+    # Control: the same two filters listed the other way round. Binding order already matched
+    # emission order for this ordering, so it was correct before the fix too — and must stay so.
+    shallow_first = M.Result.objects
+    shallow_first.values("resultid")
+    shallow_first.cjoin("raceid" => "Race", join_type = "INNER",
+                        filters = ["year" => 2009, "circuitid__country" => "Italy"], warn = false)
+    @test Set((shallow_first |> DataFrame).resultid) == expected
+
+    # A fragment can bind more than one value: `@in` over three countries beside a single-valued
+    # `year` makes the split 3-and-1, so a fix that moved only the first value of a run would still
+    # pass everything above. The set must widen to exactly the three countries' 2009 races.
+    multi = M.Result.objects
+    multi.values("resultid")
+    multi.cjoin("raceid" => "Race", join_type = "INNER",
+                filters = ["circuitid__country__@in" => ["Italy", "Monaco", "Brazil"], "year" => 2009],
+                warn = false)
+    multi_oracle = M.Result.objects
+    multi_oracle.values("resultid")
+    multi_oracle.filter("raceid__circuitid__country__@in" => ["Italy", "Monaco", "Brazil"],
+                        "raceid__year" => 2009)
+    multi_expected = Set((multi_oracle |> DataFrame).resultid)
+
+    @test length(multi_expected) > length(expected)   # the wider filter really is wider
+    @test Set((multi |> DataFrame).resultid) == multi_expected
+end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -2707,3 +2707,53 @@ end
     @test insp[:parameters] == [1, 5]               # inner param once, outer param once
     @test count(==('?'), sql) == 2                  # marker count matches — no orphan placeholder
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cjoin ON filters at two join depths bind in EMISSION order (#421)
+# `build_row_join_sql_text` resolves every ON condition in Phase 1 (binding as it goes), then
+# Phase 1b relocates a forward-referencing fragment onto the join it actually names — changing the
+# order the fragments are EMITTED in. The `:join` bucket had already been filled in binding order,
+# and nothing reconciled the two, so the first `?` took the relocated fragment's value.
+#
+# PostgreSQL was immune because `$N` numbering travels with the text; this file exists for exactly
+# the class of defect that only a positional backend can have. The two values are deliberately of
+# DIFFERENT TYPES — an Int year and a String country — so a swap is visible in the bucket rather
+# than hiding behind two interchangeable strings. On a live SQLite a swap does not even error
+# (SQLite is dynamically typed); it just returns nothing, which is why this shipped unnoticed.
+#
+# Rendering coverage for the same defect, on mock models and both backends, is in
+# `test/unit/test_order_by_joins.jl`; execution coverage is in `test/integration/test_cjoin.jl`.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Alignment Verification - cjoin ON filters across two join depths (#421)" begin
+    q = M.Result.objects
+    q.values("points")
+    # `circuitid__country` is one hop deeper than `year`, so its fragment forward-references the
+    # circuit join and Phase 1b relocates it. Listing it FIRST is what makes binding order differ
+    # from emission order — reversed, this same pair was always correct.
+    q.cjoin("raceid" => "Race",
+            filters = ["circuitid__country" => "Italy", "year" => 2009], warn = false)
+
+    insp = q |> inspect_query
+    sql = insp[:sql_text]
+
+    # Emission order: race's ON carries `year`, circuit's carries `country`, in that order.
+    @test occursin("\"Tb_1\".\"year\" = ?", sql)
+    @test occursin("\"Tb_2\".\"country\" = ?", sql)
+    @test first(findfirst("\"Tb_1\".\"year\" = ?", sql)) < first(findfirst("\"Tb_2\".\"country\" = ?", sql))
+
+    # ...so the bucket must read [year, country]. Pre-fix it was ["Italy", 2009]: the year marker
+    # bound "Italy" and the country marker bound 2009.
+    @test insp[:parameter_buckets][:join] == [2009, "Italy"]
+    @test count(==('?'), sql) == 2
+    @test insp[:parameter_buckets][:where] == []   # ON predicates stay in :join, never leak to WHERE
+
+    # Control: the same two filters listed the other way round. Binding order already matched
+    # emission order, so this was correct before the fix and must be identical after it.
+    rev = M.Result.objects
+    rev.values("points")
+    rev.cjoin("raceid" => "Race",
+              filters = ["year" => 2009, "circuitid__country" => "Italy"], warn = false)
+    rev_insp = rev |> inspect_query
+    @test rev_insp[:parameter_buckets][:join] == [2009, "Italy"]
+    @test rev_insp[:sql_text] == sql
+end

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -109,6 +109,24 @@ const DOCERR_CASES = [
         () -> DOCERR_RESULT_PG.objects.values("bad alias!" => "points").list(show_query = :dict),
     ),
     (
+        # #424. `cjoin_on`'s `on` is the whole ON clause and is NOT path-prefixed, so a bare
+        # `"ev__col" => v` resolves against a `join_field`-less (CROSS-joined) CTE — which has no ON
+        # clause to carry it. Two predicates: with only one, the "produced no ON conditions" guard
+        # fires first and the case would pin the wrong error.
+        "read/custom_joins.md — a cjoin_on ON predicate on a CROSS-joined CTE is refused",
+        QueryBuildError,
+        () -> begin
+            ev = DOCERR_STATUS_PG.objects
+            ev.values("statusid", "status")
+            q = DOCERR_RESULT_PG.objects
+            q.with("ev" => ev)                       # no join_field => CROSS JOIN (#44)
+            q.values("resultid")
+            q.cjoin_on("DOCERR_DRIVER_PG", alias = "d",
+                       on = [F("d.driverid") == F("driverid"), "ev__status" => "Finished"])
+            q.list(show_query = :dict)
+        end,
+    ),
+    (
         "write/update.md — UPDATE cannot carry LIMIT/OFFSET/ORDER BY",
         UnsafeMutationError,
         () -> DOCERR_RESULT_PG.objects.filter("resultid" => 1).limit(5).

--- a/test/unit/test_order_by_joins.jl
+++ b/test/unit/test_order_by_joins.jl
@@ -37,9 +37,24 @@ selector. Both are pinned below as controls, and both must stay byte-identical �
 by making every order term build its own join would satisfy the first three testsets here and
 quietly double-join the rest of the suite.
 
+The last four testsets cover two further defects in the same relocation machinery. Both are
+pre-existing and neither was caused by #404:
+
+  - #421 — relocation changes the order extras are EMITTED in, while Phase 1 had already bound
+    their parameters in `row_join` order. PostgreSQL is immune (`\$N` numbering travels with the
+    text); SQLite flattens the `:join` bucket in BINDING order, so a relocated extra bound its
+    neighbour's value. Valid SQL, wrong rows, no error, on one backend only.
+  - #424 — Phase 2's CROSS-join branch emits and `continue`s without consulting
+    `on_clause_extras`, so a predicate that landed there was silently dropped and the join stopped
+    filtering. A CROSS-joined CTE acquires one when its NAME collides with a join key (a `cjoin`
+    path, a `cjoin_on` alias, or an `on()` path) or when Phase 1b relocates a fragment naming its
+    alias. Four producers are pinned; the testset explains why it pins that invariant rather than a
+    list of call shapes.
+
 All assertions render through mock PostgreSQL/SQLite connections — no live database. The execution
 half (the query actually returning rows on both backends) lives in
-`test/integration/test_selection.jl`, because the pre-fix failure was at execution time.
+`test/integration/test_selection.jl` and `test/integration/test_cjoin.jl`, because the pre-fix
+failures were at execution time.
 
 Sibling coverage:
   - `test_order_by_nulls.jl`        -> #75 NULL placement on the rendered term.
@@ -361,4 +376,225 @@ end
   # would also rewrite the like-named COLUMN, which is the very ambiguity under test.)
   @test _obj_joins(control) == _obj_joins(colliding) == 3
   @test count("= \$1", control) == count("= \$1", colliding) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A relocated ON extra binds its OWN value (#421)
+# Phase 1 walks `row_join` in index order and binds as it resolves; Phase 1b then moves a fragment
+# onto a later join, changing EMISSION order. Nothing reconciled the two. PostgreSQL never noticed —
+# `$N` numbering travels with the text — but SQLite flattens the `:join` bucket in BINDING order, so
+# the first `?` took the relocated fragment's value and the two conditions swapped. Valid SQL, wrong
+# rows, no error, and on one backend only.
+#
+# The control pair is what earns this testset its length: the SAME two filters, only their order in
+# the `filters` vector swapped. The deep one relocates and the shallow one does not, so pre-fix (a)
+# was wrong while (b) was already right — a "fix" that reversed the bucket wholesale would trade one
+# failure for the other and still pass a single-case test.
+# ─────────────────────────────────────────────────────────────────────────────
+_cj_two_depth(filters) = begin
+  q = OBJ.Cj_child.objects
+  q.values("note")
+  q.cjoin("parent" => "Cj_parent", filters = filters, warn = false)
+  q
+end
+
+@testset "a relocated ON extra binds its own value (#421)" begin
+  # (a) the issue's shape — the deep filter is listed FIRST, so it binds first and emits last.
+  sl = inspect_query(_cj_two_depth(["grandparent__code" => "ZZZ", "sku" => "SSS"]); connection = _OBJ_SL)
+  sql = sl[:sql_text]
+
+  # Pin the emission order the bucket has to match rather than trusting it: cj_parent's ON carries
+  # `sku` and is emitted first, cj_grand's carries `code` and is emitted second.
+  @test occursin("\"Tb_1\".\"sku\" = ?", sql)
+  @test occursin("\"Tb_2\".\"code\" = ?", sql)
+  @test first(findfirst("\"Tb_1\".\"sku\" = ?", sql)) < first(findfirst("\"Tb_2\".\"code\" = ?", sql))
+
+  # ...so the bucket must read the sku value first. Pre-fix it was ["ZZZ", "SSS"] — swapped.
+  @test sl[:parameter_buckets][:join] == ["SSS", "ZZZ"]
+  @test count(==('?'), sql) == 2                     # no orphan marker, no orphan value
+
+  # (b) control: the same two filters the other way round. Binding order already matched emission
+  # order here, so this was correct BEFORE the fix and must be byte-identical after it.
+  rev = inspect_query(_cj_two_depth(["sku" => "SSS", "grandparent__code" => "ZZZ"]); connection = _OBJ_SL)
+  @test rev[:parameter_buckets][:join] == ["SSS", "ZZZ"]
+  @test rev[:sql_text] == sql        # the rendered text never depended on the filter order
+
+  # (c) PostgreSQL is the oracle: it was always right and must not move. The values stay in BIND
+  # order and the explicit numbering carries the mapping — which is why $2 lands on sku, not $1.
+  pg = inspect_query(_cj_two_depth(["grandparent__code" => "ZZZ", "sku" => "SSS"]); connection = _OBJ_PG)
+  @test occursin("\"Tb_1\".\"sku\" = \$2", pg[:sql_text])
+  @test occursin("\"Tb_2\".\"code\" = \$1", pg[:sql_text])
+  @test pg[:parameters] == ["ZZZ", "SSS"]
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A relocated ON extra carries ALL of its values, in order (#421)
+# One fragment can bind more than one value, so "move the fragment's parameter" is not the same
+# invariant as "move the fragment's parameter RUN". `@in` over three codes beside a single-valued
+# `sku` makes the split 3-and-1: pre-fix the bucket read [Z,Y,X,SSS] against markers emitted
+# sku-first, so all four misbound. A fix that relocated only the first value of a run would still
+# satisfy the one-value-each testset above.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a relocated ON extra carries its whole parameter run (#421)" begin
+  r = inspect_query(_cj_two_depth(["grandparent__code__@in" => ["Z", "Y", "X"], "sku" => "SSS"]);
+                    connection = _OBJ_SL)
+  @test r[:parameter_buckets][:join] == ["SSS", "Z", "Y", "X"]
+  @test count(==('?'), r[:sql_text]) == 4
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The fix reorders BETWEEN fragments, never WITHIN one (#421 control)
+# A single `Q(...)` spanning two depths is ONE fragment: Phase 1b relocates it whole, so its two
+# values were always adjacent and in the right order. Splitting the same predicates into two `Q`s
+# makes them two fragments, and only then does one relocate past the other. Both are pinned because
+# they are the pair that tells "reordered the runs" apart from "reordered the values".
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "relocation reorders fragments, not values within one (#421 control)" begin
+  one_q = inspect_query(_cj_two_depth([Q("grandparent__code" => "Z", "sku" => "S")]); connection = _OBJ_SL)
+  @test one_q[:parameter_buckets][:join] == ["Z", "S"]      # unchanged by the fix
+
+  two_q = inspect_query(_cj_two_depth([Q("grandparent__code" => "Z"), Q("sku" => "S")]); connection = _OBJ_SL)
+  @test two_q[:parameter_buckets][:join] == ["S", "Z"]      # two fragments, so the deep one moves
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# An ON predicate that lands on a CROSS-joined CTE is refused, not dropped (#424)
+# Phase 2's CROSS branch has no ON clause to merge `on_clause_extras[idx]` into, and it `continue`d
+# without consulting the dict — so the predicate vanished, the join stopped filtering, and the query
+# returned row-multiplied results with no error.
+#
+# This testset deliberately pins the INVARIANT rather than a list of call shapes. That list was
+# written twice and wrong twice: first "unreachable by any query shape", then "two shapes" — each
+# time an independent reviewer produced a shape it had missed. The invariant is:
+#
+#     a CROSS-joined CTE acquires an ON predicate when its NAME collides with a join key, or when
+#     Phase 1b relocates a fragment that names its alias.
+#
+# "Join key" means a `custom_join` key, and `custom_join` is written at three unrelated sites —
+# keyed by a `cjoin` PATH, a `cjoin_on` ALIAS, and an `on()` PATH. So a collision with any of them
+# produces this, with or without a model-field collision and with or without any relocation at all.
+# The producers below cover all four routes; a fifth `custom_join` writer would inherit the same
+# behavior, and that is exactly why the emitted message names the collision rather than the method.
+#
+# Measured pre-fix (route A), this rendered:
+#     INNER JOIN "cj_parent" AS "b2" ON ("b2"."sku" = "R1"."note")
+#     CROSS JOIN "ev" AS "R1_1"
+# — the predicate gone from the SQL while its value stayed orphaned in the `:join` bucket. #421
+# makes that strictly worse before this guard makes it better: once values travel with their
+# fragment the orphan disappears too, so the wrong query becomes perfectly well-formed. That is why
+# the two land together.
+# ─────────────────────────────────────────────────────────────────────────────
+_ob_cte() = begin
+  c = OBJ.Cj_grand.objects
+  c.values("id", "code")
+  c
+end
+
+_ob_parent_cte() = begin
+  c = OBJ.Cj_parent.objects
+  c.values("id", "sku")
+  c
+end
+
+# (label, the CTE name the message must report, builder). Each must reach the SAME guard.
+const _OB_424_PRODUCERS = [
+  (
+    "A: cjoin_on `on` names a CTE path (via Phase 1b relocation)", "ev",
+    () -> begin
+      q = OBJ.Cj_child.objects
+      q.with("ev" => _ob_cte())                       # no join_field => CROSS JOIN (#44)
+      q.values("note")
+      # Two predicates on purpose: with only one, relocating it away empties the join's extras and
+      # `cjoin_on` raises "produced no ON conditions" first — a different, separately misleading
+      # error that would mask what is under test.
+      q.cjoin_on("Cj_parent", alias = "b2",
+                 on = [F("b2.sku") == F("note"), "ev__code" => "Z"])
+      q
+    end,
+  ),
+  (
+    "B: CTE name collides with a cjoin PATH (a model field; no relocation)", "parent",
+    () -> begin
+      q = OBJ.Cj_child.objects
+      # "parent" is a ForeignKey field of Cj_child. Join resolution consults the CTE registry BEFORE
+      # the model-field branch, so the CTE shadows the field's join entirely, and the cjoin then
+      # hangs its filters on the CROSS entry as its own `on_conditions` — one row_join entry, empty
+      # relocation window, `on_clause_extras` filled in Phase 1.
+      q.with("parent" => _ob_parent_cte())
+      q.values("note")
+      q.cjoin("parent" => "Cj_parent", filters = ["sku" => "S"], warn = false)
+      q
+    end,
+  ),
+  (
+    "C: CTE name collides with a cjoin_on ALIAS (no model field involved)", "b2",
+    () -> begin
+      q = OBJ.Cj_child.objects
+      # "b2" is NOT a field of Cj_child — nothing is shadowed. The collision is with the cjoin_on
+      # ALIAS, which is what `_cjoin_on` uses as its `custom_join` key. This is the producer that
+      # proved a message blaming "a CTE named after a model FIELD" asserts something false.
+      q.with("b2" => _ob_cte())
+      q.values("note")
+      q.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("note")])
+      q.filter("b2__code" => "X")                     # forces the CTE join to be built first
+      q
+    end,
+  ),
+  (
+    "D: CTE name collides with an on() PATH declared BEFORE the .with()", "parent",
+    () -> begin
+      q = OBJ.Cj_child.objects
+      # Order matters: `.with()` then `.on()` is refused earlier by `_resolve_join_target_model`,
+      # which only sees CTEs declared so far. Reversed, that check never fires.
+      q.on("parent", "sku" => "S")
+      q.with("parent" => _ob_parent_cte())
+      q.values("note", "parent__sku")
+      q
+    end,
+  ),
+]
+
+@testset "an ON predicate landing on a CROSS-joined CTE is refused, not dropped (#424)" begin
+  for (label, cte_name, build_q) in _OB_424_PRODUCERS
+    @testset "$label" begin
+      for (backend, conn) in (("PostgreSQL", _OBJ_PG), ("SQLite", _OBJ_SL))
+        err = try
+          inspect_query(build_q(); connection = conn)
+          nothing
+        catch e
+          e
+        end
+        @test err isa PormG.QueryBuildError
+        msg = sprint(showerror, err)
+
+        # The message must describe the COLLISION, which is true of every producer — not the call
+        # method, which is true of at most one. An earlier draft asserted "shadows a field"; that
+        # passed here and was false for producer C.
+        @test occursin("CROSS", msg)
+        @test occursin("collides", msg)
+        @test occursin("#44", msg)                # points at where the correlation belongs
+        @test occursin(".filter(", msg)           # ...and at one of the three remedies
+        # Names the offending CTE by the name the caller wrote, so they can find the
+        # `.with(...)` to rename. This is per-producer on purpose: a message that named the CTE's
+        # TABLE instead would be useless for renaming, and a hardcoded name would not notice.
+        @test occursin(cte_name, msg)
+        # Never blames the caller for a PormG bug: these are user-writable shapes, and the first
+        # draft of this guard said "internal: ... please report" (review finding).
+        @test !occursin("internal", lowercase(msg))
+        @test !occursin("report", lowercase(msg))
+      end
+    end
+  end
+
+  # Control: a CROSS-joined CTE that never acquired a predicate must still render. Without this, a
+  # guard written as an unconditional `throw` would satisfy every assertion above while breaking
+  # every #44 query. (`test/unit/test_cte_ergonomics.jl` owns the full #44 coverage; this is the
+  # local tripwire that the new `haskey` check did not turn every CROSS join into an error.)
+  ok = OBJ.Cj_child.objects
+  ok.with("ev" => _ob_cte())
+  ok.values("note")
+  ok.filter(F("note") == F("ev__code"))
+  ok_sql = inspect_query(ok; connection = _OBJ_SL)[:sql_text]
+  @test occursin("CROSS JOIN \"ev\"", ok_sql)
+  @test !occursin(r"CROSS JOIN[^\n]*ON", ok_sql)
 end


### PR DESCRIPTION
Closes #421
Closes #424

Two defects in `build_row_join_sql_text`, landed together because they interact: **#421 makes #424 quieter.**

`build_row_join_sql_text` resolves every `cjoin` ON condition in Phase 1 (binding as it goes), lets Phase 1b relocate a forward-referencing fragment onto a later join, then emits in `row_join` order. Nothing reconciled binding order with emission order.

## #421 — a relocated ON predicate bound its neighbour's value

On a positional backend, a value's index in the `:join` bucket *is* its binding. The text moved; the already-appended value did not.

```julia
cjoin("parent" => "Cj_parent", filters = ["grandparent__code" => "ZZZ", "sku" => "SSS"])
```

| | rendered | `:join` bucket | effect |
|---|---|---|---|
| before | `"Tb_1"."sku" = ?` … `"Tb_2"."code" = ?` | `["ZZZ", "SSS"]` | `sku` binds the **code** value — swapped, no error |
| after | unchanged | `["SSS", "ZZZ"]` | correct |

PostgreSQL was always right (`$2` on `sku`, `$1` on `code`) because `$N` numbering travels with the text, so this was a silent SQLite-only divergence.

**Fix.** An `OnExtra` pairs a rendered fragment with the values it bound. Phase 1 detaches them the moment they are bound — nothing sits in the bucket whose clause position is not yet final — and Phase 2 re-appends at the point of emission. Binding order *is* emission order by construction. The three detach/reattach helpers live in `parameters.jl`, which owns the bucket abstraction; every one is a no-op on PostgreSQL.

## #424 — a predicate landing on a CROSS-joined CTE was dropped

Phase 2's CROSS branch emits and `continue`s without consulting `on_clause_extras`. Measured pre-fix:

```sql
INNER JOIN "cj_parent" AS "b2" ON ("b2"."sku" = "R1"."note")
CROSS JOIN "ev" AS "R1_1"
```

The predicate is gone and the join matches every row — row multiplication with no error. It now fails closed, the same posture `_get_join_condition_list` already takes on this marker (#394).

**Why it belongs in this PR.** Before #421, a dropped fragment left its value orphaned in the bucket with no `?` to consume it, so SQLite sometimes failed loudly on the count. Once values travel with their text, the orphan disappears too and the wrong query becomes perfectly well-formed. #421 removes the accident that was masking #424.

## The invariant, and why the guard states one instead of a shape list

The issue said #424 was probably unreachable. It is reachable four ways, and **each of three review rounds produced a shape the previous enumeration had missed** — including one where the error message asserted something false. So the guard, its message, and the tests now state the rule:

> A CROSS-joined CTE acquires an ON predicate when its **name collides with a join key** — a `cjoin` path, a `cjoin_on` alias, or an `on()` path — or when a **relocated fragment names its alias**.

`custom_join` is written at three unrelated sites, so a fifth writer would inherit the same behavior. The testset pins four producers against that invariant rather than against a list of methods.

## Verification

| | |
|---|---|
| Full unit suite | **8370/8370** |
| `db_sl` integration slice (`test_cjoin.jl`) | **43/43** |
| Documented-error cases | 108 (+1 new `DOCERR_CASES` entry pinning the new type) |
| Mutation check | every new assertion fails pre-fix; the designed controls pass both sides |
| PostgreSQL | rendering byte-identical before/after |
| `UPGRADING.md` code blocks + detection snippet | executed verbatim against the F1 models |

The integration test is discriminating by construction: pre-fix it returns an **empty result set** against a populated oracle, because SQLite is dynamically typed and binding `"Italy"` into `year` raises nothing — it just matches nothing. That is exactly why this shipped unnoticed.

`db_2` was **not** run — the shared PostgreSQL server was not cleared for this. The diff is query rendering only (no migrations, no driver round-trip, no pool/transaction code, no include-chain change), so the full integration suite is not owed per the workflow skill's rung-5 table.

## `UPGRADING.md`

An entry is included for the **#424 half only**. #421 is a pure correctness fix — a query that returned wrong rows now returns right ones, forcing no app edit. #424 turns a query that *ran and returned rows* into a build-time error, which does force one. The entry documents both collision routes, ships a Julia detection snippet (grep cannot find a name collision), and leads the migration with `join_field` rather than `.filter(...)` — because a literal filter over an unkeyed CTE is still a Cartesian product, not a correlation.

## Deliberately not done

**One known limit, documented at the site rather than hidden.** `@in` over a subquery that declares its own `.with(...)` binds into `:cte` while its markers render in the JOIN clause, so `OnExtra` carries no values for it. Different root cause (bucket *choice*, not fragment *movement*), and it already misbinds with no relocation at all — measured SQLite `["CTEVAL","SUBVAL",7]` against PostgreSQL `[7,"CTEVAL","SUBVAL"]`. Filed as #432.

**Five pre-existing defects surfaced during review and left alone**, all reproduced and filed rather than folded in:

- #431 — a CTE named after a model field silently shadows that field's join (the root cause of one #424 route)
- #432 — a nested render binds into a bucket that does not match its text position, SQLite (two reproductions)
- #433 — `Exists(sub)` where `sub` declares a `.with(...)` raises an internal *"please report"* error
- #434 — `on()`'s CTE rejection is order-dependent
- #435 — `cjoin_on` reports *"produced no ON conditions"* when the caller did provide one

#174's *Third-table references* box is annotated: still open, but its failure mode changed from silently-wrong-rows to a clear error.

**One reviewer claim not filed:** `update()` + `.with()` raising *"CTE has not been materialized yet"* did not reproduce for me across four variants, so I did not open an issue on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
