### PR TITLE
fix(#435): cjoin_on says which of two things emptied its ON clause

### DIFF
--- a/docs/src/read/custom_joins.md
+++ b/docs/src/read/custom_joins.md
@@ -330,17 +330,74 @@ parameters from `on` route to the JOIN clause (ahead of any WHERE parameters).
     (`"b2.col__@gte" => 3`) are not supported yet — express a joined-side comparison-to-literal by
     restructuring, or filter the base side with a bare pair (`"col__@gte" => 3`). Referencing a
     *third* table (another join's alias) inside one `cjoin_on` is also out of scope for now — and
-    when that third table is a **CROSS-joined CTE** (`.with(...)` with no `join_field`), it now
+    when that third table is a **CROSS-joined CTE** (`.with(...)` with no `join_field`), it
     raises `QueryBuildError` instead of quietly dropping the predicate (#424) — a `CROSS JOIN` has
-    no `ON` clause to carry one, so the join would otherwise match every row. The same guard fires
+    no `ON` clause to carry one, so the join would otherwise match every row. That fires even when
+    the predicate is the join's **only** one (#435). The same guard fires
     when a `cjoin_on`'s **alias** happens to equal an unkeyed CTE's name: that collision hands the
     CTE this join's predicates. Rename the CTE, give it a `join_field`, or move the predicate to
     `.filter(...)` (#44).
+
     `cjoin_on` works in reads and in the common `update()`/`delete()` (which scope rows via a
     subquery); only a **correlated** UPDATE-FROM/DELETE-USING (setting a column *from* a joined
     table) is unsupported and raises. Finally, a `cjoin_on` join is not tracked by the #74
     aggregate fan-out guard — if the join is to-many, aggregate the base table with `distinct=true`
     (or over the joined table's own column) to avoid silent row multiplication.
+
+!!! warning "Give the join a predicate that names its own alias"
+    Every predicate in `on` that references a join emitted *after* this one is moved onto that
+    join — it has to be, because a join cannot reference an alias that has not appeared yet. If
+    **all** of them move, your join is left with no `ON` clause and PormG raises, naming the alias
+    they went to (#435):
+
+    ```julia
+    query = M.Result.objects
+    query.values("points")
+    query.cjoin_on("Driver", alias = "d", on = ["raceid__circuitid__country" => "Italy"])
+    # ERROR: Every ON predicate given for d resolved onto Tb_2 instead, …
+    ```
+
+    **The fix depends on whether your predicates name the alias at all**, and the two cases pull
+    in opposite directions. The error message tells you which one you are in.
+
+    *Nothing names it* — as above. The join has nothing correlating it. Add a predicate that does
+    (`F("d.driverid") == F("driverid")`), or move the conditions to `.filter(...)` and drop the
+    `cjoin_on` entirely — it needs at least one `on` predicate, so moving them all out without
+    removing the call raises too.
+
+    Here, **do not** "fix" it by projecting the path in `values(...)` first. That builds those
+    joins ahead of the `cjoin_on`, so nothing needs to move and the query renders — as
+    `INNER JOIN "driver" AS "d" ON "Tb_2"."country" = ?`, an `ON` clause that never mentions `d`.
+    That is an unconstrained join: every `driver` row against every qualifying base row, silently.
+    The error is the better outcome.
+
+    *It names the alias and a deeper path* — `on = [F("d.nationality") == F("raceid__circuitid__country")]`,
+    drivers racing in their home country — is a real correlation that moved only because the join
+    on its other side is built later. Projecting **is** the fix here: add
+    `raceid__circuitid__country` to `values(...)` and the clause renders exactly as written.
+
+    *It names the alias and another `cjoin_on` alias* — there is no path to project, so declare
+    the predicate on whichever of the two PormG emits **later**; the reference then points
+    backwards and nothing moves. The error message names that join for you. Give the first join an
+    `ON` predicate of its own as well — it is still joined, and `cjoin_on` requires at least one:
+
+    ```julia
+    # ✗ before — d1's only predicate names d2, which is emitted after it
+    query.cjoin_on("Driver", alias = "d1", on = [F("d1.surname") == F("d2.surname")])
+    query.cjoin_on("Driver", alias = "d2", on = [F("d2.driverid") == F("driverid")])
+
+    # ✓ after — the shared predicate moves to d2, and d1 gets one of its own
+    query.cjoin_on("Driver", alias = "d1", on = [F("d1.driverid") == F("driverid")])
+    query.cjoin_on("Driver", alias = "d2", on = [F("d2.surname") == F("d1.surname")])
+    ```
+
+    (Which of two `cjoin_on` aliases is emitted first is currently decided by alias hashing rather
+    than declaration order — [#449](https://github.com/PingoLee/PormG.jl/issues/449).)
+
+    More generally, PormG checks that the join *has* an `ON` clause, not that the clause
+    constrains it — `on = ["points__@gt" => 10]` renders and multiplies rows just the same
+    ([#448](https://github.com/PingoLee/PormG.jl/issues/448)). Make sure at least one predicate
+    names the alias you gave.
 
 ## Use Cases
 

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -510,6 +510,30 @@ function build_row_join_sql_text(instruc::SQLInstruction)
   # value (#421). Each extra now carries its own values and Phase 2 re-appends them as it emits,
   # which makes binding order and emission order the same thing by construction. PostgreSQL never
   # had the problem — `$N` numbering travels with the text.
+  #
+  # `relocated_to` exists only so a later failure can say WHERE a predicate went. `delete!` below
+  # erases the fact that this join ever had extras, which left the `no_anchor` guard in Phase 2
+  # reporting "cjoin_on produced no ON conditions" at a caller who had provided one (#435). The
+  # dict is diagnostic; nothing reads it on a successful build.
+  # Destination row_join INDICES, not alias names: the raise site needs the entry itself to tell a
+  # model join (which the caller can project in `values(...)`) from another `cjoin_on` (which they
+  # cannot — there is no path to project). Names are derived from the indices where needed.
+  relocated_to = Dict{Int, Vector{Int}}()
+  # …and whether any predicate that left ALSO named the join it left. That single bit decides which
+  # advice is true when a `cjoin_on` is emptied, and the two are opposites:
+  #
+  #   named its own alias  — `F("b2.sku") == F("parent__grandparent__code")` — is a real
+  #     correlation that moved only because its other side is not built yet. Projecting that path
+  #     in `values(...)` builds it first, nothing relocates, and the join renders CORRECTLY
+  #     (`ON ("b2"."sku" = "Tb_2"."code")`). Telling this caller to "add a predicate naming b2"
+  #     is telling them to do what they already did.
+  #   named no alias of its own — `"parent__grandparent__code" => "Z"` — has nothing correlating
+  #     the join at all. Projecting makes it render `ON "Tb_2"."code" = ?`, an unconstrained join
+  #     that multiplies rows silently. Here projecting is the WRONG fix and the raise is right.
+  #
+  # Phase 1b is the only place that knows which, because it is holding the fragment when it decides
+  # to move it. Review of #435 caught the message asserting the second case's advice at both.
+  relocated_self_ref = Set{Int}()
   for idx in 1:length(instruc.row_join)
     haskey(on_clause_extras, idx) || continue
     extras = on_clause_extras[idx]
@@ -533,6 +557,11 @@ function build_row_join_sql_text(instruc::SQLInstruction)
           haskey(on_clause_extras, dep_idx) || (on_clause_extras[dep_idx] = OnExtra[])
           push!(on_clause_extras[dep_idx], extra)
           relocated[ei] = true
+          dests = get!(relocated_to, idx, Int[])
+          dep_idx in dests || push!(dests, dep_idx)
+          # Same `"alias".` form as every other alias test here, for the same reason.
+          occursin("\"$(instruc.row_join[idx]["alias_b"])\".", extra.sql) &&
+            push!(relocated_self_ref, idx)
           break
         end
       end
@@ -545,6 +574,47 @@ function build_row_join_sql_text(instruc::SQLInstruction)
     end
   end
 
+  # --- Phase 1c: refuse extras that landed where no ON clause can carry them --
+  # #424: a CROSS-joined CTE is the one join shape with no ON clause to merge `on_clause_extras`
+  # into, so a predicate that lands there simply vanishes.
+  #
+  # Do NOT enumerate call shapes here. That list was written twice and was wrong twice — first
+  # "unreachable", then "two shapes", and both missed producers. State the INVARIANT instead:
+  # `on_clause_extras[idx]` reaches a CROSS entry either because Phase 1b relocated a fragment
+  # that names its alias, or because the entry carries its own `on_conditions` — and it carries
+  # those exactly when `custom_join[<cte name>]` exists with non-empty filters. `custom_join` is
+  # written at three unrelated sites, keyed by a `cjoin` PATH, a `cjoin_on` ALIAS, and an `on()`
+  # PATH, so any of the three colliding with an unkeyed CTE's name produces this — with or
+  # without a model-field collision, and with or without any relocation. A fourth writer would
+  # inherit the same behavior, which is why the message below talks about name collision rather
+  # than about which method the caller used.
+  #
+  # Pre-fix every one of them emitted an unconstrained `CROSS JOIN` with the predicate gone — row
+  # multiplication, no error — while the orphaned value sat in the bucket with no `?` to consume
+  # it. #421 makes it worse before this makes it better: once values travel with the text, the
+  # orphan disappears too and the wrong query becomes perfectly well-formed. So fail closed, the
+  # same posture `_get_join_condition_list` takes on this marker (#394).
+  #
+  # #435 hoisted this out of the Phase 2 CROSS branch, where it lived when it was written. Phase 2
+  # walks `row_join` in index order, so whether this fired depended on where the CROSS entry sat:
+  # a `no_anchor` join at a LOWER index reported its own symptom — "produced no ON conditions",
+  # describing the state after relocation rather than the cause — and the accurate message never
+  # ran. Two test files were padding their cases with a second predicate to route around exactly
+  # that. Diagnosing before emitting makes the cause win regardless of ordering.
+  for (idx, value) in enumerate(instruc.row_join)
+    get(value, "cross", nothing) === nothing && continue
+    haskey(on_clause_extras, idx) && throw(QueryBuildError(
+      "An ON predicate resolved onto \e[4m\e[31m$(value["alias_b"])\e[0m, the CROSS-joined CTE " *
+      "\e[4m\e[31m$(value["b"])\e[0m (a \e[4m\e[32m.with(...)\e[0m declared without " *
+      "\e[4m\e[32mjoin_field\e[0m). A CROSS JOIN has no ON clause to carry that predicate, so it " *
+      "would be dropped and the join would match every row.\n  A CROSS-joined CTE picks up an ON " *
+      "predicate when its NAME collides with a join key — a \e[4m\e[32mcjoin\e[0m path, a " *
+      "\e[4m\e[32mcjoin_on\e[0m alias, or an \e[4m\e[32mon()\e[0m path — or when a predicate " *
+      "naming its alias is relocated onto it.\n  Rename the CTE so it collides with nothing, give " *
+      "it a \e[4m\e[32mjoin_field\e[0m so it emits a real ON clause, or move the predicate to " *
+      "\e[4m\e[32m.filter(...)\e[0m (#44)."))
+  end
+
   # --- Phase 2: emit JOIN SQL text in original order -------------------------
   for (idx, value) in enumerate(instruc.row_join)
     set_context!(instruc, :join)
@@ -553,37 +623,9 @@ function build_row_join_sql_text(instruc::SQLInstruction)
 
     # #44: a CROSS-joined CTE (no join_field) carries sentinel empty key columns and has no ON —
     # the correlation is supplied by the main query's F() filter(s) in WHERE. Emit it and move on
-    # before touching key_a/key_b (empty strings would fail identifier validation).
+    # before touching key_a/key_b (empty strings would fail identifier validation). Phase 1c above
+    # has already refused any entry here that picked up an ON predicate.
     if get(value, "cross", nothing) !== nothing
-      # #424: ...and it is the ONE branch below with no ON clause to merge `on_clause_extras[idx]`
-      # into, so a predicate that lands here simply vanishes.
-      #
-      # Do NOT enumerate call shapes here. That list was written twice and was wrong twice — first
-      # "unreachable", then "two shapes", and both missed producers. State the INVARIANT instead:
-      # `on_clause_extras[idx]` reaches a CROSS entry either because Phase 1b relocated a fragment
-      # that names its alias, or because the entry carries its own `on_conditions` — and it carries
-      # those exactly when `custom_join[<cte name>]` exists with non-empty filters. `custom_join` is
-      # written at three unrelated sites, keyed by a `cjoin` PATH, a `cjoin_on` ALIAS, and an `on()`
-      # PATH, so any of the three colliding with an unkeyed CTE's name produces this — with or
-      # without a model-field collision, and with or without any relocation. A fourth writer would
-      # inherit the same behavior, which is why the message below talks about name collision rather
-      # than about which method the caller used.
-      #
-      # Pre-fix every one of them emitted an unconstrained `CROSS JOIN` with the predicate gone — row
-      # multiplication, no error — while the orphaned value sat in the bucket with no `?` to consume
-      # it. #421 makes it worse before this makes it better: once values travel with the text, the
-      # orphan disappears too and the wrong query becomes perfectly well-formed. So fail closed, the
-      # same posture `_get_join_condition_list` takes on this marker (#394).
-      haskey(on_clause_extras, idx) && throw(QueryBuildError(
-        "An ON predicate resolved onto \e[4m\e[31m$(value["alias_b"])\e[0m, the CROSS-joined CTE " *
-        "\e[4m\e[31m$(value["b"])\e[0m (a \e[4m\e[32m.with(...)\e[0m declared without " *
-        "\e[4m\e[32mjoin_field\e[0m). A CROSS JOIN has no ON clause to carry that predicate, so it " *
-        "would be dropped and the join would match every row.\n  A CROSS-joined CTE picks up an ON " *
-        "predicate when its NAME collides with a join key — a \e[4m\e[32mcjoin\e[0m path, a " *
-        "\e[4m\e[32mcjoin_on\e[0m alias, or an \e[4m\e[32mon()\e[0m path — or when a predicate " *
-        "naming its alias is relocated onto it.\n  Rename the CTE so it collides with nothing, give " *
-        "it a \e[4m\e[32mjoin_field\e[0m so it emits a real ON clause, or move the predicate to " *
-        "\e[4m\e[32m.filter(...)\e[0m (#44)."))
       push!(instruc.join, """ CROSS JOIN $b_quoted AS $alias_b_quoted """)
       continue
     end
@@ -591,7 +633,84 @@ function build_row_join_sql_text(instruc::SQLInstruction)
     if get(value, "no_anchor", "") == "1"
       # #45: anchor-less join — the ON clause is entirely the user's resolved extras (no equi-anchor).
       extras = get(on_clause_extras, idx, OnExtra[])
-      isempty(extras) && throw(QueryBuildError("cjoin_on produced no ON conditions for alias '$(value["alias_b"])'."))
+      if isempty(extras)
+        # #435: two different causes reach this line, and they used to share one message that only
+        # described the first. `row_join` still carries `on_conditions` — Phase 1b mutates only the
+        # local `on_clause_extras` — so what the CALLER passed is still readable here, after
+        # relocation has erased what the join is left holding.
+        #
+        # The `!== nothing` mirrors Phase 1's gate exactly. It is dead today (`JoinDict`'s value
+        # type cannot hold `nothing`), and it stays so the two never drift: if that element type is
+        # ever widened, a `haskey`-only test here would report a relocation that never happened.
+        if haskey(value, "on_conditions") && value["on_conditions"] !== nothing
+          dest_idxs = get(relocated_to, idx, Int[])
+          # Naming the destination is diagnosis, not a remedy: relocation targets are often joins
+          # PormG built itself (`Tb_2`), and the caller cannot address those. So the message reports
+          # where the predicates went, and every remedy it offers is written in terms the caller
+          # CAN act on — their own alias, or `.filter(...)`.
+          dests = [String(instruc.row_join[d]["alias_b"]) for d in dest_idxs]
+          where_to = isempty(dests) ? "another join" :
+                     join(("\e[4m\e[31m$d\e[0m" for d in dests), ", ", " and ")
+          alias = value["alias_b"]
+
+          # A destination that is itself a `cjoin_on` has NO path to project — `values("b2…")` is
+          # not a thing — so "project it in values(...)" is unactionable there. The actionable move
+          # is the opposite one: declare the predicate on the join PormG emits LATER, which turns
+          # the forward reference into a backward one. Found in review: the self-ref remedy was
+          # written for a model-path destination and asserted at both.
+          projectable = filter(d -> get(instruc.row_join[d], "no_anchor", "") != "1", dest_idxs)
+          plural = length(projectable) > 1 ? "those paths" : "that path"
+          reorder = [String(instruc.row_join[d]["alias_b"])
+                     for d in dest_idxs if get(instruc.row_join[d], "no_anchor", "") == "1"]
+
+          self_ref_remedy =
+            "Your predicate does correlate \e[4m\e[31m$alias\e[0m; it moved only because the " *
+            "join on its other side is built later."
+          if !isempty(projectable)
+            self_ref_remedy *= " Project $plural in \e[4m\e[32mvalues(...)\e[0m so it is built " *
+              "FIRST"
+            # Only promise "nothing relocates" when projecting is the WHOLE fix. With a mixed set
+            # of destinations the other predicate still moves, and claiming otherwise contradicts
+            # the very next sentence.
+            self_ref_remedy *= isempty(reorder) ?
+              " — then nothing relocates and the ON clause renders as you wrote it." :
+              (length(projectable) > 1 ? " — then those predicates stay." :
+                                         " — then that predicate stays.")
+          end
+          if !isempty(reorder)
+            others = join(("\e[4m\e[31m$d\e[0m" for d in reorder), ", ", " and ")
+            # "Declare it on the other join" alone is a dead end: this branch fires only when the
+            # relocated predicates were ALL of them, so moving them out leaves this `cjoin_on` with
+            # an empty `on`, which `_cjoin_on` refuses — and simply dropping the call makes its
+            # alias unresolvable in the predicate that referenced it. The rewrite needs a predicate
+            # for THIS join too, and saying so is the difference between advice and a dead end.
+            # (Round 2 fixed the same omission in the `.filter(...)` remedy; it came back here.)
+            self_ref_remedy *= " $others is another \e[4m\e[32mcjoin_on\e[0m, so there is no path " *
+              "to project — declare this predicate on $others instead, which PormG emits after " *
+              "\e[4m\e[31m$alias\e[0m, so the reference points backwards and nothing moves. Give " *
+              "\e[4m\e[31m$alias\e[0m an ON predicate of its own as well: it is still joined, and " *
+              "\e[4m\e[32mcjoin_on\e[0m requires at least one."
+          end
+
+          remedy = idx in relocated_self_ref ? self_ref_remedy :
+            ("No predicate you gave names \e[4m\e[31m$alias\e[0m at all, so there is nothing to " *
+             "correlate it. Add one — for example " *
+             "\e[4m\e[32mF(\"$alias.<column>\") == F(\"<base column>\")\e[0m — or, if none of " *
+             "these conditions was ever about this join, move them to " *
+             "\e[4m\e[32m.filter(...)\e[0m and drop the \e[4m\e[32mcjoin_on\e[0m entirely.\n  " *
+             "Do NOT instead project the path in \e[4m\e[32mvalues(...)\e[0m: that stops the " *
+             "relocation and the query renders, but with an ON clause that never mentions " *
+             "\e[4m\e[31m$alias\e[0m — an unconstrained join that multiplies rows silently.")
+          throw(QueryBuildError(
+            "Every ON predicate given for \e[4m\e[31m$alias\e[0m resolved onto $where_to instead, " *
+            "leaving this join with no ON clause of its own.\n  A \e[4m\e[32mcjoin_on\e[0m " *
+            "predicate is moved onto the LAST join it references, because joins are emitted in " *
+            "order and a predicate cannot name an alias that has not appeared yet. Here that is " *
+            "every predicate you gave, so nothing is left to constrain \e[4m\e[31m$alias\e[0m " *
+            "itself.\n  $remedy (#435)."))
+        end
+        throw(QueryBuildError("cjoin_on produced no ON conditions for alias '$(value["alias_b"])'."))
+      end
       on_clause = join((e.sql for e in extras), " AND ")
       for extra in extras
         reattach_parameters!(instruc, extra.params)   # #421: bind in EMISSION order

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -125,8 +125,10 @@ const DOCERR_CASES = [
     (
         # #424. `cjoin_on`'s `on` is the whole ON clause and is NOT path-prefixed, so a bare
         # `"ev__col" => v` resolves against a `join_field`-less (CROSS-joined) CTE — which has no ON
-        # clause to carry it. Two predicates: with only one, the "produced no ON conditions" guard
-        # fires first and the case would pin the wrong error.
+        # clause to carry it. ONE predicate, which is the doc's own shape: this used to need a
+        # second as padding, because relocating the only predicate away emptied `d`'s extras and
+        # the "produced no ON conditions" guard fired first, pinning the wrong error. #435 hoisted
+        # the CROSS check ahead of emission, so the cause wins regardless of join order.
         "read/custom_joins.md — a cjoin_on ON predicate on a CROSS-joined CTE is refused",
         QueryBuildError,
         () -> begin
@@ -135,8 +137,21 @@ const DOCERR_CASES = [
             q = DOCERR_RESULT_PG.objects
             q.with("ev" => ev)                       # no join_field => CROSS JOIN (#44)
             q.values("resultid")
-            q.cjoin_on("DOCERR_DRIVER_PG", alias = "d",
-                       on = [F("d.driverid") == F("driverid"), "ev__status" => "Finished"])
+            q.cjoin_on("DOCERR_DRIVER_PG", alias = "d", on = ["ev__status" => "Finished"])
+            q.list(show_query = :dict)
+        end,
+    ),
+    (
+        # #435. Resolving `driverid__surname` builds the driver join DURING Phase 1, so it lands at
+        # a higher `row_join` index than `d` — a forward reference. Phase 1b moves the predicate
+        # onto it, and since it is `d`'s only one, `d` is left with no ON clause. The doc note tells
+        # the reader this raises and names the alias the predicates went to.
+        "read/custom_joins.md — a cjoin_on whose predicates all relocate away is refused",
+        QueryBuildError,
+        () -> begin
+            q = DOCERR_RESULT_PG.objects
+            q.values("resultid")
+            q.cjoin_on("DOCERR_STATUS_PG", alias = "d", on = ["driverid__surname" => "Senna"])
             q.list(show_query = :dict)
         end,
     ),

--- a/test/unit/test_order_by_joins.jl
+++ b/test/unit/test_order_by_joins.jl
@@ -504,11 +504,13 @@ const _OB_424_PRODUCERS = [
       q = OBJ.Cj_child.objects
       q.with("ev" => _ob_cte())                       # no join_field => CROSS JOIN (#44)
       q.values("note")
-      # Two predicates on purpose: with only one, relocating it away empties the join's extras and
-      # `cjoin_on` raises "produced no ON conditions" first — a different, separately misleading
-      # error that would mask what is under test.
-      q.cjoin_on("Cj_parent", alias = "b2",
-                 on = [F("b2.sku") == F("note"), "ev__code" => "Z"])
+      # ONE predicate, and that is the point. This case used to need a second one as padding:
+      # relocating the only predicate away emptied `b2`'s extras, and because `b2` sits at a lower
+      # `row_join` index than the CTE, Phase 2 reached its "produced no ON conditions" guard before
+      # the CROSS branch could report the actual cause. #435 hoisted this guard into Phase 1c, so
+      # the cause now wins on ordering-independent grounds and the padding is gone. This is also
+      # the issue's own reproduction, verbatim.
+      q.cjoin_on("Cj_parent", alias = "b2", on = ["ev__code" => "Z"])
       q
     end,
   ),
@@ -597,4 +599,247 @@ const _OB_424_PRODUCERS = [
   ok_sql = inspect_query(ok; connection = _OBJ_SL)[:sql_text]
   @test occursin("CROSS JOIN \"ev\"", ok_sql)
   @test !occursin(r"CROSS JOIN[^\n]*ON", ok_sql)
+end
+
+# ── #435: the anchor-less guard must say WHICH of two things went wrong ──────────────────────────
+#
+# `cjoin_on` renders its ON clause entirely from the caller's predicates — there is no equi-anchor
+# to fall back on — so an empty extras list at emission time is fatal. Two unrelated causes reach
+# that state, and one message described only the first:
+#
+#   1. the caller passed no predicates at all;
+#   2. the caller passed some, and Phase 1b relocated every one onto a join emitted later.
+#
+# In case 2 the old text — "cjoin_on produced no ON conditions for alias 'b2'" — describes the
+# internal state after relocation, and flatly contradicts what the caller wrote. It sent you looking
+# for a missing argument that is right there in the call.
+#
+# Phase 1b mutates only the local `on_clause_extras`; `row_join` keeps its `on_conditions`. So the
+# two cases stay distinguishable at the raise site with no extra bookkeeping, and `relocated_to`
+# (recorded in Phase 1b) supplies the destination alias for the message.
+@testset "cjoin_on distinguishes 'you passed none' from 'they all relocated' (#435)" begin
+
+  # ── case 2: predicates given, all relocated away ──────────────────────────
+  # The trigger is purely POSITIONAL: `b2`'s only predicate names a join that sits at a HIGHER
+  # `row_join` index, so Phase 1b moves it there and `b2` is left holding nothing. Two ways to get
+  # there, and the review of this change refuted a narrower claim that only the first counts:
+  #
+  #   - the referenced join does not exist yet and is created during Phase 1's resolution of that
+  #     very condition (this fixture: an UNPROJECTED deep path), or
+  #   - it already exists but is ordered later. For two `cjoin_on` aliases that ordering comes from
+  #     `Dict` iteration over `custom_join`, i.e. from the alias STRINGS — declaring `b3` before
+  #     `b2` and after it both yield `[b3, b2]`. Which of a pair raises is therefore decided by
+  #     hashing, which is why this fixture uses the deep path instead: it is deterministic.
+  #
+  # For THIS fixture, projecting the path first would build those joins at LOWER indices and nothing
+  # would relocate — but the query then renders an ON clause that never mentions `b2`, an
+  # unconstrained join, so the error is the better outcome and neither the docs nor the message
+  # offer projecting here. That is specific to a predicate naming no alias of its own; when the
+  # predicate DOES name the join, projecting is the correct fix and both do recommend it — see the
+  # branch testset below. A real join, not a CROSS CTE, so Phase 1c does not intercept.
+  @testset "all predicates relocated onto a later join" begin
+    for (backend, conn) in (("PostgreSQL", _OBJ_PG), ("SQLite", _OBJ_SL))
+      q = OBJ.Cj_child.objects
+      q.values("note")
+      q.cjoin_on("Cj_parent", alias = "b2", on = ["parent__grandparent__code" => "Z"])
+
+      err = try
+        inspect_query(q; connection = conn)
+        nothing
+      catch e
+        e
+      end
+      @test err isa PormG.QueryBuildError
+      msg = sprint(showerror, err)
+
+      # The regression itself: it must NOT claim the caller supplied nothing.
+      @test !occursin("produced no ON conditions", msg)
+
+      @test occursin("b2", msg)          # the join left without an ON clause
+      @test occursin("Tb_2", msg)        # …and where its predicate actually went
+      @test occursin("#435", msg)
+      # Same vocabulary as the #424 guard, which reaches this relocation from the other side.
+      @test occursin("resolved onto", msg)
+      @test occursin(".filter(", msg)    # one of the remedies
+      # A user-writable shape is never the user's fault to report (see the #424 testset).
+      @test !occursin("internal", lowercase(msg))
+      @test !occursin("report", lowercase(msg))
+    end
+  end
+
+  # ── the boundary: ONE predicate relocating is not an error ────────────────
+  # Same deep path, plus a predicate that stays. `b2` keeps an ON clause, the relocated fragment
+  # lands on the join it names, and nothing raises. Without this, a guard that fired whenever
+  # ANY predicate relocated would pass every assertion above while breaking a working shape.
+  @testset "a surviving predicate keeps the join renderable" begin
+    for (backend, conn) in (("PostgreSQL", _OBJ_PG), ("SQLite", _OBJ_SL))
+      q = OBJ.Cj_child.objects
+      q.values("note")
+      q.cjoin_on("Cj_parent", alias = "b2",
+                 on = [F("b2.sku") == F("note"), "parent__grandparent__code" => "Z"])
+      r = inspect_query(q; connection = conn)
+      sql = r[:sql_text]
+      @test occursin("JOIN \"cj_parent\" AS \"b2\" ON ", sql)
+      @test occursin("\"b2\".\"sku\" = \"Tb\".\"note\"", sql)
+      # the relocated fragment is merged into the ON of the join it references, not dropped
+      @test occursin("\"Tb_2\".\"code\" = ", sql)
+      # …and its value travels with it rather than being dropped or orphaned. Only ONE predicate
+      # binds here, so this cannot observe #421-style REORDERING — `_cj_two_depth` above owns that.
+      # What it does pin is that a relocated fragment still consumes exactly its own value, on both
+      # backends, which is the half a text-only assertion cannot see.
+      @test r[:parameters] == ["Z"]
+    end
+  end
+
+  # ── the two branches give OPPOSITE advice, and the code must pick ─────────
+  # Review of this change caught the message asserting one branch's remedy at both. The bit that
+  # decides it: did any predicate that relocated ALSO name the join it left?
+  #
+  #   names its own alias too → a real correlation whose other side is built later. Projecting that
+  #     path in `values(...)` builds it first and the clause renders AS WRITTEN. Verified below.
+  #   names no alias of its own → nothing correlates the join. Projecting renders an ON clause that
+  #     never mentions the alias — an unconstrained join, silent row multiplication (#448).
+  #
+  # So the same message must NOT recommend projecting in both cases, and these two testsets are
+  # what stop it drifting back.
+  @testset "the remedy branches on whether a relocated predicate named the alias" begin
+    # self-referencing: predicate names b2 AND the deeper join
+    q = OBJ.Cj_child.objects
+    q.values("note")
+    q.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("parent__grandparent__code")])
+    msg = try
+      inspect_query(q; connection = _OBJ_SL); ""
+    catch e
+      sprint(showerror, e)
+    end
+    @test occursin("does correlate", msg)
+    @test occursin("Project that path", msg)
+    @test !occursin("Do NOT", msg)            # projecting is the RIGHT fix here
+    @test !occursin("No predicate you gave names", msg)
+    # Second tripwire on the partition: with every destination a model join, the `cjoin_on`
+    # sentence must be absent. Without this, misclassifying destinations the other way leaves
+    # only one assertion standing (review finding).
+    @test !occursin("another cjoin_on", msg)
+    @test occursin("nothing relocates", msg)  # projecting IS the whole fix here, so promise it
+
+    # …and projecting really does render it as written, which is what the advice promises
+    ok = OBJ.Cj_child.objects
+    ok.values("note", "parent__grandparent__code")
+    ok.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("parent__grandparent__code")])
+    ok_sql = inspect_query(ok; connection = _OBJ_SL)[:sql_text]
+    @test occursin("JOIN \"cj_parent\" AS \"b2\" ON (\"b2\".\"sku\" = \"Tb_2\".\"code\")", ok_sql)
+
+    # non-self-referencing: the fixture shape, which must get the opposite advice
+    q2 = OBJ.Cj_child.objects
+    q2.values("note")
+    q2.cjoin_on("Cj_parent", alias = "b2", on = ["parent__grandparent__code" => "Z"])
+    msg2 = try
+      inspect_query(q2; connection = _OBJ_SL); ""
+    catch e
+      sprint(showerror, e)
+    end
+    @test occursin("No predicate you gave names", msg2)
+    @test occursin("Do NOT instead project", msg2)
+    @test !occursin("does correlate", msg2)
+    # the remedy must not send them to .filter() without saying the cjoin_on has to go too —
+    # `_cjoin_on` refuses an empty `on`, so moving every predicate out and leaving the call raises
+    @test occursin("drop the", msg2)
+  end
+
+  # ── self-ref, but the destination has no path to project ──────────────────
+  # "Project it in values(...)" is unactionable when the predicate relocated onto ANOTHER cjoin_on:
+  # `values("b2…")` is not a thing. Caught in review — the self-ref remedy was written for a
+  # model-path destination and asserted at both. The actionable move is the reverse: declare the
+  # predicate on the join PormG emits LATER, so the reference points backwards.
+  @testset "a cjoin_on destination gets the reorder remedy, not 'project it'" begin
+    q = OBJ.Cj_child.objects
+    q.values("note")
+    q.cjoin_on("Cj_parent", alias = "b3", on = [F("b3.sku") == F("b2.sku")])
+    q.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("note")])
+    msg = try
+      inspect_query(q; connection = _OBJ_SL); ""
+    catch e
+      sprint(showerror, e)
+    end
+
+    @test occursin("does correlate", msg)              # still the self-ref branch
+    @test occursin("another cjoin_on", msg)            # …and it says why projecting is not it
+    @test occursin("declare this predicate on", msg)
+    @test !occursin("Project that path", msg)          # the unactionable advice must be absent
+    @test !occursin("Project those paths", msg)
+
+    # Moving the predicate is only HALF the rewrite, and the message must say the other half.
+    # This branch fires only when the relocated predicates were ALL of them, so moving them out
+    # leaves `b3` with an empty `on` — which `_cjoin_on` refuses — while dropping `b3` entirely
+    # makes `b3.sku` unresolvable in the predicate that referenced it. Both dead ends were
+    # reachable by following the first draft of this remedy literally (review finding); the same
+    # omission had already been fixed once in the `.filter(...)` remedy.
+    @test occursin("an ON predicate of its own", msg)
+    @test occursin("requires at least one", msg)
+
+    # …and the full rewrite the message describes actually renders: the shared predicate declared
+    # on the LATER join, and `b3` given a predicate of its own.
+    ok = OBJ.Cj_child.objects
+    ok.values("note")
+    ok.cjoin_on("Cj_parent", alias = "b3", on = [F("b3.sku") == F("note")])
+    ok.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("b3.sku")])
+    ok_sql = inspect_query(ok; connection = _OBJ_SL)[:sql_text]
+    @test occursin("JOIN \"cj_parent\" AS \"b3\" ON (\"b3\".\"sku\" = \"Tb\".\"note\")", ok_sql)
+    @test occursin("JOIN \"cj_parent\" AS \"b2\" ON (\"b2\".\"sku\" = \"b3\".\"sku\")", ok_sql)
+  end
+
+  # ── mixed destinations: both remedies, and the projecting half must not overclaim ──
+  # With one predicate relocating onto a model join and another onto a `cjoin_on`, projecting is
+  # only half the fix. The tail "then nothing relocates and the ON clause renders as you wrote it"
+  # is false there — the other predicate still moves — and it contradicts the sentence appended
+  # right after it. Verified: projecting this shape does render, but `b3`'s ON is not as written.
+  @testset "mixed destinations get both remedies without contradicting each other" begin
+    q = OBJ.Cj_child.objects
+    q.values("note")
+    q.cjoin_on("Cj_parent", alias = "b3",
+               on = [F("b3.sku") == F("b2.sku"), F("b3.sku") == F("parent__grandparent__code")])
+    q.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("note")])
+    msg = try
+      inspect_query(q; connection = _OBJ_SL); ""
+    catch e
+      sprint(showerror, e)
+    end
+
+    @test occursin("Project that path", msg)             # the model-path destination
+    @test occursin("another cjoin_on", msg)              # …and the cjoin_on one
+    @test occursin("that predicate stays", msg)          # scoped promise
+    @test !occursin("nothing relocates and the ON clause renders as you wrote it", msg)
+  end
+
+  # ── case 1: genuinely no predicates ───────────────────────────────────────
+  # Not reachable through the public API — `_cjoin_on` refuses an empty `on` at the call site — so
+  # reach it white-box by emptying the stored filters. `_build_cjoin_on_row_join` then omits the
+  # `on_conditions` key entirely, which IS the state this branch is about.
+  @testset "no predicates passed keeps its own message" begin
+    q = OBJ.Cj_child.objects
+    q.values("note")
+    q.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("note")])
+    empty!(q.object.custom_join["b2"]["filters"])
+
+    err = try
+      inspect_query(q; connection = _OBJ_PG)
+      nothing
+    catch e
+      e
+    end
+    @test err isa PormG.QueryBuildError
+    msg = sprint(showerror, err)
+    @test occursin("produced no ON conditions", msg)   # unchanged wording
+    @test occursin("b2", msg)
+    @test !occursin("#435", msg)                       # not the relocation story
+  end
+
+  # ── control: an ordinary cjoin_on still renders ───────────────────────────
+  # Without this, splitting the guard into two throws could satisfy every assertion above while
+  # breaking the feature — the same trap the #424 testset's control covers.
+  ok = OBJ.Cj_child.objects
+  ok.values("note")
+  ok.cjoin_on("Cj_parent", alias = "b2", on = [F("b2.sku") == F("note")])
+  ok_sql = inspect_query(ok; connection = _OBJ_SL)[:sql_text]
+  @test occursin("JOIN \"cj_parent\" AS \"b2\" ON ", ok_sql)
 end

--- a/test/unit/test_order_by_joins.jl
+++ b/test/unit/test_order_by_joins.jl
@@ -617,6 +617,15 @@ end
 # Phase 1b mutates only the local `on_clause_extras`; `row_join` keeps its `on_conditions`. So the
 # two cases stay distinguishable at the raise site with no extra bookkeeping, and `relocated_to`
 # (recorded in Phase 1b) supplies the destination alias for the message.
+#
+# STRIP ANSI BEFORE MATCHING. `_emsg` keeps the SGR sequences when `Base.have_color` is true and
+# drops them otherwise, so a needle that spans a color boundary — `"another cjoin_on"`, which is
+# really `"another \e[4m\e[32mcjoin_on\e[0m"` — matches on a piped Windows run and fails on CI's
+# Linux runner. That is exactly how these two testsets went green locally and red on CI, and the
+# NEGATIVE assertions are worse: they pass for free wherever the escapes survive. Matching stripped
+# text makes every assertion here mean the same thing on both.
+_no_ansi(s::AbstractString) = replace(s, r"\e\[[0-9;]*m" => "")
+
 @testset "cjoin_on distinguishes 'you passed none' from 'they all relocated' (#435)" begin
 
   # ── case 2: predicates given, all relocated away ──────────────────────────
@@ -650,7 +659,7 @@ end
         e
       end
       @test err isa PormG.QueryBuildError
-      msg = sprint(showerror, err)
+      msg = _no_ansi(sprint(showerror, err))
 
       # The regression itself: it must NOT claim the caller supplied nothing.
       @test !occursin("produced no ON conditions", msg)
@@ -710,7 +719,7 @@ end
     msg = try
       inspect_query(q; connection = _OBJ_SL); ""
     catch e
-      sprint(showerror, e)
+      _no_ansi(sprint(showerror, e))
     end
     @test occursin("does correlate", msg)
     @test occursin("Project that path", msg)
@@ -736,7 +745,7 @@ end
     msg2 = try
       inspect_query(q2; connection = _OBJ_SL); ""
     catch e
-      sprint(showerror, e)
+      _no_ansi(sprint(showerror, e))
     end
     @test occursin("No predicate you gave names", msg2)
     @test occursin("Do NOT instead project", msg2)
@@ -759,7 +768,7 @@ end
     msg = try
       inspect_query(q; connection = _OBJ_SL); ""
     catch e
-      sprint(showerror, e)
+      _no_ansi(sprint(showerror, e))
     end
 
     @test occursin("does correlate", msg)              # still the self-ref branch
@@ -802,7 +811,7 @@ end
     msg = try
       inspect_query(q; connection = _OBJ_SL); ""
     catch e
-      sprint(showerror, e)
+      _no_ansi(sprint(showerror, e))
     end
 
     @test occursin("Project that path", msg)             # the model-path destination
@@ -828,7 +837,7 @@ end
       e
     end
     @test err isa PormG.QueryBuildError
-    msg = sprint(showerror, err)
+    msg = _no_ansi(sprint(showerror, err))
     @test occursin("produced no ON conditions", msg)   # unchanged wording
     @test occursin("b2", msg)
     @test !occursin("#435", msg)                       # not the relocation story


### PR DESCRIPTION
Closes #435

## The problem

`cjoin_on` renders its ON clause entirely from the caller's predicates — there is no equi-anchor to fall back on — so an empty extras list at emission time is fatal. Two unrelated causes reach that state, and one message described only the first:

1. the caller passed no predicates at all;
2. the caller passed some, and Phase 1b relocated **every one** onto a join emitted later.

In case 2 the old text — `cjoin_on produced no ON conditions for alias 'b2'` — describes the internal state *after* relocation and flatly contradicts the call the user wrote. It sends you looking for a missing argument that is right there.

## The fix

**The discriminator already existed.** Phase 1b mutates only the local `on_clause_extras`, never `row_join`, so `haskey(value, "on_conditions")` at the raise site still says what the caller passed. No new bookkeeping was needed to tell the two apart.

**Phase 1c hoists the #424 CROSS-CTE guard ahead of emission.** Phase 2 walks `row_join` in index order, so whether #424 fired depended on where the CROSS entry sat — a `no_anchor` join at a lower index reported *its* symptom first and the accurate message never ran. Two test files were padding their fixtures with a second predicate purely to route around that; both workarounds are gone. This cannot break a working query: `on_clause_extras` is frozen after Phase 1b, and Phase 2 visits every index testing the identical predicate, so any build that previously succeeded had no CROSS entry holding extras.

**The relocation message gives advice that is true for the query in hand.** Phase 1b records where the predicates went and whether any that left also named the join it left. That bit decides the remedy, and the first two are *opposites*:

| what relocated | remedy |
|---|---|
| nothing named the alias | add a predicate that does — and **do not** project the path, which renders an ON clause never mentioning the alias |
| named the alias; destination is a model join | **project** that path — it is built first, and the clause renders as written |
| destination is another `cjoin_on` | no path to project; declare the predicate on that join, **and** give this one a predicate of its own |

## Review

Five independent rounds. Every finding but the last was the same failure mode — generalising from the single fixture, so the advice was correct for the shape in front of me and false for a neighbouring one:

| round | found |
|---|---|
| 1 | doc advice that turned a loud error into a **silent Cartesian product**; and a claim I had stated as fact — that relocation needs the referenced join built during resolution — refuted (it is decided by alias *hashing*, not declaration order) |
| 2 | the self-ref shape where the remedy told users to do what they had already done, and warned them off the fix that works |
| 3 | "project that path" is unactionable when the destination is another `cjoin_on` — there is no path |
| 4 | the round-2 defect reintroduced in the new branch (moving the predicate out leaves an empty `on`, which `_cjoin_on` refuses); and the mixed case promising "nothing relocates" then explaining that something does |
| 5 | clean — nine mutations, nine caught |

That is why the remedy branches on real state rather than on hedged prose.

**Every claim in the new docs block was executed, not read** — 10 checks including the exact quoted SQL strings and the ✗/✓ pair. Worth recording: one check failed on first run and it was the *check*, not the code — I wrote the two-alias case as `d2` referencing `d1`, but `d1` hashes first, making it a backward reference that renders fine. #449 biting while writing a verification for it.

## Verification

- `test/unit/test_order_by_joins.jl` — #435 testset **55** assertions across 6 sub-testsets, #424 **66/66**
- `test/unit/test_docs_error_types.jl` **116/116** (one new DOCERR case)
- full `test/runtests.jl` — **8563/8563**, exit 0
- nine mutations, each failing exactly the testset that claims to cover it, including both directions of every branch

## Deliberately not done

- **No integration run.** The diff changes error messages and guard *ordering*; no happy-path SQL rendering changed. `test/integration/test_cjoin.jl` is the slice that would cover it — offered and declined for this PR.
- **No `UPGRADING.md` entry, no `Project.toml` bump.** One behavior change exists: a `cjoin_on` predicate landing on a CROSS-joined CTE previously produced `cjoin_on produced no ON conditions` and now produces the #424 message. Same `QueryBuildError` type, so no `catch` block breaks and no consuming-app source edit is forced.

## Follow-ups filed

- **#448** — `cjoin_on` checks the join *has* an ON clause, not that it *constrains* it. `on = ["points__@gt" => 10]` renders an unconstrained join today, uncaught. Raise-vs-warn left open in the issue.
- **#449** — `custom_join` is an unordered `Dict`, so alias hashing decides which of two `cjoin_on` joins is emitted first. Renaming an alias can flip a working query into an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
