### PR TITLE
fix(#438): upgrade_guide sees every entry the writing rules describe

### DIFF
--- a/.github/skills/pormg-cut-release/SKILL.md
+++ b/.github/skills/pormg-cut-release/SKILL.md
@@ -55,8 +55,31 @@ PORMG_DB=db_sl julia --project=test/integration test/integration/runtests.jl   #
 
 ## Steps
 
-1. **List the wave.** Show every `## Unreleased` entry title and its `**Severity**`, so the maintainer
-   sees exactly what's shipping. Count them.
+1. **List the wave — through the parser, not by eye.** Show every `## Unreleased` entry title and its
+   `**Severity**`, so the maintainer sees exactly what's shipping. Get the list from
+   `upgrade_guide`, which is what a consumer will actually run:
+
+   ```bash
+   julia --project=. -e 'using PormG
+     w = PormG.upgrade_guide(from = pkgversion(PormG), structured = true)
+     println(length(w), " entries")
+     for e in w
+       sev = match(r"(?m)^-[ \t]+\*\*Severity\*\*:[ \t]*(.+)$", e.body)
+       println("  ", e.title, "\n      ", sev === nothing ? "(no Severity bullet)" : sev[1])
+     end'
+   ```
+
+   Then **cross-check that count against the headings** — if they disagree, an entry is invisible to
+   the guide and cutting would ship it unannounced:
+
+   ```bash
+   grep -c '^- \*\*Version\*\*: Unreleased' UPGRADING.md   # template block adds 1
+   ```
+
+   This is #438: of an 11-entry wave, `upgrade_guide` returned **3** — three entries never reached
+   any guide, and five more were merged into a neighbour's body and rendered under its title.
+   Every step below passed anyway. `test/unit/test_upgrade_guide.jl` now fails on that state —
+   run it here if the counts disagree, it will name the heading.
 
 2. **Choose the new version.** Read the current `version` in `Project.toml`.
    - **Default: bump the `y` slot** (`0.a.z → 0.(a+1).0`) — a train that carries any
@@ -69,6 +92,17 @@ PORMG_DB=db_sl julia --project=test/integration test/integration/runtests.jl   #
 4. **Stamp `UPGRADING.md`** (use today's real date, `YYYY-MM-DD`):
    - For **each** entry currently under `## Unreleased`: replace its
      `- **Version**: Unreleased` line with `- **Version**: <new>`.
+   - **Add a `- **Recorded**: <date-the-entry-landed>` bullet to any entry missing one** (between
+     `- **PormG ref**:` and `- **Severity**:`, as the template has it). `Recorded` is the date the
+     change landed, **not** the cut date. Recover it from the **oldest** pickaxe match, not the
+     newest — a later reword of the heading would otherwise hand you its edit date:
+
+     ```bash
+     git log --reverse --format='%as' -S'<the entry heading line>' -- UPGRADING.md | head -1
+     ```
+
+     Every entry carries one as of #438; keep it that way, because the file header promises this
+     step "dates them".
    - Replace the `## Unreleased — next \`<x>\`` heading (and its italic placeholder note) with
      `## <new> — <YYYY-MM-DD>`.
    - Insert a **fresh empty** `## Unreleased — next \`<next-y>\`` block at the very top of the entries
@@ -86,8 +120,18 @@ PORMG_DB=db_sl julia --project=test/integration test/integration/runtests.jl   #
    - Leave already-stamped (older) entries untouched.
 
 5. **Verify the parser.** Run `julia --project=. test/unit/test_upgrade_guide.jl` (via a runner that
-   loads drivers, or the full `test/runtests.jl`). The stamped entries must now parse at `<new>` and
-   the empty `## Unreleased` must produce no entries. Fix any mismatch before committing.
+   loads drivers, or the full `test/runtests.jl`). Then assert the stamp actually landed — the count
+   must match step 1's, at the new version, with `## Unreleased` now empty:
+
+   ```bash
+   julia --project=. -e 'using PormG
+     println("at <new>  : ", length(PormG.upgrade_guide(from = v"<previous>", to = v"<new>", structured = true)))
+     println("uncut     : ", count(e -> e.version == PormG._UNRELEASED_VERSION, PormG._read_upgrading_entries()))'
+   ```
+
+   Expect `at <new>` == the step-1 count and `uncut` == 0. Fix any mismatch before committing —
+   before #438 this step read *"the stamped entries must now parse"* with nothing to check it, and
+   the precondition passed while being false.
 
 6. **Commit** (respect the commit gate — show the diff, get explicit approval):
    `chore(release): cut <new>` with the entry titles in the body.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,13 @@ Tracks **breaking / behavior changes in PormG** that require source-code changes
   release number when cutting a train (`/pormg-cut-release`).
 - Each entry records: the PormG **version** it shipped in, what changed, why, a *"How to find the
   calls to migrate"* grep, and the concrete **before → after** code edit.
+- **What makes it an entry, for `upgrade_guide`:** its `##` heading, plus a `- **Version**:` bullet
+  at the **start of a line**. Nothing else. The `---` rules between entries are visual — the parser
+  does not split on them — and `- **Recorded**:` is metadata, not a marker. Copying the template
+  block at the bottom of this file gives you both bullets. (#438: the parser used to require `---`
+  **and** `- **Recorded**:`, which these rules never asked for. Nine headings written to spec were
+  lost — three never reached any guide, six were rendered under a neighbour's title — and
+  `upgrade_guide(from = v"0.4.0")` returned 3 entries of 11.)
 - **Not for additive features.** This log is only what **forces** an app edit. A new opt-in
   capability (operator, kwarg, function) requires no change to keep an app working → document it in
   `docs/`, not here.
@@ -43,6 +50,7 @@ consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates
 - **Version**: Unreleased
 - **PormG ref**: #424 (landed with #421); `src/querybuilder/build_query.jl`,
   `docs/src/read/custom_joins.md`
+- **Recorded**: 2026-08-25
 - **Severity**: **behavior change (very narrow)** — two shapes that silently returned row-multiplied
   results now raise at query-build time. Part of the `0.5.x` pre-publish wave.
 
@@ -170,12 +178,15 @@ q.filter("ev__year" => 2009)
 > (`filter("raceid" => F("ev__raceid"))`, #44), never by a literal predicate. If you are not writing
 > that comparison, you want `join_field`.
 
+---
+
 ## A CTE joined in a correlated `UPDATE … FROM` is refused instead of emitting broken SQL (#394)
 
 - **Version**: Unreleased
 - **PormG ref**: #394; `src/querybuilder/sanitization.jl`, `src/querybuilder/execution.jl`,
   `src/Dialect.jl`, `src/Generator.jl`, `src/migrations/planner.jl`,
   `docs/src/schema_conventions.md`
+- **Recorded**: 2026-08-24
 - **Severity**: **behavior change (very narrow)** — one shape that was already failing now fails
   earlier and with a message. Everything else in #394 is a widening and forces nothing. Part of the
   `0.5.x` pre-publish wave.
@@ -243,11 +254,14 @@ M.Result.objects.
     update("points" => 25)
 ```
 
+---
+
 ## Reverse accessors — every relation in a multi-relation group is disambiguated (#396)
 
 - **Version**: Unreleased
 - **PormG ref**: #396; `src/Models.jl`, `docs/src/many_to_many.md`,
   `docs/src/read/values_and_joins.md`, `docs/src/fields.md`, `src/models/fields.jl`
+- **Recorded**: 2026-08-24
 - **Severity**: **breaking (narrow, source-visible)** — a model declaring **two or more** relations to
   the same target model, with `related_name` omitted on any of them, now installs different reverse
   accessors on that target. A lookup path or a `related_objects[…]` read using the old key raises
@@ -538,11 +552,14 @@ Then `makemigrations()` again; the plan should be empty. That empty second plan 
 of #409 — before it, that column churned on every run and there was no model you could write to
 stop it.
 
+---
+
 ## `bulk_update` — a `match_on` key PormG would auto-populate is refused, not bound (#379)
 
 - **Version**: Unreleased
 - **PormG ref**: #379; `src/querybuilder/execution_bulk.jl`, `docs/src/write/bulk.md`,
   `docs/src/api.md`
+- **Recorded**: 2026-08-21
 - **Severity**: **behavior change (narrow)** — a `bulk_update()` whose `match_on=` (or primary-key
   fallback) names a field PormG auto-populates, and for which the `DataFrame` supplies **no** source
   column, now raises `UnknownFieldError` where it used to run. Runtime, not compile-time. Every other
@@ -648,11 +665,14 @@ timestamp string is fine and is what every example above passes; `DateTimeField`
 the same defect surfacing rather than a new one, and the fix is the same: give the key column values
 the field can actually read.
 
+---
+
 ## Foreign keys — an unresolved `to` target is refused, not lowercased into a table name (#388)
 
 - **Version**: Unreleased
 - **PormG ref**: #388; `src/Models.jl` (`fk_target_table`), `src/querybuilder/build_joins.jl`,
   `docs/src/schema_conventions.md`
+- **Recorded**: 2026-08-18
 - **Severity**: **behavior change (narrow)** — a `ForeignKey`/`OneToOneField` whose `to` names a model
   that is **not in the models module** now raises instead of referencing/joining a fabricated table.
   Runtime, not load time: the models file still loads, and the failure happens when the key is
@@ -722,10 +742,13 @@ its table name differs from the model name:
 Tb_dia_semana = Models.Model("tb_dia_semana", co_dia_semana = Models.IDField())
 ```
 
+---
+
 ## Bulk writes — `columns=` refuses two different source columns for one model field (#380)
 
 - **Version**: Unreleased
 - **PormG ref**: #380; `src/querybuilder/execution_bulk.jl`, `docs/src/write/bulk.md`
+- **Recorded**: 2026-08-14
 - **Severity**: **behavior change (narrow)** — a `columns=` list that names the same model field twice
   from *different* `DataFrame` columns now raises `QueryBuildError` where it used to run. Runtime, not
   compile-time: the call only fails once it executes. Exact repeats are unaffected. Part of the
@@ -795,12 +818,15 @@ bulk_insert(M.Stint.objects, df, columns = ["driver", "c2" => "laps"])
 If both columns genuinely carry data you want, they belong in two different fields — or combine them
 in the `DataFrame` first (`df[!, :laps] = coalesce.(df.c1, df.c2)`) and map that one column.
 
+---
+
 ## `indexes` becomes a model-level option, so a field of that name needs `db_column` (#347)
 
 - **Version**: Unreleased
 - **PormG ref**: #347; `src/constants.jl`, `src/Models.jl`, `src/migrations/planner.jl`,
   `src/migrations/introspection.jl`, `src/migrations/importers.jl`, `docs/src/models.md`,
   `docs/src/import_django.md`
+- **Recorded**: 2026-08-14
 - **Severity**: **breaking (very narrow)** — exactly one case, and it fails loudly at model load.
   Everything else in #347 is additive: the new `Models.Index` type, the `indexes =` keyword, the
   composite-index introspection on both backends, and the Django `Meta.indexes` /
@@ -844,11 +870,14 @@ models file loads — not a silent misread. Query paths that referenced the old 
 (`"indexes"`, `"indexes__@gt"`, `values("indexes")`) must move to the new one; the physical column,
 and therefore every schema, is untouched, so no migration is generated.
 
+---
+
 ## Multi-app Django import: `ignore_table` removed, `Model_to_str` drops `settings`, unresolvable relations degrade (#346)
 
 - **Version**: Unreleased
 - **PormG ref**: #346; `src/Models.jl`, `src/migrations/importers.jl`, `docs/src/import_django.md`,
   `docs/src/schema_conventions.md`, `docs/src/configuration/connection_yml.md`
+- **Recorded**: 2026-08-14
 - **Severity**: **breaking (narrow)** — **five** cases. The first two are compile-time: a removed
   keyword and a removed positional argument, so an affected call fails loudly with a `MethodError`
   the first time it runs. The rest fire only when you **regenerate** a Django import — one for
@@ -1734,6 +1763,9 @@ q = M.Result.objects.
 Note the argument shape differs: the free function took the CTE name and sub-query as two positional
 arguments plus `q.object` (the underlying `SQLObject`); the fluent method takes a `Pair` and operates
 on the handler. Same for `cjoin(query, "result" => "Result")` → `query.cjoin("result" => "Result")`.
+
+---
+
 ## A positional model name must be lowercase (#300)
 
 - **Version**: 0.4.0

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -160,9 +160,9 @@ const _UpgradeEntry = @NamedTuple{version::VersionNumber, title::String, body::S
 # written by `/pormg-cut-release`. It groups the entries of one release; it is NOT an entry title.
 #
 # The em-dash separator is REQUIRED, not decoration: without it this also matches a real entry whose
-# title merely starts with a version (`## 0.5.0 config format is now strict`), and the parser then
-# finds no other `##` in that block and drops the entry SILENTLY — it just disappears from the
-# guide. Both forms `/pormg-cut-release` writes carry the separator, so requiring it costs nothing.
+# title merely starts with a version (`## 0.5.0 config format is now strict`), and that entry's
+# whole segment is then skipped as a marker — it disappears from the guide SILENTLY, no error.
+# Both forms `/pormg-cut-release` writes carry the separator, so requiring it costs nothing.
 const _RELEASE_MARKER = r"^(?:Unreleased|\d+\.\d+\.\d+)\s+—"
 
 _asver(v::VersionNumber) = v
@@ -189,10 +189,20 @@ Parse raw `UPGRADING.md` text into change entries, newest-first (see `_read_upgr
 Split out so the parser can be exercised on hand-fed text — the CRLF-robustness regression in
 particular — without touching the on-disk file.
 
+An entry is delimited by its own `## ` heading and runs to the next one — the marker
+`UPGRADING.md`'s *"Writing an entry"* rules actually mandate. The `---` rules between entries are
+decorative and the parser does not depend on them.
+
+#438: it used to split on `^---\$` and gate each block on a `- **Recorded**:` bullet, neither of
+which the writing rules ever asked for. Nine headings written to spec were lost — three
+(`#424`, `#394`, `#396`) never reached any guide at all, and six (`#379`, `#388`, `#380`, `#347`,
+`#346`, and `#300` since `0.4.0` shipped) were merged into a neighbour's body and rendered under
+its title. `upgrade_guide(from = v"0.4.0")` returned 3 entries of 11.
+
 Line endings are normalized to `\\n` up front: a Windows checkout can store `UPGRADING.md`
-with `\\r\\n` (only `*.jl`/`*.sh` are pinned to `eol=lf`), and the `(?m)^---[ \\t]*\$` block
-separator never matches a `---\\r` line — without this the whole file collapses into a single
-bogus entry and every scoped lookup comes back empty.
+with `\\r\\n` (only `*.jl`/`*.sh` are pinned to `eol=lf`), and a `(?m)…\$` anchor never sees past
+a trailing `\\r` — so headings and bullets would match inconsistently and the parse would be
+platform-dependent.
 """
 function _parse_upgrading(text::AbstractString)
     text = replace(text, "\r\n" => "\n", "\r" => "\n")
@@ -203,44 +213,106 @@ function _parse_upgrading(text::AbstractString)
     tmpl === nothing || (text = text[1:prevind(text, first(tmpl))])
 
     entries = _UpgradeEntry[]
-    for block in split(text, r"(?m)^---[ \t]*$")
-        # `/pormg-cut-release` writes the release marker (`## 0.3.0 — 2026-07-24`) directly above
-        # the first entry of that release with NO `---` between them, so the first `##` in a block
-        # is not necessarily the entry's own heading. Take the first non-marker heading instead —
-        # otherwise the first entry of every release is titled with the release date and its real
-        # title is lost (visible via `structured = true`).
-        title_m = nothing
-        for h in eachmatch(r"(?m)^##[ \t]+(.+)$", block)
-            occursin(_RELEASE_MARKER, strip(h[1])) && continue
-            title_m = h
-            break
-        end
 
-        # A real change entry has a non-marker `## ` heading AND a `- **Recorded**:` bullet — this
-        # rejects the header/recipe prose and any stray section, regardless of `---` placement.
-        (title_m === nothing || !occursin(r"(?m)^-[ \t]+\*\*Recorded\*\*:", block)) && continue
+    # Segment on the entry heading itself. Each segment runs from its `## ` to just before the
+    # next one, so a body ALWAYS starts at its own heading: a release marker written directly
+    # above the first entry of a release (`/pormg-cut-release` emits it with no `---` between) is
+    # its own skipped segment rather than something to trim off, and every entry renders
+    # identically no matter where it sits in a release.
+    #
+    # The flip side is that a stray `## ` inside an entry body would split that entry. There is
+    # none today, and `test_upgrade_guide.jl` fails if one appears: it asserts every non-marker
+    # heading below the first release marker comes back as a parsed entry.
+    heads = collect(eachmatch(r"(?m)^##[ \t]+(.+?)[ \t]*$", text))
+    for (i, h) in enumerate(heads)
+        occursin(_RELEASE_MARKER, h[1]) && continue
 
+        stop  = i < length(heads) ? prevind(text, heads[i + 1].offset) : lastindex(text)
+        block = text[h.offset:stop]
+
+        # A real change entry carries `- **Version**:` (the policy from 0.2.0 on) or
+        # `- **Recorded**:` (pre-0.2 history, written before that policy existed). The header
+        # prose and the "Writing an entry" recipe carry neither — their only `- **Version**:`
+        # mention is indented inside backticks, which `^-` does not match.
         ver_m = match(r"(?m)^-[ \t]+\*\*Version\*\*:[ \t]*(\S+)", block)
+        (ver_m === nothing && !occursin(r"(?m)^-[ \t]+\*\*Recorded\*\*:", block)) && continue
+
         version = ver_m === nothing        ? _UNSTAMPED_VERSION  :
                   ver_m[1] == "Unreleased" ? _UNRELEASED_VERSION :
                                              VersionNumber(ver_m[1])
 
-        # Start the body at the entry's own heading. This drops a leading release marker, so every
-        # entry renders identically — previously only the first entry of a release carried the
-        # `## <ver> — <date>` line, making later entries from *other* releases look like they
-        # belonged to it. Each entry states its own `- **Version**:`, so nothing is lost.
-        body = block[title_m.offset:end]
-
         # Trim the internal per-app rollout table (which of PormG's own apps adopted it) —
         # noise for a consuming app, which only needs the porting work.
+        body = block
         roll = findfirst("### Per-app rollout", body)
         roll === nothing || (body = body[1:prevind(body, first(roll))])
 
         push!(entries, (version = version,
-                        title = String(strip(title_m[1])),
-                        body = String(strip(body))))
+                        title = String(h[1]),
+                        body = _trim_trailing_structure(body)))
     end
     return entries
+end
+
+# A trailing `---` rule, and a trailing HTML comment (the `<!-- pre-0.2 history (unstamped) -->`
+# divider).
+#
+# THE INVARIANT: peel only WHOLE LINES of structure, never reach into a line that carries prose.
+# Every piece of both patterns exists to hold it, and it is not decorative — this function ate an
+# entry's content twice in review before the invariant was stated:
+#
+#   `\z`               anchors to the end. Structure is peeled off the tail; a rule or a comment
+#                      INSIDE an entry's prose is content and must survive, so neither pattern may
+#                      ever be applied globally.
+#   `(?:\A|\n)[ \t]*`  anchors the START to a line. Without it, `match` takes the leftmost viable
+#                      position, so a stray `<!--` anywhere in the body — a code fence documenting
+#                      HTML, a mid-line mention — paired with any `-->` at the tail swallowed
+#                      everything between them. Measured on a 400-line body: 11,645 chars → 33.
+#                      An unclosed `<!--` inside a fence was worse than lost content: it left the
+#                      fence open, and `upgrade_guide` prints entries into one stream, so every
+#                      LATER entry disappeared into it too.
+#   `(?!-->|<!--)`     tempers the scan so it crosses neither a closed comment nor another opener.
+#                      The `-->` half keeps an interior closed comment intact. The `<!--` half is
+#                      what saves the fence case, where the stray opener IS at a line start and
+#                      the line anchor alone cannot help.
+#   `[\s\S]`           spans newlines, so a multi-line comment is one unit. A single-line-only tail
+#                      check leaked a multi-line divider exactly the way the first cut of this
+#                      leaked the single-line one.
+#
+# `[ ]{0,3}` on the left, NOT `[ \t]*`: CommonMark allows up to three spaces of indent on a
+# thematic break, and four spaces or a tab makes the line an indented CODE BLOCK instead. An
+# unbounded class peels the last line of a code sample the consumer is meant to copy.
+#
+# Known residual, deliberately not chased further: a line-start `<!--` that is never closed, in a
+# body that ends with a prose `-->`, is still peeled along with everything between them. It needs
+# all four conditions at once, `UPGRADING.md` contains no such shape, and the text really is an
+# HTML comment unless a code fence makes it literal — which no regex can know. Tightening past
+# this point costs more than it buys.
+const _TRAILING_RULE    = r"(?:\A|\n)[ ]{0,3}---[ \t]*\z"
+const _TRAILING_COMMENT = r"(?:\A|\n)[ ]{0,3}<!--(?:(?!-->|<!--)[\s\S])*-->[ \t]*\z"
+
+# Drop the file structure that visually precedes the NEXT heading — blank lines, `---` rules and
+# HTML comments. None of it is the entry's content; a segment simply runs up to the next `##`, so
+# all of it lands in this one's tail.
+#
+# All three, not just rules: the divider sits BELOW its rule, so a rule-only trim leaves `---`
+# *and* the comment in `#197`'s rendered body. Caught in review — and the assertion written to
+# catch that leak (`!endswith(body, "---")`) passed anyway, because the leak ends in `-->`.
+#
+# Peeling in a loop rather than one pass: rule and comment alternate, and either may be outermost.
+# It terminates because both patterns require a non-empty match anchored at `\z`, so `s` loses at
+# least three bytes per iteration.
+function _trim_trailing_structure(body::AbstractString)
+    s = rstrip(body)
+    while true
+        m = match(_TRAILING_COMMENT, s)
+        if m === nothing
+            m = match(_TRAILING_RULE, s)
+            m === nothing && break
+        end
+        s = rstrip(s[1:prevind(s, m.offset)])
+    end
+    return String(strip(s))
 end
 
 """

--- a/test/unit/test_upgrade_guide.jl
+++ b/test/unit/test_upgrade_guide.jl
@@ -223,4 +223,238 @@ using PormG
         @test length(marked) == 1
         @test marked[1].title == "A real change (#9201)"
     end
+
+    # ══ #438 — the parser and UPGRADING.md's own "Writing an entry" rules must agree ══════════
+    #
+    # The parser used to split on `^---$` and gate each block on a `- **Recorded**:` bullet. The
+    # writing rules mandate NEITHER, so nine headings written exactly to spec were lost: three
+    # (#424, #394, #396) never reached any guide, and six (#379, #388, #380, #347, #346, and #300
+    # since 0.4.0 shipped) were merged into a neighbour's body and rendered under its title.
+    # `upgrade_guide(from = v"0.4.0")` returned 3 of 11. Nothing caught it — every other assertion
+    # in this file keys on frozen historical facts or on `!isempty(...)`, which the 40 older
+    # entries satisfied no matter how many new ones were dropped.
+    #
+    # Three layers, and they cover different things — do not collapse them:
+    #
+    #   A + B + E run against the REAL file and guard file↔parser AGREEMENT. They fail the moment
+    #     an entry is written that the parser cannot see (B), that it can see but files under the
+    #     wrong version (E), or that it silently merges into a neighbour (A). They are deliberately
+    #     blind to a parser regression on their own: with every entry carrying both of the old
+    #     markers, the pre-#438 parser also passes them. That is not a gap, it is their scope.
+    #   C + D pin the parser CONTRACT on hand-fed text — reverting `_parse_upgrading` to the
+    #     `---`/`Recorded` gate fails them immediately.
+    #   The `_trim_trailing_structure` testset pins the tail trimmer directly, on shapes the real
+    #     file does not contain and the file-level guards therefore cannot reach.
+    #
+    # Every one of them was mutation-tested before landing — each fails under a change that
+    # reintroduces the defect it describes. Together they are the only thing standing between a
+    # written entry and a consumer never being told to port it.
+
+    # ── A: every declared entry is a parsed entry ──────────────────────────────
+    @testset "every `- **Version**:` bullet parses as its own entry (#438)" begin
+        path = joinpath(pkgdir(PormG), "UPGRADING.md")
+        raw  = read(path, String)
+
+        # Same two normalizations the parser does, so the count is over the same text.
+        text = replace(raw, "\r\n" => "\n", "\r" => "\n")
+        tmpl = findfirst("## Template for new entries", text)
+        tmpl === nothing || (text = text[1:prevind(text, first(tmpl))])
+
+        declared = length(collect(eachmatch(r"(?m)^-[ \t]+\*\*Version\*\*:", text)))
+        parsed   = PormG._parse_upgrading(raw)
+        stamped  = count(e -> e.version != PormG._UNSTAMPED_VERSION, parsed)
+
+        @test declared > 0                # the file always has stamped entries
+
+        # Name the offending heading on failure — a bare count mismatch sends the maintainer
+        # hunting through 3700 lines for which entry the parser could not see.
+        #
+        # Re-segment to do it: `declared - stamped` is by definition "headings whose OWN segment
+        # declares a `- **Version**:` but produced no entry", so the segment must be re-derived to
+        # single one out. Listing every unparsed heading instead would bury the culprit among the
+        # four that never parse by design — and the likeliest culprit is a marker-shaped title,
+        # which would sit camouflaged among the three real release markers.
+        if stamped != declared
+            seen  = Set(e.title for e in parsed)
+            heads = collect(eachmatch(r"(?m)^##[ \t]+(.+?)[ \t]*$", text))
+            culprits = String[]
+            for (i, h) in enumerate(heads)
+                h[1] in seen && continue
+                stop = i < length(heads) ? prevind(text, heads[i + 1].offset) : lastindex(text)
+                occursin(r"(?m)^-[ \t]+\*\*Version\*\*:", text[h.offset:stop]) &&
+                    push!(culprits, String(h[1]))
+            end
+            @info "declared an entry but did not parse as one" culprits
+        end
+        @test stamped == declared         # …and every declared entry came back as an entry
+
+        # `---` rules and the `<!-- pre-0.2 history -->` divider are file structure, never content.
+        # NOT `!endswith(body, "---")`: the divider sits below its rule, so a real leak ends in
+        # `-->` and slips straight past a tail check. That weaker assertion shipped in the first
+        # cut of this testset and passed while `#197`'s body carried both (found in review).
+        @test all(e -> !occursin(r"(?m)^---[ \t]*$", e.body), parsed)
+        @test all(e -> !occursin("pre-0.2 history", e.body), parsed)
+    end
+
+    # ── B: no entry heading is silently dropped ────────────────────────────────
+    # Structural, not a whitelist: everything above the first release marker is prose (the file
+    # header and these very rules), everything below it is entries. So each non-marker heading
+    # from the first marker on must come back as exactly one parsed title.
+    #
+    # This also guards the one hazard heading-based segmentation introduces — a stray `## ` inside
+    # an entry body would split that entry, and the orphaned half would show up here as an
+    # unparsed heading instead of silently truncating the entry.
+    @testset "no entry heading is silently dropped (#438)" begin
+        path = joinpath(pkgdir(PormG), "UPGRADING.md")
+        raw  = read(path, String)
+
+        text = replace(raw, "\r\n" => "\n", "\r" => "\n")
+        tmpl = findfirst("## Template for new entries", text)
+        tmpl === nothing || (text = text[1:prevind(text, first(tmpl))])
+
+        heads = [String(m[1]) for m in eachmatch(r"(?m)^##[ \t]+(.+?)[ \t]*$", text)]
+        marker_at = findfirst(h -> occursin(PormG._RELEASE_MARKER, h), heads)
+        @test marker_at !== nothing
+
+        expected = filter(h -> !occursin(PormG._RELEASE_MARKER, h), heads[marker_at:end])
+        titles   = [e.title for e in PormG._parse_upgrading(raw)]
+
+        # Named so a failure prints WHICH heading vanished, not just a count mismatch.
+        unparsed = setdiff(expected, titles)
+        unexpected = setdiff(titles, expected)
+        @test unparsed == String[]
+        @test unexpected == String[]
+        @test length(titles) == length(expected)   # no heading parsed twice
+    end
+
+    # ── E: only genuine pre-0.2 history may omit `- **Version**:` ──────────────
+    # The parser accepts `- **Recorded**:` alone as an entry marker, because the pre-0.2 history
+    # predates the `- **Version**:` policy and has no such bullet. That leniency has a sharp edge:
+    # a NEW entry carrying `Recorded` but not `Version` — an easy slip, the two are adjacent in
+    # the template — parses at `_UNSTAMPED_VERSION`, sorts below 0.2.0, and is invisible to every
+    # consumer on ≥ 0.2.0. That is #438's own failure mode in a new place, and A and B both pass
+    # through it: A counts only declared bullets, B only asks that the heading parsed at all.
+    #
+    # So pin the population instead — unstamped entries are exactly the ones below the divider,
+    # and that set is closed. It never grows again.
+    @testset "only pre-0.2 history entries may omit `- **Version**:` (#438)" begin
+        path = joinpath(pkgdir(PormG), "UPGRADING.md")
+        raw  = read(path, String)
+
+        text = replace(raw, "\r\n" => "\n", "\r" => "\n")
+        tmpl = findfirst("## Template for new entries", text)
+        tmpl === nothing || (text = text[1:prevind(text, first(tmpl))])
+
+        # Match the divider COMMENT, not the bare phrase — "Writing an entry" names the marker in
+        # prose hundreds of lines above it, and `findfirst` on the phrase lands there instead.
+        divider = match(r"<!--[^\n]*pre-0\.2 history[^\n]*-->", text)
+        @test divider !== nothing        # the marker `UPGRADING.md`'s own rules point at
+        # Bail rather than let `divider.offset` throw a `FieldError` over the real diagnosis:
+        # every assertion below is about where the divider IS, so a missing one has one cause.
+        divider === nothing && return
+
+        below = count(m -> m.offset > divider.offset && !occursin(PormG._RELEASE_MARKER, m[1]),
+                      eachmatch(r"(?m)^##[ \t]+(.+?)[ \t]*$", text))
+        unstamped = count(e -> e.version == PormG._UNSTAMPED_VERSION,
+                          PormG._parse_upgrading(raw))
+
+        @test below > 0
+        @test unstamped == below
+    end
+
+    # ── C: the contract the writing rules actually state ───────────────────────
+    # A `## ` heading plus a line-start `- **Version**:` — no `---`, no `- **Recorded**:`. This is
+    # the exact shape of the eight entries #438 was filed for.
+    @testset "an entry needs neither `---` nor `- **Recorded**:` (#438)" begin
+        text = "# fixture\n\n" *
+               "## Writing an entry\n\n- One `##` entry per change, with\n" *
+               "  `- **Version**: Unreleased` on it.\n\n" *
+               "## Unreleased — next `0.9.0`\n\n" *
+               "## First uncut change (#9300)\n\n- **Version**: Unreleased\n\nFirst body.\n\n" *
+               "## Second uncut change (#9301)\n\n- **Version**: Unreleased\n\nSecond body.\n"
+        parsed = PormG._parse_upgrading(text)
+
+        @test length(parsed) == 2
+        @test parsed[1].title == "First uncut change (#9300)"
+        @test parsed[2].title == "Second uncut change (#9301)"
+        @test all(e -> e.version == PormG._UNRELEASED_VERSION, parsed)
+
+        # The regression itself: without a `---` between them the first entry used to swallow the
+        # second, which then never appeared under its own title or its own version.
+        @test occursin("First body.", parsed[1].body)
+        @test !occursin("Second uncut change", parsed[1].body)
+        @test occursin("Second body.", parsed[2].body)
+
+        # The writing rules themselves are prose, not an entry — their `- **Version**:` mention is
+        # indented inside backticks, which the line-start marker does not match.
+        @test !any(e -> occursin("Writing an entry", e.title), parsed)
+    end
+
+    # ── the tail trimmer, directly ─────────────────────────────────────────────
+    # `_trim_trailing_structure` is the one piece of #438 with a silent failure mode: whatever it
+    # fails to strip is rendered to the consumer, and whatever it strips too eagerly is content
+    # they never see. Both halves are pinned below, and the second half needs its own coverage
+    # because NO file-level guard can reach it — testset A asserts a body contains no stray rule
+    # and no divider, and eating content makes both of those assertions *more* satisfied. B only
+    # checks headings, which sit at a body's start and always survive. An over-strip is invisible
+    # everywhere except here.
+    @testset "`_trim_trailing_structure` peels structure, keeps content (#438)" begin
+        T = PormG._trim_trailing_structure
+
+        # strips: blanks, rules, single- and multi-line comments, in any order
+        @test T("Body.")                              == "Body."
+        @test T("Body.\n\n\n")                        == "Body."
+        @test T("Body.\n\n---\n")                     == "Body."
+        @test T("Body.\n\n---\n\n<!-- div -->")       == "Body."
+        @test T("Body.\n\n---\n\n<!--\nmulti\n-->")   == "Body."   # multi-line: one unit
+        @test T("Body.\n\n<!-- x -->\n")              == "Body."
+        @test T("Body.\n\n<!-- x -->\n\n---\n")       == "Body."   # alternating, either outermost
+
+        @test T("Body.\n\n  ---\n")                   == "Body."   # ≤3 spaces: still a rule
+
+        # …but 4 spaces or a tab makes it an indented CODE BLOCK, not a rule. Peeling there
+        # deletes the last line of a code sample the consumer is meant to copy.
+        @test T("Body.\n\n    ---\n")                 == "Body.\n\n    ---"
+        @test T("Body.\n\n\t---\n")                   == "Body.\n\n\t---"
+        @test T("Example:\n\n    key: v\n    ---\n")  == "Example:\n\n    key: v\n    ---"
+
+        # keeps: anything interior
+        @test T("Top\n\n---\n\nBottom.")              == "Top\n\n---\n\nBottom."
+        @test T("Top\n<!-- keep -->\nBottom.")        == "Top\n<!-- keep -->\nBottom."
+        @test T("```html\n<!-- keep me -->\n```")     == "```html\n<!-- keep me -->\n```"
+
+        # near-misses that are markdown content, not a rule
+        @test T("Body.\n\n----\n")                    == "Body.\n\n----"
+        @test T("Body.\n\n| --- |\n")                 == "Body.\n\n| --- |"
+
+        # ── the over-strip half: a line carrying prose is never peeled, whole or in part ──
+        # This is the invariant, and it is the one this function broke twice. A trimmer that can
+        # only remove whole structural LINES cannot delete prose by construction; one that can
+        # start matching mid-line always can. Every row below returned less — sometimes far less —
+        # than its input under an earlier cut.
+        @test T("<!-- a --> VISIBLE <!-- b -->")      == "<!-- a --> VISIBLE <!-- b -->"
+
+        # a stray opener + any `-->` at the tail used to swallow everything between them
+        @test T("stray <!-- opener\n\nKEEP ME\n\n<!-- div -->") == "stray <!-- opener\n\nKEEP ME"
+        @test T("prose with <!-- open\nMORE PROSE\nthe arrow points -->") ==
+              "prose with <!-- open\nMORE PROSE\nthe arrow points -->"
+
+        # worst case: an unclosed opener inside a fence. Losing the content is the small half —
+        # eating the closing fence leaves it open, and `upgrade_guide` prints entries into one
+        # stream, so every LATER entry vanishes into it as well.
+        @test T("```html\n<!-- unclosed\n```\nKEEP\n\n<!-- div -->") ==
+              "```html\n<!-- unclosed\n```\nKEEP"
+    end
+
+    # ── the `---` rule is a visual separator, never content ────────────────────
+    @testset "a decorative `---` rule never reaches an entry body (#438)" begin
+        parsed = PormG._parse_upgrading(
+            "# fixture\n\n## 0.9.0 — 2026-09-09\n\n" *
+            "## A change (#9400)\n\n- **Version**: 0.9.0\n\nBody.\n\n---\n\n" *
+            "## Another change (#9401)\n\n- **Version**: 0.9.0\n\nOther body.\n")
+        @test length(parsed) == 2
+        @test endswith(parsed[1].body, "Body.")
+        @test !occursin("---", parsed[1].body)
+        @test endswith(parsed[2].body, "Other body.")
+    end
 end


### PR DESCRIPTION
Closes #438

## The problem

`PormG.upgrade_guide` is the command `UPGRADING.md`, `docs/src/upgrading.md` and `/pormg-cut-release` all tell a consumer to run. It could not see most of the `## Unreleased` wave.

`_parse_upgrading` split the file on `^---$` and gated each block on a `- **Recorded**:` bullet. `UPGRADING.md`'s own *"Writing an entry"* rules mandate **neither** marker — they specify the `##` heading, `- **Version**: Unreleased`, the grep recipe and the before → after edit, all of which the invisible entries had. Authors followed the documented rules and produced unparseable entries. That is a spec/implementation gap, not a series of independent mistakes.

`test/unit/test_upgrade_guide.jl` could not catch it: it keys on frozen historical facts and otherwise only asserted `!isempty(all_entries)`, which the 40 older entries satisfied no matter how many new ones were dropped.

## Blast radius, measured

**Nine headings lost**, not the seven the issue estimated:

| entry | what happened |
|---|---|
| #424, #394, #396 | **vanished** — their block carried no `Recorded`, so it was skipped; no part of them reached any guide |
| #379, #388, #380, #347, #346 | **merged** into the `AutoField (#408/#409/#417)` body and rendered under its title |
| #300 | **merged** into #305's body — and this one is a *released* `0.4.0` entry, so it has been mis-rendering since 0.4.0 shipped |

Two of these were found while working the issue: #424 landed after it was filed, and #300 was not known about at all.

| | before | after |
|---|---|---|
| entries parsed | 40 | **49** |
| `upgrade_guide(from = v"0.4.0", structured = true)` | 3 | **11** |

## The fix

**Parse an entry by its own `## ` heading.** Each segment runs to the next heading and is gated on `- **Version**:` (the policy from `0.2.0` on) or `- **Recorded**:` (pre-0.2 history, written before that policy existed). `---` rules become decorative — which is what the writing rules always implied — and a release marker written directly above the first entry of a release becomes its own skipped segment rather than something to trim.

**Repair the file** so it matches its own template: the eight missing `- **Recorded**:` dates, recovered with `git log -S` on each heading, plus the `---` rules — including the one at #300 whose absence caused the mis-render.

**Close the gap**, which is what stops the recurrence:

- `UPGRADING.md` → *"Writing an entry"* now states what marks an entry.
- `/pormg-cut-release` step 1 lists the wave **through the parser** and cross-checks the count against the headings, so an invisible entry surfaces before anything is edited. Step 5's *"The stamped entries must now parse at `<new>`"* is now a runnable assertion — that precondition previously passed while being false. Step 4 gained the `Recorded` backfill recipe (using the **oldest** pickaxe match, so a reworded heading yields its landing date, not its edit date).

## Tests

Five testsets in three deliberately separate layers:

- **A + B + E** run against the real file and guard file↔parser **agreement** — an entry the parser cannot see (B), one it files under the wrong version (E), one silently merged into a neighbour (A). They are blind to a parser regression on their own, and the test file says so rather than claiming coverage it does not have.
- **C + D** pin the parser **contract** on hand-fed text.
- A fifth pins `_trim_trailing_structure` directly, on shapes the real file does not contain and the file-level guards therefore cannot reach.

Every one was mutation-tested to fail under a change that reintroduces the defect it describes.

## Review

Four independent review rounds, each of which found something real — three of them in the *previous* round's fixes:

| round | found |
|---|---|
| 1 | 10 items, incl. the tail trimmer leaking the pre-0.2 divider into #197's rendered body, and an assertion written to catch that which could not (the leak ends in `-->`, so `!endswith(body, "---")` passed) |
| 2 | the fix leaked **multi-line** comments, and ate a line of visible prose |
| 3 | the rewrite **escalated** it — an unanchored pattern meant one stray `<!--` plus any tail `-->` swallowed everything between: **11,645 chars → 33** measured, and an unclosed `<!--` in a code fence left the fence open, which would swallow every entry printed after it |
| 4 | materially clean; the indent class contradicted its own comment, peeling the last line of indented code samples |

No test could have caught round 3's bug: A's assertions are *satisfied* by eating content, and B only checks headings, which sit at a body's start. That is why the trimmer now has its own testset and why the invariant — **peel only whole lines of structure, never reach into a line carrying prose** — is stated in the code.

## Deliberately not done

- **Entry ordering.** The backfilled dates expose a pre-existing *"newest first"* violation (#408/#409/#417 at 08-25 sits below two 08-24 entries). Nothing reads `Recorded` — `upgrade_guide` preserves document order and filters on `version` — so it cannot cause a failure, and reordering means moving 200-line blocks against in-flight branches.
- **One residual over-strip** in the tail trimmer, documented in the code: it needs a line-start unclosed `<!--`, no second opener, no earlier `-->`, and a body ending in a prose `-->`, all at once. No such shape exists in the file, and the text genuinely *is* an HTML comment unless a code fence makes it literal — which no regex can know.
- **No `UPGRADING.md` change entry and no `Project.toml` bump** — this fixes something already broken and forces no consuming-app source edit.

## Verification

- `julia --project=. test/unit/test_upgrade_guide.jl` → 97/97
- `julia --project=. test/runtests.jl` → **8547/8547**, exit 0
- Body-parity diff against the old parser across all 40 shared titles: exactly **2** differences, both the intended de-merges (#305, #408/#409/#417)

No integration run: the parser reads a bundled markdown file and touches no database path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
