### PR TITLE
fix(#423): order_by() can name an alias declared by values()

### DIFF
--- a/docs/src/read/values_and_joins.md
+++ b/docs/src/read/values_and_joins.md
@@ -275,6 +275,50 @@ df = M.Driver.objects.filter("driverref" => "hamilton").
 !!! tip
     Aliasing happens at the SQL level (`SELECT "field" AS "alias"`). This is more efficient than renaming columns in a Julia DataFrame after the query.
 
+### Ordering by an Alias
+
+An alias declared in `values()` can be used as the sort key, whatever is on the right of the pair —
+a field path, a local column, an aggregate, or a window function:
+
+```julia
+query = M.Result.objects
+query.values("resultid", "driver" => "driverid__surname")
+query.order_by("driver")          # sorts on the projected alias
+```
+
+```sql
+SELECT "Tb"."resultid" as "resultid", "Tb_1"."surname" as "driver"
+FROM "result" as "Tb"
+ INNER JOIN "driver" AS "Tb_1" ON "Tb"."driverid" = "Tb_1"."driverid"
+ORDER BY "driver" ASC NULLS LAST
+```
+
+Ordering by the underlying path instead is equally valid and produces the same rows — it just
+renders the qualified column rather than the alias:
+
+```julia
+query.order_by("driverid__surname")     # ORDER BY "Tb_1"."surname" ASC NULLS LAST
+```
+
+!!! warning "An alias that shadows a column name wins"
+    If the alias reuses the name of a real column, the sort follows the **alias**, not the column:
+
+    ```julia
+    query = M.Result.objects
+    query.values("resultid", "grid" => "points")
+    query.order_by("-grid")        # sorts by POINTS (the projected value), not by the grid column
+    ```
+
+    That is what both PostgreSQL and SQLite do with a `SELECT` alias in `ORDER BY`, and it keeps the
+    sort consistent with the column the query actually returns. If you meant the underlying column,
+    name it explicitly (`order_by("-points")`) or choose an alias that shadows nothing.
+
+!!! note "Two projections may not share an alias in `order_by`"
+    `.values("x" => "grid", "x" => "points")` followed by `order_by("x")` raises `QueryBuildError`:
+    the sort key matches two different projections. PostgreSQL rejects an ambiguous `ORDER BY` alias
+    and SQLite would resolve it arbitrarily, so PormG refuses it rather than diverge. Give the two
+    projections distinct names.
+
 ---
 
 ## Common Patterns

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -116,26 +116,134 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # Check if the ORDER BY target matches a selected alias. Only those aliases can be
     # referenced directly in ORDER BY. Cached join paths created while resolving CTE join_field
     # entries must reuse their resolved SQL selector instead of quoting the raw lookup string.
-    for value in object.values
-      if isa(value, SQLTypeFunction) && value.field.aggregate == true
-        continue
-      end
+    #
+    # Scan `instruc.select` — the RENDERED projections — not `object.values`, the declared ones.
+    # The two are NOT the same set, and trusting the declared list is a silent-wrong-answer bug
+    # (#423): `get_select_query` collapses a projection whose `_as` is already cached onto the
+    # cached SQLField and DISCARDS its `custom_as`, so a name the caller declared can fail to reach
+    # the SQL at all.
+    #
+    #     values("note", "gg" => "note")   ->   SELECT "Tb"."note" as "note", "Tb"."note" as "note"
+    #
+    # `gg` is declared and never rendered. Emitting `ORDER BY "gg"` from the declared list names
+    # neither an output nor an input column: PostgreSQL raises `column "gg" does not exist`, and
+    # SQLite's double-quoted-string fallback degrades the unresolvable identifier to the literal
+    # 'gg' — a constant sort key — so the rows come back UNSORTED with no error at all. Scanning
+    # what will actually be rendered keeps that shape on the loud, backend-aligned path it was on
+    # before (an `UnknownFieldError` from the resolution branch below).
+    #
+    # `instruc.select` is authoritative and fully populated here: `build` calls `get_select_query`
+    # before `get_order_query`, and that is its only writer, assigning contiguously over
+    # `eachindex(values)`. The vector is sized up front, so the trailing slots are `undef` — hence
+    # the `isassigned` guard. It is the same discipline `_query_select` uses, not the same
+    # behavior: that one `return`s at the first gap, this one `continue`s. Equivalent only because
+    # assignment is contiguous; `continue` is the safer of the two if that ever stops being true.
+    #
+    # The scan also runs to completion rather than breaking on the first hit, so a name carried by
+    # TWO RENDERED columns over different expressions can be refused. `.values()` permits that —
+    # `values("x" => "note", "x" => "qty")` renders `as "x"` twice — and `ORDER BY "x"` is then
+    # ambiguous: PostgreSQL rejects it, SQLite picks one arbitrarily.
+    #
+    # Keyed on OBJECT IDENTITY. Two matching slots are safe exactly when they are the same
+    # `SQLField`, which is precisely `get_select_query`'s dedupe relation: it collapses a projection
+    # whose `_as` is already cached onto the cached object, so collapsed slots are `===` and render
+    # byte-identical SQL — which is what PostgreSQL's `equal()` accepts. Anything else is two
+    # distinct expressions under one output name, which PostgreSQL rejects.
+    #
+    # Two earlier keys were wrong, both for reasons worth keeping written down:
+    #
+    #   `_as`  — justified as "equal `_as` means the same object". True of the field/function
+    #            branch, FALSE of the `SQLText` one, which assigns `instruc.select[i]`
+    #            unconditionally without consulting the cache. So
+    #            `values("lbl" => Value("a"), "lbl" => Value("b"))` carries one `_as` over two
+    #            different Params and slipped through.
+    #   rendered text — closer, but SQLite renders EVERY parameter as `?`, so the text key collapses
+    #            any two parameterized projections regardless of their values. That made the guard
+    #            raise on PostgreSQL and stay silent on SQLite for the same query — the strict
+    #            engine refusing while the lax engine sorts by an arbitrary one of two DIFFERENT
+    #            values. Exactly the divergence this guard exists to prevent, introduced by the
+    #            guard itself.
+    #
+    # Identity has neither blind spot and needs no placeholder text. It IS over-strict when two
+    # distinct objects resolve to identical SQL. The reachable instance is two literal-`NULL`
+    # projections — `Value(nothing)` short-circuits to the literal, not a parameter — so
+    # `values("lbl" => Value(nothing), "lbl" => Value(nothing))` renders `NULL as "lbl"` twice.
+    # PostgreSQL parses those as equal `Const`s and accepts; PormG refuses, with a message that
+    # degenerates to "over NULL and NULL". Harmless (ordering by a doubly-projected NULL is
+    # meaningless) and loud rather than silent, which is the direction to err in — but it is a real
+    # case, not the contrived two-spellings-of-one-column one an earlier draft of this comment
+    # named.
+    # An ORDER BY term with NO alias cannot name a projection, and must not be compared as if it
+    # could: `selected_alias == v_field_copy._as` would reduce to `nothing == nothing` and match
+    # every unaliased select entry. One match then reaches `quote_identifier(nothing, …)`, two
+    # produce the nonsense `Ambiguous order_by("nothing")` — and both are reachable through the
+    # fluent surface, since a bare `Value("hi")` in `values()` projects with no alias at all and
+    # `SQLOrder(SQLField(f, nothing))` is accepted by `order_by`.
+    #
+    # Skipping the scan restores EXACT parity with the pre-#423 path for such a term. To be precise
+    # about what that parity is: the shape was already broken, raising `MethodError: Cannot convert
+    # an object of type Nothing` from the resolution branch — a raw MethodError outside the error
+    # taxonomy (#231/#239). This guard does not fix that; it only keeps #423 from replacing one
+    # untyped failure with a different, more confusing one. The underlying leak is pre-existing and
+    # tracked separately.
+    matched_value = nothing
+    for i in (v_field_copy._as === nothing ? () : eachindex(instruc.select))
+      isassigned(instruc.select, i) || continue
+      value = instruc.select[i]
 
       selected_alias = value.custom_as !== nothing ? value.custom_as : value._as
-      if selected_alias == v_field_copy._as
-        found_in_select = true
-        break
+      selected_alias == v_field_copy._as || continue
+
+      if found_in_select && !(value === matched_value)
+        # Name each side INDEPENDENTLY: a field-path projection keeps the path in `_as` (which reads
+        # far better than its rendered column), while an `SQLText` one keeps the chosen alias there.
+        # Choosing globally printed the ordered alias back as one of its own sources on a mixed
+        # pair — "over note and x" for `order_by("x")`, which is circular.
+        _name(v) = v._as == v_field_copy._as ? string(v.field) : string(v._as)
+        throw(QueryBuildError(
+          "Ambiguous \e[4m\e[31morder_by(\"$(v_field_copy._as)\")\e[0m: " *
+          "\e[4m\e[32m.values(...)\e[0m projects that name twice, over " *
+          "\e[33m$(_name(matched_value))\e[0m and \e[33m$(_name(value))\e[0m. PostgreSQL " *
+          "rejects an ambiguous ORDER BY alias and SQLite would pick one arbitrarily, so PormG " *
+          "refuses it rather than diverge. Give the two projections distinct names, or order by " *
+          "the underlying field path instead of the alias."))
       end
+      found_in_select = true
+      matched_value = value
     end
 
-    if haskey(instruc.cache, v_field_copy._as)
-      if found_in_select
-        # Use the alias name instead of the expression to avoid double parameterization.
-        # Most databases (PG, SQLite, MySQL) support aliases in ORDER BY.
-        v_field_copy.field = quote_identifier(v_field_copy._as, instruc.connection)
-      else
-        v_field_copy.field = instruc.cache[v_field_copy._as].field
-      end
+    # #423: the projection test comes FIRST. It used to be nested inside the `instruc.cache` hit
+    # below, and the two disagree about where a projection's chosen name is stored:
+    #
+    #     values("s" => "parent__sku")  ->  _as = "parent__sku"   custom_as = "s"
+    #     values("c" => Count("id"))    ->  _as = "c"             custom_as = nothing
+    #
+    # For a field-path projection the PATH becomes `_as` and the chosen name goes to `custom_as`;
+    # for a function the chosen name becomes `_as` outright. `get_select_query` caches under `_as`,
+    # so the cache has no "s" entry, the `haskey` missed, and control fell through to
+    # `_get_select_query("s")` — which resolves "s" as a physical column of the base model. That is
+    # an `UnknownFieldError` for a name like "s", and something worse for a name that happens to
+    # match a real column: `values("note" => "qty"); order_by("note")` silently emitted
+    # `ORDER BY "Tb"."note"`, sorting a DIFFERENT column than the one projected under that name.
+    # Aggregate and window aliases escaped only because their chosen name IS `_as`, so the cache
+    # key happened to match — which is exactly the asymmetry users reported.
+    #
+    # The branch inversion itself changes exactly one combination — found_in_select && cache-miss,
+    # which used to fall through to `_get_select_query`. The other three are byte-identical, and
+    # both the #76 DISTINCT guard and the `instruc.group` push below stay gated on
+    # `!found_in_select`, so neither is reachable from the new branch.
+    #
+    # The ambiguity guard above is NOT gated on the cache, so it moves a second combination:
+    # found_in_select && cache-HIT. `values("note", "note" => "qty")` renders two output columns
+    # named "note" over different expressions and used to emit `ORDER BY "note"`; PostgreSQL
+    # rejected that at execution as ambiguous, so refusing it at build time is the aligned
+    # behavior — but it IS a second change, and saying "only one" would be wrong.
+    if found_in_select
+      # Use the alias name instead of the expression to avoid double parameterization.
+      # Most databases (PG, SQLite, MySQL) support aliases in ORDER BY.
+      v_field_copy.field = quote_identifier(v_field_copy._as, instruc.connection)
+    elseif haskey(instruc.cache, v_field_copy._as)
+      v_field_copy.field = instruc.cache[v_field_copy._as].field
     else
       v_field_copy.field = _get_select_query(v_field_copy.field, instruc)
     end
@@ -151,8 +259,17 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # through `_get_filter_query(::SQLTypeField)`, which returns `instruc.cache[_as].field`
     # verbatim. Clobbering here put `"parent__sku"` (a projection alias) into an ON clause, which
     # both backends reject. The existing entry is the fully-qualified selector and is strictly
-    # better for every reader; only a path resolved fresh at :140 has nothing to preserve.
-    haskey(instruc.cache, v_field_copy._as) || (instruc.cache[v_field_copy._as] = v_field_copy)
+    # better for every reader; only a freshly resolved path has nothing to preserve.
+    #
+    # #423 adds the second half of the same rule. Inverting the branches above made
+    # `found_in_select` reachable on a cache MISS, so this would newly write the degraded alias
+    # under the caller's chosen name — the poisoned form the #404 clause above exists to keep out
+    # of the join render, arriving by a new route. DEFENSIVE, not demonstrated: no query shape is
+    # known that reads `instruc.cache` under a `custom_as` alias, so removing this would probably
+    # not turn the suite red. It costs one boolean, and a bare alias is legal in ORDER BY and
+    # nowhere else, so it is never worth caching under any circumstances.
+    (found_in_select || haskey(instruc.cache, v_field_copy._as)) ||
+      (instruc.cache[v_field_copy._as] = v_field_copy)
 
     if !found_in_select
       # #76: Under DISTINCT, an ORDER BY term that is not part of the projection is rejected by

--- a/src/querybuilder/types.jl
+++ b/src/querybuilder/types.jl
@@ -1175,8 +1175,9 @@ Each mutates the handler and returns it, so calls can be chained or accumulated 
   (ANDed), unlike `.values`/`.order_by`, which replace their previous call (#199)
 - `.values(fields...)` — choose/annotate the selected columns; `"*"` selects the main table.
   **Replaces** its previous call, last-call-wins (#199)
-- `.order_by(fields...)` — sort; prefix `-` for descending. **Replaces** its previous call, matching
-  Django's *each `order_by()` clears previous ordering* (#199)
+- `.order_by(fields...)` — sort; prefix `-` for descending. Accepts a field path or an alias
+  declared by `.values()` (#423). **Replaces** its previous call, matching Django's *each
+  `order_by()` clears previous ordering* (#199)
 - `.limit(n)` / `.offset(n)` — pagination, one clause each
 - `.page(limit)` / `.page(limit, offset)` — pagination in one call; `.page(n)` sets the limit only
   and leaves any offset already on the handler in place. Those are the only two arities — anything

--- a/test/integration/test_selection.jl
+++ b/test/integration/test_selection.jl
@@ -336,6 +336,72 @@ end
     @test all(s -> s !== missing && !isempty(s), projected_df.surname)
 end
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Ordering by a values() alias over a field path (#423)
+# `values()` puts a field-path projection's chosen name in `custom_as` and the PATH in `_as`, while
+# `get_select_query` caches under `_as`. `get_order_query` read `custom_as` to decide the term named
+# a projection, then looked it up in the `_as`-keyed cache, missed, and re-resolved the alias as a
+# physical column — `UnknownFieldError` for a name that matches nothing, and a silent sort on the
+# WRONG column for a name that matches something.
+#
+# Rendering coverage is in `test/unit/test_order_by_alias.jl`; this asserts the queries actually run
+# and come back ordered, on a real database, on both engines. The oracle pattern matches the #404
+# testset above: compare the alias-ordered result against the same ordering expressed the way that
+# always worked, so the assertion is independent of backend collation and of the fixture's contents.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by on a values() alias over a field path executes (#423)" begin
+    # (a) join-path alias. `surname` is projected under the name "driver" and ordered by that name.
+    aliased = M.Result.objects
+    aliased.values("resultid", "driver" => "driverid__surname")
+    aliased.order_by("driver", "resultid")
+    aliased.limit(25)
+    aliased_df = aliased |> DataFrame
+
+    @test nrow(aliased_df) == 25
+    # The join really produced driver rows — a NULL-filled column would satisfy the oracle below.
+    @test all(s -> s !== missing && !isempty(s), aliased_df.driver)
+
+    # Oracle: the same ordering by the UNDERLYING path, which was never affected. Ordering by the
+    # alias and by its source must agree row for row.
+    by_path = M.Result.objects
+    by_path.values("resultid", "driver" => "driverid__surname")
+    by_path.order_by("driverid__surname", "resultid")
+    by_path.limit(25)
+    @test aliased_df.resultid == (by_path |> DataFrame).resultid
+
+    # (b) local-column alias — no join involved at all, which is the half that shows the defect was
+    # never about join resolution.
+    local_alias = M.Result.objects
+    local_alias.values("id" => "resultid")
+    local_alias.order_by("-id")
+    local_alias.limit(10)
+    desc_ids = (local_alias |> DataFrame).id
+
+    @test length(desc_ids) == 10
+    @test issorted(desc_ids, rev = true)
+
+    # (c) the alias shadows a real column. `points` is projected under the name "grid", so ordering
+    # by "grid" must sort by POINTS, not by the untouched grid column. Pre-fix this emitted
+    # `ORDER BY "Tb"."grid"` and returned rows in the wrong order with no error — the silent half.
+    shadow = M.Result.objects
+    shadow.values("resultid", "grid" => "points")
+    shadow.order_by("-grid", "resultid")
+    shadow.limit(30)
+    shadow_df = shadow |> DataFrame
+
+    @test nrow(shadow_df) == 30
+    # The projected column holds points and is sorted descending. This is the discriminating
+    # assertion: pre-fix the sort ran on the untouched `grid` column, which does not order the
+    # points values, so this fails.
+    @test issorted(collect(skipmissing(shadow_df.grid)), rev = true)
+    # Oracle: ordering by the SOURCE of the alias must give the same rows as ordering by the alias.
+    by_source = M.Result.objects
+    by_source.values("resultid", "grid" => "points")
+    by_source.order_by("-points", "resultid")
+    by_source.limit(30)
+    @test shadow_df.resultid == (by_source |> DataFrame).resultid
+end
+
 @testset "ORDER BY NULL placement normalized across backends (#75)" begin
     # Scratch helpers are loaded in-suite by runtests.jl; load them for standalone runs too.
     if !isdefined(Main, :_clear_bulk_update_scratch_rows!)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,7 @@ end
     @testset "ORDER BY NULL Placement (#75)" include("unit/test_order_by_nulls.jl")
     @testset "SQLOrder Orientation Whitelist (#77)" include("unit/test_sqlorder_orientation.jl")
     @testset "ORDER BY Join Emission (#404)" include("unit/test_order_by_joins.jl")
+    @testset "ORDER BY a values() Alias (#423)" include("unit/test_order_by_alias.jl")
     @testset "PG Migration Fixture Isolated + Credential-free (#36)" include("unit/test_migration_pg_fixture.jl")
     @testset "Pool Exhaustion Typed Error (#37)" include("unit/test_connection_pool_timeout.jl")
     @testset "Connect-Failure Fast-Fail Typed Error (#72)" include("unit/test_connection_pool_connect_error.jl")

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -109,6 +109,20 @@ const DOCERR_CASES = [
         () -> DOCERR_RESULT_PG.objects.values("bad alias!" => "points").list(show_query = :dict),
     ),
     (
+        # #423. Making a values() alias resolve in ORDER BY means a name shared by two projections
+        # would emit an ambiguous `ORDER BY "x"` — PostgreSQL rejects it at execution, SQLite picks
+        # one. Refused at build time so the backends stay aligned.
+        #
+        # The doc sentence uses `grid`/`points` (F1); this model has no `grid` and adding one would
+        # change what every other case's model injects on a write (#331). Same shape, different
+        # column pair — what is pinned is the error TYPE for a duplicated alias, which is what the
+        # doc names.
+        "read/values_and_joins.md — two projections sharing an alias cannot be ordered by it",
+        QueryBuildError,
+        () -> DOCERR_RESULT_PG.objects.values("x" => "points", "x" => "resultid").
+            order_by("x").list(show_query = :dict),
+    ),
+    (
         # #424. `cjoin_on`'s `on` is the whole ON clause and is NOT path-prefixed, so a bare
         # `"ev__col" => v` resolves against a `join_field`-less (CROSS-joined) CTE — which has no ON
         # clause to carry it. Two predicates: with only one, the "produced no ON conditions" guard

--- a/test/unit/test_order_by_alias.jl
+++ b/test/unit/test_order_by_alias.jl
@@ -1,0 +1,444 @@
+"""
+Unit coverage for #423: `order_by()` on a name declared by `values()`.
+
+`values()` stores the caller's chosen name in **different fields** depending on what is on the
+right of the pair:
+
+    values("s" => "parent__sku")  ->  _as = "parent__sku"   custom_as = "s"
+    values("c" => Count("id"))    ->  _as = "c"             custom_as = nothing
+
+For a field path the PATH becomes `_as` and the chosen name goes to `custom_as`; for a function the
+chosen name becomes `_as` outright. `get_select_query` caches under `_as`, while `get_order_query`
+reads `custom_as` first to decide whether the ORDER BY term names a projection.
+
+Those two disagreed, and the disagreement was resolved in the wrong order: the alias test was
+nested INSIDE an `instruc.cache` hit, so for `order_by("s")` the cache lookup (keyed by
+`"parent__sku"`) missed, control fell through to `_get_select_query("s")`, and `"s"` was resolved as
+a physical column of the base model. Two different symptoms came out of the same line:
+
+  - a name that matches no column raises `UnknownFieldError: The field s not found in ao_child`;
+  - a name that DOES match one silently sorts the wrong column — `values("note" => "qty")` projects
+    `qty` under the name `note`, and `order_by("note")` emitted `ORDER BY "Tb"."note"`, ordering by
+    the untouched `note` column while the output column called `note` holds `qty`. No error, wrong
+    order, and only visible by reading the SQL.
+
+Aggregate and window aliases were never affected — their chosen name IS `_as`, so the cache key
+happened to match. That asymmetry (the same `"name" => value` syntax working or not depending on
+what is on the right) is what made this read as a gap rather than a restriction.
+
+The fix tests `found_in_select` FIRST, against the RENDERED projection list rather than the
+declared one (see the "never rendered" testset for why that distinction is load-bearing). The
+branch inversion moves exactly one combination — `found_in_select` on a cache miss — and the
+ambiguity guard, which is not cache-gated, moves a second. Everything else is byte-identical, so
+the controls at the bottom of this file are the substance of the change: they pin every path that
+must not move, including the ones #404 and #76 depend on.
+
+One deliberate addition: `.values()` allows two projections to share a name, and making that name
+resolve would emit an ambiguous `ORDER BY "x"` — which PostgreSQL rejects at execution and SQLite
+resolves arbitrarily. Refusing it here keeps the backends aligned rather than trading a loud error
+for a silent divergence. It is keyed on OBJECT IDENTITY — two matching slots are safe exactly when
+they are the same `SQLField`, which is `get_select_query`'s own dedupe relation — so projecting the
+SAME expression twice (`values("note", "note")`) keeps working, by construction rather than by
+proxy. Two earlier keys were wrong and both are pinned: `_as` (blind to the `SQLText` branch) and
+the rendered SQL (blind on SQLite, where every parameter renders as `?`).
+
+All assertions render through mock PostgreSQL/SQLite connections — no live database. The execution
+half lives in `test/integration/test_selection.jl`.
+
+Sibling coverage:
+  - `test_order_by_joins.jl`       -> #404 join emission, and the cjoin ON machinery.
+  - `test_order_by_nulls.jl`       -> #75 NULL placement.
+  - `test_inspect_query.jl`        -> #76 DISTINCT + ORDER BY projection guard.
+"""
+
+using Test
+using PormG
+using PormG.Models
+
+# Dedicated mock connections + config key: `runtests.jl` includes ~50 files into one `Main`, so a
+# shared name would let another file's settings decide this file's dialect.
+struct AliasOrderMockSQLite <: PormG.PormGSQLite end
+struct AliasOrderMockPostgres <: PormG.PormGPostgres end
+const _AO_SL = AliasOrderMockSQLite()
+const _AO_PG = AliasOrderMockPostgres()
+# ORDER BY renders NULL placement via a library-version probe (#75); pin a modern version so
+# order_by works on the mock without a live driver.
+PormG.backend_sqlite_version(::AliasOrderMockSQLite) = 3045000
+
+PormG.config["alias_order_mock"] = PormG.Configuration.Settings(
+  connections = _AO_PG, change_data = true, db_def_folder = "alias_order_mock",
+)
+
+# Inline fixtures in their own module: `set_models` is REQUIRED (not style), because
+# `_build_row_join` reads `instruct.object.model._module::Module` — a bare `Model(...)` leaves
+# `_module === nothing` and TypeErrors the moment a join renders.
+module AliasOrderModels
+import PormG
+import PormG.Models
+
+Ao_parent = Models.Model("ao_parent",
+  id  = Models.IDField(),
+  sku = Models.CharField(),
+)
+
+Ao_child = Models.Model("ao_child",
+  id     = Models.IDField(),
+  parent = Models.ForeignKey(Ao_parent, on_delete = "CASCADE", related_name = "kids", null = true),
+  note   = Models.CharField(null = true),
+  qty    = Models.IntegerField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "alias_order_mock")
+end
+
+const AO = AliasOrderModels
+import PormG.QueryBuilder: inspect_query, Count, Value, Rank, WindowOver
+
+_ao_joins(sql::AbstractString) = count("JOIN", sql)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A local-column alias is usable in ORDER BY (#423)
+# The simplest form, and the one that shows the defect is not about joins at all: `values("n" =>
+# "note")` needs no join, and `order_by("n")` still raised. Both backends, because nothing here is
+# dialect-specific — only the NULL-placement suffix differs.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() can name a values() alias over a local column (#423)" begin
+  for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
+    @testset "$label" begin
+      q = AO.Ao_child.objects
+      q.values("n" => "note")
+      q.order_by("n")
+
+      sql = inspect_query(q; connection = conn)[:sql_text]
+
+      @test occursin("\"Tb\".\"note\" as \"n\"", sql)
+      @test occursin("ORDER BY \"n\" ASC", sql)
+      # The alias must not be re-resolved as a column: that is the pre-fix failure.
+      @test !occursin("ORDER BY \"Tb\".\"n\"", sql)
+      @test _ao_joins(sql) == 0
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A join-path alias is usable in ORDER BY, and emits exactly one join (#423)
+# The issue's headline shape. The join count is the assertion that matters most: a "fix" that made
+# the alias resolve by re-running path resolution would satisfy the ORDER BY text and quietly
+# double-join, which no other assertion here would catch.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "order_by() can name a values() alias over a join path (#423)" begin
+  for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
+    @testset "$label" begin
+      q = AO.Ao_child.objects
+      q.values("note", "s" => "parent__sku")
+      q.order_by("s")
+
+      sql = inspect_query(q; connection = conn)[:sql_text]
+
+      @test occursin("LEFT JOIN \"ao_parent\" AS \"Tb_1\" ON \"Tb\".\"parent\" = \"Tb_1\".\"id\"", sql)
+      @test occursin("\"Tb_1\".\"sku\" as \"s\"", sql)
+      @test occursin("ORDER BY \"s\" ASC", sql)
+      @test _ao_joins(sql) == 1
+    end
+  end
+
+  # Descending, and DISTINCT — the two modifiers that route through different code below the fix.
+  # `distinct()` matters specifically: the #76 guard refuses an ORDER BY term that is not in the
+  # projection, and it is gated on `!found_in_select`. An alias IS in the projection by definition,
+  # so the guard must not fire here — pre-fix this raised UnknownFieldError before ever reaching it.
+  desc = AO.Ao_child.objects
+  desc.values("note", "s" => "parent__sku")
+  desc.order_by("-s")
+  @test occursin("ORDER BY \"s\" DESC", inspect_query(desc; connection = _AO_SL)[:sql_text])
+
+  dis = AO.Ao_child.objects
+  dis.values("note", "s" => "parent__sku")
+  dis.distinct(true)
+  dis.order_by("s")
+  dis_sql = inspect_query(dis; connection = _AO_PG)[:sql_text]
+  @test occursin("DISTINCT", dis_sql)
+  @test occursin("ORDER BY \"s\" ASC", dis_sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# An alias that shadows a real column orders the ALIAS, not the column (#423)
+# The silent half of the bug, and the only shape whose behavior CHANGES rather than starting to
+# work. `values("note" => "qty")` projects qty under the name note; pre-fix `order_by("note")`
+# emitted `ORDER BY "Tb"."note"` — the untouched note column, not the projected value. No error.
+#
+# Both backends resolve a SELECT alias in ORDER BY in preference to a same-named source column, so
+# emitting the bare alias is what makes the sort agree with the projection the caller wrote.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an alias shadowing a real column sorts the alias, not the column (#423)" begin
+  for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
+    @testset "$label" begin
+      q = AO.Ao_child.objects
+      q.values("note" => "qty")
+      q.order_by("note")
+
+      sql = inspect_query(q; connection = conn)[:sql_text]
+
+      @test occursin("\"Tb\".\"qty\" as \"note\"", sql)
+      @test occursin("ORDER BY \"note\" ASC", sql)
+      # Pre-fix this is what was emitted. It is valid SQL and returns rows in the wrong order.
+      @test !occursin("ORDER BY \"Tb\".\"note\"", sql)
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# An ambiguous alias is refused rather than resolved arbitrarily (#423)
+# `.values()` does not reject two projections sharing a name. Once such a name resolves in ORDER BY,
+# `ORDER BY "x"` is ambiguous: PostgreSQL raises at execution, SQLite picks one. Refusing at build
+# time is what keeps the two aligned — otherwise this fix would trade a loud (if confusing)
+# UnknownFieldError for a silent cross-backend divergence.
+#
+# Keyed on OBJECT IDENTITY, not on a match count and not on the rendered text. Two matching slots
+# are safe exactly when they are the same `SQLField` — which is `get_select_query`'s own dedupe
+# relation, so collapsed slots render byte-identical SQL, which is what PostgreSQL's `equal()`
+# accepts. Naming the same expression twice therefore keeps working, and it keeps working for a
+# reason that is true by construction rather than by proxy. Two earlier keys were wrong and both
+# are pinned below: `_as` (blind to the SQLText branch) and rendered text (blind on SQLite, where
+# every parameter renders as `?`).
+#
+# Note this guard is not gated on the cache, so it also moves the found_in_select && cache-HIT
+# combination: `values("note", "note" => "qty")` used to render `ORDER BY "note"` and is now
+# refused. That shape emits two output columns named "note" over different expressions, which
+# PostgreSQL rejected at execution anyway, so the refusal is the aligned behavior — but it means
+# TWO combinations change, not one. Pinned below so the claim stays honest.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "an ambiguous values() alias is refused in order_by() (#423)" begin
+  amb = AO.Ao_child.objects
+  amb.values("x" => "note", "x" => "qty")
+  amb.order_by("x")
+
+  err = try
+    inspect_query(amb; connection = _AO_PG)
+    nothing
+  catch e
+    e
+  end
+  @test err isa PormG.QueryBuildError
+  msg = sprint(showerror, err)
+  @test occursin("Ambiguous", msg)
+  @test occursin("x", msg)
+  # Names BOTH sources, so the caller can see which two projections collided.
+  @test occursin("note", msg)
+  @test occursin("qty", msg)
+
+  # Control: the same expression projected twice shares `_as`, so it is not a new ambiguity. This
+  # rendered before the fix and must still render — a guard keyed on the match count would break it.
+  dup = AO.Ao_child.objects
+  dup.values("note", "note")
+  dup.order_by("note")
+  @test occursin("ORDER BY \"note\" ASC", inspect_query(dup; connection = _AO_PG)[:sql_text])
+
+  # Two `Value(...)` projections under one name. This is the case an `_as`-keyed guard MISSES: the
+  # `SQLText` branch of `get_select_query` assigns unconditionally without consulting the cache, so
+  # both entries carry `_as == "lbl"` while rendering two different Params. PostgreSQL sees two
+  # unequal expressions under one output name and raises `ORDER BY "lbl" is ambiguous`, while an
+  # `_as`-keyed guard sees one name and stays silent. Review finding — that draft justified `_as` as
+  # a faithful proxy for PostgreSQL's rule, and it is not one for this branch.
+  # BOTH backends, deliberately. A rendered-text key made this throw on PostgreSQL (`$1`/`$2`) and
+  # render on SQLite (`?`/`?`) — the guard against divergence introducing one, with the strict
+  # engine refusing while the lax engine sorted by an arbitrary one of two DIFFERENT values.
+  # Identity keying removes the split, and looping here is what would catch its return.
+  for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
+    @testset "$label" begin
+      val_amb = AO.Ao_child.objects
+      val_amb.values("note", "lbl" => Value("a"), "lbl" => Value("b"))
+      val_amb.order_by("lbl")
+      val_err = try
+        inspect_query(val_amb; connection = conn)
+        nothing
+      catch e
+        e
+      end
+      @test val_err isa PormG.QueryBuildError
+      @test occursin("Ambiguous", sprint(showerror, val_err))
+    end
+  end
+
+  # A mixed pair — one field path, one Value — must name each side on its own terms. Choosing
+  # globally printed the ordered alias back as one of its own sources ("over note and x"), which is
+  # circular; the message must read "over note and <expr>" in either declaration order.
+  for vals in (("x" => "note", "x" => Value("hi")), ("x" => Value("hi"), "x" => "note"))
+    mixed = AO.Ao_child.objects
+    mixed.values(vals...)
+    mixed.order_by("x")
+    mixed_err = try
+      inspect_query(mixed; connection = _AO_PG)
+      nothing
+    catch e
+      e
+    end
+    @test mixed_err isa PormG.QueryBuildError
+    mixed_msg = sprint(showerror, mixed_err)
+    @test occursin("note", mixed_msg)
+    # Never names the ordered alias itself as a source.
+    @test !occursin("over x and", mixed_msg)
+    @test !occursin("and x.", mixed_msg)
+  end
+
+  # The second combination this change moves: an alias that shadows another projection's name over
+  # a DIFFERENT expression. `values("note", "note" => "qty")` renders `as "note"` twice, so it was
+  # already ambiguous to PostgreSQL at execution; it now fails at build time instead. Pinned so the
+  # "only one combination changes" claim cannot quietly reappear.
+  shadow_dup = AO.Ao_child.objects
+  shadow_dup.values("note", "note" => "qty")
+  shadow_dup.order_by("note")
+  @test_throws PormG.QueryBuildError inspect_query(shadow_dup; connection = _AO_PG)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The alias set comes from what is RENDERED, not from what was declared (#423)
+# `get_select_query` collapses a projection whose `_as` is already cached onto the cached SQLField
+# and discards its `custom_as`, so a declared name can fail to reach the SQL entirely. Deriving
+# `found_in_select` from `object.values` therefore trusted a name that is never emitted.
+#
+# This is the defect an independent review caught in the first draft of this fix, and it was
+# strictly worse than the bug being fixed: `ORDER BY "gg"` names neither an output nor an input
+# column, so PostgreSQL raises `column "gg" does not exist` while SQLite's double-quoted-string
+# fallback degrades it to the literal 'gg' — a constant sort key — and returns the rows UNSORTED
+# with no error. Silent wrong answer on one backend, runtime error on the other, replacing a clean
+# build-time `UnknownFieldError`. Scanning `instruc.select` is what keeps it on the loud path.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a declared alias that is never rendered is not treated as projected (#423)" begin
+  # `"gg" => "note"` has `_as == "note"`, which the bare `"note"` entry already cached, so the
+  # second projection collapses onto the first and renders `as "note"` — `gg` never appears.
+  collapsed = AO.Ao_child.objects
+  collapsed.values("note", "gg" => "note")
+
+  # Confirm the premise rather than assuming it: if the collapse ever stops happening, this testset
+  # is testing nothing and should be rewritten, not silently pass.
+  @test !occursin("as \"gg\"", inspect_query(collapsed; connection = _AO_PG)[:sql_text])
+
+  # These two are the discriminating assertions: under the declared-list scan, `order_by("gg")`
+  # took the `found_in_select` branch and rendered `ORDER BY "gg"` without throwing at all.
+  # The cause is asserted too — this function raises more than one error type, so a bare type check
+  # would not prove the right one fired.
+  for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
+    @testset "$label" begin
+      ordered = AO.Ao_child.objects
+      ordered.values("note", "gg" => "note")
+      ordered.order_by("gg")
+      err = try
+        inspect_query(ordered; connection = conn)
+        nothing
+      catch e
+        e
+      end
+      @test err isa PormG.UnknownFieldError
+      @test occursin("gg", sprint(showerror, err))
+    end
+  end
+
+  # ...and the ambiguity guard must not fire on a name only ONE rendered column carries. Here
+  # `"z" => "note"` collapses away, so exactly one `as "z"` is emitted and the sort is unambiguous.
+  # Scanning the declared list reported a collision between `note` and `qty` that the SQL does not
+  # contain — the same review finding, in its false-positive direction.
+  #
+  # The discriminating part is that this RENDERS AT ALL: under the declared-list scan the guard
+  # raised here. The `count == 1` below is a premise check like the one above — it describes
+  # `get_select_query`'s collapse, which this fix does not touch, so it holds in either state.
+  single = AO.Ao_child.objects
+  single.values("note", "z" => "note", "z" => "qty")
+  single.order_by("z")
+  single_sql = inspect_query(single; connection = _AO_PG)[:sql_text]
+  @test count("as \"z\"", single_sql) == 1
+  @test occursin("ORDER BY \"z\" ASC", single_sql)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Controls: every path that must stay byte-identical
+# Two combinations change — `found_in_select` on a cache MISS (the branch inversion) and
+# `found_in_select` on a cache HIT where the alias is genuinely ambiguous (the guard, which is not
+# cache-gated). These pin the rest, and they are the real content of this file: the risk of this fix
+# is not that the new shapes fail, it is that an old one moves.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "shapes that already worked are unchanged (#423 controls)" begin
+  # Aggregate alias — worked before only because its chosen name IS `_as`, so the cache key matched.
+  agg = AO.Ao_child.objects
+  agg.values("note", "c" => Count("id"))
+  agg.order_by("c")
+  agg_sql = inspect_query(agg; connection = _AO_PG)[:sql_text]
+  @test occursin("COUNT(\"Tb\".\"id\") as \"c\"", agg_sql)
+  @test occursin("ORDER BY \"c\" ASC", agg_sql)
+  # The aggregate must NOT be pushed into GROUP BY — that is what the dead `SQLTypeFunction` skip in
+  # the projection scan would cause if someone "repaired" it. Assert the EXACT clause: an earlier
+  # draft asserted `!occursin("GROUP BY 1, 2", …)`, which is unreachable by construction (this
+  # function pushes resolved SQL expressions into `instruc.group`, never ordinals — a non-projected
+  # order term renders `GROUP BY 1, "Tb"."qty"`), so it passed unconditionally. Review finding.
+  @test occursin("GROUP BY 1 ", agg_sql)
+  @test !occursin("COUNT", split(agg_sql, "GROUP BY")[2])
+
+  # Window alias — same reason, different type.
+  win = AO.Ao_child.objects
+  win.values("note", "r" => Rank(over = WindowOver(partition_by = "parent", order_by = "qty")))
+  win.order_by("r")
+  @test occursin("ORDER BY \"r\" ASC", inspect_query(win; connection = _AO_PG)[:sql_text])
+
+  # Value() alias — an SQLText projection, which caches under `custom_as` in the OTHER branch of
+  # get_select_query. Its parameter must still be bound exactly once.
+  val = AO.Ao_child.objects
+  val.values("note", "lbl" => Value("hi"))
+  val.order_by("lbl")
+  val_res = inspect_query(val; connection = _AO_PG)
+  @test occursin("ORDER BY \"lbl\" ASC", val_res[:sql_text])
+  @test val_res[:parameters] == ["hi"]
+
+  # Ordering by the UNDERLYING path while it is aliased: `_as` is the path, so `found_in_select` is
+  # false and the cache branch resolves it to the qualified selector. Exactly one join.
+  path = AO.Ao_child.objects
+  path.values("note", "s" => "parent__sku")
+  path.order_by("parent__sku")
+  path_sql = inspect_query(path; connection = _AO_PG)[:sql_text]
+  @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", path_sql)
+  @test _ao_joins(path_sql) == 1
+
+  # Unaliased projection: `_as` IS the path, so this took the alias branch before the fix too.
+  bare = AO.Ao_child.objects
+  bare.values("note", "parent__sku")
+  bare.order_by("parent__sku")
+  bare_sql = inspect_query(bare; connection = _AO_PG)[:sql_text]
+  @test occursin("ORDER BY \"parent__sku\" ASC", bare_sql)
+  @test _ao_joins(bare_sql) == 1
+
+  # #404: a path named ONLY by order_by() still discovers and emits its join.
+  only = AO.Ao_child.objects
+  only.values("note")
+  only.order_by("parent__sku")
+  only_sql = inspect_query(only; connection = _AO_PG)[:sql_text]
+  @test occursin("LEFT JOIN \"ao_parent\" AS \"Tb_1\"", only_sql)
+  @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", only_sql)
+  @test _ao_joins(only_sql) == 1
+
+  # A filtered path ordered by the same path: bound once, one join.
+  filt = AO.Ao_child.objects
+  filt.values("note")
+  filt.filter("parent__sku" => "X")
+  filt.order_by("parent__sku")
+  filt_res = inspect_query(filt; connection = _AO_PG)
+  @test occursin("ORDER BY \"Tb_1\".\"sku\" ASC", filt_res[:sql_text])
+  @test filt_res[:parameters] == ["X"]
+  @test _ao_joins(filt_res[:sql_text]) == 1
+
+  # #76: DISTINCT + an ORDER BY term that is genuinely NOT projected must still raise. The guard is
+  # gated on `!found_in_select`, so inverting the branches must not have bypassed it.
+  #
+  # The message is asserted, not just the type: this change adds a SECOND `QueryBuildError` to this
+  # same function (the ambiguity guard), so a bare `@test_throws QueryBuildError` would pass even if
+  # the #76 guard had been bypassed and something else raised. Review finding.
+  d = AO.Ao_child.objects
+  d.values("note")
+  d.distinct(true)
+  d.order_by("qty")
+  d_err = try
+    inspect_query(d; connection = _AO_PG)
+    nothing
+  catch e
+    e
+  end
+  @test d_err isa PormG.QueryBuildError
+  @test occursin("DISTINCT query cannot ORDER BY", sprint(showerror, d_err))
+end


### PR DESCRIPTION
Closes #423

`values()` stores the caller's chosen name in **different fields** depending on what is on the right of the pair:

```julia
values("s" => "parent__sku")  ->  _as = "parent__sku"   custom_as = "s"
values("c" => Count("id"))    ->  _as = "c"             custom_as = nothing
```

`get_select_query` caches under `_as`. `get_order_query` read `custom_as` to decide whether the ORDER BY term named a projection — but that test was nested **inside** a cache hit keyed by `_as`. So for `order_by("s")` the lookup missed, control fell through to `_get_select_query("s")`, and the alias was resolved as a physical column of the base model.

Two symptoms from one line:

| shape | before |
|---|---|
| `values("s" => "parent__sku"); order_by("s")` | ❌ `UnknownFieldError: The field s not found` |
| `values("note" => "qty"); order_by("note")` | ⚠️ **silent** — emitted `ORDER BY "Tb"."note"`, sorting the untouched `note` column while the output column named `note` holds `qty` |
| `values("c" => Count("id")); order_by("c")` | ✅ worked — its chosen name *is* `_as`, so the cache key happened to match |

That last row is the asymmetry the issue reported: the same `"name" => value` syntax working or not depending on what is on the right.

## The change

**1. `found_in_select` is tested first — against the RENDERED projection list.**

Scanning the *declared* list is not equivalent, and the difference is a silent-wrong-answer bug in its own right. `get_select_query` collapses a projection whose `_as` is already cached onto the cached `SQLField` and **discards its `custom_as`**:

```julia
values("note", "gg" => "note")   # renders  as "note"  twice — "gg" never appears
```

Emitting `ORDER BY "gg"` there names neither an output nor an input column: PostgreSQL raises `column "gg" does not exist`, and SQLite's double-quoted-string fallback degrades it to the literal `'gg'` — a constant sort key — returning rows **unsorted with no error**. Scanning `instruc.select` keeps that shape on the loud, backend-aligned path it was already on.

**2. The degraded bare alias is never cached.** The `found_in_select` branch reduces `field` to a bare SELECT alias — legal in ORDER BY, invalid anywhere else — and since #404 the join render reads `instruc.cache`. The inversion made that write newly reachable. Marked **defensive**: no shape is known that reads the cache under a `custom_as` alias.

**3. An ambiguous alias is refused**, keyed on **object identity**.

`.values()` permits two projections sharing a name. Once such a name resolves, `ORDER BY "x"` is ambiguous — PostgreSQL rejects it, SQLite picks one — so refusing at build time is what keeps the backends aligned rather than trading a loud error for a silent divergence. Identity is `get_select_query`'s own dedupe relation, so `values("note", "note")` still renders, by construction rather than by proxy.

Two earlier keys were wrong, and both are recorded at the site so nobody re-derives them:

| key | blind spot |
|---|---|
| `_as` | the `SQLText` branch assigns unconditionally without consulting the cache, so `values("lbl" => Value("a"), "lbl" => Value("b"))` carries one `_as` over two different Params |
| rendered SQL text | SQLite renders every parameter as `?`, so the guard raised on PostgreSQL and stayed silent on SQLite for the same query — a divergence guard introducing a divergence |

## Two combinations change, not one

The inversion moves `found_in_select` on a cache **miss**. The guard, not being cache-gated, also moves `found_in_select` on a **hit** where the alias is genuinely ambiguous: `values("note", "note" => "qty"); order_by("note")` used to render and now raises. PostgreSQL rejected that at execution anyway, so it is the aligned behavior — but it is a second change, and the tests pin it so the "only one" claim cannot quietly regrow.

## Verification

| | |
|---|---|
| Full unit suite | **8444/8444** |
| `db_sl` integration slice (`test_selection.jl`) | green — new testset 8/8, #404 3/3 |
| New unit file | 70 assertions |
| Documented-error cases | 112, incl. a new `DOCERR_CASES` entry pinning the ambiguity type |
| Doc examples | all executed against `db_sl/f1.sqlite` — SQL shape **and** live rows |

Executing the doc examples caught a real error before it shipped: the draft's SQL block said `LEFT JOIN` where the engine renders `INNER JOIN` (`Result.driverid` is a non-null FK).

`db_2` (PostgreSQL) was **not** run — it was not available. The rendering half is covered on both backends through mock connections, and the PostgreSQL semantics the fix depends on were confirmed against the spec rather than assumed:

> *If an ORDER BY expression is a simple name that matches both an output column name and an input column name, ORDER BY will interpret it as the output column name.*

That is what makes the shadowing case (`values("note" => "qty"); order_by("note")`) correct rather than merely different, and it means PostgreSQL and SQLite agree.

## Deliberately not done

**No `UPGRADING.md` entry.** #423 is a fix to already-broken behavior — a query that raised now works, and one that sorted the wrong column now sorts the right one. The one shape that goes from *rendering* to *raising* (the ambiguity guard) was already a runtime error on PostgreSQL and arbitrary ordering on SQLite, so no app was relying on it working. Happy to add one if you read that differently.

**One accepted over-refusal, documented at the site:** two `Value(nothing)` projections under one alias render `NULL as "lbl"` twice. PostgreSQL parses those as equal `Const`s and accepts; PormG refuses with "over NULL and NULL". Harmless — ordering by a doubly-projected NULL is meaningless — and it fails loud rather than silently.

**A pre-existing taxonomy leak left alone.** An ORDER BY term with a `nothing` alias (reachable via a bare `Value("hi")` in `values()` plus `SQLOrder(SQLField(f, nothing))`) raises a raw `MethodError`, outside the error taxonomy (#231/#239). Measured against `origin/main`: it raises the *identical* MethodError there. The new guard restores exact parity rather than fixing it; the leak is pre-existing and tracked separately.

**Two pre-existing bugs surfaced, not filed yet** — both from the same `get_select_query` collapse that finding 1 above turns on:

- `values("n" => Count("id"), "n" => Sum("qty"))` renders `COUNT` twice; the `Sum` is silently discarded.
- `values("h" => Exists(i1), "h" => Exists(i2))` is the severe half: on SQLite it emits **two `?` against one bound parameter** — positional misalignment — and on PostgreSQL renders `$1` twice, so it is also a backend divergence.

## Review

Four independent rounds, each finding something real. Two were behavioral defects in my own work (the phantom-alias regression in item 1, and a backend split introduced by the rendered-text key), and several were claims of mine that turned out false — including one written *as the fix* for a previous finding. One reviewer finding was itself wrong and is corrected above: the `nothing`-alias MethodError is pre-existing, not introduced here, verified by measuring `origin/main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
