### PR TITLE
fix(#414, #415): PostgreSQL introspection reads spaced identifiers and con.confkey

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,6 +45,122 @@ _Changes merged but not yet cut into a release. A consumer dev'ing PormG at HEAD
 and `PormG.upgrade_guide` surfaces them by default. When the maintainer next rolls changes into a
 consuming app, `/pormg-cut-release` stamps every entry below with `0.5.0`, dates them, and tags it._
 
+## Schema introspection reads two column shapes differently — spaced identifiers, and multi-column foreign keys (#414, #415)
+
+- **Version**: Unreleased
+- **PormG ref**: #414, #415; `src/migrations/introspection.jl`, `docs/src/schema_conventions.md`
+- **Recorded**: 2026-08-26
+- **Severity**: **behavior change (narrow — only apps whose live schema has one of these two shapes)**.
+  Nothing changes for a schema without a spaced identifier or a composite foreign key. Where one
+  exists there are **two** ways it reaches you, and the second needs no action on your part to fire:
+  a **regenerated** model file names different fields than before, **and** `makemigrations` — which
+  runs introspection on every invocation — can now start proposing a change on every run against a
+  model file you have not touched. Part of the `0.5.x` pre-publish wave.
+
+### What changed
+
+Both are corrections to what PormG **reads back** from a live database. Neither changes anything you
+declare, and neither alters your schema.
+
+**1. A column name containing a space is no longer torn in half (#414).** The PostgreSQL reader split
+its `columns` aggregate on the space between the name and the type, so an identifier that *contained*
+a space was destroyed before anything else saw it. A column named `driver ref` came back as the
+phantom `"driver` — leading quote and all — and `Parent Id` came back as `"Parent`, typed
+`TextField`, **with its foreign key dropped**, because the FK lookup keyed on the real name and no
+longer matched. `makemigrations` then proposed adding the phantom and dropping the real column on
+every run, forever. SQLite was never affected, so one schema introspected correctly on one engine and
+corruptly on the other.
+
+**2. A multi-column foreign key is now skipped rather than guessed at (#415).** PormG has no
+composite-`ForeignKey` field type. PostgreSQL used to derive the referenced column from the parent's
+*primary key index* instead of the constraint's own `confkey`, binding a composite FK to an arbitrary
+column; SQLite split it into one independent single-column relation per member. Both now import the
+member columns as **ordinary fields with no relation** and leave the constraint alone in the
+database — the same reject-rather-than-reinterpret rule that keeps a non-default index out of an
+imported model. Re-emitting either previous reading produced a *different* schema than the live one.
+
+Two more single-column cases now read **correctly** where they used to read wrong — but "correct"
+is still a *change*, so your declared model is the stale side and both need action, in the opposite
+direction from change 2:
+
+- **An FK referencing a non-primary-key `UNIQUE` column** (`REFERENCES driver_registry(licence_no)`)
+  now reports that column. The old importer wrote its wrong answer explicitly into your model file —
+  `Model_to_str` emits `pk_field=` on every introspected FK — so a model still declaring
+  `pk_field="id"` disagrees with a live read of `licence_no`, and the planner proposes `:pk_field` on
+  every run. Update the declaration to the column the constraint really names.
+- **An FK whose parent table has no primary key at all** was previously *invisible* to PostgreSQL
+  introspection (the referenced column only needs a `UNIQUE` constraint, but the old query reached it
+  through the parent's primary-key index with an inner join). Your model therefore has a plain column
+  where the live read now reports a relation. Declare the `ForeignKey`.
+
+### How to find the calls to migrate
+
+**Do not assume you are safe because you have not re-run the importer.** `makemigrations` calls the
+same introspection (`convert_schema_to_models`, `src/migrations/planner.jl`), so change 2 can bite a
+model file you never regenerate: if your model still declares `ForeignKey` on a composite-FK member
+column, the live read now says "plain integer", the declared side still says "relation",
+`describes_same_column` refuses to equate them, and the planner proposes a change **on every
+`makemigrations`** — on SQLite, a full table rebuild each time.
+
+```bash
+# 1. Which of the FOUR shapes does your schema actually have? (PostgreSQL)
+#    a. multi-column foreign keys — change 2
+psql -c "SELECT conrelid::regclass, conname FROM pg_constraint
+         WHERE contype = 'f' AND array_length(conkey, 1) > 1;"
+#    b. identifiers containing a space — change 1
+psql -c "SELECT table_name, column_name FROM information_schema.columns
+         WHERE column_name LIKE '% %';"
+#    c. foreign keys NOT pointing at the parent's primary key
+psql -c "SELECT c.conrelid::regclass, c.conname FROM pg_constraint c
+         JOIN pg_index i ON i.indrelid = c.confrelid AND i.indisprimary
+         WHERE c.contype = 'f' AND c.confkey::int[] <> i.indkey::int[];"
+#    d. foreign keys into a parent with no primary key at all
+psql -c "SELECT c.conrelid::regclass, c.conname FROM pg_constraint c
+         WHERE c.contype = 'f' AND NOT EXISTS (
+           SELECT 1 FROM pg_index i WHERE i.indrelid = c.confrelid AND i.indisprimary);"
+
+# 2. For anything those returned, grep your models for the affected columns.
+grep -n "ForeignKey" <your db_def_folder>/*.jl
+
+# 3. Then run makemigrations and read the plan BEFORE applying it. A proposal against a table you
+#    did not change is this entry — and step 3 catches all four shapes even if you skipped step 1.
+```
+
+### Migrate your app
+
+```julia
+# ── change 2: a composite-FK member column must stop declaring a relation ──
+# ✗ before — ONE constraint, `FOREIGN KEY (raceid, driverid) REFERENCES result(raceid, driverid)`,
+#   imported as two single-column relations. Note both name the SAME parent: a composite FK has one
+#   referenced table, so this is the shape to look for. Two relations pointing at DIFFERENT parents
+#   are two ordinary foreign keys, which this change does not touch — do not delete those.
+#   (The `pk_field` values below are what the old SQLite reader wrote. The old PostgreSQL reader
+#   named the parent's primary-key column on both members instead; either way, both lines go.)
+Lap_time = Models.Model("lap_time",
+  raceid   = Models.ForeignKey("result", pk_field="raceid"),
+  driverid = Models.ForeignKey("result", pk_field="driverid"),
+)
+
+# ✓ after — plain columns; the constraint stays in the database, PormG just stops modelling it.
+#   REGENERATE if you can: hand-declaring means matching the column exactly, and two attributes
+#   drift if you get them wrong. Type — introspection maps `bigint` to BigIntegerField and `integer`
+#   to IntegerField (src/constants.jl), so IntegerField() over a BIGINT column drifts on `:type`
+#   forever. And nullability — `:null` has no exemption in `_NON_SCHEMA_FIELD_ATTRS`, so a bare
+#   field declared over a NULLable column drifts on `:null` the same way.
+Lap_time = Models.Model("lap_time",
+  raceid   = Models.BigIntegerField(),
+  driverid = Models.BigIntegerField(),
+)
+
+# ── change 1: a spaced column's regenerated FIELD NAME is sanitized, and gains a db_column ──
+# ✗ before — the phantom name, truncated at the space
+M.Driver.objects.filter("driver" => "senna")
+
+# ✓ after — `Model_to_str` emits `driver_ref = CharField(db_column="driver ref", …)`,
+#           so the field is `driver_ref` and the physical column keeps its space
+M.Driver.objects.filter("driver_ref" => "senna")
+```
+
 ## `values()` refuses two projections that would render the same output name (#441)
 
 - **Version**: Unreleased

--- a/docs/src/schema_conventions.md
+++ b/docs/src/schema_conventions.md
@@ -488,6 +488,33 @@ category = Models.ForeignKey("constructor", on_delete=CASCADE)
 | `DO_NOTHING` | `NO ACTION` |
 | `PROTECT` | `RESTRICT` |
 
+### A foreign key may reference any unique column, not only the key
+
+`pk_field` records the column the constraint actually names, which does not have to be the parent's
+primary key — referencing any column with a `UNIQUE` constraint is legal on both engines, and
+introspection reads it back as declared:
+
+```julia
+# live: parent_key VARCHAR(20) REFERENCES driver_registry(licence_no)
+#       …where driver_registry's primary key is `id` and `licence_no` is UNIQUE
+registration = Models.ForeignKey("driver_registry", pk_field="licence_no", on_delete=CASCADE)
+```
+
+!!! warning "A multi-column foreign key is not read back"
+    PormG has no composite-`ForeignKey` field type, so `FOREIGN KEY (a, b) REFERENCES parent(x, y)`
+    is **skipped** by `inspectdb`/`makemigrations` introspection on both PostgreSQL and SQLite: the
+    member columns are imported as ordinary fields with no relation, and the constraint is left
+    alone in the database.
+
+    This is deliberate — the same reject-rather-than-reinterpret rule that keeps a non-default index
+    out of an imported model. The alternatives both regenerate a *different* schema: bind to one
+    arbitrary member column, or emit one single-column constraint per member, which the parent will
+    usually refuse because no member is unique on its own. Being skipped means the column reads as
+    "no relation" on both sides of the diff, so a re-diff proposes nothing rather than churning.
+
+    A **single**-column foreign key into a composite-keyed parent is unaffected and reads back
+    normally — it names one column, and that column carries its own `UNIQUE`.
+
 ## Timestamp fields
 
 PormG does **not** implicitly add `created` / `modified` columns. Auto-managed timestamps are

--- a/src/migrations/introspection.jl
+++ b/src/migrations/introspection.jl
@@ -36,6 +36,91 @@ function _unquote_ident(name::AbstractString)::String
   return replace(name[nextind(name, 1):prevind(name, lastindex(name))], "\"\"" => "\"")
 end
 
+# Peel the leading `quote_ident`-ed column name off one entry of the schema query's `columns`
+# aggregate, returning `(de-quoted name, everything after it)`.
+#
+# #414: the caller used to do `split(col, " ")` and take `[1]` as the name and `[2]` as the type. The
+# entry separator (`", "`) is unambiguous but the FIELD separator was not, so an identifier
+# CONTAINING a space was torn in half before anything else could look at it. `"Parent Id" bigint`
+# yielded the phantom name `"Parent` — the leading quote survives, because `_unquote_ident` correctly
+# refuses to strip a lone unbalanced one — and the type `Id"`, which no lookup matches, so the column
+# also degraded to `TextField`. `fk_map`, `pk_set` and `index_map` all key on names that survive a
+# space (they split on `", "`, or come from the one RAW aggregate), so the two sides genuinely
+# disagreed for exactly that class of name: the relation was lost and `makemigrations` proposed
+# `ADD COLUMN "\"Parent"` plus a DROP of the real column on every run, forever.
+#
+# The parse is the fix; the aggregate's FORMAT is untouched. `quote_ident` output is already
+# SELF-DELIMITING, which is what makes that sufficient: a name needing a space is always wrapped in
+# `"` (and any embedded `"` doubled), and a name left bare by `quote_ident` is a legal lowercase
+# identifier, which cannot contain a space. So the closing quote — not the first space — is where the
+# name ends, and scanning to it recovers every name that reaches this function whole.
+#
+# THE RESIDUAL, stated rather than implied. "Whole" is the operative word: the caller splits the
+# aggregate on `", "` BEFORE calling, so a name containing `, ` is already in two pieces and nothing
+# here can reassemble it — a column named `a, b` still yields two phantom fields. The same split is
+# what a DEFAULT expression containing `, ` breaks on (`DEFAULT 'Ferrari, Scuderia'`,
+# `DEFAULT concat('a', 'b')`, `DEFAULT '{1, 2}'::int[]`), and that one needs no odd column name at
+# all. Fixing THAT class means changing the aggregate's format — one row per column, or a
+# `json_agg(json_build_object(...))` — which is #414's Option 1 and a separate change.
+#
+# Two things fall out of returning the REMAINDER rather than re-splitting the whole entry, and the
+# caller depends on both. The name can no longer contribute a token to the flag scan, so a column
+# whose name CONTAINS a marker token (`"has UNIQUE inside"`, `"NOT NULL"`) stops inventing its own
+# constraint — the residue of #318, which fixed the `DEFAULT 'UNIQUE'` half by moving to a token test
+# but left the NAME contributing tokens; and the `double precision` → `double_precision` rewrite no
+# longer rewrites a column so named.
+#
+# Degrades rather than throws on a shape this cannot parse. Introspection never aborts a whole schema
+# read over one odd column (see `_fk_default_or_warn` below for the same policy on defaults). The two
+# degrade shapes are NOT treated alike, and the difference is deliberate:
+#
+#   * An entry with NO SEPARATOR AT ALL returns an empty remainder, and the caller WARNS on it —
+#     see the `isempty(col_rest)` guard at the parse site. That is a DELIBERATE CHANGE, not a
+#     preserved behaviour: the pre-#414 caller raised `BoundsError` on `col_parts[2]` here, killing
+#     the entire read. Trading a loud abort for a SILENT phantom column would swap one failure for
+#     the permanent `makemigrations` churn this issue exists to remove.
+#   * An UNTERMINATED QUOTE falls through to the space split and yields a non-empty remainder, so it
+#     does NOT warn. `quote_ident` cannot emit one — it always closes what it opens — so reaching
+#     this means the entry was already torn by the `", "` entry split upstream.
+#
+#     THE WARNING IS NOT A GUARANTEE, and the gap is worth stating rather than discovering. It fires
+#     only when the LAST torn fragment happens to contain no space, so a torn column can produce
+#     phantoms and stay silent: `"Driver Ref, Total"` (a name with a space AND a comma) tears into
+#     `"Driver Ref` and `Total"`, both of which have a space or land mid-entry, and warns zero times;
+#     so does a multi-argument function default followed by any marker
+#     (`DEFAULT concat('a', 'b') NOT NULL`). Measured, not assumed.
+#
+#     A tempting strengthening — warn whenever `col_name` still contains a `"` — is WRONG and was
+#     rejected: `Say"Hi` and a column genuinely named `"x"` both round-trip correctly through
+#     `quote_ident` and both legitimately carry a quote in the parsed name (each has a passing test
+#     in `test_introspection_guards.jl`). It would warn on two names that are perfectly fine. The
+#     real fix for the silent cases is the same one as for the residual above: change the
+#     aggregate's format so entries cannot be torn at all.
+function _split_leading_quoted_ident(entry::AbstractString)
+  if startswith(entry, '"')
+    i = nextind(entry, firstindex(entry))
+    while i <= lastindex(entry)
+      if entry[i] == '"'
+        j = nextind(entry, i)
+        # `""` is quote_ident's doubling of an embedded quote, not the end of the identifier.
+        if j <= lastindex(entry) && entry[j] == '"'
+          i = nextind(entry, j)
+          continue
+        end
+        name = _unquote_ident(entry[firstindex(entry):i])
+        rest = j <= lastindex(entry) ? lstrip(SubString(entry, j)) : SubString(entry, j)
+        return (name, rest)
+      end
+      i = nextind(entry, i)
+    end
+    # Unterminated: fall through to the space split, which is what the pre-#414 caller did.
+  end
+  sep = findfirst(' ', entry)
+  sep === nothing && return (_unquote_ident(entry), SubString(entry, nextind(entry, lastindex(entry))))
+  return (_unquote_ident(SubString(entry, firstindex(entry), prevind(entry, sep))),
+          SubString(entry, nextind(entry, sep)))
+end
+
 # ---
 # Shared FK helpers (both backends)
 # ---
@@ -410,11 +495,27 @@ function convertSQLToModel(db::PormGSQLite, table_name::String; type_map::Dict{S
   fields_dict = Dict{Symbol, Any}()
   fk_map = Dict{String, Any}()
   if !isempty(fks)
+    # #415: keyed on the CHILD column (`from`), which is what the per-column branches below look up —
+    # but a MULTI-COLUMN foreign key is skipped rather than split. `PRAGMA foreign_key_list` returns
+    # one row per column and groups a composite constraint under a shared `id`, so keying on `from`
+    # alone turned one composite FK into N independent single-column relations: each looked plausible
+    # on its own, and regenerating the model emitted N separate constraints the parent may not even
+    # accept. PormG has no composite-FK field type, so there is nothing faithful to read here; a
+    # skipped constraint reads as "no relation" on both sides of the diff and the schema converges.
+    #
+    # Deliberately symmetric with the PostgreSQL reader, which excludes the same shape in its
+    # `foreign_keys` CTE (`array_length(con.conkey, 1) = 1`) — this is the cross-engine alignment,
+    # not an independent SQLite decision. Both engines must agree about one schema.
+    columns_per_fk = Dict{Any, Int}()
     for fk_row in eachrow(fks)
+      columns_per_fk[fk_row.id] = get(columns_per_fk, fk_row.id, 0) + 1
+    end
+    for fk_row in eachrow(fks)
+      columns_per_fk[fk_row.id] > 1 && continue
       fk_map[fk_row.from] = fk_row
     end
   end
-  
+
   for col_row in eachrow(cols)
     col_name = col_row.name
     col_type = col_row.type |> uppercase
@@ -908,12 +1009,53 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
             -- zip in convertSQLToModel stays aligned.
             array_to_string(array_agg(con.confdeltype::text), ', ') AS delete_rules
         FROM pg_constraint con
-        JOIN pg_attribute att2 ON att2.attnum = ANY(con.conkey) AND att2.attrelid = con.conrelid
         JOIN pg_class cf ON cf.oid = con.confrelid
         JOIN pg_namespace nf ON nf.oid = cf.relnamespace
-        JOIN pg_index pk_idx ON pk_idx.indrelid = cf.oid AND pk_idx.indisprimary
-        JOIN pg_attribute pk_att ON pk_att.attrelid = pk_idx.indrelid AND pk_att.attnum = ANY(pk_idx.indkey)
+        -- #415: the child and parent columns are correlated THROUGH THE CONSTRAINT. Before this the
+        -- referenced column came from the parent's PRIMARY KEY INDEX — `con.confkey`, the array that
+        -- says which parent columns the FK actually references, was not selected anywhere in this
+        -- file — and the two `pg_attribute` joins were uncorrelated, leaving the consumer's `zip` to
+        -- pair them positionally by chance. Two distinct failures came out of that:
+        --
+        --   1. `REFERENCES parent(some_unique_col)` — legal wherever that column carries a UNIQUE
+        --      constraint — reported the parent's PK instead. `pk_field` was then wrong, and so was
+        --      every consumer of it: `Dialect.add_foreign_key`, `create_table`,
+        --      `Models.fk_target_column`, the join builder's `key_b`. `makemigrations` proposed
+        --      re-pointing a foreign key that was never mispointed, and the DDL it emitted named a
+        --      different column than the live constraint does.
+        --   2. `attnum = ANY(pk_idx.indkey)` yielded ONE ROW PER PARENT PK COLUMN, multiplying every
+        --      aggregate here. A single-column FK to a composite-keyed parent bound to an arbitrary
+        --      one of the parent's key columns (the last fanned-out row won the `fk_map[...]`
+        --      assignment), and the same fan-out duplicated `deferrable` / `initially_deferred` /
+        --      `delete_rules`, breaking the positional alignment #292 established.
+        --
+        -- A THIRD change falls out of dropping the `pg_index` join, and it is an improvement rather
+        -- than a side effect worth hiding: that join was INNER, so a foreign key whose PARENT TABLE
+        -- HAS NO PRIMARY KEY AT ALL matched nothing and vanished from this CTE entirely — the child
+        -- column introspected as having no relation. That schema is legal (a referenced column only
+        -- needs a UNIQUE constraint, not the key), and SQLite's `PRAGMA foreign_key_list` always
+        -- reported it, so the two engines disagreed about it. They now agree.
+        --
+        -- `unnest` over the two arrays in lockstep, deliberately NOT `con.conkey[1]`. Subscripting
+        -- would be shorter but would depend on the array's LOWER BOUND, which is exactly the
+        -- assumption that produced #347's off-by-one in this same file (`int2vector` has lower bound
+        -- 0 while `WITH ORDINALITY` counts from 1). `unnest` is bound-agnostic, so there is nothing
+        -- to assert. No `WITH ORDINALITY` either: nothing is subscripted, and with the single-column
+        -- filter below each constraint contributes exactly one row.
+        JOIN LATERAL unnest(con.conkey, con.confkey) AS k(child_attnum, parent_attnum) ON true
+        JOIN pg_attribute att2   ON att2.attrelid   = con.conrelid AND att2.attnum   = k.child_attnum
+        JOIN pg_attribute pk_att ON pk_att.attrelid = cf.oid       AND pk_att.attnum = k.parent_attnum
         WHERE con.contype = 'f'
+          -- A genuinely MULTI-COLUMN foreign key is skipped, not approximated — the same idiom
+          -- `unique_constraints` and `non_negative_checks` use above, and the same
+          -- reject-rather-than-reinterpret rule `_pg_composite_indexes` states in full. PormG has no
+          -- composite-FK field type, so the alternatives are both wrong: pick one column and pretend
+          -- (what the old query did), or emit N independent single-column relations that regenerate
+          -- as N separate constraints the parent may not even accept. A skipped constraint reads as
+          -- "no relation" on BOTH sides of the diff, so the schema still converges. The SQLite
+          -- reader skips the same shape for the same reason — see `fk_map` in
+          -- `convertSQLToModel(::PormGSQLite, …)`.
+          AND array_length(con.conkey, 1) = 1
         GROUP BY con.conrelid
     ),
     -- Secondary indexes, filtered down to exactly what `field.db_index = true` emits: ONE
@@ -966,11 +1108,18 @@ function get_database_schema(db::PormGPostgres; schema::Union{String, Nothing} =
             -- pg_get_constraintdef renders it as `CHECK ((octet_length(col) <= 4))`. Matching on
             -- digits after `<=` avoids backslash escapes surviving both Julia and SQL quoting.
             --
-            -- `substring(… from …)` rather than `regexp_match`: the latter is PostgreSQL 10+, and
-            -- this CTE sits in the schema query that EVERY introspection runs, so depending on it
-            -- would break `makemigrations`/`inspectdb` wholesale on 9.x — not just for binary
-            -- columns. `substring` with a capturing group returns the same first capture and has
-            -- been available since long before any version this package targets.
+            -- `substring(… from …)` rather than `regexp_match`, kept as the equivalent that carries
+            -- no version question at all. The 9.x rationale this comment used to give was already
+            -- false when it was written: the `indexes` CTE above uses `indnkeyatts`, which is
+            -- PostgreSQL 11+, and it sits in THIS SAME STATEMENT — the one every introspection runs.
+            -- So 11 is the effective floor for this query and `regexp_match` (10+) would have been
+            -- safe too. #415 leans on the same fact for multi-argument `unnest` in FROM (9.4+).
+            --
+            -- Scope of that claim, deliberately narrow: it is about THIS statement. The
+            -- `major_version >= 10` gate on `identity_case` above therefore always evaluates TRUE,
+            -- so its `else ""` branch is unreachable — but removing the branch also retires the
+            -- `version()` probe that feeds the gate, which is a separate change and is not made
+            -- here.
             --
             -- min() collapses to ONE row per (table, column). This CTE is joined per-column, not
             -- per-table like non_negative_checks above, so without the GROUP BY two matching CHECKs
@@ -1579,11 +1728,14 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
     # rows some unit tests build), so degrade to "no action recorded" rather than throwing.
     delete_rules = (:delete_rules in propertynames(row) && !ismissing(row[:delete_rules])) ?
       split(row[:delete_rules], ", ") : fill("", length(fk_columns))
-    # #415: this positional pairing is only as good as the CTE's aggregates. That CTE derives the
-    # referenced column from the PARENT'S PRIMARY KEY INDEX rather than from `con.confkey`, so an FK
-    # pointing at a non-PK unique column reports the wrong column, and a composite parent key fans
-    # every aggregate out — the last entry silently wins the `fk_map[...]` assignment below, and the
-    # `delete_rules` alignment #292 established breaks with it. Not addressed here.
+    # This positional pairing is only as good as the CTE's aggregates, and #415 is what made it
+    # sound. The `foreign_keys` CTE now correlates the child and parent columns through
+    # `con.conkey`/`con.confkey` and admits only single-column constraints, so it emits EXACTLY ONE
+    # entry per foreign key and all six aggregates are fed the same row stream in the same order.
+    # Before that it derived the referenced column from the parent's PRIMARY KEY INDEX (so an FK
+    # pointing at a non-PK unique column reported the wrong column) and fanned every aggregate out
+    # once per parent PK column (so the last entry silently won the `fk_map[...]` assignment below,
+    # and the `delete_rules` alignment #292 established broke with it).
     for (i, (fk_col, fk_table, fk_pk)) in enumerate(zip(fk_columns, fk_tables, fk_pk_columns))
         rule = i <= length(delete_rules) ? delete_rules[i] : ""
         # ALL THREE halves are DE-QUOTED. The schema query aggregates each through
@@ -1636,8 +1788,6 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
    
   # Parse each column definition
   for col in columns    
-      col_parts = split(replace(col, "double precision" => "double_precision")
-      , " ")
       # De-quoted ONCE, here (#389). `columns` is aggregated as `quote_ident(a.attname)`, so a
       # mixed-case name (or a reserved word) arrives wrapped in `"`. Every consumer below —
       # `index_map`, `pk_set`, `fk_map`, `fields_dict` — is keyed on the de-quoted form, and
@@ -1645,17 +1795,36 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # de-quoted at two of those four sites and left the other two quoted, which happened to work
       # only because their counterparts were quoted too.
       #
-      # NOT covered: an identifier containing a SPACE (#414). `col_parts` splits the aggregate on
-      # `" "` one line up, so `"Parent Id"` is torn in half before any de-quoting can help: the
-      # column is emitted under the phantom name `"Parent` — the leading quote SURVIVES, because
-      # `_unquote_ident` correctly refuses to strip a lone unbalanced one — and `col_parts[2]` is
-      # `Id"` rather than a type, so it also degrades to `TextField`. `fk_map`'s key survives the
-      # space intact (that aggregate splits on `", "`), so the two sides genuinely disagree for
-      # exactly that class of name — a live PG/SQLite divergence, since the SQLite reader takes
-      # `PRAGMA` output raw. Fixing it means changing the `columns` aggregate's format, not the
-      # de-quoting.
-      col_name = _unquote_ident(col_parts[1])
-      col_type = lowercase(col_parts[2])
+      # #414: the name is peeled off by SCANNING `quote_ident`'s own quoting rather than by splitting
+      # on the first space, which is what an identifier containing a space used to be destroyed by —
+      # see `_split_leading_quoted_ident` for the full account. The other three consumers already
+      # survived a space on their own side, so repairing `col_name` is what makes all four agree
+      # again.
+      #
+      # `col_rest` — the entry MINUS the name — is what every type/flag/marker test below reads.
+      # That is deliberate, not incidental: scanning the whole entry let a column NAMED `UNIQUE`,
+      # `NOT NULL` or `double precision` be read as carrying its own name as a constraint. The name
+      # can no longer contribute a token at all.
+      col_name, col_rest = _split_leading_quoted_ident(col)
+      # An entry with NOTHING after the name is not a column this reader can describe — every entry
+      # carries at least `quote_ident(name) || ' ' || format_type(...)`. It means the aggregate's
+      # `", "` entry split tore something: a name containing `, `, or far more likely a DEFAULT
+      # expression containing one (`DEFAULT 'Ferrari, Scuderia'`). Pre-#414 this raised `BoundsError`
+      # and killed the whole schema read; degrading is right, but SILENTLY degrading would emit a
+      # phantom column that `makemigrations` then proposes adding and dropping forever — the exact
+      # failure #414 exists to remove, moved to a new trigger. So name the table and the fragment,
+      # the same way `_fk_default_or_warn` names an unrepresentable default.
+      #
+      # The message deliberately does NOT promise what the field becomes. A torn fragment is fed to
+      # every map in this function, and `fk_map`/`pk_set` are built from aggregates split on the SAME
+      # `", "` — so the two sides can agree on the SAME wrong name and the phantom is imported as a
+      # ForeignKey (or an IDField), not as text. Claiming "bare text column" would be false in
+      # exactly the case a reader is most likely to be debugging.
+      if isempty(col_rest)
+        @warn "Introspection could not parse a column definition; the name, type and any relation on it are all unreliable. This usually means a column name or a DEFAULT expression contains a comma-space, which the schema query's entry separator cannot express." table=table_name fragment=col
+      end
+      col_parts = split(replace(col_rest, "double precision" => "double_precision"), " ")
+      col_type = lowercase(col_parts[1])
       generated::Bool = false
       max_length = nothing
       max_digits = nothing
@@ -1677,8 +1846,8 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
           max_length = parse(Int, max_length_match.captures[1])
           col_type = "varchar"
         end
-      elseif occursin(r"character varying\((\d+)\)", col)
-        max_length_match = match(r"character varying\((\d+)\)", col)
+      elseif occursin(r"character varying\((\d+)\)", col_rest)
+        max_length_match = match(r"character varying\((\d+)\)", col_rest)
         if max_length_match !== nothing
           max_length = parse(Int, max_length_match.captures[1])
           col_type = "varchar"
@@ -1686,7 +1855,7 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       elseif col_type == "bytea"
         # A BinaryField's byte bound lives in its CHECK, not in the column type — the schema query
         # surfaces it as a BYTE_LIMIT_<n> marker (#296).
-        byte_limit_match = match(r"BYTE_LIMIT_(\d+)", col)
+        byte_limit_match = match(r"BYTE_LIMIT_(\d+)", col_rest)
         if byte_limit_match !== nothing
           max_length = parse(Int, byte_limit_match.captures[1])
         end
@@ -1707,7 +1876,7 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # the column carries a `>= 0` CHECK constraint — that marker is what tells a
       # PositiveIntegerField apart from an IntegerField on round-trip.
       field_type = getfield(Models, haskey(type_map, col_type) ? type_map[col_type] : :TextField)
-      if col_type == "integer" && occursin("NON_NEGATIVE_CHECK", col)
+      if col_type == "integer" && occursin("NON_NEGATIVE_CHECK", col_rest)
         field_type = Models.PositiveIntegerField
       end
       
@@ -1718,11 +1887,11 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
       # or a `DEFAULT 'UNIQUE'` literal — inventing uniqueness that would then be diffed forever.
       # The CTE appends ' UNIQUE' as its own space-separated token, so membership is exact.
       unique::Bool = "UNIQUE" in col_parts
-      not_null::Bool = occursin("NOT NULL", col)
+      not_null::Bool = occursin("NOT NULL", col_rest)
       default_value = nothing
-      if occursin("DEFAULT", col)
+      if occursin("DEFAULT", col_rest)
         # Match DEFAULT followed by value, handling type casts like ::numeric
-        default_match = match(r"DEFAULT\s+((?:\([^)]+\)|[^:\s]+)(?:::[a-zA-Z_]+)?)", col)
+        default_match = match(r"DEFAULT\s+((?:\([^)]+\)|[^:\s]+)(?:::[a-zA-Z_]+)?)", col_rest)
         if default_match !== nothing
           raw_default = default_match.captures[1]
           # Clean up the default value: remove type casts and parentheses for simple values
@@ -1743,10 +1912,10 @@ function convertSQLToModel(row::DataFrameRow{DataFrame, DataFrames.Index}; type_
         default_value = _pg_bytea_literal_bytes(default_value)
       end
       if primary_key
-        if occursin("GENE_BY_DEF_IDENTITY", col)
+        if occursin("GENE_BY_DEF_IDENTITY", col_rest)
           generated = true
           generated_always = false
-        elseif occursin("GENE_ALWAYS_IDENTITY", col)
+        elseif occursin("GENE_ALWAYS_IDENTITY", col_rest)
           generated = true
           generated_always = true
         else 

--- a/test/integration/db_2/models.jl
+++ b/test/integration/db_2/models.jl
@@ -553,15 +553,24 @@ Db_table_col_scratch = Models.Model("db_table_col_scratch",
 # index, no unique constraint and no foreign key, so the fixture stays clear of the index-name and
 # REFERENCES renderers, which Db_table_scratch above already covers.
 #
-# The COLUMN axis is deliberately absent here. A spaced `db_column` renders and queries correctly
-# (pinned in `test/unit/test_identifier_quoting.jl`), but PostgreSQL introspection tears it in half
-# on the `columns` aggregate — a pre-existing, separately-tracked defect (#414) whose fix is a change
-# to that aggregate's format, not to any quoting. Putting one here would make this fixture re-propose
-# `Add field / Remove field` on every `makemigrations` and fail the global no-drift assertion.
+# The COLUMN axis is covered too, since #414. `driverref` pins `db_column = "driver ref"`, so this
+# one fixture carries a spaced TABLE name and a spaced COLUMN name through every layer at once:
+# `Dialect.field_to_column` escapes it in DDL, `safe_column_identifier` renders it in queries
+# (pinned at the unit layer in `test/unit/test_identifier_quoting.jl`), and PostgreSQL introspection
+# now reads it back whole.
+#
+# It could not be here before #414. The PostgreSQL `columns` aggregate is
+# `quote_ident(name) || ' ' || format_type(…)` and the reader split it on `" "`, so `"driver ref"`
+# came back as the phantom `"driver` — WITH the leading quote, which `_unquote_ident` correctly
+# refuses to strip from a lone unbalanced pair. The planner renders that phantom through
+# `_julia_field_identifier`, which sanitizes it to the legal binding `driver`, so the drift line
+# read `Add field: driverref; Remove field: driver` and never converged. That is what makes the
+# GLOBAL no-drift assertion in `test_db_table_db.jl` the live mutation gate for this issue: revert
+# the parse and this fixture drifts forever.
 Odd_identifier_scratch = Models.Model("odd_identifier_scratch",
   db_table = "Odd Identifier Scratch",
   id = Models.IDField(),
-  driverref = Models.CharField(max_length=30, null=true),
+  driverref = Models.CharField(max_length=30, null=true, db_column="driver ref"),
   points = Models.IntegerField(null=true),
 )
 

--- a/test/integration/db_sl/models.jl
+++ b/test/integration/db_sl/models.jl
@@ -550,15 +550,26 @@ Db_table_col_scratch = Models.Model("db_table_col_scratch",
 # index, no unique constraint and no foreign key, so the fixture stays clear of the index-name and
 # REFERENCES renderers, which Db_table_scratch above already covers.
 #
-# The COLUMN axis is deliberately absent here. A spaced `db_column` renders and queries correctly
-# (pinned in `test/unit/test_identifier_quoting.jl`), but PostgreSQL introspection tears it in half
-# on the `columns` aggregate — a pre-existing, separately-tracked defect (#414) whose fix is a change
-# to that aggregate's format, not to any quoting. Putting one here would make this fixture re-propose
-# `Add field / Remove field` on every `makemigrations` and fail the global no-drift assertion.
+# The COLUMN axis is covered too, since #414. `driverref` pins `db_column = "driver ref"`, so this
+# one fixture carries a spaced TABLE name and a spaced COLUMN name through every layer at once:
+# `Dialect.field_to_column` escapes it in DDL, `safe_column_identifier` renders it in queries
+# (pinned at the unit layer in `test/unit/test_identifier_quoting.jl`), and PostgreSQL introspection
+# now reads it back whole.
+#
+# It could not be here before #414 — on PostgreSQL. That reader split its `columns` aggregate on
+# `" "`, so `"driver ref"` came back as the phantom `"driver` (with the leading quote, which
+# `_unquote_ident` correctly refuses to strip from a lone unbalanced pair) and every
+# `makemigrations` proposed `Add field: driverref; Remove field: driver` — the binding
+# `_julia_field_identifier` sanitizes that phantom to — forever.
+#
+# SQLite was never affected: this reader takes `PRAGMA table_info` output raw, one identifier per
+# field, with no string splitting. The fixture is declared identically on BOTH engines on purpose,
+# so the global no-drift assertion in `test_db_table_db.jl` proves the two agree about one schema
+# rather than assuming it. The mutation gate itself lives on db_2.
 Odd_identifier_scratch = Models.Model("odd_identifier_scratch",
   db_table = "Odd Identifier Scratch",
   id = Models.IDField(),
-  driverref = Models.CharField(max_length=30, null=true),
+  driverref = Models.CharField(max_length=30, null=true, db_column="driver ref"),
   points = Models.IntegerField(null=true),
 )
 

--- a/test/integration/test_db_table_db.jl
+++ b/test/integration/test_db_table_db.jl
@@ -135,14 +135,23 @@ end
 # each table as a Julia binding. The unit layer pins the renderers agreeing on a string; only a live
 # database proves the statements they produce actually execute, and that the schema converges.
 #
-# The COLUMN axis is not exercised here — see the fixture comment in `models.jl`. It renders and
-# queries correctly, but PostgreSQL introspection tears a spaced column name in half (#414).
+# The COLUMN axis rides along since #414: `driverref` pins `db_column = "driver ref"`, so the same
+# fixture carries a spaced table name and a spaced column name. It always rendered and queried
+# correctly; what it could not do was survive PostgreSQL introspection, which split the `columns`
+# aggregate on `" "` and read the column back as the phantom `"driver` — rendered in the drift line
+# as the sanitized binding `driver`. So the global no-drift assertion below is the live mutation
+# gate for #414 as well as for #59/#325 — ON db_2 specifically. SQLite reads `PRAGMA` output raw and
+# never had the defect, so on db_sl that assertion proves the two engines agree, not that the parse
+# was fixed.
 # ─────────────────────────────────────────────────────────────────────────────
 @testset "db_table: a spaced table round-trips end to end (#394)" begin
     pool = PormG.config[PORMG_DB_FOLDER].connections
 
     cols = column_names(pool, "Odd Identifier Scratch")
-    @test "driverref" in cols
+    # The PHYSICAL name, which is now the spaced one (#414). The logical field stays `driverref`
+    # everywhere below — that split is what `db_column` is for.
+    @test "driver ref" in cols
+    @test !("driverref" in cols)
     @test "points" in cols
 
     # The folded/underscored twin must not exist — a renderer that sanitized the name instead of

--- a/test/integration/test_importers_introspection.jl
+++ b/test/integration/test_importers_introspection.jl
@@ -23,6 +23,21 @@
 # `pormg_it_` prefix and are dropped in a `finally`, leaving the schema untouched.
 # ==============================================================================
 
+# Standalone guard, added with #414/#415. Every fixture in this file is created and dropped by the
+# file itself, and the one table it borrows (`field_validation_scratch`, section 5) comes from the
+# bootstrap — so against an ALREADY-BOOTSTRAPPED database this file runs on its own:
+#
+#   julia --project=test/integration test/integration/test_importers_introspection.jl
+#   PORMG_DB=db_sl julia --project=test/integration test/integration/test_importers_introspection.jl
+#
+# It used to be the one file in the suite with no guard at all, which forced every change reaching
+# introspection through the full `runtests.jl` prologue (~170 DDL statements plus a fixture reseed)
+# to see a single assertion. A slice still does NO DDL and NO reseed: bootstrap the target database
+# with a full run first.
+if !isdefined(Main, :PormG)
+    include("common_setup.jl")
+end
+
 @testset "Schema Importer / Introspection ($(PORMG_DB_FOLDER))" begin
   settings = PormG.config[PORMG_DB_FOLDER]
   pool = settings.connections
@@ -32,7 +47,11 @@
   # Child before parent: since #276 SQLite enforces foreign keys, so dropping the parent while the
   # child still references it raises instead of silently succeeding.
   fixtures = ("pormg_it_fk_child", "pormg_it_fk_parent",
+              "pormg_it_spaced",
               "pormg_it_MixedChild", "pormg_it_MixedParent",
+              "pormg_it_comp_child", "pormg_it_comp_parent",
+              "pormg_it_uq_child", "pormg_it_uq_parent",
+              "pormg_it_nopk_child", "pormg_it_nopk_parent",
               "pormg_it_natural_key", "pormg_it_numeric_key", "pormg_it_ignored",
               "pormg_it_uniq")
   drop_fixtures() = for t in fixtures
@@ -97,6 +116,106 @@
          "ParentId" INTEGER REFERENCES "pormg_it_MixedParent"("Id") ON DELETE CASCADE
        )"""
 
+  # #414 fixture: an identifier CONTAINING A SPACE, on the two axes that used to disagree about it.
+  # The PostgreSQL `columns` aggregate is `quote_ident(name) || ' ' || format_type(…)`, and the
+  # reader split it on `" "` — so `"Parent Id" bigint` was torn into the phantom name `"Parent` and
+  # the non-type `Id"`. `fk_map`, `pk_set` and `index_map` all key on names that survive a space
+  # (they split on `", "`, or come from the one RAW aggregate), so the relation was LOST and every
+  # `makemigrations` proposed `ADD COLUMN "\"Parent"` plus a DROP of the real column.
+  #
+  # `"Parent Id"` is the FK axis and `"driver ref"` the index axis; the latter is the exact spelling
+  # #394's `Odd_identifier_scratch` fixture carries, and the reason that fixture could not use it as
+  # a `db_column` until now. Reuses `pormg_it_MixedParent` as the parent so the spaced CHILD column
+  # and a quoted mixed-case referenced column are exercised in one constraint.
+  #
+  # Both backends: SQLite reads `PRAGMA` output raw and was never affected, so asserting there is
+  # what makes this a cross-engine agreement rather than an assumption.
+  spaced_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_spaced" (
+         id           BIGINT PRIMARY KEY,
+         "driver ref" VARCHAR(30),
+         "Parent Id"  BIGINT REFERENCES "pormg_it_MixedParent"("Id") ON DELETE CASCADE
+       )""" :
+    """CREATE TABLE "pormg_it_spaced" (
+         id           INTEGER PRIMARY KEY,
+         "driver ref" TEXT,
+         "Parent Id"  INTEGER REFERENCES "pormg_it_MixedParent"("Id") ON DELETE CASCADE
+       )"""
+
+  # #415 fixture A: a foreign key that references a NON-PRIMARY-KEY unique column. Legal wherever
+  # that column carries a UNIQUE constraint, and the shape the old CTE could not express at all —
+  # it read the referenced column from the parent's PRIMARY KEY INDEX, never from `con.confkey`,
+  # so this introspected as pointing at `id`. `pk_field` was then wrong and so was every consumer
+  # of it, and the DDL PormG emitted named a different column than the live constraint does.
+  uq_parent_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_uq_parent" (id BIGINT PRIMARY KEY, ukey VARCHAR(20) UNIQUE, label VARCHAR(50))""" :
+    """CREATE TABLE "pormg_it_uq_parent" (id INTEGER PRIMARY KEY, ukey TEXT UNIQUE, label TEXT)"""
+  uq_child_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_uq_child" (
+         id         BIGINT PRIMARY KEY,
+         parent_key VARCHAR(20) REFERENCES "pormg_it_uq_parent"(ukey) ON DELETE CASCADE
+       )""" :
+    """CREATE TABLE "pormg_it_uq_child" (
+         id         INTEGER PRIMARY KEY,
+         parent_key TEXT REFERENCES "pormg_it_uq_parent"(ukey) ON DELETE CASCADE
+       )"""
+
+  # #415 fixture B: a COMPOSITE-KEYED parent carrying both remaining shapes on one child table.
+  #
+  #   * `parent_a` — a SINGLE-column FK into that parent. The old CTE joined the parent's PK index
+  #     with `attnum = ANY(pk_idx.indkey)`, yielding one row per parent key column and multiplying
+  #     every aggregate; the LAST fanned-out entry won the `fk_map[...]` assignment. The referenced
+  #     column is `a` and the parent's key is `(a, b)`, so the pre-fix answer was `b` — the fixture
+  #     is ordered that way deliberately, since a parent keyed `(b, a)` would have made the wrong
+  #     answer coincide with the right one and the test would pass on a defect.
+  #   * `(ca, cb)` — a genuine MULTI-column FK, which PormG has no field type for and now skips on
+  #     both engines rather than splitting into two plausible-looking single-column relations.
+  #
+  # Both on ONE table on purpose: `parent_a` is the control proving the skip is per-CONSTRAINT, not
+  # per-table. `a` carries its own UNIQUE because a single-column FK requires one.
+  comp_parent_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_comp_parent" (
+         a BIGINT UNIQUE, b BIGINT, label VARCHAR(50), PRIMARY KEY (a, b)
+       )""" :
+    """CREATE TABLE "pormg_it_comp_parent" (
+         a INTEGER UNIQUE, b INTEGER, label TEXT, PRIMARY KEY (a, b)
+       )"""
+  comp_child_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_comp_child" (
+         id       BIGINT PRIMARY KEY,
+         parent_a BIGINT REFERENCES "pormg_it_comp_parent"(a) ON DELETE SET NULL,
+         ca       BIGINT,
+         cb       BIGINT,
+         FOREIGN KEY (ca, cb) REFERENCES "pormg_it_comp_parent"(a, b) ON DELETE CASCADE
+       )""" :
+    """CREATE TABLE "pormg_it_comp_child" (
+         id       INTEGER PRIMARY KEY,
+         parent_a INTEGER REFERENCES "pormg_it_comp_parent"(a) ON DELETE SET NULL,
+         ca       INTEGER,
+         cb       INTEGER,
+         FOREIGN KEY (ca, cb) REFERENCES "pormg_it_comp_parent"(a, b) ON DELETE CASCADE
+       )"""
+
+  # #415 fixture C: a parent with NO PRIMARY KEY, only a UNIQUE column. Legal on both engines — a
+  # referenced column needs uniqueness, not the key — and it used to be INVISIBLE to PostgreSQL
+  # introspection: the old CTE joined `pg_index ... AND pk_idx.indisprimary` as an INNER join, so a
+  # keyless parent matched no row and the whole foreign key dropped out of the aggregate. The child
+  # column then introspected as an ordinary integer with no relation, while SQLite (whose
+  # `PRAGMA foreign_key_list` never consulted a primary key) reported it correctly. Dropping that
+  # join is what makes the two engines agree, and this is the fixture that says so.
+  nopk_parent_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_nopk_parent" (ukey VARCHAR(20) UNIQUE, label VARCHAR(50))""" :
+    """CREATE TABLE "pormg_it_nopk_parent" (ukey TEXT UNIQUE, label TEXT)"""
+  nopk_child_ddl = is_pg ?
+    """CREATE TABLE "pormg_it_nopk_child" (
+         id         BIGINT PRIMARY KEY,
+         parent_key VARCHAR(20) REFERENCES "pormg_it_nopk_parent"(ukey) ON DELETE RESTRICT
+       )""" :
+    """CREATE TABLE "pormg_it_nopk_child" (
+         id         INTEGER PRIMARY KEY,
+         parent_key TEXT REFERENCES "pormg_it_nopk_parent"(ukey) ON DELETE RESTRICT
+       )"""
+
   # #318: TWO separate single-column UNIQUEs on one table plus a composite. This is the ONLY place
   # PostgreSQL's `unique_constraints` CTE actually runs, and the two-uniques shape is precisely what
   # it got wrong (it merged both constraints' columns into one per-table array, then rejected both
@@ -119,6 +238,16 @@
   ddl(fk_child_ddl)
   ddl(mixed_parent_ddl)
   ddl(mixed_child_ddl)
+  ddl(spaced_ddl)
+  # The index axis of #414. NOT on the UNIQUE column: the `indexes` CTE excludes `indisunique`, so a
+  # unique column's backing index never reaches `index_map` and the assertion would be vacuous.
+  ddl("""CREATE INDEX "pormg_it_spaced_ref_idx" ON "pormg_it_spaced" ("driver ref")""")
+  ddl(uq_parent_ddl)
+  ddl(uq_child_ddl)
+  ddl(comp_parent_ddl)
+  ddl(comp_child_ddl)
+  ddl(nopk_parent_ddl)
+  ddl(nopk_child_ddl)
   ddl(uniq_ddl)
   # #347: a composite NON-unique index on the same table, deliberately in the REVERSE column order
   # of the composite UNIQUE declared above. Both backends excluded every multi-column index from
@@ -345,6 +474,123 @@
     # The #360 half still holds for a mixed-case parent table.
     @test mixed_child.fields["ParentId"].to_table == "pormg_it_MixedParent"
     @test mixed_child.fields["ParentId"].on_delete === PormG.Models.CASCADE
+
+    # ── 3e. An identifier containing a SPACE survives the columns parse (#414) ──
+    # THE live half of this issue, and the only one that executes the PostgreSQL `columns`
+    # aggregate. The reader split that aggregate on `" "` to separate the name from the type, so a
+    # spaced identifier was destroyed before any de-quoting could help — the column arrived under
+    # the phantom name `"Parent` (the leading quote survives; `_unquote_ident` correctly refuses to
+    # strip a lone unbalanced one), its type read as `Id"` so it degraded to `TextField`, and the
+    # foreign key was LOST because `fk_map`'s key — from an aggregate split on `", "` — was the
+    # correct `Parent Id` and no longer matched.
+    #
+    # Since #394 this was the last layer where a spaced `db_column` broke; `Dialect.field_to_column`
+    # escapes it in DDL and `safe_column_identifier` renders it in queries. Asserted on BOTH engines
+    # because SQLite was never affected — that is what makes this an agreement rather than an
+    # assumption, and it is the same PG/SQLite divergence #414 reports.
+    spaced_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_spaced", "pormg_it_MixedParent"])
+    spaced = Dict(lowercase(string(m.name)) => m for m in spaced_models)["pormg_it_spaced"]
+
+    # Exact key set: the phantom name must not appear under ANY spelling, and the real names must
+    # be the only ones present. A bare `haskey` would pass while a phantom sat beside it.
+    @test Set(keys(spaced.fields)) == Set(["id", "driver ref", "Parent Id"])
+
+    # The FK axis — the relation, not the TextField the torn type produced.
+    @test spaced.fields["Parent Id"] isa PormG.Models.sForeignKey
+    @test spaced.fields["Parent Id"].pk_field == "Id"
+    @test spaced.fields["Parent Id"].to_table == "pormg_it_MixedParent"
+    @test spaced.fields["Parent Id"].on_delete === PormG.Models.CASCADE
+
+    # The index axis — `index_map`'s key comes from the one RAW aggregate and was therefore already
+    # `driver ref`, so it stopped matching `col_name` the moment the name was torn. `db_index=true`
+    # reading back false is the #325 churn, in a new place.
+    @test spaced.fields["driver ref"].db_index
+    @test spaced.cache["index"]["driver ref"] == "pormg_it_spaced_ref_idx"
+    if is_pg
+      # The type survived too: `col_parts[2]` was `Id"`-shaped for the FK column and equally wrong
+      # here, so a sized textual column degraded to TextField and lost its length.
+      @test spaced.fields["driver ref"] isa PormG.Models.sCharField
+      @test spaced.fields["driver ref"].max_length == 30
+    end
+
+    # ── 3f. An FK reads the column its constraint names, not the parent's PK (#415) ──
+    # The PostgreSQL `foreign_keys` CTE derived the referenced column from the parent's PRIMARY KEY
+    # INDEX; `con.confkey` — the array saying which parent columns the FK actually references — was
+    # never selected anywhere in the file. `REFERENCES parent(ukey)` is legal wherever that column
+    # carries a UNIQUE constraint, and it introspected as pointing at `id`.
+    #
+    # Live-only by construction: this is a SQL change, and a `DataFrameRow` fixture cannot execute
+    # SQL. The hermetic block in test/unit/test_introspection_guards.jl pins the consumer contract
+    # this relies on (one entry per FK, aggregates paired by position) and says so explicitly.
+    uq_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_uq_parent", "pormg_it_uq_child"])
+    uq_child = Dict(lowercase(string(m.name)) => m for m in uq_models)["pormg_it_uq_child"]
+
+    @test uq_child.fields["parent_key"] isa PormG.Models.sForeignKey
+    @test uq_child.fields["parent_key"].pk_field == "ukey"      # pre-fix: "id"
+    @test uq_child.fields["parent_key"].to_table == "pormg_it_uq_parent"
+    @test uq_child.fields["parent_key"].on_delete === PormG.Models.CASCADE
+    # …and resolved the same way, since `pk_field` is what every consumer of the relation reads.
+    @test PormG.Models.fk_target_column(uq_child.fields["parent_key"]) == "ukey"
+
+    # ── 3g. A composite parent key no longer fans the aggregates out (#415) ──
+    # `attnum = ANY(pk_idx.indkey)` yielded one row per parent PK column, multiplying every
+    # aggregate in the CTE — and the LAST fanned-out entry silently won the `fk_map[...]`
+    # assignment. The parent's key is `(a, b)` and the constraint references `a`, so the pre-fix
+    # answer was `b`: a single-column FK bound to an arbitrary one of the parent's key columns, with
+    # no warning. The same fan-out duplicated `delete_rules`, breaking the alignment #292
+    # established.
+    comp_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_comp_parent", "pormg_it_comp_child"])
+    comp_child = Dict(lowercase(string(m.name)) => m for m in comp_models)["pormg_it_comp_child"]
+
+    @test comp_child.fields["parent_a"] isa PormG.Models.sForeignKey
+    @test comp_child.fields["parent_a"].pk_field == "a"          # pre-fix: "b"
+    @test comp_child.fields["parent_a"].to_table == "pormg_it_comp_parent"
+    # The action survived the de-fan: read off a duplicated position it was still `n` here, so this
+    # is a no-regression pin for #292 rather than a mutation gate on its own.
+    @test comp_child.fields["parent_a"].on_delete === PormG.Models.SET_NULL
+
+    # The genuine MULTI-column foreign key is SKIPPED, not split. PormG has no composite-FK field
+    # type, so the alternatives are both wrong: pick one column and pretend, or emit two independent
+    # single-column relations that regenerate as two constraints the parent cannot accept (neither
+    # `a` nor `b` is unique on its own — `a` is here only so `parent_a` above is legal, and `b` is
+    # not). A skipped constraint reads as "no relation" on both sides of the diff, so the schema
+    # still converges.
+    #
+    # Both engines: PostgreSQL excludes it in the CTE (`array_length(con.conkey, 1) = 1`), SQLite by
+    # grouping `PRAGMA foreign_key_list` on `id`. Before this SQLite split it into two relations and
+    # PostgreSQL fanned it out — one schema, two wrong answers.
+    @test !(comp_child.fields["ca"] isa PormG.Models.sForeignKey)
+    @test !(comp_child.fields["cb"] isa PormG.Models.sForeignKey)
+    # The TYPE the member falls back to, not merely "not a relation". `UPGRADING.md` tells a
+    # consuming app to redeclare these columns by hand, so the type it names has to be the one
+    # introspection actually reports — `bigint` maps to `BigIntegerField` (src/constants.jl), and
+    # advising `IntegerField` would trade the lost relation for a permanent `:type` proposal.
+    # PostgreSQL only: the SQLite fixture declares `INTEGER`, which is a different (correct) answer.
+    if is_pg
+      @test comp_child.fields["ca"] isa PormG.Models.sBigIntegerField
+      @test comp_child.fields["cb"] isa PormG.Models.sBigIntegerField
+    end
+
+    # ── 3h. A foreign key into a PRIMARY-KEY-LESS parent is visible at all (#415) ──
+    # The third consequence of correlating through `confkey`, and the one that is a pure gain. The
+    # old CTE reached the referenced column through `JOIN pg_index … AND pk_idx.indisprimary` — an
+    # INNER join — so a parent with no primary key matched no row and the foreign key dropped out of
+    # the aggregate entirely. The child column introspected as a plain integer with no relation.
+    #
+    # That schema is legal: a referenced column needs a UNIQUE constraint, not the key. SQLite read
+    # it correctly all along (`PRAGMA foreign_key_list` never consults a primary key), so this is
+    # another case of one schema reading two ways — asserted on both engines for that reason.
+    nopk_models = PormG.Migrations.convert_schema_to_models(pool;
+        include_table = ["pormg_it_nopk_parent", "pormg_it_nopk_child"])
+    nopk_child = Dict(lowercase(string(m.name)) => m for m in nopk_models)["pormg_it_nopk_child"]
+
+    @test nopk_child.fields["parent_key"] isa PormG.Models.sForeignKey
+    @test nopk_child.fields["parent_key"].pk_field == "ukey"
+    @test nopk_child.fields["parent_key"].to_table == "pormg_it_nopk_parent"
+    @test nopk_child.fields["parent_key"].on_delete === PormG.Models.RESTRICT
 
     # ── 4. The regenerated module registers via set_models (#287/#291) ───────
     # THE regression assertion. Before #292 this threw ModelDefinitionError ("declares on_delete

--- a/test/unit/test_importers.jl
+++ b/test/unit/test_importers.jl
@@ -232,5 +232,61 @@ end
       end
     end
   end
-
 end
+
+# ───────────────────────────────────────────────────────────────────────────
+# 6. #415 — a genuinely MULTI-COLUMN foreign key is skipped, not split into N single-column ones.
+#
+#    `PRAGMA foreign_key_list` returns one row per column and groups a composite constraint under
+#    a shared `id`. The reader keyed `fk_map` on the child column (`from`) alone, so one composite
+#    constraint became TWO independent single-column relations — each plausible on its own, and
+#    each regenerating as a separate `REFERENCES parent(col)` that the parent may not even accept,
+#    since neither member of a composite key is unique by itself. PormG has no composite-FK field
+#    type, so there is nothing faithful to read: the reject-rather-than-reinterpret rule this file
+#    already applies to composite UNIQUE and to non-default indexes applies here too.
+#
+#    This is the SQLite half of a cross-engine change. PostgreSQL excludes the same shape in its
+#    `foreign_keys` CTE (`array_length(con.conkey, 1) = 1`), and the two are kept symmetric on
+#    purpose — one schema must not read two ways.
+#
+#    Mutation gate: drop the `columns_per_fk[...] > 1 && continue` skip and `child_a`/`child_b`
+#    come back as `sForeignKey`, failing the two `isa` assertions below.
+# ───────────────────────────────────────────────────────────────────────────
+@testset "a composite foreign key is skipped rather than split (#415)" begin
+  mktempdir() do dir
+    dbfile = joinpath(dir, "scratch_composite_fk.sqlite")
+    pool   = SQLiteConnectionPool(dbfile; pool_size = 1)
+    try
+      # `parent` carries a two-column PRIMARY KEY; `child` references BOTH columns as one
+      # constraint, and separately carries an ordinary single-column FK into a normal parent.
+      fetch(pool, "CREATE TABLE parent (a INTEGER, b INTEGER, PRIMARY KEY (a, b));")
+      fetch(pool, "CREATE TABLE solo (id INTEGER PRIMARY KEY);")
+      fetch(pool, """CREATE TABLE child (
+                       id      INTEGER PRIMARY KEY,
+                       child_a INTEGER,
+                       child_b INTEGER,
+                       solo_id INTEGER REFERENCES solo(id),
+                       FOREIGN KEY (child_a, child_b) REFERENCES parent(a, b)
+                     );""")
+
+      model = PormG.Migrations.convertSQLToModel(pool, "child")
+
+      # The composite members are ordinary columns, not relations. Pre-fix each came back as an
+      # `sForeignKey` bound to its own half of the parent key.
+      @test !(model.fields["child_a"] isa PormG.Models.sForeignKey)
+      @test !(model.fields["child_b"] isa PormG.Models.sForeignKey)
+      @test model.fields["child_a"] isa PormG.Models.sIntegerField
+      @test model.fields["child_b"] isa PormG.Models.sIntegerField
+
+      # CONTROL, and the reason the skip is per-CONSTRAINT rather than per-table: an ordinary
+      # single-column foreign key on the SAME table is untouched. A guard that keyed off "this
+      # table has a composite FK" would take this one out with it.
+      @test model.fields["solo_id"] isa PormG.Models.sForeignKey
+      @test model.fields["solo_id"].pk_field == "id"
+      @test model.fields["solo_id"].to_table == "solo"
+    finally
+      close_pool!(pool)
+    end
+  end
+end
+

--- a/test/unit/test_introspection_guards.jl
+++ b/test/unit/test_introspection_guards.jl
@@ -847,3 +847,166 @@ struct MockPg389 <: PormG.PormGPostgres end
     @test model.fields["driverid"].on_delete === PormG.Models.CASCADE
   end
 end
+
+# ───────────────────────────────────────────────────────────────────────────
+# #414 — an identifier CONTAINING A SPACE survives the columns parse.
+#
+# The reader used to `split(col, " ")` and take `[1]` as the name and `[2]` as the type, so
+# `"Parent Id" bigint` was torn in half before anything else could look at it. Three things went
+# wrong at once and this block gates all three: the phantom name `"Parent` (the leading quote
+# SURVIVES — `_unquote_ident` correctly refuses to strip a lone unbalanced one), the type `Id"`
+# which no lookup matches so the column degraded to `TextField`, and the LOST RELATION, because
+# `fk_map`'s key comes from an aggregate split on `", "` and therefore survived the space intact.
+# The two sides genuinely disagreed for exactly this class of name.
+#
+# Since #394 this was the only layer where a spaced `db_column` still broke — the DDL and the
+# query builder both handle it — which is what made every `makemigrations` propose
+# `ADD COLUMN "\"Parent"` plus a DROP of the real column, forever.
+# ───────────────────────────────────────────────────────────────────────────
+@testset "a column name containing a space is not torn in half (#414)" begin
+  model = convertSQLToModel(_introspection_row(
+    table_name              = "probe",
+    columns                 = "id bigint NOT NULL, \"Parent Id\" bigint",
+    primary_keys            = "id",
+    foreign_keys            = "\"Parent Id\"",
+    foreign_tables          = "\"MixedParent\"",
+    referenced_primary_keys = "\"Id\"",
+    delete_rules            = "a"))
+
+  # The name, whole. `"Parent` — the measured pre-fix value — must not appear under any key.
+  @test haskey(model.fields, "Parent Id")
+  @test !any(k -> occursin('"', k), keys(model.fields))
+  @test Set(keys(model.fields)) == Set(["id", "Parent Id"])
+
+  # The RELATION, not a TextField. This is the discriminating assertion: the type degraded
+  # because `col_parts[2]` was `Id"` rather than `bigint`, and the FK lookup missed because it
+  # was keyed on the phantom name.
+  @test model.fields["Parent Id"] isa PormG.Models.sForeignKey
+  @test !(model.fields["Parent Id"] isa PormG.Models.sTextField)
+  @test model.fields["Parent Id"].pk_field == "Id"
+  @test model.fields["Parent Id"].to_table == "MixedParent"
+end
+
+@testset "a spaced name reaches pk_set and index_map too (#414)" begin
+  # The other two consumers keyed on `col_name`. Both already survived a space on their own side
+  # (`primary_keys` splits on `", "`; `index_columns` is the one RAW aggregate), so they were
+  # correct all along and only `col_name` disagreed with them — which is why repairing the one
+  # parse site is what makes all four agree. A spaced PRIMARY KEY left the table KEYLESS before.
+  model = convertSQLToModel(_introspection_row(
+    table_name    = "probe2",
+    columns       = "\"Key Col\" bigint NOT NULL, \"Idx Col\" bigint",
+    primary_keys  = "\"Key Col\"",
+    index_columns = "Idx Col",
+    index_names   = "probe2_idx"))
+
+  @test model.fields["Key Col"] isa PormG.Models.sIDField
+  @test model.fields["Key Col"].primary_key
+  @test model.fields["Idx Col"].db_index
+  @test model.cache["index"]["Idx Col"] == "probe2_idx"
+end
+
+@testset "a column NAMED like a marker does not mark itself (#414)" begin
+  # The sibling class the same parse defect created, and the reason the flag/type scans moved off
+  # the whole entry and onto the post-name remainder.
+  #
+  # Which shapes actually broke, measured rather than assumed — a bare reserved word did NOT.
+  # `quote_ident` wraps it, so `"UNIQUE" bigint` split to `["\"UNIQUE\"", "bigint"]`, and #318's
+  # token test (`"UNIQUE" in col_parts`) does not match the quoted form. That case was safe by
+  # accident of quoting, and is kept below as a control. The three that broke are the ones where a
+  # SPACE inside the name puts a bare marker token, or a rewritten type, into the split:
+  #
+  #   * `"has UNIQUE inside"` → `[…, "UNIQUE", …]`, so #318's token test fires on the NAME and the
+  #     column is read as carrying a uniqueness constraint it never had — inventing drift the
+  #     planner then proposes forever. #318 closed the `DEFAULT 'UNIQUE'` half of this; the name
+  #     half stayed open because the split it depends on was the defect underneath.
+  #   * `"NOT NULL"` → `occursin("NOT NULL", col)` fires on the name alone, so a nullable column
+  #     reads as NOT NULL.
+  #   * `"double precision"` → the reader rewrites that two-word TYPE to `double_precision` before
+  #     splitting, and the rewrite hit a column so NAMED.
+  model = convertSQLToModel(_introspection_row(
+    table_name   = "marker_probe",
+    columns      = "id bigint NOT NULL, \"has UNIQUE inside\" bigint, \"NOT NULL\" bigint, \"double precision\" bigint, \"UNIQUE\" bigint",
+    primary_keys = "id"))
+
+  @test Set(keys(model.fields)) ==
+        Set(["id", "has UNIQUE inside", "NOT NULL", "double precision", "UNIQUE"])
+  @test !model.fields["has UNIQUE inside"].unique   # says it, does not have it
+  @test model.fields["NOT NULL"].null               # says it, is still nullable
+  # The name was NOT rewritten to `double_precision`, and the column keeps its declared bigint
+  # type rather than being read as the float that rewrite would have implied.
+  @test model.fields["double precision"] isa PormG.Models.sBigIntegerField
+  @test !model.fields["UNIQUE"].unique               # control: was already correct pre-#414
+
+  # Control: the real markers still work, on a column whose name says nothing.
+  plain = convertSQLToModel(_introspection_row(
+    table_name   = "marker_control",
+    columns      = "id bigint NOT NULL, slug character varying(30) NOT NULL UNIQUE, dp double precision",
+    primary_keys = "id"))
+  @test plain.fields["slug"].unique
+  @test !plain.fields["slug"].null
+  @test plain.fields["slug"].max_length == 30
+  @test plain.fields["dp"] isa PormG.Models.sFloatField
+end
+
+# ───────────────────────────────────────────────────────────────────────────
+# #415 — the CONSUMER half. Read the scope of this block literally.
+#
+# The defect was in the `foreign_keys` CTE (it derived the referenced column from the parent's
+# PRIMARY KEY INDEX instead of from `con.confkey`, and fanned every aggregate out once per parent
+# PK column). A `DataFrameRow` fixture cannot execute SQL, so NOTHING HERE PROVES THE FIX — that
+# is `test/integration/test_importers_introspection.jl`'s job, against a live server.
+#
+# What this pins is the contract the fixed CTE now relies on: given ONE entry per foreign key,
+# every aggregate pairs by position. The values are made mutually distinguishable on purpose —
+# two FKs with different parents, different referenced columns and different delete rules — so a
+# future off-by-one or a reintroduced fan-out fails here rather than passing on symmetry.
+# ───────────────────────────────────────────────────────────────────────────
+@testset "one entry per FK: every aggregate pairs by position (#415)" begin
+  model = convertSQLToModel(_introspection_row(
+    table_name              = "child",
+    columns                 = "id bigint NOT NULL, a_id bigint, b_id bigint",
+    primary_keys            = "id",
+    foreign_keys            = "a_id, b_id",
+    foreign_tables          = "parent_a, parent_b",
+    # NOT the parents' primary keys: `parent_a` is referenced on a non-PK UNIQUE column. This is
+    # the value the old CTE could not produce at all, because it never selected `confkey`.
+    referenced_primary_keys = "some_unique_col, id",
+    delete_rules            = "c, n"))
+
+  @test model.fields["a_id"].pk_field == "some_unique_col"
+  @test model.fields["a_id"].to_table == "parent_a"
+  @test model.fields["a_id"].on_delete === PormG.Models.CASCADE
+
+  @test model.fields["b_id"].pk_field == "id"
+  @test model.fields["b_id"].to_table == "parent_b"
+  @test model.fields["b_id"].on_delete === PormG.Models.SET_NULL
+end
+
+@testset "the fanned-out row shape is what the CTE must no longer emit (#415)" begin
+  # The measurement from the issue, kept as documentation of the defect rather than as a
+  # requirement on the reader. A composite-keyed parent used to multiply every aggregate, so this
+  # row — `foreign_keys` naming ONE child column twice, `referenced_primary_keys` naming the
+  # parent's two key columns — is what reached the consumer, and the LAST entry won the
+  # `fk_map[...]` assignment: `pk_field` came back as `"b"` for a relation that references `a`.
+  #
+  # The reader still behaves that way given that input, and deliberately so: last-write-wins on a
+  # duplicate key is not a defect the consumer can detect, and inventing a guard here would
+  # duplicate — badly — a fix that belongs in the SQL. The assertion is that the shape is
+  # DEGENERATE, which is the argument for why the CTE must not produce it.
+  model = convertSQLToModel(_introspection_row(
+    table_name              = "probe",
+    columns                 = "id bigint NOT NULL, parent_id bigint",
+    primary_keys            = "id",
+    foreign_keys            = "parent_id, parent_id",
+    foreign_tables          = "comp_parent, comp_parent",
+    referenced_primary_keys = "a, b",
+    delete_rules            = "a, a"))
+
+  # MEMBERSHIP, not the exact value. `== "b"` is what this actually returns today (last write wins),
+  # but pinning it would freeze an answer the codebase calls wrong: anyone later adding a
+  # consumer-side guard — warn or skip on a duplicated `fk_map` key, a reasonable defence in depth —
+  # would have to DELETE this test to go green. What is worth pinning is that the reader picks one
+  # of the parent's key columns arbitrarily and reports no problem, which is the argument for fixing
+  # it upstream in the CTE.
+  @test model.fields["parent_id"].pk_field in ("a", "b")
+end


### PR DESCRIPTION
Closes #414
Closes #415

Two defects in the PostgreSQL schema reader (`src/migrations/introspection.jl`), both found during #389 and deferred there with in-place comments. Landed together because they share a file, a test surface and a verification cost.

## #414 — a spaced identifier was torn in half

The `columns` aggregate is `quote_ident(name) || ' ' || format_type(...)` and the reader split it on `" "`, so an identifier *containing* a space was destroyed before anything else saw it. Three things went wrong at once:

* the phantom name `"Parent` — the leading quote **survives**, because `_unquote_ident` correctly refuses to strip a lone unbalanced one;
* the non-type `Id"`, so the column degraded to `TextField`;
* the **relation was lost** — `fk_map`, `pk_set` and `index_map` all key on names that survive a space (they split on `", "`, or come from the one RAW aggregate), so the two sides disagreed for exactly this class of name.

`makemigrations` then proposed adding the phantom and dropping the real column on every run, forever. SQLite was never affected, so one schema introspected correctly on one engine and corruptly on the other.

**Fixed in the parser, not the aggregate.** `quote_ident` output is self-delimiting, so scanning to the closing quote recovers every name that reaches the function whole. The flag and type scans move onto the post-name remainder in the same change, which closes the sibling class where a column *named* like a marker marked itself (`"has UNIQUE inside"`, `"NOT NULL"`, `"double precision"`).

## #415 — the referenced column came from the parent's PK index

`con.confkey` — the array saying which parent columns an FK actually references — was not selected anywhere in the file. An FK pointing at a non-PK `UNIQUE` column reported the wrong column, and a composite parent key fanned every aggregate out once per parent key column, so the last entry silently won the `fk_map` assignment and the `delete_rules` alignment #292 established broke with it.

Now correlated through `unnest(con.conkey, con.confkey)` — bound-agnostic, so unlike a `conkey[1]` subscript it carries none of #347's lower-bound hazard. It adds no version floor: the `indexes` CTE in the same statement already requires PostgreSQL 11+.

Three behavior changes fall out, all deliberate and documented in `UPGRADING.md`:

1. A genuine **multi-column FK is skipped rather than guessed at, on both engines** — PostgreSQL by `array_length(con.conkey, 1) = 1`, SQLite by grouping `PRAGMA foreign_key_list` on `id`, which used to split one constraint into N independent single-column relations. PormG has no composite-FK field type; reading one approximately regenerates a *different* schema, so this follows the same reject-rather-than-reinterpret rule as `_pg_composite_indexes`.
2. An FK referencing a **non-PK `UNIQUE` column** reads that column.
3. An FK whose parent has **no primary key at all** is visible — the dropped `pg_index` join was INNER, so such a key vanished from the PostgreSQL read entirely while SQLite reported it.

## Also here

* `Odd_identifier_scratch` regains `db_column = "driver ref"` on both engines. #394 had to leave the column axis out *because* of #414; the global no-drift assertion in `test_db_table_db.jl` is now the live gate for this parse.
* `test_importers_introspection.jl` gains the standalone `isdefined(Main, :PormG)` guard it uniquely lacked, so it no longer forces the full `runtests.jl` prologue (~170 DDL statements plus a reseed) to see one assertion. It now slices in ~14s.

## Verification

| | |
|---|---|
| Unit | **8874 / 8874** |
| SQLite integration, full suite | **2172 pass / 1 pre-existing broken / 0 fail** |
| `db_sl` introspection slice | **78 / 78** |
| Docs | build exits 0; `upgrade_guide` parses both `Unreleased` entries |
| Mutation-checked | reverting the parser fails 13 assertions; removing the SQLite composite skip fails 4 |

## NOT verified — please read before merging

**The PostgreSQL behavior of #415 is unproven.** A read-only probe confirms the new CTE parses and executes against `db_2`, and that none of its 28 existing FK tables regress. But running the old and new CTE side by side, **they agree on all 28** — `db_2` carries neither affected shape today, so that probe is a no-regression check, not a gate.

Still needing a full `db_2` run: integration sections 3f (non-PK unique target), 3g (composite parent + composite-FK skip), 3h (PK-less parent), the `db_column="driver ref"` no-drift assertion, and the `sBigIntegerField` fallback assertion.

## Deliberately not done

* **The `columns` serialization residual.** The aggregate's `", "` *entry* separator is still ambiguous: an identifier containing `, `, or a DEFAULT literal containing one (`DEFAULT 'Ferrari, Scuderia'`, `DEFAULT concat('a', 'b')`), still tears. The parser fix cannot reach that — it needs the aggregate's format to change (`json_agg(json_build_object(...))`). Documented in place, a `@warn` added on the one degrade path that can detect it, and a follow-up issue is owed.
* **The dead `major_version >= 10` branch.** Provably unreachable given the PG 11+ floor, but retiring it also retires the `version()` probe that feeds it — a separate change. Named in the comment rather than removed.
* **A composite FK is skipped silently.** Warning would need a separate detection pass; the skip converges (no relation on either side of the diff), so this is a gap rather than a defect.

## Review

Three independent review rounds, each finding real defects in the previous round's fixes. Notable:

* A fix of mine turned a `BoundsError` into a *silent* phantom column — trading a loud abort for the exact permanent churn #414 exists to remove. Now warns.
* I removed a false "only regenerating is affected" claim from `UPGRADING.md` and reintroduced the same assumption one paragraph above it. `makemigrations` runs introspection on every invocation, so changes 2 and 3 bite model files that are never regenerated.
* Mid-review the branch fell 6 commits behind after #451 landed, at which point `git diff origin/main` silently became "this change **plus a revert of #451**". Rebased; both `UPGRADING.md` entries are preserved.

**One finding declined:** strengthening the parse warning to fire whenever `col_name` still contains a `"`. It would fire on `Say"Hi` and on a column genuinely named `"x"` — both legitimate, both with passing tests in `test_introspection_guards.jl`. The comment states the coverage gap honestly instead.

No `Project.toml` bump — release trains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
