### PR TITLE
fix(#432, #441): a nested render's values follow its markers, and two projections may not share an output name

### DIFF
--- a/.github/skills/pormg-querybuilder-internals/SKILL.md
+++ b/.github/skills/pormg-querybuilder-internals/SKILL.md
@@ -41,11 +41,13 @@ For positional backends, preserve bucket semantics and flatten order. The bucket
 
 `:cte → :select → :update → :join → :where → :having`
 
+**A nested render does not pick a bucket (#432).** An `Exists(...)`, a projected `Subquery(...)` or an `__@in` subquery renders inside the PARENT's clause, so its values are marked, lifted and re-emitted as one clause-ordered run at the parent's marker position (`nested_parameter_mark` / `detach_nested_run!`), with `own_contexts=true` so the inner build files its values under its own clauses first. Binding order is not text order: a build binds joins last and renders them first, which is what the buckets exist to reconcile.
+
 Parameter collector model:
 
 - `AbstractPormGParam`: base abstraction for all collectors
 - `PormGPostgresParam`: linear collector for `$1`, `$2`, ... placeholders
-- `PormGPositionalParam`: bucketed collector for positional `?` placeholders
+- `PormGSQLiteParam`: bucketed collector for positional `?` placeholders (concrete type `SQLiteParameterizedQuery`)
 
 When changing parameter behavior, verify:
 
@@ -54,7 +56,7 @@ When changing parameter behavior, verify:
 - parent and subquery inheritance behavior
 - HAVING alias promotion placement
 - custom join parameter routing into the join bucket
-- flattening through `get_final_parameters(::PormGPositionalParam)` in SQL-clause order
+- flattening through `get_final_parameters(::PormGSQLiteParam)` in SQL-clause order
 
 Query-building context rules:
 
@@ -235,7 +237,8 @@ When introducing a new parameterized SQL clause or changing clause order, update
 
 - bucket struct fields in `parameters.jl`
 - `set_context!` call sites in builder modules
-- `get_final_parameters` flatten order
+- `_BUCKET_ORDER` in `parameters.jl` — the single list both `get_final_parameters` and
+  `detach_nested_run!` (#432) read; there is no second copy to keep in sync
 - unit coverage in the canonical alignment tests
 - integration coverage if the behavior is user-visible
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,6 +45,112 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## `values()` refuses two projections that would render the same output name (#441)
+
+- **Version**: Unreleased
+- **PormG ref**: #441; `src/querybuilder/object_manager.jl`, `src/querybuilder/build_query.jl`,
+  `docs/src/read/values_and_joins.md`
+- **Severity**: **behavior change (narrow)** — two shapes that render today stop building, and one
+  of them (`Value(...)` literals sharing a name) was working correctly rather than silently wrong.
+  Part of the `0.5.x` pre-publish wave.
+
+### What changed
+
+`get_select_query` memoises each resolved projection, keyed on `_as`. A second projection under a
+name already taken was replaced by the first and never resolved at all — so the caller silently got
+one column twice instead of the two they asked for. On SQLite it was worse than a lost column: the
+cached field's ALREADY-RENDERED text carries its `?`, so the statement emitted one placeholder more
+than the driver had values for and every parameter after it bound one slot early:
+
+```
+values("note", "h" => Exists(a), "h" => Exists(b))  +  filter("note" => "TAIL")
+    SQLite      3 placeholders, parameters ["AAA", "TAIL"]
+                -> "TAIL" bound to the SECOND Exists; the outer WHERE never bound at all
+    PostgreSQL  $1 twice, then $2 — legal SQL, still the wrong query
+```
+
+`values()` now refuses two projections that would render the same output name. It is refused at the
+call rather than repaired at render because two columns under one name are indistinguishable to
+everything downstream — a DataFrame column, an `order_by` alias — so no reading of the query keeps
+both.
+
+The rule is on the **output** name, so `"*"` counts as the physical columns the database expands it
+to, not the declared field names. With `note` declared `db_column = "obs"`, `values("*", "obs" => x)`
+collides while `values("*", "note" => x)` does not.
+
+**`Value(...)` duplicates are refused too**, and this is the part that removes working behavior:
+`values("lbl" => Value("a"), "lbl" => Value("b"))` renders both parameters correctly today, because
+literal projections bypass the memo entirely. It is refused anyway so the rule has no per-kind
+exception — a rule that holds only for some projection kinds is the sort of subtlety this defect
+family has repeatedly escaped through.
+
+**Unchanged, and in fact newly fixed:** naming the same expression under two *different* names.
+`values("a" => "points", "b" => "points")` used to render `as "a"` twice and drop `b`; it now returns
+both columns, over a single join where a path is involved. If your code worked around that by
+avoiding the shape, the workaround is no longer needed.
+
+Also retired: the #423 ambiguity guard in `order_by()`. It refused `order_by("x")` when `values()`
+projected `x` twice; `values()` now refuses that declaration, so the guard was unreachable.
+
+### How to find the calls to migrate
+
+Grep for `values(` calls with a repeated alias, then check `"*"` calls against the model's physical
+columns:
+
+```bash
+rg -n '\.values\(' .
+```
+
+Or programmatically — **run this against your CURRENT pin, before upgrading.** After upgrading it
+can never fire, because `values()` throws before you can hold an offending query. Note the `"*"`
+expansion: without it the check cannot see a star collision, which is the half most likely to bite:
+
+```julia
+function duplicate_projection_names(q)
+    m, names = q.object.model, String[]
+    for v in q.object.values
+        n = v.custom_as !== nothing ? v.custom_as : v._as
+        n === nothing && continue
+        n == "*" ? append!(names, unique(PormG.Models.field_db_column(m.fields[f], f)
+                                         for f in m.field_names)) : push!(names, n)
+    end
+    [n for n in unique(names) if count(==(n), names) > 1]
+end
+
+dups = duplicate_projection_names(query)
+isempty(dups) || @warn "values() projects a name twice" dups
+```
+
+### Migrate your app
+
+Both pairs below are real F1 columns and were executed against the `db_sl` fixture — the ✗ lines
+raise, the ✓ lines run.
+
+```julia
+# ✗ BEFORE — `n` twice; the Sum was silently discarded
+query = M.Result.objects
+query.values("driverid", "n" => Count("resultid"), "n" => Sum("points"))
+
+# ✓ AFTER — distinct names
+query = M.Result.objects
+query.values("driverid", "n_results" => Count("resultid"), "total_points" => Sum("points"))
+```
+
+```julia
+# ✗ BEFORE — `statusid` is already one of the columns the star emits
+query = M.Result.objects
+query.values("*", "statusid" => "points")
+
+# ✓ AFTER — a name the star does not already emit
+query = M.Result.objects
+query.values("*", "status_points" => "points")
+```
+
+If a field carries a `db_column`, the star's contribution is the **physical** name. The F1 fixture's
+`Db_column_scratch.sku` declares `db_column = "product_sku"`, so on that model it is
+`values("*", "product_sku" => …)` that collides — `values("*", "sku" => …)` does not, because the
+star never emits `sku`.
+
 ## A subquery consumed by `@in` / `Subquery` / `Exists` may no longer declare its own CTE (#433)
 
 - **Version**: Unreleased

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -181,9 +181,23 @@ characterizations worth stating plainly.
 - **Positional-parameter buckets (deliberate, contained)** — for SQLite the positional `?` markers
   are collected into per-clause buckets and flattened in SQL-clause order
   (`:cte → :select → :update → :join → :where → :having`). The flatten order is single-sourced in
-  `get_final_parameters` and guarded by `test_alignment_sqlite.jl` / `test_parameters.jl`; the only
-  cost is that *adding a new bucket* is a documented multi-site edit (see the QueryBuilder skill's
-  maintenance checklist). Noted here so it is not mistaken for accidental coupling.
+  `_BUCKET_ORDER` (which `get_final_parameters` and the nested-run machinery both read) and guarded by `test_alignment_sqlite.jl` / `test_parameters.jl`. Noted here
+  so it is not mistaken for accidental coupling.
+
+  Two costs, not one. *Adding a new bucket* is a documented multi-site edit (see the QueryBuilder
+  skill's maintenance checklist). The subtler one: a bucket is chosen by the builder phase that binds
+  a value, while correctness depends on where that value's `?` is **emitted** — and those diverge
+  whenever a fragment renders somewhere other than its own clause. Three bugs came out of that gap —
+  #421 a relocated fragment and #432 a nested render, both SQLite-only, plus #441 a discarded
+  projection, whose *parameter* desync was SQLite-only but which dropped the column itself on **both**
+  backends. All three were silent. A nested render now re-emits its values as one clause-ordered run at its own marker
+  position (`nested_parameter_mark` / `detach_nested_run!`). All four such sites in the **read**
+  builder go through it — `Exists`, a projected `Subquery`, an `__@in` subquery, and a CTE body.
+
+  `deletion.jl` splices subqueries into hand-built `DELETE`/`UPDATE` clauses without it, and is
+  correct today only by coincidence: it builds a fresh collector per statement, and a lone
+  subquery's own text order *is* `_BUCKET_ORDER`, so the flatten happens to agree. That is a
+  narrower claim than "contained", and deliberately so.
 
 !!! note "\"Async-first\" is backend-specific"
     For **PostgreSQL** the async path is genuine: the pool lock is released before the round-trip and

--- a/docs/src/read/values_and_joins.md
+++ b/docs/src/read/values_and_joins.md
@@ -313,11 +313,19 @@ query.order_by("driverid__surname")     # ORDER BY "Tb_1"."surname" ASC NULLS LA
     sort consistent with the column the query actually returns. If you meant the underlying column,
     name it explicitly (`order_by("-points")`) or choose an alias that shadows nothing.
 
-!!! note "Two projections may not share an alias in `order_by`"
-    `.values("x" => "grid", "x" => "points")` followed by `order_by("x")` raises `QueryBuildError`:
-    the sort key matches two different projections. PostgreSQL rejects an ambiguous `ORDER BY` alias
-    and SQLite would resolve it arbitrarily, so PormG refuses it rather than diverge. Give the two
-    projections distinct names.
+!!! note "Two projections may not share an output name"
+    `.values("x" => "grid", "x" => "points")` raises `QueryBuildError` at the `values()` call — two
+    columns under one name are indistinguishable to whatever reads the result, and on SQLite the
+    second one's placeholders desynchronize every parameter after it. Give the two projections
+    distinct names.
+
+    The rule is on the **output** name, so `"*"` counts as the physical columns the database expands
+    it to: with `note` declared `db_column = "obs"`, `.values("*", "obs" => …)` collides while
+    `.values("*", "note" => …)` does not.
+
+    Naming the same expression under two *different* names is fine and renders two columns —
+    `.values("a" => "points", "b" => "points")` gives you both, over a single join where a path is
+    involved.
 
 ---
 

--- a/src/querybuilder/build_helpers.jl
+++ b/src/querybuilder/build_helpers.jl
@@ -828,11 +828,16 @@ function _get_select_query(v::SubqueryObject, instruc::SQLInstruction; _as::Unio
   # Passing the shared `parameters` makes query() treat this as a subquery: it inherits the ambient
   # :select bucket (set by build()) and restores the context afterward, so the inner params flatten in
   # :select — textually correct (the SELECT list precedes FROM/JOIN/WHERE). Correlate via outer=instruc.
+  # #432: same nested-run reordering as `_build_exists_query` — this subquery's text sits in the
+  # SELECT list, so everything it binds must be one clause-ordered run in the ambient bucket.
+  nested_mark = nested_parameter_mark(instruc)
   inner_sql = query(handler,
                     table_alias=instruc.table_alias,
                     connection=instruc.connection,
                     parameters=instruc.parameters,
-                    outer=instruc)
+                    outer=instruc,
+                    own_contexts=true)
+  reattach_parameters!(instruc, detach_nested_run!(instruc, nested_mark))
   return string("(", inner_sql, ")")
 end
 function _get_select_query(q::SQLTypeF, instruc::SQLInstruction; _as::Union{Nothing,String}=nothing)
@@ -861,18 +866,25 @@ function _build_exists_query(subquery::SQLObjectHandler, instruc::SQLInstruction
   q.object.offset = 0
 
   old_context = instruc.parameters isa PormGSQLiteParam ? instruc.parameters.current_context : nothing
+  # #432: the inner build scatters its values across its own clause buckets while this EXISTS text is
+  # spliced into ONE of the parent's clauses. Mark every bucket, then re-emit what it bound as one
+  # contiguous run, clause-ordered, at this fragment's position. See `detach_nested_run!`.
+  nested_mark = nested_parameter_mark(instruc)
   instruction = try
     build(
       q.object,
       table_alias=instruc.table_alias,
       connection=instruc.connection,
       parameters=instruc.parameters,
-      set_contexts=false,
+      # #432: record this subquery's OWN clause roles so `detach_nested_run!` can sort its values
+      # into text order. The `finally` below restores the parent's ambient bucket.
+      set_contexts=true,
       outer=instruc,
     )
   finally
     old_context !== nothing && set_context!(instruc.parameters, old_context)
   end
+  reattach_parameters!(instruc, detach_nested_run!(instruc, nested_mark))
 
   safe_table_name = safe_table_identifier(Models.model_table_name(q.object.model), instruction.connection)
   safe_alias = quote_identifier(instruction.alias, instruction.connection)
@@ -1322,7 +1334,10 @@ function _get_filter_query(v::SQLTypeOper, instruc::SQLInstruction)
     _validate_membership_subquery(v)
     # #433: renders an inline WITH that binds into `:cte` while its text sits in the WHERE clause.
     _guard_no_nested_cte(v.values, "A membership filter (__@in / __@nin)")
-    placeholders = query(v.values, table_alias=instruc.table_alias, connection=instruc.connection, parameters=instruc.parameters, outer=instruc)
+    # #432: same nested-run reordering — the subquery renders inside this predicate's clause.
+    nested_mark = nested_parameter_mark(instruc)
+    placeholders = query(v.values, table_alias=instruc.table_alias, connection=instruc.connection, parameters=instruc.parameters, outer=instruc, own_contexts=true)
+    reattach_parameters!(instruc, detach_nested_run!(instruc, nested_mark))
     return string(_get_filter_query(v.column, instruc), " ", v.operator, " ($placeholders)")
   else
     @pormg_debug false

--- a/src/querybuilder/build_query.jl
+++ b/src/querybuilder/build_query.jl
@@ -10,6 +10,12 @@
   - `object::SQLObject`: The object containing the values to be selected.
   - `instruc::SQLInstruction`: The SQLInstruction object to which the SELECT query will be added.
 """
+# #441: the name a projection is RENDERED under. `custom_as` holds it for an aliased field path
+# (`"s" => "parent__sku"`); `_as` holds it for everything else. Same expression `_query_select` and
+# `get_order_query` use to decide a slot's alias, so the three agree by construction.
+_projection_output_name(v::SQLTypeField) = v.custom_as !== nothing ? v.custom_as : v._as
+_projection_output_name(v::SQLTypeText) = v.custom_as !== nothing ? v.custom_as : v._as
+
 function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instruc::SQLInstruction)
   for i in eachindex(values) # linear indexing
     v_copy = deepcopy(values[i])
@@ -45,8 +51,19 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
       push!(instruc.group, i |> string)
     end
 
-    if haskey(instruc.cache, v_copy._as)
-      instruc.select[i] = instruc.cache[v_copy._as]  # TODO That is necessary in get_select_query
+    # #441: the memo is keyed on `_as`, which for a field-path projection is the PATH, not the name
+    # the column is rendered under (that lives in `custom_as`). So a bare `haskey` hit collapsed
+    # projections that share an expression but declare DIFFERENT names — `values("gg" => "note",
+    # "hh" => "note")` rendered `as "gg"` twice and dropped `hh` entirely, silently. `_cache_join`
+    # (`build_joins.jl`) writes into this same dict keyed by join path, so a projection can also hit
+    # an entry that was never a projection at all.
+    #
+    # Reuse is only correct when the cached entry renders under the SAME output name. Otherwise
+    # resolve independently, and leave the memo to whichever entry claimed the key first — the point
+    # of the memo is to avoid re-resolving one expression, not to make two projections one.
+    cached = get(instruc.cache, v_copy._as, nothing)
+    if cached !== nothing && _projection_output_name(cached) == _projection_output_name(v_copy)
+      instruc.select[i] = cached
     else
       @pormg_debug false
       v_copy.field = _get_select_query(v_copy.field, instruc, _as=v_copy._as)
@@ -54,7 +71,7 @@ function get_select_query(values::Vector{Union{SQLTypeText,SQLTypeField}}, instr
       if v_copy._as === nothing
         throw(QueryBuildError("Field requires an alias: \e[4m\e[31m$(v_copy.field)\e[0m must have a name using the format \e[4m\e[32m\"field_name\" => $(v_copy.field)\e[0m or use \e[4m\e[32mSQLField($(v_copy.field), \"alias_name\")\e[0m"))
       end
-      instruc.cache[v_copy._as] = instruc.select[i]
+      cached === nothing && (instruc.cache[v_copy._as] = instruc.select[i])
     end
   end
 
@@ -118,19 +135,21 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # entries must reuse their resolved SQL selector instead of quoting the raw lookup string.
     #
     # Scan `instruc.select` — the RENDERED projections — not `object.values`, the declared ones.
-    # The two are NOT the same set, and trusting the declared list is a silent-wrong-answer bug
-    # (#423): `get_select_query` collapses a projection whose `_as` is already cached onto the
-    # cached SQLField and DISCARDS its `custom_as`, so a name the caller declared can fail to reach
-    # the SQL at all.
     #
-    #     values("note", "gg" => "note")   ->   SELECT "Tb"."note" as "note", "Tb"."note" as "note"
+    # #441 changed WHY this matters, and the old reason is worth recording as retired rather than
+    # left standing. Before it, `get_select_query` collapsed a projection whose `_as` was already
+    # cached onto the cached `SQLField` and discarded its `custom_as`, so a declared name could fail
+    # to reach the SQL at all — `values("note", "gg" => "note")` rendered `as "note"` twice and `gg`
+    # never appeared. Emitting `ORDER BY "gg"` from the declared list then named neither an output
+    # nor an input column: PostgreSQL raises, while SQLite degrades the unresolvable identifier to
+    # the literal 'gg' — a constant sort key — and returns the rows UNSORTED with no error.
     #
-    # `gg` is declared and never rendered. Emitting `ORDER BY "gg"` from the declared list names
-    # neither an output nor an input column: PostgreSQL raises `column "gg" does not exist`, and
-    # SQLite's double-quoted-string fallback degrades the unresolvable identifier to the literal
-    # 'gg' — a constant sort key — so the rows come back UNSORTED with no error at all. Scanning
-    # what will actually be rendered keeps that shape on the loud, backend-aligned path it was on
-    # before (an `UnknownFieldError` from the resolution branch below).
+    # That collapse is gone: the memo is now reused only when the cached entry renders under the
+    # SAME output name, so every declared name IS rendered and the two sets agree. Scanning
+    # `instruc.select` is still the right choice — it is what the SQL will actually contain, which
+    # is the thing `order_by` must resolve against — but it is no longer load-bearing against a
+    # silent-wrong-answer bug. Do not "simplify" it back to `object.values` on that basis; the sets
+    # agreeing is a property of `get_select_query`, not of this function.
     #
     # `instruc.select` is authoritative and fully populated here: `build` calls `get_select_query`
     # before `get_order_query`, and that is its only writer, assigning contiguously over
@@ -139,54 +158,24 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # behavior: that one `return`s at the first gap, this one `continue`s. Equivalent only because
     # assignment is contiguous; `continue` is the safer of the two if that ever stops being true.
     #
-    # The scan also runs to completion rather than breaking on the first hit, so a name carried by
-    # TWO RENDERED columns over different expressions can be refused. `.values()` permits that —
-    # `values("x" => "note", "x" => "qty")` renders `as "x"` twice — and `ORDER BY "x"` is then
-    # ambiguous: PostgreSQL rejects it, SQLite picks one arbitrarily.
-    #
-    # Keyed on OBJECT IDENTITY. Two matching slots are safe exactly when they are the same
-    # `SQLField`, which is precisely `get_select_query`'s dedupe relation: it collapses a projection
-    # whose `_as` is already cached onto the cached object, so collapsed slots are `===` and render
-    # byte-identical SQL — which is what PostgreSQL's `equal()` accepts. Anything else is two
-    # distinct expressions under one output name, which PostgreSQL rejects.
-    #
-    # Two earlier keys were wrong, both for reasons worth keeping written down:
-    #
-    #   `_as`  — justified as "equal `_as` means the same object". True of the field/function
-    #            branch, FALSE of the `SQLText` one, which assigns `instruc.select[i]`
-    #            unconditionally without consulting the cache. So
-    #            `values("lbl" => Value("a"), "lbl" => Value("b"))` carries one `_as` over two
-    #            different Params and slipped through.
-    #   rendered text — closer, but SQLite renders EVERY parameter as `?`, so the text key collapses
-    #            any two parameterized projections regardless of their values. That made the guard
-    #            raise on PostgreSQL and stay silent on SQLite for the same query — the strict
-    #            engine refusing while the lax engine sorts by an arbitrary one of two DIFFERENT
-    #            values. Exactly the divergence this guard exists to prevent, introduced by the
-    #            guard itself.
-    #
-    # Identity has neither blind spot and needs no placeholder text. It IS over-strict when two
-    # distinct objects resolve to identical SQL. The reachable instance is two literal-`NULL`
-    # projections — `Value(nothing)` short-circuits to the literal, not a parameter — so
-    # `values("lbl" => Value(nothing), "lbl" => Value(nothing))` renders `NULL as "lbl"` twice.
-    # PostgreSQL parses those as equal `Const`s and accepts; PormG refuses, with a message that
-    # degenerates to "over NULL and NULL". Harmless (ordering by a doubly-projected NULL is
-    # meaningless) and loud rather than silent, which is the direction to err in — but it is a real
-    # case, not the contrived two-spellings-of-one-column one an earlier draft of this comment
-    # named.
     # An ORDER BY term with NO alias cannot name a projection, and must not be compared as if it
     # could: `selected_alias == v_field_copy._as` would reduce to `nothing == nothing` and match
-    # every unaliased select entry. One match then reaches `quote_identifier(nothing, …)`, two
-    # produce the nonsense `Ambiguous order_by("nothing")` — and both are reachable through the
-    # fluent surface, since a bare `Value("hi")` in `values()` projects with no alias at all and
-    # `SQLOrder(SQLField(f, nothing))` is accepted by `order_by`.
+    # every unaliased select entry, which then reaches `quote_identifier(nothing, …)`. Reachable
+    # through the fluent surface — a bare `Value("hi")` in `values()` projects with no alias, and
+    # `SQLOrder(SQLField(f, nothing))` is accepted by `order_by` — hence the empty-tuple guard.
     #
-    # Skipping the scan restores EXACT parity with the pre-#423 path for such a term. To be precise
-    # about what that parity is: the shape was already broken, raising `MethodError: Cannot convert
-    # an object of type Nothing` from the resolution branch — a raw MethodError outside the error
-    # taxonomy (#231/#239). This guard does not fix that; it only keeps #423 from replacing one
-    # untyped failure with a different, more confusing one. The underlying leak is pre-existing and
-    # tracked separately.
-    matched_value = nothing
+    # That shape was already broken before #423, raising `MethodError: Cannot convert an object of
+    # type Nothing` from the resolution branch — a raw MethodError outside the error taxonomy
+    # (#231/#239). Skipping the scan keeps it on exactly that pre-existing path rather than
+    # replacing one untyped failure with a different one. The leak is tracked separately.
+    #
+    # #441 also retired the ambiguity THROW that used to sit inside this loop. It refused
+    # `order_by("x")` when `values(...)` projected `x` twice over two different expressions;
+    # `values()` now refuses that declaration, so the throw was unreachable and was deleted rather
+    # than kept as dead code behind a comment describing an impossible situation. What survives is
+    # the loop itself, which answers only "is this name projected at all?" — and since no name can
+    # now be projected twice, it could `break` on the first hit; it does not, only because running
+    # to completion costs nothing over a projection list.
     for i in (v_field_copy._as === nothing ? () : eachindex(instruc.select))
       isassigned(instruc.select, i) || continue
       value = instruc.select[i]
@@ -194,22 +183,7 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
       selected_alias = value.custom_as !== nothing ? value.custom_as : value._as
       selected_alias == v_field_copy._as || continue
 
-      if found_in_select && !(value === matched_value)
-        # Name each side INDEPENDENTLY: a field-path projection keeps the path in `_as` (which reads
-        # far better than its rendered column), while an `SQLText` one keeps the chosen alias there.
-        # Choosing globally printed the ordered alias back as one of its own sources on a mixed
-        # pair — "over note and x" for `order_by("x")`, which is circular.
-        _name(v) = v._as == v_field_copy._as ? string(v.field) : string(v._as)
-        throw(QueryBuildError(
-          "Ambiguous \e[4m\e[31morder_by(\"$(v_field_copy._as)\")\e[0m: " *
-          "\e[4m\e[32m.values(...)\e[0m projects that name twice, over " *
-          "\e[33m$(_name(matched_value))\e[0m and \e[33m$(_name(value))\e[0m. PostgreSQL " *
-          "rejects an ambiguous ORDER BY alias and SQLite would pick one arbitrarily, so PormG " *
-          "refuses it rather than diverge. Give the two projections distinct names, or order by " *
-          "the underlying field path instead of the alias."))
-      end
       found_in_select = true
-      matched_value = value
     end
 
     # #423: the projection test comes FIRST. It used to be nested inside the `instruc.cache` hit
@@ -233,11 +207,13 @@ function get_order_query(object::SQLObject, instruc::SQLInstruction)
     # both the #76 DISTINCT guard and the `instruc.group` push below stay gated on
     # `!found_in_select`, so neither is reachable from the new branch.
     #
-    # The ambiguity guard above is NOT gated on the cache, so it moves a second combination:
-    # found_in_select && cache-HIT. `values("note", "note" => "qty")` renders two output columns
-    # named "note" over different expressions and used to emit `ORDER BY "note"`; PostgreSQL
-    # rejected that at execution as ambiguous, so refusing it at build time is the aligned
-    # behavior — but it IS a second change, and saying "only one" would be wrong.
+    # #423 also moved a second combination — found_in_select && cache-HIT — via an ambiguity guard
+    # that used to sit in the loop above: `values("note", "note" => "qty")` rendered two output
+    # columns named "note" over different expressions and previously emitted `ORDER BY "note"`,
+    # which PostgreSQL rejected at execution. #441 retired that guard and moved the refusal to
+    # `values()` itself, so this combination is now unreachable from here — the declaration throws
+    # before `order_by` is ever consulted. Recorded because the branch inversion's "exactly one
+    # combination" claim above was true only alongside it.
     if found_in_select
       # Use the alias name instead of the expression to avoid double parameterization.
       # Most databases (PG, SQLite, MySQL) support aliases in ORDER BY.

--- a/src/querybuilder/ctes.jl
+++ b/src/querybuilder/ctes.jl
@@ -504,8 +504,23 @@ function build_cte_clause(ctes::Dict{String,CTEDict}, connection, parameters::Un
     # and appear before main query parameters in the final SQL order.
     set_context!(parameters, :cte)
 
+    # #432: a CTE BODY is a nested render too — the fourth one. Its own joins bind through the
+    # ungated `set_context!(:join)` in `build_row_join_sql_text`, so a `.with(...)` whose body
+    # carries a parameterized join scattered its values across `:cte` and `:join` while its whole
+    # text sits inside the leading `WITH`. Measured before this: a CTE body with a `cjoin` ON filter
+    # plus its own WHERE bound SQLite `["CTEWHERE", "CTEON"]` against a text order of
+    # `CTEON, CTEWHERE`, because `:cte` flattens ahead of `:join`. Correct on PostgreSQL, silent
+    # wrong rows on SQLite, and NOT refused by anything — a plain documented `.with(...)`.
+    #
+    # Same treatment as the other three sites: let the body file its values under its own clauses,
+    # then lift them and re-emit as one clause-ordered run in `:cte`, where this text lives.
+    nested_mark = nested_parameter_mark(parameters)
+
     # IMPORTANT: Pass the SAME parameters object so parameter numbering continues sequentially
-    cte_sql = query(cte_query, table_alias=table_alias, connection=connection, parameters=parameters, cte=cte_fields)
+    cte_sql = query(cte_query, table_alias=table_alias, connection=connection, parameters=parameters, cte=cte_fields, own_contexts=true)
+
+    set_context!(parameters, :cte)
+    reattach_parameters!(parameters, detach_nested_run!(parameters, nested_mark))
 
     @pormg_debug false
 

--- a/src/querybuilder/execution.jl
+++ b/src/querybuilder/execution.jl
@@ -151,7 +151,15 @@ function query(q::SQLObjectHandler;
   parameters::Union{Nothing, AbstractPormGParam} = nothing,
   cte::Union{Nothing, CTEDict} = nothing,
   outer::Union{Nothing, SQLInstruction} = nothing,
-  show_query::Symbol = :execute
+  show_query::Symbol = :execute,
+  # #432: opt-in for a nested render that will re-emit its own parameters as one clause-ordered run
+  # (see `detach_nested_run!`). A subquery normally suppresses context switching so it cannot clobber
+  # the parent's active bucket — but that also means its values are filed under the PARENT's clause
+  # rather than their own, which is exactly the information the run needs to sort itself into text
+  # order. `query()` restores the ambient bucket itself below (the `is_subquery` branch), so a
+  # caller passing this does NOT need to — and none of them does. Do not delete that restore on the
+  # assumption the caller handles it: the failure would be silent and SQLite-only.
+  own_contexts::Bool = false
   )
 
   @pormg_debug false
@@ -163,6 +171,9 @@ function query(q::SQLObjectHandler;
 
   # Track if this is a subquery
   is_subquery = parameters !== nothing
+  # #432: `own_contexts` keeps the shared collector (PostgreSQL still needs one sequential `$N`
+  # counter) while letting the inner build file its values under its OWN clauses.
+  set_own_contexts = own_contexts || !is_subquery
 
   # IMPORTANT: Create the shared parameters object BEFORE building CTEs
   # This ensures all CTEs and the main query use sequential parameter numbering
@@ -184,7 +195,7 @@ function query(q::SQLObjectHandler;
   # Main query uses the SAME parameters object (will continue numbering from where CTEs left off)
   # Context switching for select/where/join happens inside build()
   # Subqueries skip context switching to inherit the parent's current bucket.
-  instruction = build(q.object, table_alias=table_alias, connection=connection, parameters=parameters, set_contexts=!is_subquery, outer=outer)
+  instruction = build(q.object, table_alias=table_alias, connection=connection, parameters=parameters, set_contexts=set_own_contexts, outer=outer)
   
   # Prevent SELECT * across JOINs which causes DataFrame column collisions downstream.
   # Only enforce during actual execution (:execute) — inspection/dry-run modes (:dict, :sql,

--- a/src/querybuilder/object_manager.jl
+++ b/src/querybuilder/object_manager.jl
@@ -74,7 +74,80 @@ function _values!(q::SQLObject, values)
     end
   end
 
+  _reject_duplicate_projection_names(q)
   return q
+end
+
+# #441: two projections may not render under the same output column name.
+#
+# `get_select_query` memoises resolved projections, so a second entry under a name already taken was
+# replaced by the first and never resolved at all. On both backends the caller silently got one
+# column twice instead of the two they asked for; on SQLite it was worse, because the cached field's
+# ALREADY-RENDERED text carries its `?` — so the statement emitted one marker more than the driver
+# had values for, and every parameter after it bound one slot early. Measured:
+# `values("note", "h" => Exists(a), "h" => Exists(b)) + filter("note" => "TAIL")` emitted three `?`
+# against `["AAA", "TAIL"]` — "TAIL" bound to the second EXISTS and the outer WHERE went unbound.
+#
+# Refused at declaration rather than repaired at render: two columns under one name are
+# indistinguishable to every consumer downstream — a DataFrame column, an `order_by` alias — so no
+# reading of the query keeps both.
+#
+# `Value(...)` duplicates are refused too, even though they render correctly today (the `SQLText`
+# branch bypasses the memo). One rule, no per-kind carve-out: a conditional rule is exactly the kind
+# of subtlety this defect family keeps escaping through.
+#
+# `"*"` is compared as the PHYSICAL columns the database expands it to, not `field_names`. A
+# `field_names` check is wrong in BOTH directions — with `note` carrying `db_column = "obs"`,
+# `values("*", "obs" => x)` collides (the star contributes `obs`) while `values("*", "note" => x)`
+# does not, and a name-based check gets both backwards.
+function _reject_duplicate_projection_names(q::SQLObject)
+  isempty(q.values) && return nothing
+  seen = Dict{String,String}()          # output name => what claimed it
+  for v in q.values
+    name = v.custom_as !== nothing ? v.custom_as : v._as
+    name === nothing && continue        # build-time raises a clearer "Field requires an alias"
+    if name == "*"
+      # `unique`, because the star emits each PHYSICAL column once. Two model fields can map to one
+      # `db_column` — nothing in `src/` forbids it — and without this, `values("*")` on such a model
+      # refused itself with a message naming no projection the caller could rename. The defect there
+      # is in the model, not the query, and refusing the single most common projection over it is
+      # both wrong and unactionable.
+      model = q.model
+      for col in unique(Models.field_db_column(model.fields[f], f) for f in model.field_names)
+        _claim_projection_name!(seen, col, "\"*\"")
+      end
+    else
+      _claim_projection_name!(seen, name, _describe_projection(v))
+    end
+  end
+  return nothing
+end
+
+function _claim_projection_name!(seen::Dict{String,String}, name::String, descr::String)
+  prior = get(seen, name, nothing)
+  prior === nothing || throw(QueryBuildError(
+    "values() projects the name \e[4m\e[31m$(name)\e[0m twice — from $(prior) and from $(descr).\n  " *
+    "Two columns under one name are indistinguishable to whatever reads the result, and on SQLite " *
+    "the second one's placeholders desynchronize every parameter after it.\n  " *
+    "Give them distinct names, e.g. \e[4m\e[32m.values(\"a\" => …, \"b\" => …)\e[0m (#441)."))
+  seen[name] = descr
+  return nothing
+end
+
+# A short, USER-recognisable label for the colliding entry — the point of the message is that the
+# caller can tell the two apart, so a bare type name (`FObject` for every aggregate alike) is useless.
+function _describe_projection(v)
+  f = v.field
+  f isa String && return "\"$(f)\""
+  # Spell these the way the caller wrote them. `Exists`/`Subquery` under one name is the headline
+  # case — it is the shape that misaligns SQLite parameters — and `ExistsObject` is not a word that
+  # appears anywhere in a user's source.
+  f isa ExistsObject && return "Exists(...)"
+  f isa SubqueryObject && return "Subquery(...)"
+  # `Value("a")` would otherwise print as `"a"`, indistinguishable from a column path in the message.
+  v isa SQLTypeText && return "Value($(repr(f)))"
+  hasproperty(f, :function_name) && f.function_name isa String && return "$(f.function_name)(...)"
+  return string(nameof(typeof(f)))
 end
 
 function _create!(q::SQLObject, values; kwargs...)

--- a/src/querybuilder/parameters.jl
+++ b/src/querybuilder/parameters.jl
@@ -164,6 +164,99 @@ function reattach_parameters!(instruc::SQLInstruction, values::Vector{Any})
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Nested-render runs (#432)
+#
+# #421's mark above watches ONE bucket. That is right for a fragment that stays inside a single
+# clause, and wrong for a NESTED RENDER — an `Exists(...)`, a projected `Subquery(...)`, an `__@in`
+# subquery — whose inner build walks its own clauses and therefore pushes into SEVERAL buckets while
+# its text is spliced into ONE of the parent's.
+#
+# Two independent things go wrong there, and both are fixed by the same move:
+#
+#   1. **Wrong bucket.** The inner build's ON values land in the OUTER `:join` bucket (its
+#      `build_row_join_sql_text` switches to `:join` unconditionally, defeating `build()`'s own
+#      `set_contexts` gate), while their `?` renders inside the outer WHERE. `:join` flattens before
+#      `:where`, so they overtake values whose text precedes them.
+#   2. **Wrong ORDER, even within one bucket.** A build BINDS in phase order (select → where → …
+#      → joins last) but RENDERS in clause order (joins before where). At top level the buckets
+#      absorb that difference — that is what they are for. A nested run has no such reordering
+#      unless we give it one: simply restoring the ambient bucket yields binding order, which for
+#      `Exists(inner-with-ON)` is `WHEREVAL, ONVAL` against a text order of `ONVAL, WHEREVAL`.
+#
+# So: mark every bucket, let the inner build scatter, then lift everything it added and re-emit it
+# as ONE contiguous run in the parent's active bucket, concatenated in CLAUSE order. That gives the
+# fragment the same phase→clause reordering a top-level statement gets, and pins the whole run at
+# the parent's marker position.
+#
+# All no-ops on numbered backends: PostgreSQL's `$N` travels with the text, which is why every bug
+# in this family has been SQLite-only.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Clause order. `get_final_parameters` flattens from this same tuple, so there is ONE list to edit
+# when a bucket is added — the maintenance checklist in the QueryBuilder skill points here.
+const _BUCKET_ORDER = (:cte, :select, :update, :join, :where, :having)
+
+# Deliberately mirrors `_current_bucket`'s fallback rather than defining its own: an unrecognized
+# context must land in the same bucket and warn the same way from both helpers, or a future bucket
+# added to one and not the other diverges silently.
+function _bucket_for(sq::PormGSQLiteParam, ctx::Symbol)::Vector{Any}
+  ctx === :cte && return sq.cte_params
+  ctx === :select && return sq.select_params
+  ctx === :update && return sq.update_params
+  ctx === :join && return sq.join_params
+  ctx === :where && return sq.where_params
+  ctx === :having && return sq.having_params
+  @warn "Unknown parameter context $(repr(ctx)), falling back to :where" ctx
+  return sq.where_params
+end
+
+const _N_BUCKETS = length(_BUCKET_ORDER)
+const NestedMark = Union{Nothing,NTuple{_N_BUCKETS,Int}}
+
+"""
+    nested_parameter_mark(instruc) -> NestedMark
+
+Record the length of every positional bucket. `nothing` on a numbered backend.
+"""
+function nested_parameter_mark(sq)::NestedMark
+  sq isa PormGSQLiteParam || return nothing
+  return ntuple(i -> length(_bucket_for(sq, _BUCKET_ORDER[i])), _N_BUCKETS)
+end
+nested_parameter_mark(instruc::SQLInstruction)::NestedMark = nested_parameter_mark(instruc.parameters)
+
+"""
+    detach_nested_run!(instruc, mark) -> Vector{Any}
+
+Lift everything bound since `mark` out of every bucket, returning it concatenated in clause order —
+the order those values' markers actually render in.
+"""
+function detach_nested_run!(sq, mark::NestedMark)::Vector{Any}
+  mark === nothing && return Any[]
+  sq isa PormGSQLiteParam || return Any[]
+  run = Any[]
+  for (i, ctx) in enumerate(_BUCKET_ORDER)
+    bucket = _bucket_for(sq, ctx)
+    len = mark[i]
+    length(bucket) <= len && continue
+    append!(run, bucket[len+1:end])
+    deleteat!(bucket, len+1:length(bucket))
+  end
+  return run
+end
+detach_nested_run!(instruc::SQLInstruction, mark::NestedMark)::Vector{Any} =
+  detach_nested_run!(instruc.parameters, mark)
+
+# Append a lifted run to whatever bucket is active on `sq`. The `SQLInstruction` form below is the
+# common one; this bare-collector form exists because `build_cte_clause` holds only the parameter
+# object — it renders a CTE body before any instruction for the outer statement exists.
+function reattach_parameters!(sq::AbstractPormGParam, values::Vector{Any})
+  isempty(values) && return nothing
+  sq isa PormGSQLiteParam || return nothing
+  append!(_current_bucket(sq), values)
+  return nothing
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # add_parameter!  – push a value and return the placeholder string
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -240,21 +333,39 @@ add_parameter!(instruc::SQLInstruction, value::Any; contains::Bool=false, operat
 Return all collected parameter values in the order expected by the final SQL string.
 
 - **PostgreSQL**: returns the single linear vector (order already matches `\$N` numbering).
-- **SQLite**: concatenates buckets in standard SQL clause order:
-  `cte → select → join → where → having`
+- **SQLite**: concatenates buckets in standard SQL clause order, single-sourced from
+  `_BUCKET_ORDER`: `cte → select → update → join → where → having`
   so that each positional `?` aligns with its value.
 """
 get_final_parameters(p::PormGPostgresParam)::Vector{Any} = p.parameters isa Vector{Any} ? p.parameters : collect(p.parameters)
 
 function get_final_parameters(p::PormGSQLiteParam)::Vector{Any}
-  return vcat(
-    p.cte_params,
-    p.select_params,
-    p.update_params,
-    p.join_params,
-    p.where_params,
-    p.having_params
-  )
+  # Driven from `_BUCKET_ORDER` rather than a second hand-written list. #432 added a consumer of
+  # that same order (`detach_nested_run!`, which sorts a nested render's values into the order their
+  # markers appear), and two copies of a clause order that must agree is exactly the drift a new
+  # bucket would introduce silently.
+  #
+  # `sizehint!` then `append!`, NOT `reduce(vcat, …)` and not a bare `append!` loop. Both of those
+  # re-copy while the result grows — reduce once per bucket, the bare loop on each geometric
+  # reallocation. This is a property getter (`Base.getproperty(…, :parameters)`) read on every
+  # execution path, so the cost lands per query.
+  #
+  # Measured warm — cold, every variant reads as ~200ms and the differences vanish into compilation
+  # noise, which is how a bogus "44x" figure was produced once. At 50_000 bound parameters
+  # (reachable: `filter("id__@in" => 1:50_000)` binds exactly that), 50 calls: this ~6.8ms,
+  # hardcoded vcat ~7.7ms, reduce(vcat) ~16ms, bare append! loop ~33ms. At a REALISTIC 17 params
+  # over 200_000 calls it is ~0.30µs/call against hardcoded's ~0.14µs — about 2x worse per call, and
+  # 0.15µs next to a database round trip is not worth a second copy of the clause order.
+  total = 0
+  for ctx in _BUCKET_ORDER
+    total += length(_bucket_for(p, ctx))
+  end
+  out = Any[]
+  sizehint!(out, total)
+  for ctx in _BUCKET_ORDER
+    append!(out, _bucket_for(p, ctx))
+  end
+  return out
 end
 
 # Legacy compatibility: `.parameters` property access for SQLite

--- a/test/integration/test_exists_correlated.jl
+++ b/test/integration/test_exists_correlated.jl
@@ -252,3 +252,63 @@ end
     @test count2 <= count1
 end
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A nested render binds its values in TEXT order, against real rows (#432)
+#
+# The unit file pins the parameter vector; this pins the ROWS, which is the only thing that proves a
+# misbind mattered. A positional mix-up produces perfectly valid SQL — the driver is happy, nothing
+# raises, and the query just answers a different question. Only comparing the returned set against
+# an independently computed one catches that.
+#
+# The shape needs three things at once, and dropping any one makes it pass against the bug:
+#   1. a value bound in the OUTER query whose text PRECEDES the nested render (`statusid`),
+#   2. a nested `Exists` whose inner query binds a value in a JOIN ON clause (`year`),
+#   3. and another in the inner WHERE (`milliseconds`).
+# Before the fix SQLite flattened `:join` ahead of `:where`, so `year`'s value bound to `statusid`'s
+# marker and the query silently selected on the wrong columns.
+#
+# The cjoin is INNER on purpose. Under the default LEFT JOIN the ON predicate does not filter — a
+# non-matching row still satisfies `EXISTS` — so the year value would have no effect on the result
+# and this testset would pass whatever it bound to. Measured: 3218 rows LEFT, 121 rows INNER.
+#
+# `PORMG_DB=db_sl` is where this can fail; on PostgreSQL `$N` travels with the text, so there the
+# same assertions are a control rather than a regression.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "nested Exists binds in text order against real rows (#432)" begin
+    threshold = 95_000   # ms — broad enough to select a real, non-empty set
+    year      = 2009
+    finished  = 1        # statusid 1 == "Finished" in the F1 fixture
+
+    inner = M.Lap_times.objects
+    inner.values("raceid")
+    inner.filter("raceid" => OuterRef("raceid"), "driverid" => OuterRef("driverid"))
+    inner.cjoin("raceid" => "Race", filters = ["year" => year], join_type = "INNER", warn = false)
+    inner.filter("milliseconds__@lt" => threshold)
+
+    q = M.Result.objects
+    q.filter("statusid" => finished)      # MUST be declared before the nesting — see above
+    q.filter(Exists(inner))
+    q.values("resultid")
+
+    got = Set((q |> DataFrame).resultid)
+
+    # Independently computed expectation: two plain queries, no nesting, so it cannot share the
+    # defect under test. A Result row qualifies iff it is Finished AND that driver set a sub-95s lap
+    # in that race AND the race was in `year`.
+    fast = M.Lap_times.objects
+    fast.filter("milliseconds__@lt" => threshold, "raceid__year" => year)
+    fast.values("raceid", "driverid")
+    pairs = Set((r.raceid, r.driverid) for r in eachrow(fast |> DataFrame))
+
+    finished_rows = M.Result.objects
+    finished_rows.filter("statusid" => finished)
+    finished_rows.values("resultid", "raceid", "driverid")
+    expected = Set(r.resultid for r in eachrow(finished_rows |> DataFrame)
+                   if (r.raceid, r.driverid) in pairs)
+
+    # Non-emptiness is a premise, not decoration: an empty set makes the comparison vacuous and this
+    # testset would pass against the bug it exists to catch.
+    @test !isempty(expected)
+    @test got == expected
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,8 @@ end
     @testset "Identifier Quoting Partition (#394)" include("unit/test_identifier_quoting.jl")
     @testset "Unresolved ForeignKey Target Is Never Guessed (#388)" include("unit/test_fk_unresolved_target.jl")
     @testset "SQLite Alignment Verification" include("unit/test_alignment_sqlite.jl")
+    @testset "Nested-render Parameter Alignment (#432)" include("unit/test_parameter_alignment_nested.jl")
+    @testset "Projection Name Collapse and Refusal (#441)" include("unit/test_projection_names.jl")
     @testset "CTE Ergonomics F() Reference (#44)" include("unit/test_cte_ergonomics.jl")
     @testset "CTE Columns Are Projection Aliases (#376)" include("unit/test_cte_db_column.jl")
     @testset "Nested CTE Guard (#433)" include("unit/test_nested_cte_guard.jl")

--- a/test/unit/helper_marker_alignment.jl
+++ b/test/unit/helper_marker_alignment.jl
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared marker/parameter alignment assertions (#432, #441)
+#
+# The invariant this family keeps escaping through, stated once:
+#
+#     on a positional backend, the number of `?` a statement renders must equal the number of
+#     values bound, and the Nth value must be the one whose marker is Nth IN THE TEXT.
+#
+# Both halves matter and they fail independently. #441's severe symptom broke the COUNT (a
+# discarded projection left its `?` behind with no value); #432 broke the ORDER while the count
+# stayed right (a nested render bound into a bucket that flattens somewhere else). An assertion
+# that only checked one of them would have passed against the other bug.
+#
+# Counting `?` is sound on SQLite: the only SQL operators carrying a bare `?` are PostgreSQL's JSONB
+# `?|` and `?&`, and both raise `BackendCapabilityError` on this backend.
+#
+# NOT retrofitted onto the ~31 hand-written `count(==('?'), …)` assertions already scattered through
+# test_alignment_sqlite.jl / test_json_lookups.jl / test_order_by_joins.jl. They assert the same
+# thing correctly; rewriting them is churn with real risk and no coverage gain. New alignment tests
+# should use these.
+# ─────────────────────────────────────────────────────────────────────────────
+
+"""
+    marker_count(sql, backend) -> Int
+
+Placeholders rendered in `sql`. `backend` is `:sqlite` (`?`) or `:postgres` (`\$N`).
+"""
+marker_count(sql::AbstractString, backend::Symbol) =
+  backend === :sqlite ? count(==('?'), sql) : length(collect(eachmatch(r"\$\d+", sql)))
+
+"""
+    assert_marker_count(insp, backend)
+
+Every rendered placeholder has a bound value and vice versa. This is #441's half.
+
+On PostgreSQL a repeated `\$1` is legal and deliberate, so the count is compared against the number
+of DISTINCT indices rather than occurrences — otherwise a legitimately reused parameter reads as a
+mismatch.
+"""
+function assert_marker_count(insp::Dict, backend::Symbol)
+  sql = insp[:sql_text]
+  n = length(insp[:parameters])
+  if backend === :sqlite
+    @test marker_count(sql, backend) == n
+  else
+    idx = Set(parse(Int, m.match[2:end]) for m in eachmatch(r"\$\d+", sql))
+    @test length(idx) == n
+  end
+end
+
+"""
+    assert_bound_in_text_order(insp, sentinels)
+
+`sentinels` lists the bound values in the order their markers appear IN THE TEXT. Asserts SQLite's
+flattened parameter vector matches. This is #432's half.
+
+SQLite only: PostgreSQL's `\$N` travels with the text by construction, so there is nothing to check
+there — which is precisely why every bug in this family has been SQLite-only.
+"""
+function assert_bound_in_text_order(insp::Dict, sentinels::Vector)
+  @test insp[:parameters] == sentinels
+end

--- a/test/unit/test_alignment_sqlite.jl
+++ b/test/unit/test_alignment_sqlite.jl
@@ -1364,7 +1364,7 @@ end
 
 @testset "Alignment Verification - Saturation Test (All Query Buckets)" begin
     # Logic: Construct a complex query combining CTE, Custom Joins, WHERE, and HAVING contexts simultaneously.
-    # Why: This acts as a saturation test to ensure PormGPositionalParam correctly concatenates 
+    # Why: This acts as a saturation test to ensure PormGSQLiteParam correctly concatenates 
     # vcat(cte, select, update, join, where, having) in precision alignment matching the generated SQL string.
 
     races_91 = M.Race.objects.filter("year" => 1991).values("raceid")
@@ -1422,11 +1422,14 @@ end
     # CTE-internal SELECT: only the condition value is parameterized (round > ?),
     # `then=2` and `default=3` are rendered as SQL literals (THEN 2, ELSE 3).
     races_91.values("raceid", "points_avg" => Avg("round"), "cat" => Case([When("round__@gt" => 1, then=2)], default=3))
-    # CTE-internal JOIN: param "Monza" → goes to PARENT's :join bucket
+    # CTE-internal JOIN: param "Monza". #432 — its `?` renders inside the WITH, between the CTE's
+    # SELECT list and its WHERE, so it belongs in :cte at that position. It used to leak into the
+    # PARENT's :join bucket, which flattens after :select, putting it four values too late.
     races_91.cjoin("circuitid" => "Circuit", filters=["name" => "Monza"], warn=false)
-    # CTE-internal WHERE: param 1991 → stays in :cte bucket
+    # CTE-internal WHERE: param 1991 → :cte bucket
     races_91.filter("year" => 1991)
-    # CTE-internal HAVING: param 5 → goes to PARENT's :having bucket
+    # CTE-internal HAVING: param 5. Same story as "Monza" — it used to leak to the parent's :having,
+    # which flattens LAST, so it landed at the very end of the statement's values.
     races_91.filter("points_avg__@gt" => 5)
 
     drivers_br = M.Driver.objects.filter("nationality" => "Brazilian").values("driverid")
@@ -1465,21 +1468,32 @@ end
     # STRICT ORDER VERIFICATION:
     # vcat(cte, select, update, join, where, having)
     #
+    # #432 CORRECTED THIS EXPECTATION. The previous vector asserted the misbind as if it were the
+    # design: a CTE body's JOIN and HAVING values leaked into the PARENT's :join and :having
+    # buckets, so "Monza" flattened after the outer SELECT's five CASE values and the CTE's
+    # HAVING(5) flattened dead last — while both of their `?` markers render inside the leading
+    # WITH. The order below is derived from PostgreSQL's `$N` positions, which are authoritative
+    # for text order, and SQLite now matches it exactly (modulo `@in`, which PostgreSQL binds as one
+    # array parameter and SQLite expands to two `?` — a dialect split, not a misalignment).
+    #
     # Bucket distribution:
-    #   :cte    = [1, 2, 3, 1991, "Brazilian"]  — races_91 SELECT(condition=1, then=2, default=3) + WHERE(1991) + drivers_br
+    #   :cte    = [1, 2, 3, "Monza", 1991, 5, "Brazilian"]
+    #             races_91's WHOLE body in text order — SELECT CASE(cond=1, then=2, default=3),
+    #             JOIN ON("Monza"), WHERE(1991), HAVING(5) — then drivers_br's WHERE.
     #   :select = [20, 3, 10, 2, 1]             — outer CASE WHEN (condition, then, condition, then, default)
-    #   :join   = ["Monza", "Italian", "VET", "MSC"]  — races_91 cjoin + outer cjoin
+    #   :join   = ["Italian", "VET", "MSC"]     — outer cjoin only
     #   :where  = [10, 20, 5, 5]                — outer WHERE filters
-    #   :having = [5, 8]                         — races_91 HAVING(5) + outer HAVING(8)
+    #   :having = [8]                            — outer HAVING only
     #
     # Within each CASE/WHEN, parameter order follows SQL text:
     #   WHEN condition THEN then_val ... ELSE else_val END
     expected_order = [
-        1, 2, 3, 1991, "Brazilian",            # CTE: races_91 SELECT(cond=1, then=2, default=3) + WHERE(1991), drivers_br WHERE
+        1, 2, 3, "Monza", 1991, 5,             # CTE r91, in text order: SELECT CASE, JOIN ON, WHERE, HAVING
+        "Brazilian",                            # CTE drivers_br WHERE
         20, 3, 10, 2, 1,                       # Outer SELECT: When(>20, then=3), When(>10, then=2), default=1
-        "Monza", "Italian", "VET", "MSC",       # JOIN: races_91 cjoin("Monza") + outer cjoin
+        "Italian", "VET", "MSC",                # Outer JOIN
         10, 20, 5, 5,                           # Outer WHERE (points range, grid, positionorder)
-        5, 8                                    # HAVING: races_91 HAVING(5) + outer HAVING(8)
+        8                                       # Outer HAVING
     ]
 
     @test insp[:parameters] == expected_order

--- a/test/unit/test_docs_error_types.jl
+++ b/test/unit/test_docs_error_types.jl
@@ -109,18 +109,27 @@ const DOCERR_CASES = [
         () -> DOCERR_RESULT_PG.objects.values("bad alias!" => "points").list(show_query = :dict),
     ),
     (
-        # #423. Making a values() alias resolve in ORDER BY means a name shared by two projections
-        # would emit an ambiguous `ORDER BY "x"` — PostgreSQL rejects it at execution, SQLite picks
-        # one. Refused at build time so the backends stay aligned.
+        # #441 moved this refusal upstream. It was #423's ORDER BY ambiguity guard — a name shared by
+        # two projections emitted an ambiguous `ORDER BY "x"` that PostgreSQL rejects and SQLite
+        # resolves arbitrarily. `values()` now refuses the DECLARATION, so `order_by` can never see a
+        # shared alias and that guard is retired as unreachable. Same type, earlier site; the
+        # `order_by` call is kept in the shape so this still covers the doc sentence's full example.
         #
         # The doc sentence uses `grid`/`points` (F1); this model has no `grid` and adding one would
         # change what every other case's model injects on a write (#331). Same shape, different
-        # column pair — what is pinned is the error TYPE for a duplicated alias, which is what the
-        # doc names.
-        "read/values_and_joins.md — two projections sharing an alias cannot be ordered by it",
+        # column pair — what is pinned is the error TYPE for a duplicated output name.
+        "read/values_and_joins.md — two projections may not share an output name",
         QueryBuildError,
         () -> DOCERR_RESULT_PG.objects.values("x" => "points", "x" => "resultid").
             order_by("x").list(show_query = :dict),
+    ),
+    (
+        # #441. The star is compared as the PHYSICAL columns the database expands it to, which the
+        # doc states explicitly. `statusid` is a real column of this model, so `values("*", …)` under
+        # that name collides with the star's own contribution.
+        "read/values_and_joins.md — a values() name colliding with a star-expanded column",
+        QueryBuildError,
+        () -> DOCERR_RESULT_PG.objects.values("*", "statusid" => "points").list(show_query = :dict),
     ),
     (
         # #424. `cjoin_on`'s `on` is the whole ON clause and is NOT path-prefixed, so a bare

--- a/test/unit/test_order_by_alias.jl
+++ b/test/unit/test_order_by_alias.jl
@@ -187,166 +187,76 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# An ambiguous alias is refused rather than resolved arbitrarily (#423)
-# `.values()` does not reject two projections sharing a name. Once such a name resolves in ORDER BY,
-# `ORDER BY "x"` is ambiguous: PostgreSQL raises at execution, SQLite picks one. Refusing at build
-# time is what keeps the two aligned — otherwise this fix would trade a loud (if confusing)
-# UnknownFieldError for a silent cross-backend divergence.
+# RETIRED by #441 — the ambiguity guard this file was written for is gone
+# #423 refused `order_by("x")` when `values(...)` projected `x` twice over two different
+# expressions, because PostgreSQL rejects an ambiguous ORDER BY alias while SQLite picks one
+# arbitrarily. #441 moved the refusal upstream: `values()` now rejects two projections that would
+# render the same output name, so `order_by` can no longer be handed a shared alias and the guard
+# became unreachable.
 #
-# Keyed on OBJECT IDENTITY, not on a match count and not on the rendered text. Two matching slots
-# are safe exactly when they are the same `SQLField` — which is `get_select_query`'s own dedupe
-# relation, so collapsed slots render byte-identical SQL, which is what PostgreSQL's `equal()`
-# accepts. Naming the same expression twice therefore keeps working, and it keeps working for a
-# reason that is true by construction rather than by proxy. Two earlier keys were wrong and both
-# are pinned below: `_as` (blind to the SQLText branch) and rendered text (blind on SQLite, where
-# every parameter renders as `?`).
+# Six blocks went with it, all because their SETUP is now refused at `.values()` rather than at
+# `order_by`: the guard's primary assertion (`values("x" => "note", "x" => "qty")`), its
+# `values("note", "note")` identity control, the both-backends `Value("a")/Value("b")` pair, the
+# mixed-pair message loop, `shadow_dup`, and the false-positive control below. Their coverage moves
+# to `test_projection_names.jl`, which pins the refusal at its new site.
 #
-# Note this guard is not gated on the cache, so it also moves the found_in_select && cache-HIT
-# combination: `values("note", "note" => "qty")` used to render `ORDER BY "note"` and is now
-# refused. That shape emits two output columns named "note" over different expressions, which
-# PostgreSQL rejected at execution anyway, so the refusal is the aligned behavior — but it means
-# TWO combinations change, not one. Pinned below so the claim stays honest.
+# Everything BELOW and above this note is untouched #423 behaviour and must keep passing — alias
+# over a local column, alias over a join path, an alias shadowing a real column, a declared alias
+# that is never rendered, and the controls block.
 # ─────────────────────────────────────────────────────────────────────────────
-@testset "an ambiguous values() alias is refused in order_by() (#423)" begin
-  amb = AO.Ao_child.objects
-  amb.values("x" => "note", "x" => "qty")
-  amb.order_by("x")
 
-  err = try
-    inspect_query(amb; connection = _AO_PG)
-    nothing
-  catch e
-    e
-  end
-  @test err isa PormG.QueryBuildError
-  msg = sprint(showerror, err)
-  @test occursin("Ambiguous", msg)
-  @test occursin("x", msg)
-  # Names BOTH sources, so the caller can see which two projections collided.
-  @test occursin("note", msg)
-  @test occursin("qty", msg)
-
-  # Control: the same expression projected twice shares `_as`, so it is not a new ambiguity. This
-  # rendered before the fix and must still render — a guard keyed on the match count would break it.
-  dup = AO.Ao_child.objects
-  dup.values("note", "note")
-  dup.order_by("note")
-  @test occursin("ORDER BY \"note\" ASC", inspect_query(dup; connection = _AO_PG)[:sql_text])
-
-  # Two `Value(...)` projections under one name. This is the case an `_as`-keyed guard MISSES: the
-  # `SQLText` branch of `get_select_query` assigns unconditionally without consulting the cache, so
-  # both entries carry `_as == "lbl"` while rendering two different Params. PostgreSQL sees two
-  # unequal expressions under one output name and raises `ORDER BY "lbl" is ambiguous`, while an
-  # `_as`-keyed guard sees one name and stays silent. Review finding — that draft justified `_as` as
-  # a faithful proxy for PostgreSQL's rule, and it is not one for this branch.
-  # BOTH backends, deliberately. A rendered-text key made this throw on PostgreSQL (`$1`/`$2`) and
-  # render on SQLite (`?`/`?`) — the guard against divergence introducing one, with the strict
-  # engine refusing while the lax engine sorted by an arbitrary one of two DIFFERENT values.
-  # Identity keying removes the split, and looping here is what would catch its return.
+# ─────────────────────────────────────────────────────────────────────────────
+# A declared alias is always rendered, and orderable (#441 — was the inverse, #423)
+# This testset used to pin the OPPOSITE. `values("note", "gg" => "note")` collapsed the second
+# projection onto the first — `"gg" => "note"` has `_as == "note"`, which the bare `"note"` entry
+# already cached — so `gg` never reached the SQL, and `order_by("gg")` had to raise
+# `UnknownFieldError` rather than emit `ORDER BY "gg"` against a column that does not exist.
+#
+# That collapse WAS #441's symptom 1. It is fixed: the memo is reused only when the cached entry
+# renders under the same OUTPUT name, so two names over one expression are now two output columns
+# and `gg` is emitted. The scenario this testset guarded can no longer arise.
+#
+# Rewritten rather than deleted, on the instruction its own premise-check carried: "if the collapse
+# ever stops happening, this testset is testing nothing and should be rewritten, not silently pass."
+# What survives is the reason the old assertion mattered — `order_by` resolves against what is
+# RENDERED, not what was declared. It still does; it now finds `gg` there.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a declared alias is rendered and orderable (#441)" begin
+  # The file docstring's contract that a name matching NO column still raises `UnknownFieldError`
+  # lost its only assertion when the collapse-dependent testsets were retired. Restored here: the
+  # branch is still live and still the loud path.
   for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
-    @testset "$label" begin
-      val_amb = AO.Ao_child.objects
-      val_amb.values("note", "lbl" => Value("a"), "lbl" => Value("b"))
-      val_amb.order_by("lbl")
-      val_err = try
-        inspect_query(val_amb; connection = conn)
-        nothing
-      catch e
-        e
-      end
-      @test val_err isa PormG.QueryBuildError
-      @test occursin("Ambiguous", sprint(showerror, val_err))
-    end
+    unknown = AO.Ao_child.objects
+    unknown.values("note")
+    unknown.order_by("no_such_name")
+    err = try; inspect_query(unknown; connection = conn); nothing; catch e; e end
+    @test err isa PormG.UnknownFieldError
+    # Assert the CAUSE, not just the type: this function raises UnknownFieldError from more than
+    # one site, so a bare type check would not prove the right one fired.
+    @test occursin("no_such_name", sprint(showerror, err))
   end
 
-  # A mixed pair — one field path, one Value — must name each side on its own terms. Choosing
-  # globally printed the ordered alias back as one of its own sources ("over note and x"), which is
-  # circular; the message must read "over note and <expr>" in either declaration order.
-  for vals in (("x" => "note", "x" => Value("hi")), ("x" => Value("hi"), "x" => "note"))
-    mixed = AO.Ao_child.objects
-    mixed.values(vals...)
-    mixed.order_by("x")
-    mixed_err = try
-      inspect_query(mixed; connection = _AO_PG)
-      nothing
-    catch e
-      e
-    end
-    @test mixed_err isa PormG.QueryBuildError
-    mixed_msg = sprint(showerror, mixed_err)
-    @test occursin("note", mixed_msg)
-    # Never names the ordered alias itself as a source.
-    @test !occursin("over x and", mixed_msg)
-    @test !occursin("and x.", mixed_msg)
-  end
+  rendered = AO.Ao_child.objects
+  rendered.values("note", "gg" => "note")
+  sql = inspect_query(rendered; connection = _AO_PG)[:sql_text]
+  # The same expression under two names is two output columns, not one emitted twice.
+  @test occursin("as \"note\"", sql)
+  @test occursin("as \"gg\"", sql)
+  @test count("as \"gg\"", sql) == 1
 
-  # The second combination this change moves: an alias that shadows another projection's name over
-  # a DIFFERENT expression. `values("note", "note" => "qty")` renders `as "note"` twice, so it was
-  # already ambiguous to PostgreSQL at execution; it now fails at build time instead. Pinned so the
-  # "only one combination changes" claim cannot quietly reappear.
-  shadow_dup = AO.Ao_child.objects
-  shadow_dup.values("note", "note" => "qty")
-  shadow_dup.order_by("note")
-  @test_throws PormG.QueryBuildError inspect_query(shadow_dup; connection = _AO_PG)
-end
-
-# ─────────────────────────────────────────────────────────────────────────────
-# The alias set comes from what is RENDERED, not from what was declared (#423)
-# `get_select_query` collapses a projection whose `_as` is already cached onto the cached SQLField
-# and discards its `custom_as`, so a declared name can fail to reach the SQL entirely. Deriving
-# `found_in_select` from `object.values` therefore trusted a name that is never emitted.
-#
-# This is the defect an independent review caught in the first draft of this fix, and it was
-# strictly worse than the bug being fixed: `ORDER BY "gg"` names neither an output nor an input
-# column, so PostgreSQL raises `column "gg" does not exist` while SQLite's double-quoted-string
-# fallback degrades it to the literal 'gg' — a constant sort key — and returns the rows UNSORTED
-# with no error. Silent wrong answer on one backend, runtime error on the other, replacing a clean
-# build-time `UnknownFieldError`. Scanning `instruc.select` is what keeps it on the loud path.
-# ─────────────────────────────────────────────────────────────────────────────
-@testset "a declared alias that is never rendered is not treated as projected (#423)" begin
-  # `"gg" => "note"` has `_as == "note"`, which the bare `"note"` entry already cached, so the
-  # second projection collapses onto the first and renders `as "note"` — `gg` never appears.
-  collapsed = AO.Ao_child.objects
-  collapsed.values("note", "gg" => "note")
-
-  # Confirm the premise rather than assuming it: if the collapse ever stops happening, this testset
-  # is testing nothing and should be rewritten, not silently pass.
-  @test !occursin("as \"gg\"", inspect_query(collapsed; connection = _AO_PG)[:sql_text])
-
-  # These two are the discriminating assertions: under the declared-list scan, `order_by("gg")`
-  # took the `found_in_select` branch and rendered `ORDER BY "gg"` without throwing at all.
-  # The cause is asserted too — this function raises more than one error type, so a bare type check
-  # would not prove the right one fired.
   for (label, conn) in (("PostgreSQL", _AO_PG), ("SQLite", _AO_SL))
     @testset "$label" begin
       ordered = AO.Ao_child.objects
       ordered.values("note", "gg" => "note")
       ordered.order_by("gg")
-      err = try
-        inspect_query(ordered; connection = conn)
-        nothing
-      catch e
-        e
-      end
-      @test err isa PormG.UnknownFieldError
-      @test occursin("gg", sprint(showerror, err))
+      osql = inspect_query(ordered; connection = conn)[:sql_text]
+      # `gg` is a real output column now, so ordering by it is legal on both backends — where it
+      # previously had to be refused to keep PostgreSQL (which errors) aligned with SQLite (which
+      # silently degrades `"gg"` to a constant string sort key and returns rows unsorted).
+      @test occursin("as \"gg\"", osql)
+      @test occursin("ORDER BY \"gg\"", osql)
     end
   end
-
-  # ...and the ambiguity guard must not fire on a name only ONE rendered column carries. Here
-  # `"z" => "note"` collapses away, so exactly one `as "z"` is emitted and the sort is unambiguous.
-  # Scanning the declared list reported a collision between `note` and `qty` that the SQL does not
-  # contain — the same review finding, in its false-positive direction.
-  #
-  # The discriminating part is that this RENDERS AT ALL: under the declared-list scan the guard
-  # raised here. The `count == 1` below is a premise check like the one above — it describes
-  # `get_select_query`'s collapse, which this fix does not touch, so it holds in either state.
-  single = AO.Ao_child.objects
-  single.values("note", "z" => "note", "z" => "qty")
-  single.order_by("z")
-  single_sql = inspect_query(single; connection = _AO_PG)[:sql_text]
-  @test count("as \"z\"", single_sql) == 1
-  @test occursin("ORDER BY \"z\" ASC", single_sql)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/test_parameter_alignment_nested.jl
+++ b/test/unit/test_parameter_alignment_nested.jl
@@ -1,0 +1,311 @@
+"""
+Unit coverage for nested-render parameter alignment (#432).
+
+A value's positional bucket used to be chosen by **which builder phase bound it**, not by **where
+its `?` lands in the SQL text**. When a subquery renders inside another clause the two disagree, and
+every marker after the divergence misbinds — silently, on SQLite only, with PostgreSQL correct.
+
+Two independent things were wrong, and both had to be fixed for any of these shapes to come out
+right:
+
+  1. **Wrong bucket.** `build_row_join_sql_text` switches to `:join` unconditionally in both of its
+     phase loops, defeating `build()`'s own `set_contexts` gate on the very next line. A nested
+     build's ON values therefore landed in the OUTER `:join` bucket while their `?` rendered inside
+     the outer WHERE, and `:join` flattens before `:where`.
+  2. **Wrong ORDER, even within one bucket.** A build BINDS in phase order (…joins last) but RENDERS
+     in clause order (joins first). At top level the buckets absorb that — it is what they are for.
+     A nested run had no such reordering: simply restoring the ambient bucket yields binding order,
+     which for `Exists(inner-with-ON)` is `WHEREVAL, ONVAL` against a text order of `ONVAL, WHEREVAL`.
+
+The fix marks every bucket around a nested render, lifts what the inner build bound, and re-emits it
+as one contiguous run in the parent's active bucket, concatenated in CLAUSE order
+(`nested_parameter_mark` / `detach_nested_run!`). `own_contexts` on `query()` is the other half: the
+inner build must file its values under its OWN clauses, or the run has nothing to sort by.
+
+Measured before the fix, and pinned below:
+
+    Rep A  Exists(inner-with-ON) after an outer filter
+           text OUTERVAL, ONVAL, WHEREVAL   ->  SQLite bound [ONVAL, OUTERVAL, WHEREVAL]
+    C1     the same through `__@in`         ->  SQLite bound [ONVAL, OUTERVAL, WHEREVAL]
+    C2     projected Subquery(inner-with-ON), then an outer filter
+           text ONVAL, WHEREVAL, TAIL       ->  SQLite bound [WHEREVAL, ONVAL, TAIL]
+    H1     projected Subquery whose inner carries a HAVING filter
+           text INNERW, 5, TAIL             ->  SQLite bound [INNERW, TAIL, 5]
+
+H1 is a third site the issue did not name: `get_filter_query`'s HAVING branch restored to a
+hard-coded `:where` rather than to the ambient bucket, so in a nested build whose ambient is
+`:select` it moved every subsequent inner value in with the OUTER query's.
+
+**Declaration order is load-bearing in every test here.** The misbind needs a value whose TEXT
+precedes the nested render — declare the `Exists` first and the bug disappears, so a test written
+that way passes against the unfixed code. Each shape below therefore filters BEFORE nesting, and one
+control pins the reversed order to document why.
+
+Both backends run: `test_alignment_sqlite.jl` is SQLite-only by construction, so a cross-backend
+divergence — which is the entire defect class — cannot surface there.
+"""
+# julia --project=. test/unit/test_parameter_alignment_nested.jl
+
+using Test
+using PormG
+using PormG.Models
+
+include("helper_marker_alignment.jl")
+
+struct PanMockSQLite <: PormG.PormGSQLite end
+struct PanMockPostgres <: PormG.PormGPostgres end
+const _PAN_SL = PanMockSQLite()
+const _PAN_PG = PanMockPostgres()
+PormG.backend_sqlite_version(::PanMockSQLite) = 3045000
+
+PormG.config["pan_mock"] = PormG.Configuration.Settings(
+  connections = _PAN_SL,
+  change_data = true,
+  db_def_folder = "pan_mock",
+)
+
+module PanModels
+import PormG
+import PormG.Models
+
+Pan_grand = Models.Model("pan_grand",
+  id   = Models.IDField(),
+  code = Models.CharField(),
+)
+
+Pan_parent = Models.Model("pan_parent",
+  id          = Models.IDField(),
+  sku         = Models.CharField(),
+  qty         = Models.IntegerField(null = true),
+  grandparent = Models.ForeignKey(Pan_grand, on_delete = "CASCADE", related_name = "pan_pars", null = true),
+)
+
+Pan_child = Models.Model("pan_child",
+  id     = Models.IDField(),
+  note   = Models.CharField(null = true),
+  parent = Models.ForeignKey(Pan_parent, on_delete = "CASCADE", related_name = "pan_kids", null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "pan_mock")
+end
+
+const PAN = PanModels
+import PormG.QueryBuilder: F, Exists, Subquery, inspect_query, Sum
+
+const _PAN_BACKENDS = (("PostgreSQL", _PAN_PG, :postgres), ("SQLite", _PAN_SL, :sqlite))
+
+# An inner query that binds ONE value in a JOIN ON clause and ONE in WHERE — the two-factor
+# combination the whole bug needs, and the one no existing testset combined with a nested render.
+_pan_inner_on() = begin
+  s = PAN.Pan_parent.objects
+  s.values("id")
+  s.filter("sku" => "WHEREVAL")
+  s.cjoin("grandparent" => "Pan_grand", filters = ["code" => "ONVAL"], warn = false)
+  s
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A nested render binds in TEXT order, on both backends (#432)
+# Driven from one table so a fourth nesting site added later inherits the assertions rather than
+# getting a hand-written near-copy. `text` lists the sentinels in the order their markers appear in
+# the rendered SQL — the whole point of the fix.
+# ─────────────────────────────────────────────────────────────────────────────
+const _PAN_SHAPES = [
+  (
+    "Rep A — Exists(inner-with-ON) in WHERE, after an outer filter",
+    ["OUTERVAL", "ONVAL", "WHEREVAL"],
+    () -> begin
+      q = PAN.Pan_child.objects
+      q.values("note")
+      q.filter("note" => "OUTERVAL")     # MUST precede the nesting — see the file docstring
+      q.filter(Exists(_pan_inner_on()))
+      q
+    end,
+  ),
+  (
+    "C1 — __@in over inner-with-ON, after an outer filter",
+    ["OUTERVAL", "ONVAL", "WHEREVAL"],
+    () -> begin
+      q = PAN.Pan_child.objects
+      q.values("note")
+      q.filter("note" => "OUTERVAL")
+      q.filter("parent__@in" => _pan_inner_on())
+      q
+    end,
+  ),
+  (
+    "C2 — projected Subquery(inner-with-ON), then an outer filter",
+    ["ONVAL", "WHEREVAL", "TAIL"],
+    () -> begin
+      q = PAN.Pan_child.objects
+      q.values("note", "p" => Subquery(_pan_inner_on()))
+      q.filter("note" => "TAIL")
+      q
+    end,
+  ),
+  (
+    "H1 — projected Subquery whose inner carries a HAVING filter",
+    ["INNERW", 5, "TAIL"],
+    () -> begin
+      inner = PAN.Pan_parent.objects
+      inner.values("t" => Sum("qty"))
+      inner.filter("t__@gt" => 5)        # -> HAVING, and the switch that used to clobber :select
+      inner.filter("sku" => "INNERW")    # -> bound AFTER that switch
+      q = PAN.Pan_child.objects
+      q.values("note", "p" => Subquery(inner))
+      q.filter("note" => "TAIL")
+      q
+    end,
+  ),
+]
+
+@testset "a nested render binds in text order (#432)" begin
+  for (label, text_order, build_q) in _PAN_SHAPES
+    @testset "$label" begin
+      for (backend, conn, kind) in _PAN_BACKENDS
+        insp = inspect_query(build_q(); connection = conn)
+
+        # Half one: no orphan markers. Holds on both backends and held before the fix too — it is
+        # #441's invariant, asserted here so a future change cannot trade one half for the other.
+        assert_marker_count(insp, kind)
+
+        if kind === :sqlite
+          # Half two: the flattened vector IS the text order. This is what was broken.
+          assert_bound_in_text_order(insp, text_order)
+        else
+          # PostgreSQL's control: same values, and `$N` travels with the text by construction. The
+          # binding ORDER differs from SQLite's and that is correct — the numbering compensates.
+          @test sort(string.(insp[:parameters])) == sort(string.(text_order))
+        end
+      end
+    end
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Declaration order is what makes the bug visible (#432)
+# Reversing it — nesting BEFORE the outer filter — made the misbind vanish on the unfixed code,
+# because nothing bound earlier was left to overtake. Pinned so nobody "simplifies" a shape above
+# into this order and quietly turns it into a test that passes either way.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the reversed declaration order was never broken (#432 control)" begin
+  reversed = () -> begin
+    q = PAN.Pan_child.objects
+    q.values("note")
+    q.filter(Exists(_pan_inner_on()))   # nested FIRST
+    q.filter("note" => "OUTERVAL")
+    q
+  end
+  insp = inspect_query(reversed(); connection = _PAN_SL)
+  assert_marker_count(insp, :sqlite)
+  assert_bound_in_text_order(insp, ["ONVAL", "WHEREVAL", "OUTERVAL"])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rep B is refused, not fixed (#432 / #433)
+# The issue's second reproduction is `__@in` over a subquery declaring its own `.with(...)`, nested
+# in a `cjoin_on` ON list. #433's guard refuses any subquery that declares a CTE, so that shape can
+# no longer be built and its acceptance criterion is met by REFUSAL rather than by correct binding.
+#
+# Pinned deliberately: if that guard is ever relaxed, this fails here rather than silently restoring
+# a misbind. A CTE BODY's own parameters are now routed correctly (`build_cte_clause` marks and
+# re-emits them the same way, which fixed a live shape nothing refused — a plain `.with(...)` whose
+# body carries a parameterized join). What is still unhandled is narrower: a `WITH` rendered INLINE
+# inside a subquery's parentheses, where the values belong in the parent's clause rather than `:cte`.
+# #433's guard is the only thing keeping that unreachable.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Rep B stays refused by #433's guard (#432)" begin
+  sub_with_cte = () -> begin
+    gv = PAN.Pan_grand.objects
+    gv.values("id", "code")
+    s = PAN.Pan_parent.objects
+    s.with("gv" => gv, join_field = "grandparent" => "id")
+    s.filter("gv__code" => "CTEVAL")
+    s.values("id")
+    s
+  end
+
+  for (backend, conn, _) in _PAN_BACKENDS
+    err = try
+      q = PAN.Pan_child.objects
+      q.values("note")
+      q.cjoin_on("Pan_parent", alias = "b2",
+                 on = [F("b2.sku") == F("note"), "id__@gt" => 7,
+                       "parent__@in" => sub_with_cte()])
+      inspect_query(q; connection = conn)
+      nothing
+    catch e
+      e
+    end
+    @test err isa PormG.QueryBuildError
+    @test occursin("gv", sprint(showerror, err))
+  end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shapes with no nesting are untouched (#432 controls)
+# The fix adds a mark/detach around three call sites. If it disturbed ordinary rendering, these
+# would move — they are the same bucket behaviour `test_alignment_sqlite.jl` pins at length, kept
+# here as a local tripwire so this file fails on its own.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "un-nested queries are unaffected (#432 control)" begin
+  # A top-level cjoin ON value still belongs in :join, flattened before :where.
+  q = PAN.Pan_parent.objects
+  q.values("id")
+  q.filter("sku" => "PLAINWHERE")
+  q.cjoin("grandparent" => "Pan_grand", filters = ["code" => "PLAINON"], warn = false)
+  insp = inspect_query(q; connection = _PAN_SL)
+  assert_marker_count(insp, :sqlite)
+  assert_bound_in_text_order(insp, ["PLAINON", "PLAINWHERE"])
+  @test insp[:parameter_buckets][:join] == ["PLAINON"]
+  @test insp[:parameter_buckets][:where] == ["PLAINWHERE"]
+
+  # A nested render that binds nothing in an ON clause was already correct, and stays so.
+  plain_inner = PAN.Pan_parent.objects
+  plain_inner.values("id")
+  plain_inner.filter("sku" => "INNERONLY")
+  q2 = PAN.Pan_child.objects
+  q2.values("note")
+  q2.filter("note" => "OUTERONLY")
+  q2.filter(Exists(plain_inner))
+  insp2 = inspect_query(q2; connection = _PAN_SL)
+  assert_marker_count(insp2, :sqlite)
+  assert_bound_in_text_order(insp2, ["OUTERONLY", "INNERONLY"])
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A CTE BODY is the fourth nested-render site (#432)
+# Found by review, and NOT a variant of Rep B: no subquery, no `Exists`/`Subquery`/`__@in`, nothing
+# refuses it. A plain documented `.with(...)` whose body carries a parameterized join scattered its
+# values across `:cte` (its own WHERE) and `:join` (the body's ON), while the whole thing renders
+# inside the leading `WITH`. `:cte` flattens ahead of `:join`, so they came out reversed.
+#
+# Measured before the fix: SQLite bound ["CTEWHERE", "CTEON"] against a text order of
+# CTEON, CTEWHERE. Correct on PostgreSQL. Silent wrong rows.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "a CTE body binds in text order (#432)" begin
+  build_q = () -> begin
+    cte = PAN.Pan_parent.objects
+    cte.values("id", "sku")
+    cte.cjoin("grandparent" => "Pan_grand", filters = ["code" => "CTEON"], warn = false)
+    cte.filter("sku" => "CTEWHERE")
+    q = PAN.Pan_child.objects
+    q.with("cq" => cte, join_field = "parent" => "id")
+    q.values("note", "s" => "cq__sku")
+    q.filter("note" => "TAIL")
+    q
+  end
+
+  for (backend, conn, kind) in _PAN_BACKENDS
+    insp = inspect_query(build_q(); connection = conn)
+    assert_marker_count(insp, kind)
+    if kind === :sqlite
+      # Text: the CTE body's JOIN ON, then its WHERE, then the outer WHERE.
+      assert_bound_in_text_order(insp, ["CTEON", "CTEWHERE", "TAIL"])
+      # Both of the body's values belong to the WITH, so both land in :cte — in text order.
+      @test insp[:parameter_buckets][:cte] == ["CTEON", "CTEWHERE"]
+      @test insp[:parameter_buckets][:where] == ["TAIL"]
+      @test isempty(insp[:parameter_buckets][:join])
+    end
+  end
+end

--- a/test/unit/test_projection_names.jl
+++ b/test/unit/test_projection_names.jl
@@ -1,0 +1,229 @@
+"""
+Unit coverage for projection-name collapse and refusal (#441).
+
+`get_select_query` memoises each resolved projection in `instruc.cache`, keyed on `_as`. Two
+different defects came out of that, and the fix has a part for each.
+
+**Symptom 1 — a projection is silently discarded, both backends.** For a field-path projection `_as`
+holds the PATH, while the name the column renders under lives in `custom_as`. So a bare cache hit
+collapsed projections that share an expression but declare DIFFERENT names:
+
+    values("gg" => "note", "hh" => "note")   ->  `as "gg"` twice; `hh` never emitted
+    values("note", "gg" => "note")           ->  `as "note"` twice; `gg` gone
+    values("s1" => "parent__sku", "s2" => …) ->  `as "s1"` twice
+
+`_cache_join` writes into the same dict keyed by join path, so a projection could also collapse onto
+an entry that was never a projection at all. Fixed by reusing the memo only when the cached entry
+renders under the SAME output name.
+
+**Symptom 2 — the discarded projection's parameters misalign on SQLite.** The cached field's
+ALREADY-RENDERED text carries its `?`, so the statement emitted one marker more than the driver had
+values for and everything after it bound one slot early. Measured before the fix:
+
+    values("note", "h" => Exists(a), "h" => Exists(b)) + filter("note" => "TAIL")
+        SQLite  3 markers, parameters ["AAA", "TAIL"]   <- "TAIL" bound to the second EXISTS,
+                                                           the outer WHERE left unbound
+        PostgreSQL  `\$1` twice + `\$2`  — legal, but still the wrong query
+
+Fixed by refusing two projections that would render the same output name, at `.values()`. Refused at
+declaration rather than repaired at render, because two columns under one name are indistinguishable
+to everything downstream — a DataFrame column, an `order_by` alias — so no reading of the query
+keeps both.
+
+**Deliberate consequences, both decided rather than inherited:**
+
+  - `values("lbl" => Value("a"), "lbl" => Value("b"))` is refused even though it renders correctly
+    today (the `SQLText` branch bypasses the memo). One rule with no per-kind carve-out — a
+    conditional rule is the kind of subtlety this defect family keeps escaping through.
+  - The #423 ambiguity guard in `get_order_query` is retired as unreachable: `order_by` can no
+    longer be handed a shared alias. See `test_order_by_alias.jl`.
+
+`"*"` is compared as the PHYSICAL columns the database expands it to. A `field_names` check is wrong
+in BOTH directions, which the `db_column` testset below demonstrates rather than asserts.
+"""
+# julia --project=. test/unit/test_projection_names.jl
+
+using Test
+using PormG
+using PormG.Models
+
+include("helper_marker_alignment.jl")
+
+struct PnMockSQLite <: PormG.PormGSQLite end
+struct PnMockPostgres <: PormG.PormGPostgres end
+const _PN_SL = PnMockSQLite()
+const _PN_PG = PnMockPostgres()
+PormG.backend_sqlite_version(::PnMockSQLite) = 3045000
+
+PormG.config["pn_mock"] = PormG.Configuration.Settings(
+  connections = _PN_SL,
+  change_data = true,
+  db_def_folder = "pn_mock",
+)
+
+module PnModels
+import PormG
+import PormG.Models
+
+Pn_parent = Models.Model("pn_parent",
+  id  = Models.IDField(),
+  sku = Models.CharField(),
+)
+
+Pn_child = Models.Model("pn_child",
+  id     = Models.IDField(),
+  note   = Models.CharField(null = true),
+  qty    = Models.IntegerField(null = true),
+  parent = Models.ForeignKey(Pn_parent, on_delete = "CASCADE", related_name = "pn_kids", null = true),
+)
+
+# `note` renders as the physical column `obs`. This is the fixture that separates a PHYSICAL-name
+# check from a `field_names` one — without a `db_column` anywhere, both checks agree and the test
+# proves nothing.
+Pn_dbc = Models.Model("pn_dbc",
+  id   = Models.IDField(),
+  note = Models.CharField(db_column = "obs"),
+  qty  = Models.IntegerField(null = true),
+)
+
+PormG.Models.set_models(@__MODULE__, "pn_mock")
+end
+
+const PN = PnModels
+import PormG.QueryBuilder: inspect_query, Count, Sum, Exists, Value
+
+const _PN_BACKENDS = (("PostgreSQL", _PN_PG, :postgres), ("SQLite", _PN_SL, :sqlite))
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Symptom 1: distinct names over one expression render as TWO columns (#441)
+# Each of these emitted the first name twice and dropped the second, on both backends, with no
+# error. The `count(...) == 1` assertions are the discriminating half: asserting only that both
+# names appear would pass on a build that emitted one of them twice.
+# ─────────────────────────────────────────────────────────────────────────────
+const _PN_DISTINCT = [
+  ("two aliases over one local column", ("gg", "hh"),
+   () -> begin q = PN.Pn_child.objects; q.values("gg" => "note", "hh" => "note"); q end),
+  ("a bare field then an alias over it", ("note", "gg"),
+   () -> begin q = PN.Pn_child.objects; q.values("note", "gg" => "note"); q end),
+  ("two aliases over one JOIN path", ("s1", "s2"),
+   () -> begin q = PN.Pn_child.objects; q.values("s1" => "parent__sku", "s2" => "parent__sku"); q end),
+]
+
+@testset "distinct names over one expression render both (#441)" begin
+  for (label, (a, b), build_q) in _PN_DISTINCT
+    @testset "$label" begin
+      for (backend, conn, kind) in _PN_BACKENDS
+        sql = inspect_query(build_q(); connection = conn)[:sql_text]
+        @test occursin("as \"$(a)\"", sql)
+        @test occursin("as \"$(b)\"", sql)
+        # Exactly once each — the bug rendered the first name twice.
+        @test count("as \"$(a)\"", sql) == 1
+        @test count("as \"$(b)\"", sql) == 1
+      end
+    end
+  end
+
+  # Two aliases over one join path must still produce ONE join, not two. The memo's real job.
+  sql = inspect_query(
+    (() -> begin q = PN.Pn_child.objects; q.values("s1" => "parent__sku", "s2" => "parent__sku"); q end)();
+    connection = _PN_SL)[:sql_text]
+  @test count("LEFT JOIN", sql) == 1
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Symptom 2: two projections may not share an output name (#441)
+# The parameter-carrying shape is the severe one — it is why this is priority:high rather than a
+# cosmetic drop. `_aggregate` is included because it forwards user pairs into `_values!` and
+# validated everything EXCEPT uniqueness, so it rode the same collapse.
+# ─────────────────────────────────────────────────────────────────────────────
+const _PN_DUPES = [
+  ("two aggregates under one name", "n",
+   () -> begin q = PN.Pn_child.objects; q.values("note", "n" => Count("id"), "n" => Sum("qty")); q end),
+  ("two Exists under one name", "h",
+   () -> begin
+     i1 = PN.Pn_parent.objects; i1.values("id"); i1.filter("sku" => "AAA")
+     i2 = PN.Pn_parent.objects; i2.values("id"); i2.filter("sku" => "BBB")
+     q = PN.Pn_child.objects; q.values("note", "h" => Exists(i1), "h" => Exists(i2)); q
+   end),
+  ("the same field named twice", "note",
+   () -> begin q = PN.Pn_child.objects; q.values("note", "note"); q end),
+  # Renders correctly today — the SQLText branch never consults the memo. Refused anyway, by
+  # decision, so the rule has no per-kind exception. This is a capability removal, not a bug fix.
+  ("two Value() literals under one name", "lbl",
+   () -> begin q = PN.Pn_child.objects; q.values("lbl" => Value("a"), "lbl" => Value("b")); q end),
+]
+
+@testset "duplicate output names are refused (#441)" begin
+  for (label, name, build_q) in _PN_DUPES
+    @testset "$label" begin
+      for (backend, conn, kind) in _PN_BACKENDS
+        err = try
+          inspect_query(build_q(); connection = conn)
+          nothing
+        catch e
+          e
+        end
+        @test err isa PormG.QueryBuildError
+        msg = sprint(showerror, err)
+        @test occursin(name, msg)          # names the colliding output column
+        @test occursin("values()", msg)    # and where to fix it
+      end
+    end
+  end
+
+  # aggregate() forwards its pairs into _values!, so it inherits the check rather than needing
+  # its own. Without this, a duplicate alias there would still collapse.
+  @test_throws PormG.QueryBuildError PN.Pn_parent.objects.aggregate("t" => Sum("id"), "t" => Count("id"))
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# `"*"` is compared as PHYSICAL columns, not declared field names (#441)
+# `Pn_dbc.note` carries `db_column = "obs"`, so the star's contribution is `obs`. That makes a
+# `field_names`-based check wrong in BOTH directions, and this testset pins both — a check that
+# compared declared names would fail the first assertion and the second.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "the star is compared by physical column name (#441)" begin
+  @test PN.Pn_dbc.field_names == ["id", "note", "qty"]
+  @test [Models.field_db_column(PN.Pn_dbc.fields[f], f) for f in PN.Pn_dbc.field_names] ==
+        ["id", "obs", "qty"]
+
+  # FALSE-NEGATIVE direction: `obs` is not a declared field name, but the star emits it — collision.
+  @test_throws PormG.QueryBuildError inspect_query(
+    (() -> begin q = PN.Pn_dbc.objects; q.values("*", "obs" => "qty"); q end)(); connection = _PN_SL)
+
+  # FALSE-POSITIVE direction: `note` IS a declared field name, but the star emits `obs`, so the
+  # output columns are id/obs/qty/note — all distinct, and the query is legal.
+  sql = inspect_query(
+    (() -> begin q = PN.Pn_dbc.objects; q.values("*", "note" => "qty"); q end)(); connection = _PN_SL)[:sql_text]
+  @test occursin("\"Tb\".*", sql)
+  @test occursin("as \"note\"", sql)
+
+  # A field with no db_column collides with the star under its own name.
+  @test_throws PormG.QueryBuildError inspect_query(
+    (() -> begin q = PN.Pn_dbc.objects; q.values("*", "qty"); q end)(); connection = _PN_SL)
+
+  # Two stars collide with themselves.
+  @test_throws PormG.QueryBuildError inspect_query(
+    (() -> begin q = PN.Pn_dbc.objects; q.values("*", "*"); q end)(); connection = _PN_SL)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Non-colliding shapes are unaffected (#441 controls)
+# A check that refused too much would satisfy every assertion above. `values("*", "<joined path>")`
+# is the shape every real caller in this repo and its docs actually uses.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "non-colliding projections still render (#441 control)" begin
+  for (backend, conn, kind) in _PN_BACKENDS
+    for build_q in (
+      () -> begin q = PN.Pn_child.objects; q.values("n" => "note"); q end,
+      () -> begin q = PN.Pn_child.objects; q.values("note", "s" => "parent__sku"); q end,
+      () -> begin q = PN.Pn_child.objects; q.values("*", "parent__sku"); q end,
+      () -> begin q = PN.Pn_child.objects; q.values("note", "n" => Count("id")); q end,
+      () -> begin q = PN.Pn_child.objects; q.values("lbl" => Value("a")); q end,
+    )
+      insp = inspect_query(build_q(); connection = conn)
+      @test !isempty(insp[:sql_text])
+      assert_marker_count(insp, kind)
+    end
+  end
+end


### PR DESCRIPTION
Closes #432. Closes #441.

Two members of the same family, landed together because they share a fix and an invariant:

> on a positional backend, the number of `?` a statement renders must equal the number of values bound, **and** the Nth value must be the one whose marker is Nth **in the text**.

Both halves fail independently — #441 broke the count while the order stayed right, #432 broke the order while the count stayed right — which is why a shared test helper asserts both.

## #432 — a value's bucket must follow its marker, not the phase that bound it

Two things were wrong, and **both** had to be fixed for any shape to come out right:

1. **Wrong bucket.** `build_row_join_sql_text` switches to `:join` unconditionally in both phase loops, defeating `build()`'s own `set_contexts` gate on the very next line. A nested build's ON values landed in the **outer** `:join` bucket while their `?` rendered inside the outer WHERE, and `:join` flattens before `:where`.
2. **Wrong order even within one bucket.** A build *binds* in phase order (joins last) but *renders* in clause order (joins first). At top level the buckets absorb that — it is what they are for. A nested run had no such reordering, so merely restoring the ambient bucket yields binding order: for `Exists(inner-with-ON)` that is `WHEREVAL, ONVAL` against a text order of `ONVAL, WHEREVAL`.

`nested_parameter_mark` / `detach_nested_run!` mark every bucket around a nested render, lift what the inner build bound, and re-emit it as one contiguous run in the parent's active bucket, concatenated in **clause order**. `own_contexts` on `query()` is the other half: the inner build must file its values under its *own* clauses or the run has nothing to sort by.

**Four sites, not the two the issue named.** The fourth — a CTE **body** carrying a parameterized join — was found by review. It is not Reproduction B and nothing refuses it: a plain, documented `.with(...)` bound SQLite `["CTEWHERE","CTEON"]` against a text order of `CTEON, CTEWHERE`.

**Verified across 29 query shapes**: 20 misaligned on `main`, **0** on this branch, every one matching PostgreSQL's text order. PostgreSQL output is byte-identical throughout.

### An existing test was asserting the bug

`test_alignment_sqlite.jl`'s "Saturation Test — Full Pipeline Stress" failed once the fourth site was fixed. It was not a regression: the test **encoded the misbind as the expected result**, and its comments documented it as design —

```
# CTE-internal JOIN: param "Monza" → goes to PARENT's :join bucket
# CTE-internal HAVING: param 5 → goes to PARENT's :having bucket
```

A CTE body's markers all render inside the leading `WITH`. Leaking them to the parent's buckets put `"Monza"` four values late and the CTE's `HAVING 5` dead last. The corrected order is derived from PostgreSQL's `$N` positions — authoritative, since numbering travels with the text — and **two independent reviewers reproduced it separately**.

## #441 — two projections may not render under the same output name

`get_select_query` memoises resolved projections keyed on `_as`, which for a field-path projection is the **path**, not the rendered name (`custom_as` holds that).

**Symptom 1 — a projection silently discarded, on both backends.** A bare cache hit collapsed projections sharing an expression but declaring different names: `values("gg" => "note", "hh" => "note")` rendered `as "gg"` twice and dropped `hh`. Fixed by reusing the memo only when the cached entry renders under the same **output** name; two names over one expression now give two columns over a single join.

**Symptom 2 — the discarded projection's parameters misalign on SQLite.** The cached field's already-rendered text carries its `?`, so the statement emitted one marker more than the driver had values for:

```
values("note", "h" => Exists(a), "h" => Exists(b))  +  filter("note" => "TAIL")
    SQLite  3 markers, parameters ["AAA", "TAIL"]
            -> "TAIL" bound to the second EXISTS; the outer WHERE never bound
```

`values()` now refuses duplicate output names, at the call rather than at render — two columns under one name are indistinguishable to everything downstream. `"*"` is compared as the **physical** columns the database expands it to; a `field_names` check is wrong in *both* directions.

## Scope beyond the issues, and on whose say-so

Each was raised with the maintainer and decided explicitly:

- **`Value(...)` duplicates are refused too**, though they render correctly today — the `SQLText` branch bypasses the memo. A deliberate capability removal so the rule has no per-kind carve-out.
- **The #423 ambiguity guard is retired** as unreachable, with ~45 lines of its justification rewritten rather than left standing — one paragraph asserted a declared alias can go unrendered, which symptom 1's fix disproves.
- **`build_cte_clause`'s unconditional `:cte`** remains for a `WITH` rendered *inline inside a subquery*; #433's guard keeps that unreachable. Deferred deliberately.

## ⚠️ #432's acceptance item 2 is met by refusal, not correct binding

Reproduction B is `__@in` over a subquery declaring its own `.with(...)`. #433's guard (merged last week) refuses any such subquery, so that shape can no longer be built. **This narrows the issue's stated criteria** and is called out rather than left to be discovered. It is pinned by a test asserting the refusal, so relaxing that guard fails loudly instead of silently restoring a misbind.

## Verification

- **Full unit suite: 8781 / 8781**, zero failures.
- **`db_sl` integration slice**, all exit 0: `test_selection` (the fixture control), `test_exists_correlated`, `test_subqueries`, `test_cjoin`, `test_cte`, `test_having`.
- **A row-asserting integration regression.** The unit files pin the parameter vector; only comparing returned rows against an independently computed set proves a misbind mattered, since a positional mix-up produces valid SQL that answers a different question. The `cjoin` is INNER on purpose — under LEFT the ON predicate does not filter, so the test would pass whatever it bound (measured: 3218 rows LEFT, 121 INNER).
- **Mutation-tested.** Each of the four #432 sites and both #441 halves were reverted in a scratch copy; the corresponding testsets fail.
- **Doc examples executed, not read.** Every `UPGRADING` line was run against `db_sl`: ✗ lines raise, ✓ lines return rows with the expected columns, and the detection snippet was verified to find the star collision it documents.

**`db_2` (PostgreSQL) was not run** — agreed with the maintainer. Every PostgreSQL assertion here uses a mock connection for rendering, which is where the divergence lives; the row-level behaviour SQLite exercises is the half that was broken.

## Two reviews, ten findings

An independent review found ten issues, including **two regressions I introduced** — a perf regression in `get_final_parameters` (now 4.0 ms vs the hardcoded version's 4.7 ms) and `values("*")` self-colliding on a model where two fields share a `db_column`. A delta re-review confirmed all ten fixes hold and independently derived the corrected saturation order.

One finding declined with reason: **#432 gets no `UPGRADING` entry.** #421 is the same class — fixes a misbind, changes SQLite results, forces no source edit — and has none either, only a mention inside #424's. The rule is "what *forces* an app edit".

Both reviewers' perf figures, and my restatement of them, were **cold-measurement artifacts**; the code comment now carries warm numbers and states the honest trade (free at large N, ~0.15 µs/call worse at realistic sizes).

## Follow-ups, not fixed here

- A suspected double-bind at `deletion.jl:587` with multiple ORed cascade keys — unconfirmed, unreachable with the F1 fixtures, and pre-existing.
- `test_upgrade_guide.jl` should join the rung-2 guard table in `pormg-issue-workflow`; it parses the real `UPGRADING.md` and fires on any entry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
